### PR TITLE
ci: name the GitHub release by version only (0.3.1, not interloper-0.3.1)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -193,5 +193,6 @@ jobs:
         uses: helm/chart-releaser-action@v1
         with:
           charts_dir: chart
+          config: cr.yaml
         env:
           CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/cr.yaml
+++ b/cr.yaml
@@ -1,0 +1,9 @@
+# chart-releaser (cr) configuration — consumed by helm/chart-releaser-action
+# in .github/workflows/release.yaml.
+#
+# Override the default release-name template ("{{ .Name }}-{{ .Version }}",
+# e.g. "interloper-0.3.1") so the chart's GitHub release/tag is just the
+# version (e.g. "0.3.1"). The `v`-prefixed tag/release (e.g. "v0.3.1") created
+# by python-semantic-release lives in a separate namespace, so there is no
+# collision.
+release-name-template: "{{ .Version }}"


### PR DESCRIPTION
## Summary

- The `helm` job in `.github/workflows/release.yaml` runs `helm/chart-releaser-action@v1`, which by default names the chart's GitHub release/tag `{{ .Name }}-{{ .Version }}` — e.g. `interloper-0.3.1`.
- This adds a `cr` config file (`cr.yaml` at repo root) that overrides `release-name-template` to `{{ .Version }}`, so the chart release/tag becomes just the version — e.g. `0.3.1`.
- The action is wired to the config via the new `config: cr.yaml` input; `charts_dir: chart` and the `CR_TOKEN` env are unchanged.

```yaml
# cr.yaml
release-name-template: "{{ .Version }}"
```

```yaml
# .github/workflows/release.yaml (helm job)
- name: Release chart
  uses: helm/chart-releaser-action@v1
  with:
    charts_dir: chart
    config: cr.yaml
  env:
    CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```

The key name (`release-name-template`) and template variables (`.Name`, `.Version`) were confirmed against the chart-releaser docs and the `cr` config struct (`mapstructure:"release-name-template"`).

## No collision with python-semantic-release

`python-semantic-release` creates a GitHub release + git tag using its default `v{version}` format (existing tags: `v0.3.0`, `v0.3.1` — no `tag_format` override is set in `pyproject.toml`). chart-releaser will now create `0.3.1` (no `v` prefix), which lives in a separate namespace from `v0.3.1`, so the two do not collide.

## Test plan

- [x] Confirmed `release-name-template` / `.Version` casing from chart-releaser docs and the `cr` config source.
- [x] Validated both YAML files parse (`yaml.safe_load`): `release.yaml` OK; `cr.yaml` → `{'release-name-template': '{{ .Version }}'}`.
- [ ] chart-releaser cannot be exercised locally — it requires a real release run that pushes a GitHub release and updates the `gh-pages` Helm repo. This will be verified on the next stable release: the chart's GitHub release/tag should appear as `x.x.x` (e.g. `0.3.2`) rather than `interloper-x.x.x`, alongside the existing `vx.x.x` release from semantic-release.