### PR TITLE
ci: publish all workspace packages to PyPI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,18 +75,8 @@ jobs:
           git_committer_email: "${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
           git_committer_name: "Semantic Release"
 
-      # Publish the library packages only. The app-layer packages
-      # (interloper-api, -scheduler, -agent, -app) ship as Docker images,
-      # not PyPI distributions, so they are built but not uploaded.
       - name: Build & Publish
         if: steps.release.outputs.released == 'true'
         run: |
           uv build --all-packages
-          uv publish --trusted-publishing always \
-            "dist/interloper_core-*" \
-            "dist/interloper_assets-*" \
-            "dist/interloper_pandas-*" \
-            "dist/interloper_db-*" \
-            "dist/interloper_google_cloud-*" \
-            "dist/interloper_docker-*" \
-            "dist/interloper_k8s-*"
+          uv publish --trusted-publishing always


### PR DESCRIPTION
## Summary

Follow-up to #3. That PR merged with a library-only publish step (explicit `dist/` globs for the 7 library packages); the intended change to publish **all** packages landed on the branch after the merge and never reached `main`. This applies it as a clean one-line change off the current `main`.

- Drops the per-library `dist/` globs from the `Build & Publish` step.
- `uv publish --trusted-publishing always` now uploads everything `uv build --all-packages` produces — all 11 workspace packages, including the app-layer `api` / `scheduler` / `agent` / `app`.

## Requires (repo configuration)

- [ ] PyPI **trusted publishing** configured for **all 11 packages**, each pointing at `digitl-cloud/interloper` + the `Release` workflow. If any package lacks a trusted-publishing entry (or doesn't yet exist as a PyPI project / pending publisher), the publish step fails. The four app-layer names likely need to be registered.

## Test plan

- [ ] Trigger the workflow on `main` with `release_type=release-candidate` as a dry run.
- [ ] Confirm all 11 distributions are uploaded to PyPI.