### PR TITLE
refactor: rename encryption key env var to INTERLOPER_ENCRYPTION_KEY

### DIFF
--- a/chart/interloper/README.md
+++ b/chart/interloper/README.md
@@ -113,7 +113,7 @@ secrets:
   existingSecret: my-interloper-secret
 ```
 
-Expected keys: `INTERLOPER_POSTGRES_PASSWORD`, `SECRETS_ENCRYPTION_KEY`
+Expected keys: `INTERLOPER_POSTGRES_PASSWORD`, `INTERLOPER_ENCRYPTION_KEY`
 (recommended), `INTERLOPER_SMTP_PASSWORD` (optional).
 
 ### Ingress vs Gateway API

--- a/chart/interloper/templates/_helpers.tpl
+++ b/chart/interloper/templates/_helpers.tpl
@@ -165,11 +165,11 @@ Contains Postgres connection info + the encryption key secret.
     secretKeyRef:
       name: {{ include "interloper.secretName" . }}
       key: INTERLOPER_POSTGRES_PASSWORD
-- name: SECRETS_ENCRYPTION_KEY
+- name: INTERLOPER_ENCRYPTION_KEY
   valueFrom:
     secretKeyRef:
       name: {{ include "interloper.secretName" . }}
-      key: SECRETS_ENCRYPTION_KEY
+      key: INTERLOPER_ENCRYPTION_KEY
       optional: true
 - name: INTERLOPER_AUTH_GOOGLE_CLIENT_SECRET
   valueFrom:

--- a/chart/interloper/templates/secret.yaml
+++ b/chart/interloper/templates/secret.yaml
@@ -9,7 +9,7 @@ type: Opaque
 stringData:
   INTERLOPER_POSTGRES_PASSWORD: {{ required "secrets.postgresPassword is required" .Values.secrets.postgresPassword | quote }}
   {{- if .Values.secrets.encryptionKey }}
-  SECRETS_ENCRYPTION_KEY: {{ .Values.secrets.encryptionKey | quote }}
+  INTERLOPER_ENCRYPTION_KEY: {{ .Values.secrets.encryptionKey | quote }}
   {{- end }}
   {{- if .Values.secrets.smtpPassword }}
   INTERLOPER_SMTP_PASSWORD: {{ .Values.secrets.smtpPassword | quote }}

--- a/chart/interloper/values.yaml
+++ b/chart/interloper/values.yaml
@@ -180,7 +180,7 @@ secrets:
   # Inline values (only used when existingSecret is empty).
   # Required keys:
   #   - INTERLOPER_POSTGRES_PASSWORD
-  #   - SECRETS_ENCRYPTION_KEY (used to encrypt resource secrets at rest)
+  #   - INTERLOPER_ENCRYPTION_KEY (used to encrypt resource secrets at rest)
   # Optional:
   #   - INTERLOPER_SMTP_PASSWORD
   postgresPassword: "postgres"

--- a/packages/interloper-core/src/interloper/settings.py
+++ b/packages/interloper-core/src/interloper/settings.py
@@ -53,12 +53,12 @@ class SecretsSettings(BaseSettings):
     """Secrets used to protect sensitive data at rest.
 
     ``encryption_key`` enables symmetric encryption of resource ``data`` blobs
-    marked ``encrypted=True``. It is read from ``SECRETS_ENCRYPTION_KEY`` (no
-    ``INTERLOPER_`` prefix) to match the Helm chart and runner launchers, which
-    forward that exact variable into spawned containers.
+    marked ``encrypted=True``. It is read from ``INTERLOPER_ENCRYPTION_KEY``;
+    the Helm chart and runner launchers forward that exact variable into
+    spawned containers.
     """
 
-    model_config = SettingsConfigDict(env_prefix="SECRETS_")
+    model_config = SettingsConfigDict(env_prefix=PREFIX)
 
     encryption_key: str = ""
 

--- a/packages/interloper-db/src/interloper_db/crypto.py
+++ b/packages/interloper-db/src/interloper_db/crypto.py
@@ -1,6 +1,6 @@
 """Symmetric encryption for resource data at rest.
 
-A single configured secret (``SECRETS_ENCRYPTION_KEY``) is turned into a
+A single configured secret (``INTERLOPER_ENCRYPTION_KEY``) is turned into a
 pair of ``(bytes) -> bytes`` callables that the :class:`~interloper_db.store.Store`
 uses to encrypt/decrypt resource ``data`` blobs marked ``encrypted=True``.
 

--- a/packages/interloper-db/src/interloper_db/hydration.py
+++ b/packages/interloper-db/src/interloper_db/hydration.py
@@ -105,7 +105,7 @@ class Hydrator:
         if db_resource.encrypted:
             if not self._decrypt:
                 raise HydrationError(
-                    f"Resource {db_resource.id} is encrypted but SECRETS_ENCRYPTION_KEY "
+                    f"Resource {db_resource.id} is encrypted but INTERLOPER_ENCRYPTION_KEY "
                     "is not configured; cannot decrypt"
                 )
             try:
@@ -113,7 +113,7 @@ class Hydrator:
             except Exception as e:
                 raise HydrationError(
                     f"Failed to decrypt resource {db_resource.id}; the configured "
-                    "SECRETS_ENCRYPTION_KEY may be wrong or the data was not encrypted "
+                    "INTERLOPER_ENCRYPTION_KEY may be wrong or the data was not encrypted "
                     f"with it: {e}"
                 ) from e
         return json.loads(raw)

--- a/packages/interloper-db/src/interloper_db/store/__init__.py
+++ b/packages/interloper-db/src/interloper_db/store/__init__.py
@@ -75,7 +75,7 @@ class Store(AuthMixin, ResourceMixin, SourceMixin, AssetMixin, JobMixin, RunMixi
     def from_settings(cls, catalog: Catalog) -> Store:
         """Build a Store with encryption wired from runtime settings.
 
-        Reads ``SECRETS_ENCRYPTION_KEY`` via :class:`AppSettings`. When set, the
+        Reads ``INTERLOPER_ENCRYPTION_KEY`` via :class:`AppSettings`. When set, the
         derived cipher is attached so resources marked ``encrypted=True`` are
         encrypted at rest; when unset, the store falls back to plaintext and
         rejects any attempt to persist an encrypted resource.

--- a/packages/interloper-db/src/interloper_db/store/resources.py
+++ b/packages/interloper-db/src/interloper_db/store/resources.py
@@ -44,7 +44,7 @@ class ResourceMixin:
         if should_encrypt:
             if not self._encrypt:
                 raise ConfigError(
-                    "Cannot store an encrypted resource: SECRETS_ENCRYPTION_KEY is not configured"
+                    "Cannot store an encrypted resource: INTERLOPER_ENCRYPTION_KEY is not configured"
                 )
             raw = self._encrypt(raw)
         return raw, should_encrypt

--- a/packages/interloper-docker/src/interloper_docker/launcher.py
+++ b/packages/interloper-docker/src/interloper_docker/launcher.py
@@ -159,7 +159,7 @@ class DockerLauncher(Launcher):
             "INTERLOPER_RUNNER_TYPE": self._runner_type,
             "INTERLOPER_RUNNER_CONFIG": json.dumps(self._runner_config),
         }
-        encryption_key = os.environ.get("SECRETS_ENCRYPTION_KEY")
+        encryption_key = os.environ.get("INTERLOPER_ENCRYPTION_KEY")
         if encryption_key:
-            environment["SECRETS_ENCRYPTION_KEY"] = encryption_key
+            environment["INTERLOPER_ENCRYPTION_KEY"] = encryption_key
         return environment

--- a/packages/interloper-k8s/src/interloper_k8s/launcher.py
+++ b/packages/interloper-k8s/src/interloper_k8s/launcher.py
@@ -233,9 +233,9 @@ class KubernetesLauncher(Launcher):
             "INTERLOPER_RUNNER_TYPE": self._runner_type,
             "INTERLOPER_RUNNER_CONFIG": json.dumps(self._runner_config),
         }
-        encryption_key = os.environ.get("SECRETS_ENCRYPTION_KEY")
+        encryption_key = os.environ.get("INTERLOPER_ENCRYPTION_KEY")
         if encryption_key:
-            env_map["SECRETS_ENCRYPTION_KEY"] = encryption_key
+            env_map["INTERLOPER_ENCRYPTION_KEY"] = encryption_key
 
         return [client.V1EnvVar(name=k, value=v) for k, v in env_map.items()]
 


### PR DESCRIPTION
## What & why

The resource-encryption feature (#13) reads its key from `SECRETS_ENCRYPTION_KEY` — the odd one out vs. every other setting, which uses the `INTERLOPER_*` convention. Rename it to **`INTERLOPER_ENCRYPTION_KEY`**.

The encryption feature landed **after** the `0.4.0` release, so it's unreleased — this rename has no migration cost.

## Changes (one consistent rename)

- **core** — `SecretsSettings` now uses `env_prefix=INTERLOPER_` so the key is read from `INTERLOPER_ENCRYPTION_KEY` (field/class/`AppSettings.secrets` names unchanged).
- **launchers** — the k8s and docker launchers forward the key into spawned worker containers under an explicit env allowlist; both updated to read/forward `INTERLOPER_ENCRYPTION_KEY` (critical: the API encrypts, workers decrypt — the name must match on both sides).
- **chart** — the generated Secret key and the `commonEnv` `secretKeyRef` are now `INTERLOPER_ENCRYPTION_KEY`. The helm **value** name (`secrets.encryptionKey`) is unchanged — only the rendered Secret key / env var changes.
- **docs/messages** — `crypto.py`, `hydration.py`, `store/*`, chart `values.yaml`/`README.md` references updated.

## Verification

- `uv run ruff check` ✓ · `uv run pyright` ✓ (0 errors) · `uv run pytest` ✓ (270 passed, incl. crypto/encoding tests)
- Settings smoke: `INTERLOPER_ENCRYPTION_KEY` resolves to `AppSettings.secrets.encryption_key`.
- `helm template` renders the Secret key + api/scheduler/db-init env as `INTERLOPER_ENCRYPTION_KEY`; **zero** `SECRETS_ENCRYPTION_KEY` remain in the repo.

## Deployment note

The mk3 GSM secret / chart values must provide the key under `INTERLOPER_ENCRYPTION_KEY` (or `secrets.encryptionKey` if using the chart's inline Secret). Worktree `.env` already uses `INTERLOPER_ENCRYPTION_KEY`.