### PR TITLE
feat: encrypt resource data at rest with SECRETS_ENCRYPTION_KEY

### DIFF
--- a/packages/interloper-agent/src/interloper_agent/context.py
+++ b/packages/interloper-agent/src/interloper_agent/context.py
@@ -24,7 +24,7 @@ def init(database_url: str, catalog: Catalog) -> None:
     global _store, _catalog  # noqa: PLW0603
     init_engine(database_url)
     _catalog = catalog
-    _store = Store(catalog=catalog)
+    _store = Store.from_settings(catalog=catalog)
 
 
 def set_store(store: Store) -> None:

--- a/packages/interloper-api/src/interloper_api/routes/resources.py
+++ b/packages/interloper-api/src/interloper_api/routes/resources.py
@@ -25,7 +25,9 @@ class ResourceCreateRequest(BaseModel):
     key: str
     name: str
     data: dict[str, Any]
-    encrypted: bool = False
+    # None (default) encrypts when an encryption key is configured; pass an
+    # explicit bool to force encryption on/off.
+    encrypted: bool | None = None
 
 
 class ResourceResponse(BaseModel):

--- a/packages/interloper-app/app/app/components/resources/Stepper.vue
+++ b/packages/interloper-app/app/app/components/resources/Stepper.vue
@@ -124,7 +124,6 @@ async function submit() {
             key: selectedType.value,
             name: resourceName.value.trim(),
             data: formData.value,
-            encrypted: false,
         }
 
         if (isEditing.value && props.resource) {

--- a/packages/interloper-app/app/app/components/sources/ResourceStep.vue
+++ b/packages/interloper-app/app/app/components/sources/ResourceStep.vue
@@ -103,7 +103,6 @@ async function handleCreate() {
             key: props.definition.key,
             name: newName.value.trim(),
             data: formData.value,
-            encrypted: false,
         })
         selectedId.value = resource.id
         drawerOpen.value = false

--- a/packages/interloper-app/app/app/types/resource.ts
+++ b/packages/interloper-app/app/app/types/resource.ts
@@ -18,5 +18,4 @@ export interface ResourceInput {
     key: string
     name: string
     data: Record<string, any>
-    encrypted?: boolean
 }

--- a/packages/interloper-core/src/interloper/cli/commands/app.py
+++ b/packages/interloper-core/src/interloper/cli/commands/app.py
@@ -137,7 +137,7 @@ def _cmd_app(args: argparse.Namespace) -> None:
         create_all()
 
     catalog = Catalog.from_settings()
-    store = Store(catalog=catalog)
+    store = Store.from_settings(catalog=catalog)
 
     run_services(
         settings=settings,

--- a/packages/interloper-core/src/interloper/cli/commands/launch.py
+++ b/packages/interloper-core/src/interloper/cli/commands/launch.py
@@ -56,7 +56,7 @@ def _cmd_launch(args: argparse.Namespace) -> None:
     catalog = Catalog.from_settings()
     logger.info(f"Catalog: {catalog.to_paths()}")
 
-    store = Store(catalog=catalog)
+    store = Store.from_settings(catalog=catalog)
 
     try:
         from interloper_scheduler import RunExecutor

--- a/packages/interloper-core/src/interloper/settings.py
+++ b/packages/interloper-core/src/interloper/settings.py
@@ -101,6 +101,20 @@ class OAuthSettings(BaseSettings):
     tiktok_redirect_uri: str = ""
 
 
+class SecretsSettings(BaseSettings):
+    """Secrets used to protect sensitive data at rest.
+
+    ``encryption_key`` enables symmetric encryption of resource ``data`` blobs
+    marked ``encrypted=True``. It is read from ``SECRETS_ENCRYPTION_KEY`` (no
+    ``INTERLOPER_`` prefix) to match the Helm chart and runner launchers, which
+    forward that exact variable into spawned containers.
+    """
+
+    model_config = SettingsConfigDict(env_prefix="SECRETS_")
+
+    encryption_key: str = ""
+
+
 class ServerSettings(BaseSettings):
     """HTTP server settings (API + frontend)."""
 
@@ -189,6 +203,7 @@ class AppSettings(BaseSettings):
     )
 
     postgres: PostgresSettings = Field(default_factory=PostgresSettings)
+    secrets: SecretsSettings = Field(default_factory=SecretsSettings)
     auth: AuthSettings = Field(default_factory=AuthSettings)
     oauth: OAuthSettings = Field(default_factory=OAuthSettings)
     server: ServerSettings = Field(default_factory=ServerSettings)

--- a/packages/interloper-db/pyproject.toml
+++ b/packages/interloper-db/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "sqlalchemy>=2.0.0",
     "psycopg2-binary>=2.9.0",
     "alembic>=1.18.4",
+    "cryptography>=43.0.0",
 ]
 
 [build-system]

--- a/packages/interloper-db/src/interloper_db/crypto.py
+++ b/packages/interloper-db/src/interloper_db/crypto.py
@@ -1,0 +1,54 @@
+"""Symmetric encryption for resource data at rest.
+
+A single configured secret (``SECRETS_ENCRYPTION_KEY``) is turned into a
+pair of ``(bytes) -> bytes`` callables that the :class:`~interloper_db.store.Store`
+uses to encrypt/decrypt resource ``data`` blobs marked ``encrypted=True``.
+
+The secret may be any non-empty string. It is run through SHA-256 and
+url-safe base64-encoded to produce a valid 32-byte Fernet key, so operators
+are not constrained to Fernet's exact key format (e.g. the chart's
+``openssl rand -base64 32`` recommendation works as-is).
+
+Fernet provides authenticated encryption (AES-128-CBC + HMAC-SHA256), so a
+blob that was not produced with the active key fails to decrypt rather than
+returning garbage.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+from collections.abc import Callable
+
+from cryptography.fernet import Fernet
+
+
+def derive_fernet_key(secret_key: str) -> bytes:
+    """Derive a valid Fernet key from an arbitrary secret string.
+
+    Args:
+        secret_key: Any non-empty operator-provided secret.
+
+    Returns:
+        A 32-byte url-safe base64-encoded key suitable for :class:`Fernet`.
+    """
+    digest = hashlib.sha256(secret_key.encode()).digest()
+    return base64.urlsafe_b64encode(digest)
+
+
+def make_cipher(secret_key: str) -> tuple[Callable[[bytes], bytes], Callable[[bytes], bytes]]:
+    """Build ``(encrypt, decrypt)`` callables from a secret string.
+
+    Args:
+        secret_key: The operator-provided encryption secret. Must be non-empty.
+
+    Returns:
+        A ``(encrypt, decrypt)`` tuple, each a ``(bytes) -> bytes`` callable.
+
+    Raises:
+        ValueError: If ``secret_key`` is empty.
+    """
+    if not secret_key:
+        raise ValueError("Cannot build a cipher from an empty secret key")
+    fernet = Fernet(derive_fernet_key(secret_key))
+    return fernet.encrypt, fernet.decrypt

--- a/packages/interloper-db/src/interloper_db/hydration.py
+++ b/packages/interloper-db/src/interloper_db/hydration.py
@@ -25,7 +25,7 @@ from uuid import UUID
 
 from interloper.catalog.base import Catalog
 from interloper.component.base import ComponentSpec
-from interloper.errors import CatalogKeyError
+from interloper.errors import CatalogKeyError, HydrationError
 from sqlmodel import Session, select
 
 from interloper_db.models import (
@@ -102,8 +102,20 @@ class Hydrator:
         if db_resource.data is None:
             return {}
         raw = db_resource.data
-        if db_resource.encrypted and self._decrypt:
-            raw = self._decrypt(raw)
+        if db_resource.encrypted:
+            if not self._decrypt:
+                raise HydrationError(
+                    f"Resource {db_resource.id} is encrypted but SECRETS_ENCRYPTION_KEY "
+                    "is not configured; cannot decrypt"
+                )
+            try:
+                raw = self._decrypt(raw)
+            except Exception as e:
+                raise HydrationError(
+                    f"Failed to decrypt resource {db_resource.id}; the configured "
+                    "SECRETS_ENCRYPTION_KEY may be wrong or the data was not encrypted "
+                    f"with it: {e}"
+                ) from e
         return json.loads(raw)
 
     # ------------------------------------------------------------------

--- a/packages/interloper-db/src/interloper_db/store/__init__.py
+++ b/packages/interloper-db/src/interloper_db/store/__init__.py
@@ -9,7 +9,7 @@ Usage::
     from interloper_db import Store, init_engine
 
     init_engine("postgresql://...")
-    store = Store()
+    store = Store.from_settings(catalog)  # wires encryption from settings
 
     # Hydrate a source from DB
     source = store.load_source(source_id)
@@ -70,3 +70,33 @@ class Store(AuthMixin, ResourceMixin, SourceMixin, AssetMixin, JobMixin, RunMixi
         self._encrypt = encrypt
         self._decrypt = decrypt
         self._hydrator = Hydrator(catalog, decrypt=decrypt)
+
+    @classmethod
+    def from_settings(cls, catalog: Catalog) -> Store:
+        """Build a Store with encryption wired from runtime settings.
+
+        Reads ``SECRETS_ENCRYPTION_KEY`` via :class:`AppSettings`. When set, the
+        derived cipher is attached so resources marked ``encrypted=True`` are
+        encrypted at rest; when unset, the store falls back to plaintext and
+        rejects any attempt to persist an encrypted resource.
+
+        This is the canonical constructor for every long-lived process (API,
+        scheduler, runner, agent) — prefer it over ``Store(catalog)`` so the
+        crypto wiring stays consistent across entry points.
+
+        Args:
+            catalog: Catalog instance. Required for hydration.
+
+        Returns:
+            A configured Store.
+        """
+        from interloper.settings import AppSettings
+
+        key = AppSettings.get().secrets.encryption_key
+        if not key:
+            return cls(catalog=catalog)
+
+        from interloper_db.crypto import make_cipher
+
+        encrypt, decrypt = make_cipher(key)
+        return cls(catalog=catalog, encrypt=encrypt, decrypt=decrypt)

--- a/packages/interloper-db/src/interloper_db/store/resources.py
+++ b/packages/interloper-db/src/interloper_db/store/resources.py
@@ -7,7 +7,7 @@ from typing import Any
 from uuid import UUID
 
 import interloper as il
-from interloper.errors import HydrationError, ResourceNotFoundError
+from interloper.errors import ConfigError, HydrationError, ResourceNotFoundError
 from sqlmodel import Session, select
 
 from interloper_db.engine import get_engine
@@ -22,6 +22,33 @@ class ResourceMixin:
     _decrypt: Any
     _hydrator: Hydrator
 
+    def _encode_data(self, data: dict[str, Any], encrypted: bool | None) -> tuple[bytes, bool]:
+        """Serialise ``data`` and encrypt it according to ``encrypted``.
+
+        Args:
+            data: Resource configuration dict.
+            encrypted: ``True`` to require encryption, ``False`` to force
+                plaintext, or ``None`` (default) to encrypt only when an
+                encryption key is configured.
+
+        Returns:
+            A ``(blob, encrypted)`` tuple: the bytes to persist and whether
+            they are encrypted.
+
+        Raises:
+            ConfigError: If encryption is explicitly requested but no
+                encryption key is configured.
+        """
+        should_encrypt = self._encrypt is not None if encrypted is None else encrypted
+        raw = json.dumps(data).encode()
+        if should_encrypt:
+            if not self._encrypt:
+                raise ConfigError(
+                    "Cannot store an encrypted resource: SECRETS_ENCRYPTION_KEY is not configured"
+                )
+            raw = self._encrypt(raw)
+        return raw, should_encrypt
+
     def create_resource(
         self,
         org_id: UUID,
@@ -30,7 +57,7 @@ class ResourceMixin:
         key: str,
         name: str,
         data: dict[str, Any],
-        encrypted: bool = False,
+        encrypted: bool | None = None,
     ) -> Resource:
         """Create a new resource.
 
@@ -40,14 +67,14 @@ class ResourceMixin:
             key: Catalog key identifying the resource class.
             name: User-facing label.
             data: Resource configuration dict.
-            encrypted: Whether to encrypt the data before storing.
+            encrypted: ``True`` to require encryption, ``False`` to force
+                plaintext, or ``None`` (default) to encrypt when an
+                encryption key is configured.
 
         Returns:
             The saved Resource row.
         """
-        raw = json.dumps(data).encode()
-        if encrypted and self._encrypt:
-            raw = self._encrypt(raw)
+        raw, encrypted = self._encode_data(data, encrypted)
 
         with Session(get_engine()) as session:
             db_resource = Resource(
@@ -71,7 +98,7 @@ class ResourceMixin:
         key: str,
         name: str,
         data: dict[str, Any],
-        encrypted: bool = False,
+        encrypted: bool | None = None,
     ) -> Resource:
         """Update an existing resource.
 
@@ -81,7 +108,9 @@ class ResourceMixin:
             key: Catalog key.
             name: User-facing label.
             data: Resource configuration dict.
-            encrypted: Whether to encrypt the data before storing.
+            encrypted: ``True`` to require encryption, ``False`` to force
+                plaintext, or ``None`` (default) to encrypt when an
+                encryption key is configured.
 
         Returns:
             The updated Resource row.
@@ -89,9 +118,7 @@ class ResourceMixin:
         Raises:
             ResourceNotFoundError: If the resource is not found.
         """
-        raw = json.dumps(data).encode()
-        if encrypted and self._encrypt:
-            raw = self._encrypt(raw)
+        raw, encrypted = self._encode_data(data, encrypted)
 
         with Session(get_engine()) as session:
             db_resource = session.get(Resource, resource_id)

--- a/packages/interloper-db/tests/test_crypto.py
+++ b/packages/interloper-db/tests/test_crypto.py
@@ -1,0 +1,49 @@
+"""Unit tests for resource-data encryption helpers."""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+from cryptography.fernet import Fernet, InvalidToken
+
+from interloper_db.crypto import derive_fernet_key, make_cipher
+
+
+def test_derive_fernet_key_is_valid_and_deterministic() -> None:
+    key = derive_fernet_key("my-secret")
+    # Same input → same key.
+    assert derive_fernet_key("my-secret") == key
+    # Different input → different key.
+    assert derive_fernet_key("other-secret") != key
+    # Valid Fernet key: url-safe base64 of 32 bytes.
+    assert len(base64.urlsafe_b64decode(key)) == 32
+    Fernet(key)  # does not raise
+
+
+def test_cipher_round_trips() -> None:
+    encrypt, decrypt = make_cipher("correct horse battery staple")
+    plaintext = b'{"token": "s3cr3t"}'
+    blob = encrypt(plaintext)
+    assert blob != plaintext
+    assert decrypt(blob) == plaintext
+
+
+def test_cipher_accepts_arbitrary_key_strings() -> None:
+    # The chart recommends `openssl rand -base64 32`, which is standard (not
+    # url-safe) base64 — it must work without the operator massaging it.
+    openssl_style = base64.b64encode(b"\x00" * 32 + b"\xff\xfe").decode()
+    encrypt, decrypt = make_cipher(openssl_style)
+    assert decrypt(encrypt(b"payload")) == b"payload"
+
+
+def test_wrong_key_cannot_decrypt() -> None:
+    encrypt, _ = make_cipher("key-a")
+    _, decrypt_b = make_cipher("key-b")
+    with pytest.raises(InvalidToken):
+        decrypt_b(encrypt(b"payload"))
+
+
+def test_empty_key_is_rejected() -> None:
+    with pytest.raises(ValueError):
+        make_cipher("")

--- a/packages/interloper-db/tests/test_resource_encoding.py
+++ b/packages/interloper-db/tests/test_resource_encoding.py
@@ -1,0 +1,49 @@
+"""Tests for the resource encrypt-on-write default logic.
+
+These exercise ``ResourceMixin._encode_data`` directly (no DB), which is the
+single place that decides whether a resource blob is encrypted.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+
+import pytest
+from interloper.errors import ConfigError
+
+from interloper_db.store.resources import ResourceMixin
+
+
+class _Encoder(ResourceMixin):
+    """Minimal ResourceMixin carrier exposing only the cipher hook."""
+
+    def __init__(self, encrypt: Callable[[bytes], bytes] | None = None) -> None:
+        self._encrypt = encrypt
+
+
+def _fake_encrypt(data: bytes) -> bytes:
+    return b"ENC:" + data
+
+
+def test_default_encrypts_when_key_is_configured() -> None:
+    raw, encrypted = _Encoder(encrypt=_fake_encrypt)._encode_data({"a": 1}, None)
+    assert encrypted is True
+    assert raw == b"ENC:" + json.dumps({"a": 1}).encode()
+
+
+def test_default_is_plaintext_when_no_key() -> None:
+    raw, encrypted = _Encoder(encrypt=None)._encode_data({"a": 1}, None)
+    assert encrypted is False
+    assert raw == json.dumps({"a": 1}).encode()
+
+
+def test_explicit_true_without_key_raises() -> None:
+    with pytest.raises(ConfigError):
+        _Encoder(encrypt=None)._encode_data({"a": 1}, True)
+
+
+def test_explicit_false_stays_plaintext_even_with_key() -> None:
+    raw, encrypted = _Encoder(encrypt=_fake_encrypt)._encode_data({"a": 1}, False)
+    assert encrypted is False
+    assert raw == json.dumps({"a": 1}).encode()

--- a/packages/interloper-scheduler/src/interloper_scheduler/cron.py
+++ b/packages/interloper-scheduler/src/interloper_scheduler/cron.py
@@ -46,7 +46,7 @@ class CronController:
         if store is None:
             from interloper.catalog import Catalog
 
-            store = Store(catalog=Catalog.from_settings())
+            store = Store.from_settings(catalog=Catalog.from_settings())
         self._store = store
         self._batch_size = batch_size
         self._reconcile_interval = reconcile_interval or int(os.getenv("JOB_RECONCILE_INTERVAL", "10"))

--- a/packages/interloper-scheduler/src/interloper_scheduler/executor.py
+++ b/packages/interloper-scheduler/src/interloper_scheduler/executor.py
@@ -37,7 +37,7 @@ class RunExecutor:
         if store is None:
             from interloper.catalog import Catalog
 
-            store = Store(catalog=Catalog.from_settings())
+            store = Store.from_settings(catalog=Catalog.from_settings())
         self._store = store
         self._runner_type = runner_type
         self._runner_kwargs = runner_kwargs or {}

--- a/uv.lock
+++ b/uv.lock
@@ -1885,7 +1885,7 @@ wheels = [
 
 [[package]]
 name = "interloper-agent"
-version = "0.2.0"
+version = "0.4.0"
 source = { editable = "packages/interloper-agent" }
 dependencies = [
     { name = "google-adk" },
@@ -1904,7 +1904,7 @@ requires-dist = [
 
 [[package]]
 name = "interloper-api"
-version = "0.2.0"
+version = "0.4.0"
 source = { editable = "packages/interloper-api" }
 dependencies = [
     { name = "fastapi" },
@@ -1936,7 +1936,7 @@ provides-extras = ["agent"]
 
 [[package]]
 name = "interloper-app"
-version = "0.2.0"
+version = "0.4.0"
 source = { editable = "packages/interloper-app" }
 dependencies = [
     { name = "interloper-api" },
@@ -1953,7 +1953,7 @@ requires-dist = [
 
 [[package]]
 name = "interloper-assets"
-version = "0.2.0"
+version = "0.4.0"
 source = { editable = "packages/interloper-assets" }
 dependencies = [
     { name = "httpx" },
@@ -1989,7 +1989,7 @@ provides-extras = ["bing", "google", "facebook"]
 
 [[package]]
 name = "interloper-core"
-version = "0.2.0"
+version = "0.4.0"
 source = { editable = "packages/interloper-core" }
 dependencies = [
     { name = "httpx" },
@@ -2029,10 +2029,11 @@ dev = [
 
 [[package]]
 name = "interloper-db"
-version = "0.2.0"
+version = "0.4.0"
 source = { editable = "packages/interloper-db" }
 dependencies = [
     { name = "alembic" },
+    { name = "cryptography" },
     { name = "interloper-core" },
     { name = "psycopg2-binary" },
     { name = "sqlalchemy" },
@@ -2042,6 +2043,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
+    { name = "cryptography", specifier = ">=43.0.0" },
     { name = "interloper-core", editable = "packages/interloper-core" },
     { name = "psycopg2-binary", specifier = ">=2.9.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
@@ -2050,7 +2052,7 @@ requires-dist = [
 
 [[package]]
 name = "interloper-docker"
-version = "0.2.0"
+version = "0.4.0"
 source = { editable = "packages/interloper-docker" }
 dependencies = [
     { name = "docker" },
@@ -2067,7 +2069,7 @@ requires-dist = [
 
 [[package]]
 name = "interloper-google-cloud"
-version = "0.2.0"
+version = "0.4.0"
 source = { editable = "packages/interloper-google-cloud" }
 dependencies = [
     { name = "google-cloud-bigquery" },
@@ -2082,7 +2084,7 @@ requires-dist = [
 
 [[package]]
 name = "interloper-k8s"
-version = "0.2.0"
+version = "0.4.0"
 source = { editable = "packages/interloper-k8s" }
 dependencies = [
     { name = "interloper-core" },
@@ -2099,7 +2101,7 @@ requires-dist = [
 
 [[package]]
 name = "interloper-pandas"
-version = "0.2.0"
+version = "0.4.0"
 source = { editable = "packages/interloper-pandas" }
 dependencies = [
     { name = "interloper-core" },
@@ -2115,7 +2117,7 @@ requires-dist = [
 
 [[package]]
 name = "interloper-scheduler"
-version = "0.2.0"
+version = "0.4.0"
 source = { editable = "packages/interloper-scheduler" }
 dependencies = [
     { name = "croniter" },
@@ -2143,7 +2145,7 @@ provides-extras = ["docker", "k8s"]
 
 [[package]]
 name = "interloper-workspace"
-version = "0.2.0"
+version = "0.4.0"
 source = { virtual = "." }
 dependencies = [
     { name = "interloper-agent" },


### PR DESCRIPTION
## Summary

`SECRETS_ENCRYPTION_KEY` was defined, documented, and forwarded into runner containers — but never turned into a cipher. Every `Store` was built without `encrypt`/`decrypt` callables, so resources flagged `encrypted=True` were silently persisted as **plaintext**, while the chart comment promised encryption at rest. This wires encryption end to end and makes it the default.

## What changed

**Cipher + settings**
- New `interloper_db.crypto.make_cipher` — Fernet (authenticated AES-128-CBC + HMAC), deriving the key from the configured secret via SHA-256 so any key string works (including the chart's `openssl rand -base64 32`).
- New `SecretsSettings` exposing `SECRETS_ENCRYPTION_KEY` (no `INTERLOPER_` prefix, to match the chart and launchers). Adds `cryptography>=43` to `interloper-db`.

**Wiring**
- New `Store.from_settings()` canonical constructor; all five entry points (API, runner launch, agent, scheduler executor, cron) now go through it.

**Fail loud instead of silent plaintext**
- Writing an encrypted resource with no key → `ConfigError`.
- Reading an encrypted resource with no key, or a decrypt failure (wrong key / legacy plaintext) → `HydrationError` with a clear message.

**Encrypted by default**
- `encrypted` is now tri-state: `None` (default) encrypts when a key is configured, an explicit bool forces on/off. Covers connector OAuth secrets and other resources wherever a key is set, without breaking keyless dev.
- Frontend no longer forces `encrypted: false`; dropped the now-unused `ResourceInput.encrypted` field.

> [!NOTE]
> Intended behavior change: editing an existing plaintext resource re-saves it encrypted when a key is configured. No data migration is included (the prior code never actually encrypted, so there are no real ciphertext rows to migrate).

## Testing
- `ruff` clean · `pyright` 0 errors · `pytest` (core + db + api) green; new DB-free unit tests for the cipher and the encrypt-on-write default logic.
- Frontend `lint` clean (pre-existing warnings only) · `nuxt typecheck` 0 errors.