### PR TITLE
fix: paginate runs table on executions page

### DIFF
--- a/packages/interloper-api/src/interloper_api/routes/runs.py
+++ b/packages/interloper-api/src/interloper_api/routes/runs.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import datetime as dt
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Response
 from interloper.errors import NotFoundError
 from interloper_db import Profile, Store
 from interloper_db.models import Event, Run
@@ -107,6 +107,7 @@ def _event_to_response(event: Event) -> EventResponse:
 
 @router.get("/")
 def list_runs(
+    response: Response,
     job_id: UUID | None = None,
     backfill_id: UUID | None = None,
     status: str | None = None,
@@ -116,7 +117,13 @@ def list_runs(
     org_id: UUID = Depends(get_org_id),
     store: Store = Depends(get_store),
 ) -> list[RunResponse]:
-    """List runs with optional filters."""
+    """List runs with optional filters.
+
+    The total number of matching runs (ignoring ``limit``/``offset``) is
+    returned in the ``X-Total-Count`` response header so clients can paginate.
+    """
+    total = store.count_runs(org_id, job_id=job_id, backfill_id=backfill_id, status=status)
+    response.headers["X-Total-Count"] = str(total)
     runs = store.list_runs(
         org_id,
         job_id=job_id,

--- a/packages/interloper-app/app/app/composables/api.ts
+++ b/packages/interloper-app/app/app/composables/api.ts
@@ -6,5 +6,13 @@ export function useApi() {
         }) as Promise<T>
     }
 
-    return { apiFetch }
+    /** Like `apiFetch` but returns the full response so callers can read headers (e.g. pagination totals). */
+    async function apiFetchRaw<T>(path: string, options?: Parameters<typeof $fetch.raw>[1]) {
+        return $fetch.raw<T>(`/api${path}`, {
+            credentials: 'include',
+            ...options,
+        })
+    }
+
+    return { apiFetch, apiFetchRaw }
 }

--- a/packages/interloper-app/app/app/stores/runs.ts
+++ b/packages/interloper-app/app/app/stores/runs.ts
@@ -1,7 +1,7 @@
 import type { Run } from '~/types/run'
 
 export const useRunsStore = defineStore('runs', () => {
-    const { apiFetch } = useApi()
+    const { apiFetch, apiFetchRaw } = useApi()
     const orgStore = useOrganisationStore()
 
     /**********************
@@ -66,7 +66,9 @@ export const useRunsStore = defineStore('runs', () => {
             if (filters?.jobId) params.set('job_id', filters.jobId)
             if (filters?.backfillId) params.set('backfill_id', filters.backfillId)
             if (filters?.status) params.set('status', filters.status)
-            runs.value = await apiFetch<Run[]>(`/runs?${params}`)
+            const res = await apiFetchRaw<Run[]>(`/runs?${params}`)
+            runs.value = res._data ?? []
+            total.value = Number(res.headers.get('X-Total-Count') ?? runs.value.length)
         }
         catch (e) {
             error.value = e as Error

--- a/packages/interloper-db/src/interloper_db/store/runs.py
+++ b/packages/interloper-db/src/interloper_db/store/runs.py
@@ -9,7 +9,7 @@ from uuid import UUID
 
 import interloper as il
 from interloper.errors import NotFoundError, RunNotFoundError
-from sqlalchemy import text
+from sqlalchemy import func, text
 from sqlmodel import Session, col, select
 
 from interloper_db.engine import get_engine
@@ -177,6 +177,35 @@ class RunMixin:
                 statement = statement.where(Run.status == status)
             statement = statement.order_by(col(Run.created_at).desc()).offset(offset).limit(limit)
             return list(session.exec(statement).all())
+
+    def count_runs(
+        self,
+        org_id: UUID,
+        *,
+        job_id: UUID | None = None,
+        backfill_id: UUID | None = None,
+        status: str | None = None,
+    ) -> int:
+        """Count runs matching the same filters as :meth:`list_runs`.
+
+        Args:
+            org_id: Organisation UUID.
+            job_id: Optional job filter.
+            backfill_id: Optional backfill filter.
+            status: Optional status filter.
+
+        Returns:
+            Total number of matching runs (ignoring limit/offset).
+        """
+        with Session(get_engine()) as session:
+            statement = select(func.count()).select_from(Run).where(Run.org_id == org_id)
+            if job_id:
+                statement = statement.where(Run.job_id == job_id)
+            if backfill_id:
+                statement = statement.where(Run.backfill_id == backfill_id)
+            if status:
+                statement = statement.where(Run.status == status)
+            return session.exec(statement).one()
 
     def complete_run(self, run_id: UUID, *, success: bool) -> Run:
         """Mark a run as completed and advance its backfill if applicable.


### PR DESCRIPTION
## Problem

On the **Executions** page, the backfills table paginates but the runs table doesn't.

The runs table actually *had* server-side pagination fully wired up (store with `pageIndex`/`pageSize`, `limit`/`offset` query params, a `UPagination` component). The pager just never rendered because the store's `total` was always `0`:

- `fetch()` set `runs.value` from the API response but **nothing ever set `total`** — the `GET /runs` endpoint returns a bare `list[RunResponse]` with no count.
- `totalPages = ceil(total / pageSize) = ceil(0/50) = 0`, so `v-if="totalPages > 1"` was always false → no pager.

(Backfills use *client-side* pagination over the full list, which is fine because they're few. Runs grow unbounded — one per partition/job/day — so server-side pagination is the right approach; it just needed the total.)

## Fix

Report the total count from the backend and wire it into the store.

- **db** — add `Store.count_runs()`, mirroring `list_runs()`'s filters (`job_id`/`backfill_id`/`status`) without limit/offset.
- **api** — `GET /runs` now sets an `X-Total-Count` response header with the full count. Response body shape is unchanged.
- **app** — add `apiFetchRaw()` to the API composable (via `$fetch.raw`) so callers can read response headers; the runs store reads `X-Total-Count` into `total`. Existing realtime upsert/remove logic already adjusts `total`, so it stays consistent.

Same-origin (`/api` proxy), so no CORS `Access-Control-Expose-Headers` needed.

## Verification

- `ruff check`, `pyright`, `pytest` — pass (pre-commit hooks green)
- frontend `eslint` — 0 errors; `nuxt typecheck` — 0 errors