### PR TITLE
feat(chart): support serviceAccount.annotations

### DIFF
--- a/chart/interloper/templates/rbac.yaml
+++ b/chart/interloper/templates/rbac.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "interloper.serviceAccountName" . }}
   labels:
     {{- include "interloper.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/chart/interloper/values.yaml
+++ b/chart/interloper/values.yaml
@@ -261,6 +261,11 @@ serviceAccount:
   # When rbac.create is true, a ServiceAccount is created with this name
   # and bound to the Role.  If unset, defaults to "{{ .Release.Name }}-scheduler".
   name: ""
+  # Annotations added to the ServiceAccount.  Use for cloud IAM bindings such
+  # as GKE Workload Identity:
+  #   annotations:
+  #     iam.gke.io/gcp-service-account: my-sa@my-project.iam.gserviceaccount.com
+  annotations: {}
 
 # =============================================================================
 # Pod defaults


### PR DESCRIPTION
## Summary
Adds a `serviceAccount.annotations` value, rendered onto the chart-managed ServiceAccount.

## Why
Enables cloud IAM bindings — specifically GKE Workload Identity (`iam.gke.io/gcp-service-account`). Previously the chart's SA had no annotations passthrough, so a GKE deployment needing GCP access (BigQuery, Secret Manager) had to set `rbac.create=false` and manage the SA externally. Now the chart can own the SA.

## Changes
- `values.yaml`: new `serviceAccount.annotations: {}` (documented with a Workload Identity example).
- `templates/rbac.yaml`: render `metadata.annotations` on the ServiceAccount when set; omitted entirely when empty.

## Test plan
- `helm lint` passes.
- `helm template` with `serviceAccount.annotations.iam\.gke\.io/gcp-service-account=...` → annotation present on the SA.
- `helm template` with no annotations → no `annotations:` key rendered (verified).

## Follow-up
Needed by the `int-dwh-kubernetes` ArgoCD migration of `apps/interloper` onto this chart, which uses Workload Identity for GCP access.