### PR TITLE
feat(chart): default FORWARDED_ALLOW_IPS on the API

### DIFF
--- a/chart/interloper/templates/api-deployment.yaml
+++ b/chart/interloper/templates/api-deployment.yaml
@@ -47,6 +47,10 @@ spec:
               protocol: TCP
           env:
             {{- include "interloper.commonEnv" . | nindent 12 }}
+            {{- with .Values.api.forwardedAllowIps }}
+            - name: FORWARDED_ALLOW_IPS
+              value: {{ . | quote }}
+            {{- end }}
             {{- with .Values.api.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/chart/interloper/values.yaml
+++ b/chart/interloper/values.yaml
@@ -66,6 +66,11 @@ api:
   service:
     type: ClusterIP
     port: 3000
+  # IPs uvicorn trusts for X-Forwarded-* headers. The API runs behind the
+  # chart's ingress/HTTPRoute (TLS terminated upstream), so it must trust the
+  # proxy to emit correct https redirects (e.g. the /api/catalog -> /api/catalog/
+  # 307). Defaults to "*"; set to "" to disable, or a comma-separated IP list.
+  forwardedAllowIps: "*"
   nodeSelector: {}
   tolerations: []
   affinity: {}


### PR DESCRIPTION
## Summary
Adds `api.forwardedAllowIps` (default `"*"`), rendered as the `FORWARDED_ALLOW_IPS` env var on the API container.

## Why
The API runs behind the chart's ingress/HTTPRoute with TLS terminated upstream. uvicorn trusts `X-Forwarded-*` only from `127.0.0.1` by default, so it ignored the proxy's `X-Forwarded-Proto: https` and emitted **`http://`** redirects — e.g. the `/api/catalog` → `/api/catalog/` trailing-slash `307`. Browsers block following a cross-scheme (`https`→`http`) redirect, which broke the SPA's `/api/catalog` fetch (`500 / Failed to fetch`).

With `FORWARDED_ALLOW_IPS=*`, uvicorn's `ProxyHeadersMiddleware` honors the proxy and keeps redirects on `https`.

This was first applied as a per-deployment `api.extraEnv` workaround in the GKE deployment (digitl-cloud/int-dwh-kubernetes#423); this PR makes it the chart default since the API is effectively always proxied in-cluster.

## Changes
- `values.yaml`: new `api.forwardedAllowIps: "*"` (documented; set `""` to disable, or a comma-separated IP list to restrict).
- `templates/api-deployment.yaml`: render `FORWARDED_ALLOW_IPS` before `extraEnv` (so user `extraEnv` can still override).

## Test plan
- `helm lint` passes.
- `helm template` (default) → `FORWARDED_ALLOW_IPS: "*"` present on the API container.
- `helm template --set api.forwardedAllowIps=""` → env var omitted (0 occurrences).
- Verified live on GKE: with the proxy trusted, `/api/catalog` → `307` → `https://…/api/catalog/` → `200` (browser follows successfully).