### PR TITLE
feat(chart): default image registry to GHCR

### DIFF
--- a/chart/interloper/README.md
+++ b/chart/interloper/README.md
@@ -15,19 +15,22 @@ disabled via `<component>.enabled: false`.
 
 ## Images
 
-Each component is its own image, named `interloper-<component>`:
+Each component is its own image, named `interloper-<component>`. Images are
+published to GitHub Container Registry, which is the chart's default
+`image.registry` (`ghcr.io/digitl-cloud`):
 
 ```
-<registry>/interloper-scheduler:<version>          # in-process launcher
-<registry>/interloper-scheduler-k8s:<version>      # kubernetes launcher
-<registry>/interloper-scheduler-docker:<version>   # docker launcher
-<registry>/interloper-api:<version>
-<registry>/interloper-frontend:<version>
-<registry>/interloper-worker:<version>             # k8s runner per-asset Job target
+ghcr.io/digitl-cloud/interloper-scheduler:<version>          # in-process launcher
+ghcr.io/digitl-cloud/interloper-scheduler-k8s:<version>      # kubernetes launcher
+ghcr.io/digitl-cloud/interloper-scheduler-docker:<version>   # docker launcher
+ghcr.io/digitl-cloud/interloper-api:<version>
+ghcr.io/digitl-cloud/interloper-frontend:<version>
+ghcr.io/digitl-cloud/interloper-worker:<version>             # k8s runner per-asset Job target
 ```
 
 The chart picks the scheduler image suffix from `config.launcher.type`
-automatically — no manual mapping.
+automatically — no manual mapping. Override `image.registry` (and
+`image.pullSecrets` for a private registry) to pull from elsewhere.
 
 ## Quick start (dev)
 

--- a/chart/interloper/values.yaml
+++ b/chart/interloper/values.yaml
@@ -4,12 +4,13 @@
 
 # Global image defaults (overridable per-component below).
 #
-# Images follow the convention "<registry>/interloper-<component>:<tag>".
-# For launcher-aware images (scheduler) the image name gets a "-k8s" or
-# "-docker" suffix derived from config.launcher.type (the tag is just the
-# version).
+# Images are published to GitHub Container Registry and follow the
+# convention "<registry>/interloper-<component>:<tag>" — e.g.
+# ghcr.io/digitl-cloud/interloper-api:0.3.1. For launcher-aware images
+# (scheduler) the image name gets a "-k8s" or "-docker" suffix derived from
+# config.launcher.type (the tag is just the version).
 image:
-  registry: europe-docker.pkg.dev/dc-int-connectors-prd/docker
+  registry: ghcr.io/digitl-cloud
   tag: ""  # defaults to Chart.appVersion
   pullPolicy: IfNotPresent
   pullSecrets: []


### PR DESCRIPTION
## Summary

Container images are now published to GitHub Container Registry at `ghcr.io/digitl-cloud/interloper-<role>` (roles: `api`, `frontend`, `worker`, `scheduler`, `scheduler-k8s`, `scheduler-docker`). The Helm chart, however, still defaulted `image.registry` to the retired GCP Artifact Registry (`europe-docker.pkg.dev/dc-int-connectors-prd/docker`), so a default `helm install` would pull from a registry that no longer receives images.

- `chart/interloper/values.yaml`: change default `image.registry` to `ghcr.io/digitl-cloud` and refresh the surrounding comment to reference GHCR and an example ref.
- `chart/interloper/README.md`: update the Images section to show the concrete GHCR image names and note the registry/pullSecrets override path.

The image-ref helper in `chart/interloper/templates/_helpers.tpl` already builds refs as `{{ .Values.image.registry }}/interloper-<component>[<launcher-suffix>]:<tag>`, so changing `image.registry` alone yields correct refs — no helper change was needed.

> [!NOTE]
> If the GHCR packages are **private**, deployments must supply an `imagePullSecrets` entry. The chart already supports this via `image.pullSecrets` (a list of `{ name: <secret> }`). **Public** packages need no secret.

## Test plan

`helm lint chart/interloper -f chart/interloper/ci/test-values.yaml` passes (0 charts failed).

`helm template chart/interloper -f chart/interloper/ci/test-values.yaml | grep -E 'image:'` — every image reference now resolves to GHCR:

```
image: ghcr.io/digitl-cloud/interloper-scheduler-k8s:0.3.1
image: ghcr.io/digitl-cloud/interloper-api:0.3.1
image: ghcr.io/digitl-cloud/interloper-frontend:0.3.1
image: ghcr.io/digitl-cloud/interloper-scheduler-k8s:0.3.1
image: ghcr.io/digitl-cloud/interloper-api:0.3.1
```

The scheduler resolves to `-k8s` because the default `config.launcher.type` is `kubernetes`. The worker image (only referenced by the k8s runner) was also verified with `--set config.runner.type=k8s`, rendering `ghcr.io/digitl-cloud/interloper-worker:0.3.1`.

- [ ] Confirm GHCR package visibility (public vs private) and wire `image.pullSecrets` if private.