### PR TITLE
ci: build multi-arch release images (amd64 + arm64)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -120,6 +120,11 @@ jobs:
         with:
           ref: ${{ needs.release.outputs.tag }}
 
+      - name: Setup QEMU
+        # Registers binfmt handlers so the amd64 runner can build the
+        # linux/arm64 image via emulation.
+        uses: docker/setup-qemu-action@v3
+
       - name: Setup Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -147,7 +152,7 @@ jobs:
           context: .
           file: dockerfile
           target: ${{ matrix.target }}
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.tags.outputs.tags }}
           build-args: |


### PR DESCRIPTION
## Summary
- Adds `docker/setup-qemu-action@v3` to the `docker` job so the amd64 runner can build `linux/arm64` via emulation.
- Extends `platforms` from `linux/amd64` → `linux/amd64,linux/arm64`, so every released GHCR image (`api`, `frontend`, `worker`, `scheduler`, `scheduler-k8s`, `scheduler-docker`) ships a multi-arch manifest list.

## Why
The released images were amd64-only, so they failed to pull natively on arm64 nodes (`no matching manifest for linux/arm64/v8`) — e.g. Apple Silicon local clusters or arm64 cloud nodes. This was surfaced while testing the Helm chart on a local docker-desktop (arm64) cluster: the chart and images work, but only via emulation. Multi-arch manifests fix native arm64 pulls.

## Trade-off
arm64 layers are built under QEMU emulation on the amd64 runner, so per-image build time roughly doubles. GHA layer cache (already configured per image) mitigates repeat builds. If build time becomes a problem, a follow-up could split into native per-arch runners (`ubuntu-24.04-arm`) + a manifest-merge step.

## Scope notes
- Only the **release** pipeline is changed. The `checks.yaml` Docker smoke build stays amd64-only on purpose (it's a fast build sanity check, not a publish).
- The `Makefile` local build targets are unchanged.

## Test plan
- [ ] Can't be exercised locally — verified on the next stable release: confirm each `ghcr.io/digitl-cloud/interloper-*` tag is a manifest list with `linux/amd64` + `linux/arm64` (e.g. `docker buildx imagetools inspect ghcr.io/digitl-cloud/interloper-api:<version>`).
- [ ] Confirm a native arm64 pull succeeds (no `no matching manifest` error).