### PR TITLE
chore: improve Claude agent environment and dev tooling

### DIFF
--- a/.claude/commands/build-app.md
+++ b/.claude/commands/build-app.md
@@ -1,0 +1,18 @@
+---
+description: Build the Nuxt SPA and stage it inside the interloper-app Python package
+---
+
+Build the frontend and stage the static output inside the Python package:
+
+```
+make build-app
+```
+
+This installs deps, runs `NUXT_PRESET=static pnpm build` in
+`packages/interloper-app/app`, wipes
+`packages/interloper-app/src/interloper_app/static/`, and copies the fresh
+`.output/public/*` into it (keeping a `.gitkeep`).
+
+If the build succeeds, report what changed under `static/` in one line. If it
+fails, diagnose the root cause (it's usually a TypeScript/lint error — try
+`make check-typescript` to surface it cleanly) and fix it before rebuilding.

--- a/.claude/commands/check-py.md
+++ b/.claude/commands/check-py.md
@@ -1,0 +1,18 @@
+---
+description: Run only the Python checks (ruff + pyright + pytest) and fix failures
+---
+
+Run the Python half of the check suite from the repo root:
+
+```
+make check-python
+```
+
+This runs `uv run ruff check packages`, `uv run pyright`, and `uv run pytest`
+(the `functional` marker is excluded by default).
+
+If everything passes, report a one-line summary and stop.
+
+If anything fails, diagnose and fix the root cause, then re-run
+`make check-python` to confirm. Honor repo conventions: ruff line length 120,
+pyright `basic` mode.

--- a/.claude/commands/check.md
+++ b/.claude/commands/check.md
@@ -1,0 +1,21 @@
+---
+description: Run the full Python + frontend check suite and fix any failures
+---
+
+Run the complete check suite from the repo root:
+
+```
+make check
+```
+
+This runs both halves:
+
+- `make check-python` — `uv run ruff check packages`, `uv run pyright`, `uv run pytest`
+- `make check-typescript` — `pnpm run lint` + `pnpm exec nuxt typecheck` in `packages/interloper-app/app`
+
+If everything passes, report a one-line summary and stop.
+
+If anything fails, diagnose the root cause and fix it (don't just silence the
+error), then re-run the relevant half — `make check-python` or
+`make check-typescript` — to confirm. Stay within repo conventions: ruff line
+length 120, pyright `basic` mode, Python ≥3.10.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,21 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(uv run:*)",
+      "Bash(uv sync:*)",
+      "Bash(uv build:*)",
+      "Bash(uv lock:*)",
+      "Bash(pnpm run:*)",
+      "Bash(pnpm exec:*)",
+      "Bash(pnpm install:*)",
+      "Bash(pnpm build)",
+      "Bash(make:*)",
+      "Bash(git status)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git show:*)",
+      "Bash(git branch:*)",
+      "Bash(git stash list)"
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "includeCoAuthoredBy": false,
   "permissions": {
     "allow": [
       "Bash(uv run:*)",

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -50,11 +50,12 @@ jobs:
       - name: Pytest
         run: uv run pytest --cov --cov-report=xml
 
-      - name: Upload coverage
+      - name: Upload coverage reports to Codecov
         if: matrix.python-version == '3.12'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          slug: digitl-cloud/interloper
 
   typescript:
     name: TypeScript

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,82 @@
-# interloper-core
+# interloper
+
+Python monorepo (uv workspace under `packages/`) plus a bundled Nuxt SPA. Provides a data-asset framework (`interloper-core`) and the runners, IO backends, API, scheduler, agent, and web UI built on top of it.
+
+## Layout
+
+```
+packages/
+  interloper-core/           framework: assets, sources, DAG, runners, IO, partitioning
+  interloper-assets/         pre-built source definitions (bing, facebook, google, …)
+  interloper-pandas/         pandas DataFrame normalizer/adapter
+  interloper-db/             database persistence layer
+  interloper-google-cloud/   BigQuery destination
+  interloper-docker/         Docker runner + backfiller
+  interloper-k8s/            Kubernetes runner + backfiller
+  interloper-scheduler/      cron + queue worker + reaper (singleton process)
+  interloper-api/            FastAPI HTTP backend — reads catalog metadata only, never executes assets
+  interloper-agent/          AI agent (Google ADK)
+  interloper-app/            Nuxt SPA + Python package that serves it as static assets
+examples/                    runnable usage examples
+chart/                       Helm chart
+docker/                      uv-sync.sh helper and nginx template
+dockerfile                   multi-target build (core / scheduler / worker / api / frontend)
+```
+
+The frontend lives at `packages/interloper-app/app/` and has its own toolchain (pnpm + Nuxt) and its own [AGENTS.md](packages/interloper-app/app/AGENTS.md). `make build-app` builds the SPA and copies it into `packages/interloper-app/src/interloper_app/static/`.
 
 ## Commands
 
+Python (uv workspace, run from repo root):
+
 - Lint: `uv run ruff check`
 - Type check: `uv run pyright`
-- Test: `uv run pytest`
+- Test: `uv run pytest` (markers: `integration`, `functional` — `functional` is excluded by default)
+
+Frontend (run from `packages/interloper-app/app/`):
+
+- Lint: `pnpm run lint`
+- Type check: `pnpm exec nuxt typecheck`
+
+Combined (from repo root):
+
+- `make check` — both Python and frontend checks
+- `make check-python` / `make check-typescript` — individual halves
+- `make build-app` — build the SPA and stage it inside the Python package
+- `make setup` — `pre-commit install` + `uv sync --all-packages --all-extras`
+
+## Docker images
+
+Built from a single multi-target [dockerfile](dockerfile). The image catalog is defined in the [Makefile](Makefile):
+
+- `ROLES` (`api`, `frontend`, `worker`) → image `interloper-<role>:<version>`.
+- `ROLES_LAUNCHER_AWARE` (`scheduler`) builds one image per launcher: `interloper-scheduler`, `interloper-scheduler-k8s`, `interloper-scheduler-docker`. The launcher lives in the **image name**, not the tag; the Helm chart picks the suffix from `config.launcher.type`.
+- Build one target: `make docker-build-<role>` or `make docker-build-<role>-<launcher>`.
+- Build everything: `make docker-build` (host arch) or `make docker-build-linux` (linux/amd64 for the registry).
+- Push: `make docker-push`, or `make docker-build-push` to build linux + push in one step.
+
+Override extras at `make` time: `CORE_EXTRAS`, `ASSETS_EXTRAS`, `SCHEDULER_EXTRAS`.
+
+## Conventions
+
+- Conventional Commits (`feat:`, `fix:`, `chore:`, `refactor:`, …). Breaking changes use `!` — see the recent `refactor!:` commits.
+- Branch names use the same type prefix with a slash: `feat/xxx`, `fix/xxx`, `chore/xxx`, …
+- PR titles follow Conventional Commits (`feat: …`, `fix: …`); every commit that lands on `main` feeds `python-semantic-release`.
+- Python ≥3.10, ruff line length 120, pyright `basic` mode.
+- Pre-commit runs ruff + pyright + pytest on every commit ([.pre-commit-config.yaml](.pre-commit-config.yaml)).
+- All workspace packages share `version = "0.2.0"`, bumped by `python-semantic-release` from commit history.
+
+### Git flow
+
+`main` is kept strictly linear — no merge commits. Feature branches rebase onto `main`; merges into `main` are rebase-merges.
+
+1. Branch from `main`: `git checkout -b feat/xxx`.
+2. Each commit on the branch is itself a valid Conventional Commit — it may land on `main` as-is.
+3. Keep up to date with `main` by rebase, never merge:
+   ```
+   git fetch origin
+   git rebase origin/main
+   ```
+4. After a rebase (or `rebase -i` cleanup), push with `--force-with-lease` — never plain `--force`.
+5. Merge the PR with **rebase-and-merge** (or squash, when the branch is one logical change). Never create a merge commit.
+6. Resolve conflicts during rebase rather than discarding work or abandoning the branch.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,20 @@ exclude_also = [
 allow_zero_version = true
 build_command = "uv build --all-packages"
 commit_message = "chore(release): {version} [skip ci]"
-version_toml = ["pyproject.toml:project.version"]
+version_toml = [
+    "pyproject.toml:project.version",
+    "packages/interloper-core/pyproject.toml:project.version",
+    "packages/interloper-assets/pyproject.toml:project.version",
+    "packages/interloper-pandas/pyproject.toml:project.version",
+    "packages/interloper-db/pyproject.toml:project.version",
+    "packages/interloper-google-cloud/pyproject.toml:project.version",
+    "packages/interloper-docker/pyproject.toml:project.version",
+    "packages/interloper-k8s/pyproject.toml:project.version",
+    "packages/interloper-scheduler/pyproject.toml:project.version",
+    "packages/interloper-api/pyproject.toml:project.version",
+    "packages/interloper-agent/pyproject.toml:project.version",
+    "packages/interloper-app/pyproject.toml:project.version",
+]
 
 [tool.semantic_release.branches.main]
 match = "main"


### PR DESCRIPTION
## Summary

Improves the repo's agent/dev environment so common workflows run with fewer prompts and the agent has accurate, structural context.

- **AGENTS.md**: replaced the 3-line stub with a structural overview — the 11-package uv workspace map, the Python/frontend toolchain split (pointing at the nested `interloper-app` AGENTS.md), `make` entry points, and the role/launcher Docker image convention. Also documents branch/PR naming and the rebase-based git flow (linear `main`, `--force-with-lease`, rebase-merge).
- **Claude Code config** (checked-in `.claude/settings.json`): shared permissions allowlist for the documented dev commands (`uv`, `pnpm`, `make`) and read-only `git`, plus `includeCoAuthoredBy: false` to drop the co-author trailer (matching the existing `claude-commit` Makefile preference). Personal overrides stay in the gitignored `settings.local.json`.
- **Slash commands** (`.claude/commands/`): `/check`, `/check-py`, and `/build-app` wrap the existing `make` targets.
- **semantic-release**: extended `version_toml` so a release bumps the root and all 11 workspace packages in lockstep, not just the root.

No runtime/library code changes. The `docs:`/`chore:` commit types intentionally do not trigger a semantic-release version bump.

## Test plan

- [ ] `.claude/settings.json` parses and permissions resolve (no prompts for `make`/`uv`/`pnpm`)
- [ ] `/check`, `/check-py`, `/build-app` invoke the expected `make` targets
- [ ] Confirm a future release bumps every `packages/*/pyproject.toml` version, not just the root
- [ ] New commits no longer include the `Co-Authored-By: Claude` trailer