### PR TITLE
ci: publish docker images to ghcr and helm chart to pages

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,11 @@ jobs:
     if: github.ref_name == 'main'
     runs-on: ubuntu-latest
 
+    outputs:
+      released: ${{ steps.release.outputs.released }}
+      version: ${{ steps.release.outputs.version }}
+      tag: ${{ steps.release.outputs.tag }}
+
     permissions:
       contents: "write"
       id-token: "write"
@@ -80,3 +85,113 @@ jobs:
         run: |
           uv build --all-packages
           uv publish --trusted-publishing always
+
+  # ────────────────────────────────────────────────────────────────────
+  # Docker images → GitHub Container Registry (ghcr.io)
+  #
+  # One image per component, tagged with the released version (plus `latest`
+  # on stable releases only). The matrix mirrors the image catalog in the
+  # Makefile (ROLES + ROLES_LAUNCHER_AWARE) — keep the two in sync.
+  # ────────────────────────────────────────────────────────────────────
+  docker:
+    name: Docker (${{ matrix.image }})
+    needs: release
+    if: needs.release.outputs.released == 'true'
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: "read"
+      packages: "write"
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { target: api,       image: interloper-api,              scheduler_extras: "" }
+          - { target: frontend,  image: interloper-frontend,         scheduler_extras: "" }
+          - { target: worker,    image: interloper-worker,           scheduler_extras: "" }
+          - { target: scheduler, image: interloper-scheduler,        scheduler_extras: "" }
+          - { target: scheduler, image: interloper-scheduler-k8s,    scheduler_extras: "k8s" }
+          - { target: scheduler, image: interloper-scheduler-docker, scheduler_extras: "docker" }
+
+    steps:
+      - name: Checkout (released tag)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release.outputs.tag }}
+
+      - name: Setup Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute tags
+        id: tags
+        run: |
+          owner="$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
+          repo="ghcr.io/${owner}/${{ matrix.image }}"
+          tags="${repo}:${{ needs.release.outputs.version }}"
+          if [ "${{ inputs.release_type }}" = "stable" ]; then
+            tags="${tags},${repo}:latest"
+          fi
+          echo "tags=${tags}" >> "$GITHUB_OUTPUT"
+
+      - name: Build & Push (${{ matrix.target }})
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: dockerfile
+          target: ${{ matrix.target }}
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          build-args: |
+            CORE_EXTRAS=google-cloud
+            ASSETS_EXTRAS=bing,facebook,google
+            SCHEDULER_EXTRAS=${{ matrix.scheduler_extras }}
+          cache-from: type=gha,scope=docker-${{ matrix.image }}
+          cache-to: type=gha,scope=docker-${{ matrix.image }},mode=max
+
+  # ────────────────────────────────────────────────────────────────────
+  # Helm chart → GitHub Pages (chart-releaser)
+  #
+  # Packages chart/interloper and publishes it to the gh-pages Helm repo,
+  # creating a per-chart GitHub release. Stable releases only — RC chart
+  # versions would clutter the public repo. Chart `version`/`appVersion`
+  # are bumped by semantic-release, so the checked-out tag is ready to ship.
+  # ────────────────────────────────────────────────────────────────────
+  helm:
+    name: Helm chart release
+    needs: release
+    if: needs.release.outputs.released == 'true' && inputs.release_type == 'stable'
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: "write"
+
+    steps:
+      - name: Checkout (released tag)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release.outputs.tag }}
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+
+      - name: Release chart
+        uses: helm/chart-releaser-action@v1
+        with:
+          charts_dir: chart
+        env:
+          CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,8 @@ CORE_EXTRAS   ?= google-cloud
 ASSETS_EXTRAS ?= bing,facebook,google
 
 # Image catalog. Each component is its own repository: "interloper-<role>".
+# NOTE: the `docker` job matrix in .github/workflows/release.yaml mirrors this
+# catalog — update both together when adding or removing a role.
 #   ROLES                  → image "interloper-<role>",         tag = "<version>"
 #   ROLES_LAUNCHER_AWARE   → one image per (role, launcher) pair, all tagged
 #                            "<version>", with the launcher in the image name:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,17 +2,35 @@
 
 Releases are automated by the **Release** workflow
 ([`.github/workflows/release.yaml`](.github/workflows/release.yaml)), triggered
-manually (`workflow_dispatch`, `stable` or `release-candidate`). It runs
-`python-semantic-release` to bump the shared version, tag, and create the GitHub
-release, then `uv build --all-packages` + `uv publish --trusted-publishing always`
-to publish every workspace package to PyPI.
+manually (`workflow_dispatch`, `stable` or `release-candidate`). The `release`
+job runs `python-semantic-release` to bump the shared version, tag, and create
+the GitHub release. When a release is cut, three sets of artifacts are then
+published in parallel:
 
-Two things must be configured on the repo before the first release:
+1. **PyPI** — `uv build --all-packages` + `uv publish --trusted-publishing always`
+   publishes every workspace package (in the `release` job).
+2. **Docker images → GHCR** — the `docker` job builds each component image and
+   pushes it to `ghcr.io/<owner>/interloper-<role>` (see below).
+3. **Helm chart → GitHub Pages** — the `helm` job packages `chart/interloper`
+   and publishes it to the gh-pages Helm repo via `chart-releaser` (stable
+   releases only; see below).
+
+`semantic-release` bumps the chart's `version` and `appVersion` in
+[`chart/interloper/Chart.yaml`](chart/interloper/Chart.yaml) alongside the
+Python version, so the published chart and the image tag it deploys always
+match the release.
+
+Things to configure on the repo before the first release:
 
 - **GitHub App credentials** — variable `SEMANTIC_RELEASE_APP_ID` and secret
   `SEMANTIC_RELEASE_APP_KEY` (a GitHub App with `contents: write`), used to author
   the release commit and tag.
 - **PyPI trusted publishing** for each published package — see below.
+- **GitHub Pages** enabled with the `gh-pages` branch as source — see the Helm
+  section below.
+
+The Docker push uses the built-in `GITHUB_TOKEN` (`packages: write`) — no extra
+secret needed.
 
 ## PyPI trusted publishing (one-time bootstrap)
 
@@ -74,3 +92,62 @@ All workspace packages are published:
 `interloper-core`, `interloper-assets`, `interloper-pandas`, `interloper-db`,
 `interloper-google-cloud`, `interloper-docker`, `interloper-k8s`,
 `interloper-scheduler`, `interloper-api`, `interloper-agent`, `interloper-app`.
+
+## Docker images (GitHub Container Registry)
+
+The `docker` job builds one image per component and pushes it to GHCR. The
+matrix mirrors the image catalog in the [`Makefile`](Makefile) — keep the two in
+sync if a role is added or removed.
+
+| Image | Dockerfile target | Notes |
+| --- | --- | --- |
+| `ghcr.io/<owner>/interloper-api` | `api` | |
+| `ghcr.io/<owner>/interloper-frontend` | `frontend` | nginx serving the built SPA |
+| `ghcr.io/<owner>/interloper-worker` | `worker` | |
+| `ghcr.io/<owner>/interloper-scheduler` | `scheduler` | no launcher extras |
+| `ghcr.io/<owner>/interloper-scheduler-k8s` | `scheduler` | `SCHEDULER_EXTRAS=k8s` |
+| `ghcr.io/<owner>/interloper-scheduler-docker` | `scheduler` | `SCHEDULER_EXTRAS=docker` |
+
+Each image is tagged with the released version. On **stable** releases the
+`latest` tag is also moved; release candidates push the version tag only.
+
+One-time setup: the first push creates each package as **private** and not yet
+linked to the repository. After the first release, for each package go to the
+package page → *Package settings* and (a) set the visibility you want (public if
+the chart/consumers pull without auth) and (b) under *Manage Actions access*,
+confirm the `interloper` repo has write access. Public images need no pull
+secret; private images require an `imagePullSecrets` entry in the Helm values.
+
+> **Registry consistency (action needed):** `chart/interloper/values.yaml` and
+> the `Makefile` still default `image.registry` to the GCP Artifact Registry
+> (`europe-docker.pkg.dev/dc-int-connectors-prd/docker`). Now that releases push
+> to GHCR, decide whether GHCR is the canonical registry — if so, update both
+> defaults to `ghcr.io/<owner>` so deployed charts pull the images that were
+> actually published.
+
+## Helm chart (GitHub Pages)
+
+The `helm` job runs [`chart-releaser`](https://github.com/helm/chart-releaser-action)
+on **stable** releases. It packages `chart/interloper`, creates a per-chart
+GitHub release (tagged `interloper-<version>`), and updates `index.yaml` on the
+`gh-pages` branch. Release candidates are skipped to keep the public repo clean.
+
+One-time setup:
+
+1. Let the first stable release run — `chart-releaser` creates the `gh-pages`
+   branch and the initial `index.yaml`.
+2. Repo → *Settings* → *Pages* → set **Source** to *Deploy from a branch*,
+   branch `gh-pages`, folder `/ (root)`.
+
+Consumers then add the repo and install:
+
+```bash
+helm repo add interloper https://<owner>.github.io/interloper
+helm repo update
+helm install interloper interloper/interloper
+```
+
+> The chart's `home`/`sources` URLs in `Chart.yaml` currently read
+> `github.com/digitlcloud/interloper` (no hyphen) while the repo is
+> `digitl-cloud/interloper`. Fix those so the generated Pages URL
+> (`https://digitl-cloud.github.io/interloper`) and chart metadata line up.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,6 +134,14 @@ version_toml = [
     "packages/interloper-agent/pyproject.toml:project.version",
     "packages/interloper-app/pyproject.toml:project.version",
 ]
+# Keep the Helm chart in lockstep with the Python version. `version` (chart
+# SemVer) and `appVersion` (the image tag the chart deploys) both track the
+# released version. Note the case difference saves the `version` pattern from
+# also matching `appVersion`.
+version_variables = [
+    "chart/interloper/Chart.yaml:version",
+    "chart/interloper/Chart.yaml:appVersion",
+]
 
 [tool.semantic_release.branches.main]
 match = "main"


### PR DESCRIPTION
Extend the Release workflow beyond PyPI:

- `docker` job builds each component image (api, frontend, worker, scheduler + k8s/docker launcher variants) and pushes to ghcr.io/<owner>/interloper-<role>, tagged with the released version (and `latest` on stable only). Auth uses the built-in GITHUB_TOKEN.
- `helm` job packages chart/interloper and publishes it to the gh-pages Helm repo via chart-releaser (stable releases only).
- semantic-release now bumps the chart `version`/`appVersion` so the published chart and image tags stay in lockstep with the release.

Document the new flow and one-time setup (GHCR package visibility, GitHub Pages source) in RELEASING.md, and flag the registry-consistency follow-up (chart/Makefile still default to GCP AR).