### PR TITLE
docs: document PyPI, GHCR, and Helm release channels in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Define assets as functions, group them in sources, wire dependencies automatical
 <p align="center">
   <a href="https://github.com/digitl-cloud/interloper/actions/workflows/checks.yaml"><img src="https://github.com/digitl-cloud/interloper/actions/workflows/checks.yaml/badge.svg?branch=main" alt="CI"></a>
   <a href="https://codecov.io/gh/digitl-cloud/interloper"><img src="https://codecov.io/gh/digitl-cloud/interloper/graph/badge.svg" alt="Coverage"></a>
+  <a href="https://pypi.org/project/interloper-core/"><img src="https://img.shields.io/pypi/v/interloper-core?logo=pypi&logoColor=white&label=PyPI" alt="PyPI"></a>
   <img src="https://img.shields.io/badge/python-3.10+-3776ab?logo=python&logoColor=white" alt="Python 3.10+">
   <a href="https://github.com/digitl-cloud/interloper/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License"></a>
 </p>
@@ -40,19 +41,59 @@ dag.materialize()
 
 ## Packages
 
-| Package                   | Description                                              |
-| ------------------------- | -------------------------------------------------------- |
-| `interloper-core`         | Core: assets, sources, DAG, runners, IO, partitioning    |
-| `interloper-assets`       | Pre-built source definitions (bing, facebook, google, …) |
-| `interloper-pandas`       | pandas DataFrame normalizer and adapter                  |
-| `interloper-db`           | Database persistence layer                               |
-| `interloper-google-cloud` | Google Cloud integration: BigQuery destination           |
-| `interloper-docker`       | Docker runner and backfiller                             |
-| `interloper-k8s`          | Kubernetes runner and backfiller                         |
-| `interloper-scheduler`    | Cron scheduler, queue worker, and reaper                 |
-| `interloper-api`          | FastAPI HTTP backend (reads catalog metadata only)       |
-| `interloper-agent`        | AI agent (Google ADK)                                    |
-| `interloper-app`          | Web UI (Nuxt SPA, bundled as static assets)              |
+| Package                                                                       | Description                                              |
+| ----------------------------------------------------------------------------- | -------------------------------------------------------- |
+| [`interloper-core`](https://pypi.org/project/interloper-core/)                 | Core: assets, sources, DAG, runners, IO, partitioning    |
+| [`interloper-assets`](https://pypi.org/project/interloper-assets/)             | Pre-built source definitions (bing, facebook, google, …) |
+| [`interloper-pandas`](https://pypi.org/project/interloper-pandas/)             | pandas DataFrame normalizer and adapter                  |
+| [`interloper-db`](https://pypi.org/project/interloper-db/)                     | Database persistence layer                               |
+| [`interloper-google-cloud`](https://pypi.org/project/interloper-google-cloud/) | Google Cloud integration: BigQuery destination           |
+| [`interloper-docker`](https://pypi.org/project/interloper-docker/)             | Docker runner and backfiller                             |
+| [`interloper-k8s`](https://pypi.org/project/interloper-k8s/)                   | Kubernetes runner and backfiller                         |
+| [`interloper-scheduler`](https://pypi.org/project/interloper-scheduler/)       | Cron scheduler, queue worker, and reaper                 |
+| [`interloper-api`](https://pypi.org/project/interloper-api/)                   | FastAPI HTTP backend (reads catalog metadata only)       |
+| [`interloper-agent`](https://pypi.org/project/interloper-agent/)               | AI agent (Google ADK)                                    |
+| [`interloper-app`](https://pypi.org/project/interloper-app/)                   | Web UI (Nuxt SPA, bundled as static assets)              |
+
+## Releases
+
+Every release publishes across three channels, all versioned together by [`python-semantic-release`](https://python-semantic-release.readthedocs.io/) from the commit history.
+
+### PyPI
+
+All workspace packages are published to [PyPI](https://pypi.org/project/interloper-core/) (see the [Packages](#packages) table above for the full list and links).
+
+```bash
+pip install interloper-core
+# or: uv add interloper-core
+```
+
+### Docker images (GHCR)
+
+Container images are published to the [GitHub Container Registry](https://github.com/orgs/digitl-cloud/packages?repo_name=interloper), tagged with the release version and `latest`.
+
+| Image                                                                                                            | Role                              |
+| ---------------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| [`ghcr.io/digitl-cloud/interloper-api`](https://github.com/digitl-cloud/interloper/pkgs/container/interloper-api)                             | FastAPI HTTP backend              |
+| [`ghcr.io/digitl-cloud/interloper-frontend`](https://github.com/digitl-cloud/interloper/pkgs/container/interloper-frontend)                   | Web UI (nginx-served SPA)         |
+| [`ghcr.io/digitl-cloud/interloper-worker`](https://github.com/digitl-cloud/interloper/pkgs/container/interloper-worker)                       | Queue worker                      |
+| [`ghcr.io/digitl-cloud/interloper-scheduler`](https://github.com/digitl-cloud/interloper/pkgs/container/interloper-scheduler)                 | Scheduler (local launcher)        |
+| [`ghcr.io/digitl-cloud/interloper-scheduler-k8s`](https://github.com/digitl-cloud/interloper/pkgs/container/interloper-scheduler-k8s)         | Scheduler (Kubernetes launcher)   |
+| [`ghcr.io/digitl-cloud/interloper-scheduler-docker`](https://github.com/digitl-cloud/interloper/pkgs/container/interloper-scheduler-docker)   | Scheduler (Docker launcher)       |
+
+```bash
+docker pull ghcr.io/digitl-cloud/interloper-api:latest
+```
+
+### Helm chart
+
+The Helm chart is published to a GitHub Pages Helm repository at [`https://digitl-cloud.github.io/interloper`](https://digitl-cloud.github.io/interloper).
+
+```bash
+helm repo add interloper https://digitl-cloud.github.io/interloper
+helm repo update
+helm install interloper interloper/interloper
+```
 
 ## Development
 


### PR DESCRIPTION
## Summary
- Add a **Releases** section to the root `README.md` documenting the three distribution channels: PyPI, GHCR Docker images, and the GitHub Pages Helm repo.
- Link each of the 11 workspace packages in the Packages table to its PyPI project page, and add a PyPI version badge for `interloper-core` to the header.
- Include copy-paste install snippets: `pip install interloper-core`, `docker pull ghcr.io/digitl-cloud/interloper-api:latest`, and the `helm repo add` / `install` steps.

The GHCR image roles (`api`, `frontend`, `worker`, `scheduler`, `scheduler-k8s`, `scheduler-docker`) mirror the Docker matrix in `.github/workflows/release.yaml`. The Helm repo index (`https://digitl-cloud.github.io/interloper/index.yaml`) and PyPI pages were spot-checked and resolve to the current `0.3.1` release.

Docs-only change — no code, no release trigger.

## Test plan
- [ ] Render `README.md` (GitHub preview) and confirm the new Releases section, the PyPI badge, and the package table links display correctly.
- [ ] Click through a few links: a PyPI package page, the GHCR org packages page, and the Helm repo URL.