### PR TITLE
refactor: source connector OAuth credentials from provider env vars

### DIFF
--- a/chart/interloper/templates/_helpers.tpl
+++ b/chart/interloper/templates/_helpers.tpl
@@ -177,12 +177,4 @@ Contains Postgres connection info + the encryption key secret.
       name: {{ include "interloper.secretName" . }}
       key: INTERLOPER_AUTH_GOOGLE_CLIENT_SECRET
       optional: true
-{{- range $provider := (list "amazon" "criteo" "facebook" "google" "linkedin" "microsoft" "pinterest" "snapchat" "tiktok") }}
-- name: INTERLOPER_OAUTH_{{ $provider | upper }}_CLIENT_SECRET
-  valueFrom:
-    secretKeyRef:
-      name: {{ include "interloper.secretName" $ }}
-      key: INTERLOPER_OAUTH_{{ $provider | upper }}_CLIENT_SECRET
-      optional: true
-{{- end }}
 {{- end -}}

--- a/chart/interloper/templates/secret.yaml
+++ b/chart/interloper/templates/secret.yaml
@@ -17,9 +17,4 @@ stringData:
   {{- if .Values.secrets.googleClientSecret }}
   INTERLOPER_AUTH_GOOGLE_CLIENT_SECRET: {{ .Values.secrets.googleClientSecret | quote }}
   {{- end }}
-  {{- range $provider, $secret := .Values.secrets.oauthClientSecrets }}
-  {{- if $secret }}
-  INTERLOPER_OAUTH_{{ $provider | upper }}_CLIENT_SECRET: {{ $secret | quote }}
-  {{- end }}
-  {{- end }}
 {{- end }}

--- a/chart/interloper/values.yaml
+++ b/chart/interloper/values.yaml
@@ -166,17 +166,6 @@ config:
   # auth:
   #   google_client_id: "..."
 
-  # Per-connector OAuth app config for the data-source connect flow.
-  # Set the public client_id + redirect_uri here (per provider); the matching
-  # client_secret goes in secrets.oauthClientSecrets. Providers: amazon, criteo,
-  # facebook, google, linkedin, microsoft, pinterest, snapchat, tiktok.
-  oauth: {}
-  # oauth:
-  #   amazon_client_id: "..."
-  #   amazon_redirect_uri: "https://app.example.com/auth/amazon"
-  #   facebook_client_id: "..."
-  #   facebook_redirect_uri: "https://app.example.com/auth/facebook"
-
 # =============================================================================
 # Secrets
 # =============================================================================
@@ -198,12 +187,6 @@ secrets:
   encryptionKey: ""  # recommended to generate: openssl rand -base64 32
   smtpPassword: ""
   googleClientSecret: ""  # OAuth client secret (paired with config.auth.google_client_id)
-  # Per-connector OAuth client secrets, keyed by provider. Each becomes
-  # INTERLOPER_OAUTH_<PROVIDER>_CLIENT_SECRET in the Secret and on the pod env.
-  oauthClientSecrets: {}
-  # oauthClientSecrets:
-  #   amazon: "..."
-  #   facebook: "..."
 
 # =============================================================================
 # Postgres

--- a/interloper.yaml
+++ b/interloper.yaml
@@ -78,13 +78,3 @@ smtp:
   host: smtp.gmail.com
   port: 465
   user: "no-reply@digitlcloud.com"
-
-# Per-connector OAuth app credentials for the data-source connect flow.
-# One trio per provider (amazon, criteo, facebook, google, linkedin, microsoft,
-# pinterest, snapchat, tiktok). Keep client_secret out of YAML — set it via env,
-# e.g. INTERLOPER_OAUTH_AMAZON_CLIENT_SECRET.
-# oauth:
-#   amazon_client_id: "..."
-#   amazon_redirect_uri: "https://app.example.com/auth/amazon"
-#   facebook_client_id: "..."
-#   facebook_redirect_uri: "https://app.example.com/auth/facebook"

--- a/packages/interloper-api/src/interloper_api/routes/oauth.py
+++ b/packages/interloper-api/src/interloper_api/routes/oauth.py
@@ -2,9 +2,8 @@
 
 Each provider has an explicit exchange function with its own URL,
 HTTP method, body encoding, and parameter names.  The ``client_id``
-and ``client_secret`` are read from settings (:attr:`AppSettings.oauth`)
-and injected into the token response so they can be stored alongside
-the tokens.
+and ``client_secret`` are read from environment variables and injected
+into the token response so they can be stored alongside the tokens.
 
 The ``GET /providers`` endpoint returns metadata for all providers
 that have credentials configured, so the frontend knows which
@@ -15,11 +14,11 @@ from __future__ import annotations
 
 import base64
 import logging
+import os
 from typing import Any
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException
-from interloper.settings import AppSettings, OAuthSettings
 from pydantic import BaseModel
 
 from interloper_api.dependencies import get_catalog
@@ -35,13 +34,14 @@ router = APIRouter(prefix="/oauth", tags=["oauth"])
 
 
 class _ProviderConfig:
-    """Runtime provider config resolved from :class:`OAuthSettings`."""
+    """Runtime provider config resolved from environment variables."""
 
-    def __init__(self, key: str, oauth: OAuthSettings) -> None:
+    def __init__(self, key: str, *, env_prefix: str | None = None) -> None:
+        prefix = (env_prefix or key).upper()
         self.key = key
-        self.client_id = getattr(oauth, f"{key}_client_id", "")
-        self.client_secret = getattr(oauth, f"{key}_client_secret", "")
-        self.redirect_uri = getattr(oauth, f"{key}_redirect_uri", "")
+        self.client_id = os.environ.get(f"{prefix}_CLIENT_ID", "")
+        self.client_secret = os.environ.get(f"{prefix}_CLIENT_SECRET", "")
+        self.redirect_uri = os.environ.get(f"{prefix}_REDIRECT_URI", "")
 
     @property
     def configured(self) -> bool:
@@ -62,8 +62,7 @@ _PROVIDER_KEYS = [
 
 
 def _load_providers() -> dict[str, _ProviderConfig]:
-    oauth = AppSettings.get().oauth
-    return {k: _ProviderConfig(k, oauth) for k in _PROVIDER_KEYS}
+    return {k: _ProviderConfig(k) for k in _PROVIDER_KEYS}
 
 
 # ---------------------------------------------------------------------------

--- a/packages/interloper-api/tests/test_oauth.py
+++ b/packages/interloper-api/tests/test_oauth.py
@@ -1,48 +1,34 @@
-"""Tests for ``interloper_api.routes.oauth`` and connector OAuth settings.
+"""Tests for ``interloper_api.routes.oauth`` (connector connect flow).
 
-Covers that per-connector OAuth *app* credentials resolve from
-:class:`~interloper.settings.OAuthSettings` (env + YAML, mirroring the
-``auth``/``smtp`` pattern), and that the connect-flow endpoints only expose
-providers whose credentials are fully configured.
+Connector OAuth *app* credentials are read at the route implementation level
+from provider-scoped environment variables (``<PROVIDER>_CLIENT_ID`` /
+``_CLIENT_SECRET`` / ``_REDIRECT_URI``). These tests cover that resolution and
+that the public ``/providers`` endpoint only exposes fully-configured providers.
 """
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterator
-from pathlib import Path
-
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from interloper.settings import AppSettings, OAuthSettings
 
 from interloper_api.dependencies import get_catalog
 from interloper_api.routes import oauth as oauth_module
 
-ActivateOAuth = Callable[..., AppSettings]
-
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
+_SUFFIXES = ("CLIENT_ID", "CLIENT_SECRET", "REDIRECT_URI")
 
 
-@pytest.fixture
-def activate_oauth() -> Iterator[ActivateOAuth]:
-    """Activate AppSettings whose ``oauth`` section is set inline, then clear it.
+@pytest.fixture(autouse=True)
+def _clean_oauth_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Isolate tests from ambient / .env connector OAuth variables."""
+    for key in oauth_module._PROVIDER_KEYS:
+        for suffix in _SUFFIXES:
+            monkeypatch.delenv(f"{key.upper()}_{suffix}", raising=False)
 
-    Passing ``oauth=`` as an init arg makes it win over env/YAML, keeping the
-    test hermetic regardless of the runner's cwd or environment.
-    """
 
-    def _activate(**oauth_kwargs: str) -> AppSettings:
-        settings = AppSettings(oauth=OAuthSettings(**oauth_kwargs))  # type: ignore[call-arg]
-        AppSettings.activate(settings)
-        return settings
-
-    try:
-        yield _activate
-    finally:
-        AppSettings.clear_active()
+def _configure(monkeypatch: pytest.MonkeyPatch, provider: str, **vals: str) -> None:
+    for suffix, val in vals.items():
+        monkeypatch.setenv(f"{provider.upper()}_{suffix.upper()}", val)
 
 
 def _client(catalog: dict | None = None) -> TestClient:
@@ -52,55 +38,18 @@ def _client(catalog: dict | None = None) -> TestClient:
     return TestClient(app)
 
 
-# ---------------------------------------------------------------------------
-# Settings resolution
-# ---------------------------------------------------------------------------
+def test_provider_config_reads_bare_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    _configure(monkeypatch, "amazon", client_id="id", client_secret="secret", redirect_uri="uri")
+
+    cfg = oauth_module._ProviderConfig("amazon")
+
+    assert (cfg.client_id, cfg.client_secret, cfg.redirect_uri) == ("id", "secret", "uri")
+    assert cfg.configured is True
 
 
-def test_oauth_settings_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("INTERLOPER_OAUTH_TIKTOK_CLIENT_ID", "id")
-    monkeypatch.setenv("INTERLOPER_OAUTH_TIKTOK_CLIENT_SECRET", "secret")
-    monkeypatch.setenv("INTERLOPER_OAUTH_TIKTOK_REDIRECT_URI", "uri")
-
-    settings = OAuthSettings()
-
-    assert settings.tiktok_client_id == "id"
-    assert settings.tiktok_client_secret == "secret"
-    assert settings.tiktok_redirect_uri == "uri"
-
-
-def test_app_settings_merges_yaml_config_and_env_secret(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """The production split: client_id/redirect_uri from YAML (ConfigMap),
-    client_secret from env (Secret), merged onto AppSettings.oauth."""
-    (tmp_path / "interloper.yaml").write_text(
-        "oauth:\n"
-        "  amazon_client_id: amzn-id\n"
-        "  amazon_redirect_uri: https://app.example.com/auth/amazon\n"
-    )
-    monkeypatch.chdir(tmp_path)
-    monkeypatch.setenv("INTERLOPER_OAUTH_AMAZON_CLIENT_SECRET", "amzn-secret")
-
-    oauth = AppSettings.from_sources().oauth
-
-    assert oauth.amazon_client_id == "amzn-id"
-    assert oauth.amazon_redirect_uri == "https://app.example.com/auth/amazon"
-    assert oauth.amazon_client_secret == "amzn-secret"
-
-
-# ---------------------------------------------------------------------------
-# Provider loading + endpoint
-# ---------------------------------------------------------------------------
-
-
-def test_load_providers_marks_only_fully_configured(activate_oauth: ActivateOAuth) -> None:
-    activate_oauth(
-        amazon_client_id="id",
-        amazon_client_secret="secret",
-        amazon_redirect_uri="uri",
-        criteo_client_id="id-only",  # incomplete -> not configured
-    )
+def test_load_providers_marks_only_fully_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    _configure(monkeypatch, "amazon", client_id="id", client_secret="secret", redirect_uri="uri")
+    _configure(monkeypatch, "criteo", client_id="id-only")  # incomplete -> not configured
 
     providers = oauth_module._load_providers()
 
@@ -109,11 +58,13 @@ def test_load_providers_marks_only_fully_configured(activate_oauth: ActivateOAut
     assert providers["tiktok"].configured is False
 
 
-def test_list_providers_returns_configured_only_with_metadata(activate_oauth: ActivateOAuth) -> None:
-    activate_oauth(
-        amazon_client_id="amzn-id",
-        amazon_client_secret="amzn-secret",
-        amazon_redirect_uri="https://app.example.com/auth/amazon",
+def test_list_providers_returns_configured_only_with_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
+    _configure(
+        monkeypatch,
+        "amazon",
+        client_id="amzn-id",
+        client_secret="amzn-secret",
+        redirect_uri="https://app.example.com/auth/amazon",
     )
     catalog = {
         "amazon_ads": {
@@ -122,7 +73,7 @@ def test_list_providers_returns_configured_only_with_metadata(activate_oauth: Ac
                     "provider": "amazon",
                     "auth_url": "https://www.amazon.com/ap/oa",
                     "label": "Amazon",
-                    "icon": "logos:amazon",
+                    "icon": "icon:amazon",
                 }
             }
         }
@@ -141,13 +92,11 @@ def test_list_providers_returns_configured_only_with_metadata(activate_oauth: Ac
     assert "client_secret" not in amazon
 
 
-def test_exchange_unknown_provider_is_rejected(activate_oauth: ActivateOAuth) -> None:
-    activate_oauth()
+def test_exchange_unknown_provider_is_rejected() -> None:
     resp = _client().post("/oauth/nope", json={"code": "x"})
     assert resp.status_code == 400
 
 
-def test_exchange_unconfigured_provider_is_rejected(activate_oauth: ActivateOAuth) -> None:
-    activate_oauth()  # nothing configured
+def test_exchange_unconfigured_provider_is_rejected() -> None:
     resp = _client().post("/oauth/amazon", json={"code": "x"})
     assert resp.status_code == 400

--- a/packages/interloper-core/src/interloper/settings.py
+++ b/packages/interloper-core/src/interloper/settings.py
@@ -49,58 +49,6 @@ class AuthSettings(BaseSettings):
     session_expiry_days: int = 30
 
 
-class OAuthSettings(BaseSettings):
-    """Per-connector OAuth *app* credentials for the data-source connect flow.
-
-    These are the ``client_id`` / ``client_secret`` / ``redirect_uri`` of the
-    OAuth apps used to authorize external ad-platform connectors (distinct from
-    the Google app-login credentials in :class:`AuthSettings`). One trio per
-    provider; a provider is only offered in the connect UI once all three are set.
-
-    ``client_id`` and ``redirect_uri`` are public and can live in YAML config;
-    ``client_secret`` is sensitive and should come from the environment, e.g.
-    ``INTERLOPER_OAUTH_AMAZON_CLIENT_SECRET``.
-    """
-
-    model_config = SettingsConfigDict(env_prefix=f"{PREFIX}OAUTH_")
-
-    amazon_client_id: str = ""
-    amazon_client_secret: str = ""
-    amazon_redirect_uri: str = ""
-
-    criteo_client_id: str = ""
-    criteo_client_secret: str = ""
-    criteo_redirect_uri: str = ""
-
-    facebook_client_id: str = ""
-    facebook_client_secret: str = ""
-    facebook_redirect_uri: str = ""
-
-    google_client_id: str = ""
-    google_client_secret: str = ""
-    google_redirect_uri: str = ""
-
-    linkedin_client_id: str = ""
-    linkedin_client_secret: str = ""
-    linkedin_redirect_uri: str = ""
-
-    microsoft_client_id: str = ""
-    microsoft_client_secret: str = ""
-    microsoft_redirect_uri: str = ""
-
-    pinterest_client_id: str = ""
-    pinterest_client_secret: str = ""
-    pinterest_redirect_uri: str = ""
-
-    snapchat_client_id: str = ""
-    snapchat_client_secret: str = ""
-    snapchat_redirect_uri: str = ""
-
-    tiktok_client_id: str = ""
-    tiktok_client_secret: str = ""
-    tiktok_redirect_uri: str = ""
-
-
 class SecretsSettings(BaseSettings):
     """Secrets used to protect sensitive data at rest.
 
@@ -205,7 +153,6 @@ class AppSettings(BaseSettings):
     postgres: PostgresSettings = Field(default_factory=PostgresSettings)
     secrets: SecretsSettings = Field(default_factory=SecretsSettings)
     auth: AuthSettings = Field(default_factory=AuthSettings)
-    oauth: OAuthSettings = Field(default_factory=OAuthSettings)
     server: ServerSettings = Field(default_factory=ServerSettings)
     cron: CronSettings = Field(default_factory=CronSettings)
     smtp: SmtpSettings = Field(default_factory=SmtpSettings)


### PR DESCRIPTION
## What & why

Walks back the connector-OAuth **app-config** approach added in #12 (commits `9c498eb` feat(api), `b884f32` feat(chart)). That PR hoisted the per-provider connect-flow credentials into a central `OAuthSettings` section on `AppSettings` (`INTERLOPER_OAUTH_*`) and a dedicated chart `config.oauth` / `secrets.oauthClientSecrets` surface.

On reflection that was the wrong layer: connector OAuth credentials belong at the **source/route implementation level** — the same place connection credentials like `developer_token` (`bing_ads_developer_token`) and the connections' own `client_id`/`client_secret` already live — not promoted into core app settings and chart app-config. The central section also duplicated credentials the connections already define.

Since `0.4.0` was released **before** those commits landed, this OAuth work is unreleased — reverting it now means it simply never ships in that form.

## Changes

- **api/core** — `oauth.py` resolves each provider's `client_id` / `client_secret` / `redirect_uri` from provider-scoped env vars (`<PROVIDER>_CLIENT_ID`, …) at the route level, exactly as before #12 (the file is now byte-identical to its pre-#12 state). Remove `OAuthSettings` from `interloper-core` and the sample `interloper.yaml` `oauth:` block.
- **chart** — remove `config.oauth` + `secrets.oauthClientSecrets` and the per-provider Secret/`commonEnv` wiring. Connector OAuth credentials are injected at deploy time as provider-scoped env vars via the existing `api.extraEnv`.
- **tests** — keep a focused test suite for the env-based provider resolution and `/providers` filtering (isolated from ambient/`.env`).

## Kept (not reverted)

- The dead-frontend-config removal from #12 (`nuxt.config.ts`) stays — it was an independent, correct cleanup.
- Untouched: the resource-encryption feature (#13, `SecretsSettings`) and `forwarded_allow_ips`, both of which also touched `settings.py` / `values.yaml`.

## Verification

- `uv run ruff check` ✓ · `uv run pyright` ✓ (0 errors) · `uv run pytest` ✓ (270 passed)
- `helm lint` ✓ + `helm template` renders **zero** `INTERLOPER_OAUTH_*` keys.
- `oauth.py` confirmed byte-identical to its pre-#12 version.

## Deployment note (step 3)

mk3 connector OAuth is now configured by setting provider-scoped env vars on the API via `api.extraEnv` (e.g. `AMAZON_CLIENT_ID` / `AMAZON_CLIENT_SECRET` / `AMAZON_REDIRECT_URI`), sourced from the GSM secret. Only providers declared by a connector's `OAuthConfig` render a connect button today: **amazon, facebook, linkedin, pinterest**.