### PR TITLE
feat: add platform-wide super-admin role

### DIFF
--- a/packages/interloper-api/src/interloper_api/app.py
+++ b/packages/interloper-api/src/interloper_api/app.py
@@ -11,6 +11,7 @@ from interloper_db import Store
 
 from interloper_api.dependencies import set_auth_config, set_catalog, set_smtp_config, set_store
 from interloper_api.routes import (
+    admin,
     assets,
     auth,
     backfills,
@@ -72,6 +73,7 @@ def create_app(
     api = APIRouter(prefix="/api")
     api.include_router(auth.router, tags=["auth"])
     api.include_router(organisations.router, tags=["organisations"])
+    api.include_router(admin.router, tags=["admin"])
     api.include_router(catalog_routes.router, prefix="/catalog", tags=["catalog"])
     api.include_router(resources.router, prefix="/resources", tags=["resources"])
     api.include_router(sources.router, prefix="/sources", tags=["sources"])

--- a/packages/interloper-api/src/interloper_api/dependencies.py
+++ b/packages/interloper-api/src/interloper_api/dependencies.py
@@ -291,3 +291,22 @@ def require_admin(
         HTTPException: 401/403 on auth or role failure.
     """
     return _check_role("admin", user, org_id, store)
+
+
+def require_super_admin(
+    user: Profile = Depends(get_current_user),
+) -> Profile:
+    """Require platform-wide super-admin privileges.
+
+    Unlike the org-scoped role dependencies, this is not bound to the session's
+    active organisation — it gates the cross-org admin surface.
+
+    Returns:
+        The authenticated Profile.
+
+    Raises:
+        HTTPException: 401 if not authenticated, 403 if not a super-admin.
+    """
+    if not user.is_super_admin:
+        raise HTTPException(status_code=403, detail="Requires super-admin privileges")
+    return user

--- a/packages/interloper-api/src/interloper_api/routes/admin.py
+++ b/packages/interloper-api/src/interloper_api/routes/admin.py
@@ -1,0 +1,305 @@
+"""Super-admin routes — cross-organisation management.
+
+These endpoints are gated by :func:`require_super_admin` and are NOT bound to
+the session's active organisation. They let a platform super-admin manage every
+organisation's metadata, membership, and invitations. They deliberately grant
+no access to org-scoped *data* (sources, jobs, runs, …).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from interloper_db import Profile, Store
+from pydantic import BaseModel
+
+from interloper_api.dependencies import get_store, require_super_admin
+from interloper_api.email import send_invite_email
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+_ROLES = {"viewer", "editor", "admin"}
+
+
+# -- Response / Request models ------------------------------------------------
+
+
+class AdminOrganisationResponse(BaseModel):
+    """Organisation summary with member count for the admin surface."""
+
+    id: UUID
+    name: str
+    member_count: int
+    created_at: datetime | None = None
+
+
+class CreateOrganisationRequest(BaseModel):
+    """Request body for creating an organisation."""
+
+    name: str
+
+
+class UpdateOrganisationRequest(BaseModel):
+    """Request body for renaming an organisation."""
+
+    name: str
+
+
+class MemberResponse(BaseModel):
+    """Organisation member."""
+
+    id: UUID
+    email: str
+    name: str | None = None
+    avatar_url: str | None = None
+    role: str
+
+
+class UpdateRoleRequest(BaseModel):
+    """Request body for changing a member's role."""
+
+    role: str
+
+
+class InviteRequest(BaseModel):
+    """Request body for inviting a user."""
+
+    email: str
+    role: str = "viewer"
+
+
+class InvitationResponse(BaseModel):
+    """Pending invitation."""
+
+    id: UUID
+    email: str
+    role: str
+    created_at: datetime | None = None
+    expires_at: datetime
+
+
+# -- Helpers ------------------------------------------------------------------
+
+
+def _require_org(store: Store, org_id: UUID) -> object:
+    """Fetch an organisation or raise 404."""
+    org = store.get_organisation(org_id)
+    if not org:
+        raise HTTPException(status_code=404, detail="Organisation not found")
+    return org
+
+
+def _validate_role(role: str) -> str:
+    """Validate a role string or raise 400."""
+    if role not in _ROLES:
+        raise HTTPException(status_code=400, detail=f"Invalid role: {role}")
+    return role
+
+
+def _send_invitation_email(
+    request: Request,
+    invitation: object,
+    org_name: str,
+    inviter_name: str,
+) -> None:
+    """Send the invitation email if SMTP is configured, never failing the request."""
+    from interloper_api.dependencies import get_smtp_config
+
+    smtp_config = get_smtp_config()
+    if not smtp_config or not smtp_config.enabled:  # type: ignore[attr-defined]
+        return
+
+    token = invitation.token  # type: ignore[attr-defined]
+    email = invitation.email  # type: ignore[attr-defined]
+    base_url = str(request.base_url).rstrip("/")
+    invite_url = f"{base_url}/invite/{token}"
+
+    try:
+        send_invite_email(
+            smtp_config=smtp_config,
+            to=email,
+            org_name=org_name,
+            inviter_name=inviter_name,
+            invite_url=invite_url,
+        )
+    except Exception:
+        logger.exception("Failed to send invitation email to %s", email)
+
+
+# -- Organisations ------------------------------------------------------------
+
+
+@router.get("/organisations")
+def list_all_organisations(
+    user: Profile = Depends(require_super_admin),
+    store: Store = Depends(get_store),
+) -> list[AdminOrganisationResponse]:
+    """List every organisation with its member count."""
+    return [
+        AdminOrganisationResponse(
+            id=org.id,  # type: ignore[arg-type]
+            name=org.name,
+            member_count=count,
+            created_at=org.created_at,
+        )
+        for org, count in store.list_all_organisations()
+    ]
+
+
+@router.post("/organisations", status_code=201)
+def create_organisation(
+    body: CreateOrganisationRequest,
+    user: Profile = Depends(require_super_admin),
+    store: Store = Depends(get_store),
+) -> AdminOrganisationResponse:
+    """Create an organisation. The super-admin is not added as a member."""
+    org = store.create_organisation(name=body.name)
+    return AdminOrganisationResponse(
+        id=org.id,  # type: ignore[arg-type]
+        name=org.name,
+        member_count=0,
+        created_at=org.created_at,
+    )
+
+
+@router.patch("/organisations/{org_id}")
+def update_organisation(
+    org_id: UUID,
+    body: UpdateOrganisationRequest,
+    user: Profile = Depends(require_super_admin),
+    store: Store = Depends(get_store),
+) -> AdminOrganisationResponse:
+    """Rename an organisation."""
+    org = store.update_organisation(org_id, body.name)
+    if not org:
+        raise HTTPException(status_code=404, detail="Organisation not found")
+    members = store.list_org_members(org_id)
+    return AdminOrganisationResponse(
+        id=org.id,  # type: ignore[arg-type]
+        name=org.name,
+        member_count=len(members),
+        created_at=org.created_at,
+    )
+
+
+# -- Members ------------------------------------------------------------------
+
+
+@router.get("/organisations/{org_id}/members")
+def list_members(
+    org_id: UUID,
+    user: Profile = Depends(require_super_admin),
+    store: Store = Depends(get_store),
+) -> list[MemberResponse]:
+    """List all members of any organisation."""
+    _require_org(store, org_id)
+    members = store.list_org_members(org_id)
+    return [
+        MemberResponse(
+            id=profile.id,  # type: ignore[arg-type]
+            email=profile.email,
+            name=profile.name,
+            avatar_url=profile.avatar_url,
+            role=role,
+        )
+        for profile, role in members
+    ]
+
+
+@router.patch("/organisations/{org_id}/members/{user_id}")
+def update_member_role(
+    org_id: UUID,
+    user_id: UUID,
+    body: UpdateRoleRequest,
+    user: Profile = Depends(require_super_admin),
+    store: Store = Depends(get_store),
+) -> dict[str, str]:
+    """Change a member's role in any organisation."""
+    _validate_role(body.role)
+    if not store.update_member_role(org_id, user_id, body.role):
+        raise HTTPException(status_code=404, detail="Member not found")
+    return {"status": "ok"}
+
+
+@router.delete("/organisations/{org_id}/members/{user_id}")
+def remove_member(
+    org_id: UUID,
+    user_id: UUID,
+    user: Profile = Depends(require_super_admin),
+    store: Store = Depends(get_store),
+) -> dict[str, str]:
+    """Remove a member from any organisation."""
+    if not store.remove_org_member(org_id, user_id):
+        raise HTTPException(status_code=404, detail="Member not found")
+    return {"status": "ok"}
+
+
+# -- Invitations --------------------------------------------------------------
+
+
+@router.get("/organisations/{org_id}/invitations")
+def list_invitations(
+    org_id: UUID,
+    user: Profile = Depends(require_super_admin),
+    store: Store = Depends(get_store),
+) -> list[InvitationResponse]:
+    """List pending invitations for any organisation."""
+    _require_org(store, org_id)
+    return [
+        InvitationResponse(
+            id=inv.id,  # type: ignore[arg-type]
+            email=inv.email,
+            role=inv.role,
+            created_at=inv.created_at,
+            expires_at=inv.expires_at,
+        )
+        for inv in store.list_invitations(org_id)
+    ]
+
+
+@router.post("/organisations/{org_id}/invitations", status_code=201)
+def invite_member(
+    org_id: UUID,
+    body: InviteRequest,
+    request: Request,
+    user: Profile = Depends(require_super_admin),
+    store: Store = Depends(get_store),
+) -> InvitationResponse:
+    """Invite a user to any organisation by email."""
+    org = _require_org(store, org_id)
+    _validate_role(body.role)
+    invitation = store.create_invitation(
+        org_id=org_id,
+        email=body.email.strip(),
+        role=body.role,
+        invited_by=user.id,  # type: ignore[arg-type]
+    )
+
+    inviter_name = user.name or user.email
+    _send_invitation_email(request, invitation, org.name, inviter_name)  # type: ignore[attr-defined]
+
+    return InvitationResponse(
+        id=invitation.id,  # type: ignore[arg-type]
+        email=invitation.email,
+        role=invitation.role,
+        created_at=invitation.created_at,
+        expires_at=invitation.expires_at,
+    )
+
+
+@router.delete("/organisations/{org_id}/invitations/{invitation_id}")
+def cancel_invitation(
+    org_id: UUID,
+    invitation_id: UUID,
+    user: Profile = Depends(require_super_admin),
+    store: Store = Depends(get_store),
+) -> dict[str, str]:
+    """Cancel a pending invitation in any organisation."""
+    if not store.delete_invitation(invitation_id):
+        raise HTTPException(status_code=404, detail="Invitation not found")
+    return {"status": "ok"}

--- a/packages/interloper-api/src/interloper_api/routes/auth.py
+++ b/packages/interloper-api/src/interloper_api/routes/auth.py
@@ -37,6 +37,7 @@ class AuthUserResponse(BaseModel):
     name: str | None = None
     avatar_url: str | None = None
     role: str
+    is_super_admin: bool = False
     organisation: OrganisationResponse | None = None
     last_organisation_id: UUID | None = None
 
@@ -188,6 +189,7 @@ def get_me(
         name=profile.name,
         avatar_url=profile.avatar_url,
         role=role,
+        is_super_admin=profile.is_super_admin,
         organisation=OrganisationResponse.model_validate(org, from_attributes=True) if org else None,
         last_organisation_id=profile.last_organisation_id,
     )

--- a/packages/interloper-api/tests/test_admin.py
+++ b/packages/interloper-api/tests/test_admin.py
@@ -1,0 +1,186 @@
+"""Tests for ``interloper_api.routes.admin`` (super-admin cross-org surface).
+
+The critical property is that every endpoint is gated by ``require_super_admin``
+and is *not* bound to the session's active organisation. A lightweight fake
+store stands in for persistence so these stay pure unit tests.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from interloper_api.dependencies import get_current_user, get_store
+from interloper_api.routes import admin as admin_module
+
+
+class FakeStore:
+    """In-memory stand-in implementing only the methods admin routes call."""
+
+    def __init__(self) -> None:
+        self.org = SimpleNamespace(id=uuid4(), name="Acme", created_at=datetime.now(timezone.utc))
+        self.member = SimpleNamespace(
+            id=uuid4(), email="member@acme.test", name="Member", avatar_url=None
+        )
+        self.role_updates: list[tuple[UUID, UUID, str]] = []
+        self.removed: list[tuple[UUID, UUID]] = []
+        self.created_invites: list[dict] = []
+
+    # -- organisations --
+    def list_all_organisations(self):
+        return [(self.org, 1)]
+
+    def create_organisation(self, name: str, creator_id: UUID | None = None):
+        return SimpleNamespace(id=uuid4(), name=name, created_at=datetime.now(timezone.utc))
+
+    def update_organisation(self, org_id: UUID, name: str):
+        return SimpleNamespace(id=org_id, name=name, created_at=self.org.created_at)
+
+    def get_organisation(self, org_id: UUID):
+        return self.org
+
+    # -- members --
+    def list_org_members(self, org_id: UUID):
+        return [(self.member, "admin")]
+
+    def update_member_role(self, org_id: UUID, user_id: UUID, role: str) -> bool:
+        self.role_updates.append((org_id, user_id, role))
+        return True
+
+    def remove_org_member(self, org_id: UUID, user_id: UUID) -> bool:
+        self.removed.append((org_id, user_id))
+        return True
+
+    # -- invitations --
+    def list_invitations(self, org_id: UUID):
+        return [
+            SimpleNamespace(
+                id=uuid4(),
+                email="invitee@acme.test",
+                role="viewer",
+                created_at=datetime.now(timezone.utc),
+                expires_at=datetime.now(timezone.utc),
+            )
+        ]
+
+    def create_invitation(self, org_id: UUID, email: str, role: str, invited_by: UUID):
+        self.created_invites.append({"org_id": org_id, "email": email, "role": role})
+        return SimpleNamespace(
+            id=uuid4(),
+            email=email,
+            role=role,
+            created_at=datetime.now(timezone.utc),
+            expires_at=datetime.now(timezone.utc),
+        )
+
+    def delete_invitation(self, invitation_id: UUID) -> bool:
+        return True
+
+
+def _profile(*, is_super_admin: bool):
+    return SimpleNamespace(
+        id=uuid4(),
+        email="user@test",
+        name="User",
+        avatar_url=None,
+        is_super_admin=is_super_admin,
+    )
+
+
+def _client(store: FakeStore, *, is_super_admin: bool) -> TestClient:
+    app = FastAPI()
+    app.include_router(admin_module.router)
+    app.dependency_overrides[get_store] = lambda: store
+    app.dependency_overrides[get_current_user] = lambda: _profile(is_super_admin=is_super_admin)
+    return TestClient(app)
+
+
+@pytest.fixture
+def store() -> FakeStore:
+    return FakeStore()
+
+
+# -- gating -------------------------------------------------------------------
+
+
+def test_non_super_admin_is_forbidden(store: FakeStore) -> None:
+    resp = _client(store, is_super_admin=False).get("/admin/organisations")
+    assert resp.status_code == 403
+
+
+def test_super_admin_lists_all_organisations(store: FakeStore) -> None:
+    resp = _client(store, is_super_admin=True).get("/admin/organisations")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body[0]["name"] == "Acme"
+    assert body[0]["member_count"] == 1
+
+
+# -- organisations ------------------------------------------------------------
+
+
+def test_create_organisation_does_not_add_creator(store: FakeStore) -> None:
+    resp = _client(store, is_super_admin=True).post("/admin/organisations", json={"name": "New"})
+    assert resp.status_code == 201
+    assert resp.json()["name"] == "New"
+    assert resp.json()["member_count"] == 0
+
+
+def test_rename_organisation(store: FakeStore) -> None:
+    org_id = store.org.id
+    resp = _client(store, is_super_admin=True).patch(
+        f"/admin/organisations/{org_id}", json={"name": "Renamed"}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "Renamed"
+
+
+# -- members ------------------------------------------------------------------
+
+
+def test_list_members_of_any_org(store: FakeStore) -> None:
+    resp = _client(store, is_super_admin=True).get(f"/admin/organisations/{store.org.id}/members")
+    assert resp.status_code == 200
+    assert resp.json()[0]["email"] == "member@acme.test"
+
+
+def test_update_member_role(store: FakeStore) -> None:
+    user_id = uuid4()
+    resp = _client(store, is_super_admin=True).patch(
+        f"/admin/organisations/{store.org.id}/members/{user_id}", json={"role": "editor"}
+    )
+    assert resp.status_code == 200
+    assert store.role_updates[0][2] == "editor"
+
+
+def test_update_member_role_rejects_invalid_role(store: FakeStore) -> None:
+    resp = _client(store, is_super_admin=True).patch(
+        f"/admin/organisations/{store.org.id}/members/{uuid4()}", json={"role": "root"}
+    )
+    assert resp.status_code == 400
+
+
+def test_remove_member(store: FakeStore) -> None:
+    user_id = uuid4()
+    resp = _client(store, is_super_admin=True).delete(
+        f"/admin/organisations/{store.org.id}/members/{user_id}"
+    )
+    assert resp.status_code == 200
+    assert store.removed[0][1] == user_id
+
+
+# -- invitations --------------------------------------------------------------
+
+
+def test_invite_into_any_org(store: FakeStore) -> None:
+    resp = _client(store, is_super_admin=True).post(
+        f"/admin/organisations/{store.org.id}/invitations",
+        json={"email": "x@acme.test", "role": "viewer"},
+    )
+    assert resp.status_code == 201
+    assert store.created_invites[0]["email"] == "x@acme.test"

--- a/packages/interloper-app/app/app/components/nav/Organisation.vue
+++ b/packages/interloper-app/app/app/components/nav/Organisation.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+import type { DropdownMenuItem } from '@nuxt/ui'
+import type { Organisation } from '~/types/organisation'
+
+defineProps<{
+    collapsed?: boolean
+}>()
+
+const route = useRoute()
+const orgStore = useOrganisationStore()
+
+const userOrgs = ref<Organisation[]>([])
+const orgsLoaded = ref(false)
+
+async function loadUserOrgs() {
+    if (orgsLoaded.value) return
+    userOrgs.value = await orgStore.fetchOrganisations()
+    orgsLoaded.value = true
+}
+
+const orgItems = computed<DropdownMenuItem[]>(() => {
+    if (!orgsLoaded.value) return [{ label: 'Loading...', disabled: true }]
+    if (userOrgs.value.length === 0) return [{ label: 'No organisations', disabled: true }]
+
+    const currentId = orgStore.organisation?.id
+    return userOrgs.value.map((org) => {
+        if (org.id === currentId) {
+            return {
+                label: org.name,
+                icon: 'i-lucide-building-2',
+                type: 'checkbox' as const,
+                checked: true,
+            }
+        }
+        return {
+            label: org.name,
+            icon: 'i-lucide-building-2',
+            onSelect: () => {
+                orgStore.switchOrg(org.id)
+                orgsLoaded.value = false
+            },
+        }
+    })
+})
+
+const items = computed<DropdownMenuItem[][]>(() => [
+    orgItems.value,
+    [{
+        label: 'Manage',
+        icon: 'i-lucide-users',
+        onSelect: () => navigateTo('/organization'),
+    }],
+])
+</script>
+
+<template>
+    <UDropdownMenu :items="items"
+                   :content="{ align: 'start', side: 'top' }"
+                   :ui="{ content: 'w-(--reka-dropdown-menu-trigger-width)' }"
+                   @update:open="(open: boolean) => { if (open) loadUserOrgs() }">
+        <UButton :avatar="{ icon: 'i-lucide-building-2' }"
+                 :label="collapsed ? undefined : (orgStore.organisation?.name || 'Organization')"
+                 class="w-full justify-start data-[state=open]:bg-elevated"
+                 variant="ghost"
+                 color="neutral"
+                 :square="collapsed"
+                 :class="{ 'text-highlighted': route.path === '/organization' }"
+                 truncate>
+            <template v-if="!collapsed"
+                      #trailing>
+                <UIcon name="i-lucide-chevrons-up-down"
+                       class="size-4 ms-auto text-dimmed" />
+            </template>
+        </UButton>
+    </UDropdownMenu>
+</template>

--- a/packages/interloper-app/app/app/components/nav/User.vue
+++ b/packages/interloper-app/app/app/components/nav/User.vue
@@ -67,18 +67,19 @@ const items = computed<DropdownMenuItem[][]>(() => {
 
 <template>
     <UDropdownMenu :items="items"
-                   :content="{ align: 'end', side: 'right' }">
-        <UButton :avatar="{ text: initials }"
+                   :content="{ align: 'start', side: 'top' }"
+                   :ui="{ content: 'w-(--reka-dropdown-menu-trigger-width)' }">
+        <UButton :avatar="{ src: userStore.user?.avatar_url ?? undefined, text: initials }"
                  :label="collapsed ? undefined : displayName"
-                 class="w-full justify-start"
+                 class="w-full justify-start data-[state=open]:bg-elevated"
                  variant="ghost"
                  color="neutral"
                  :square="collapsed"
                  truncate>
             <template v-if="!collapsed"
                       #trailing>
-                <UIcon name="i-lucide-chevron-right"
-                       class="size-4 ms-auto text-muted" />
+                <UIcon name="i-lucide-chevrons-up-down"
+                       class="size-4 ms-auto text-dimmed" />
             </template>
         </UButton>
     </UDropdownMenu>

--- a/packages/interloper-app/app/app/components/nav/User.vue
+++ b/packages/interloper-app/app/app/components/nav/User.vue
@@ -24,30 +24,45 @@ const initials = computed(() => {
     return userStore.user?.email?.charAt(0).toUpperCase() ?? '?'
 })
 
-const items = computed<DropdownMenuItem[][]>(() => [
-    [{
-        label: displayName.value,
-        avatar: { text: initials.value },
-        type: 'label',
-    }],
-    [
-        {
-            label: 'Settings',
-            icon: 'i-lucide-sliders-horizontal',
-            onSelect: () => navigateTo('/settings'),
-        },
-        {
-            label: colorMode.value === 'dark' ? 'Light Mode' : 'Dark Mode',
-            icon: colorMode.value === 'dark' ? 'i-lucide-sun' : 'i-lucide-moon',
-            onSelect: toggleColorMode,
-        },
-    ],
-    [{
-        label: 'Log out',
-        icon: 'i-lucide-log-out',
-        onSelect: () => userStore.signOut(),
-    }],
-])
+const items = computed<DropdownMenuItem[][]>(() => {
+    const groups: DropdownMenuItem[][] = [
+        [{
+            label: displayName.value,
+            avatar: { text: initials.value },
+            type: 'label',
+        }],
+    ]
+
+    if (userStore.isSuperAdmin) {
+        groups.push([{
+            label: 'Platform admin',
+            icon: 'i-lucide-shield',
+            onSelect: () => navigateTo('/admin'),
+        }])
+    }
+
+    groups.push(
+        [
+            {
+                label: 'Settings',
+                icon: 'i-lucide-sliders-horizontal',
+                onSelect: () => navigateTo('/settings'),
+            },
+            {
+                label: colorMode.value === 'dark' ? 'Light Mode' : 'Dark Mode',
+                icon: colorMode.value === 'dark' ? 'i-lucide-sun' : 'i-lucide-moon',
+                onSelect: toggleColorMode,
+            },
+        ],
+        [{
+            label: 'Log out',
+            icon: 'i-lucide-log-out',
+            onSelect: () => userStore.signOut(),
+        }],
+    )
+
+    return groups
+})
 </script>
 
 <template>

--- a/packages/interloper-app/app/app/components/organization/InviteModal.vue
+++ b/packages/interloper-app/app/app/components/organization/InviteModal.vue
@@ -1,6 +1,13 @@
 <script setup lang="ts">
 const open = defineModel<boolean>('open', { default: false })
 
+const props = withDefaults(defineProps<{
+    /** API path that accepts `{ email, role }` POST bodies. */
+    endpoint?: string
+}>(), {
+    endpoint: '/organisations/invite',
+})
+
 const { apiFetch } = useApi()
 const toast = useToast()
 
@@ -48,7 +55,7 @@ async function submit() {
 
     for (const invite of invites) {
         try {
-            await apiFetch('/organisations/invite', {
+            await apiFetch(props.endpoint, {
                 method: 'POST',
                 body: { email: invite.email.trim(), role: invite.role },
             })

--- a/packages/interloper-app/app/app/composables/orgScope.ts
+++ b/packages/interloper-app/app/app/composables/orgScope.ts
@@ -1,0 +1,31 @@
+/**
+ * Refetch an org-scoped store whenever the active organisation changes.
+ *
+ * Entity stores (sources, assets, destinations, resources, jobs) fetch their
+ * data on page mount. Because switching organisation doesn't remount the page,
+ * they would otherwise keep showing the previous org's data until a full
+ * reload. Execution stores (runs, backfills, events, …) already get this for
+ * free through `useRealtimeSubscription`'s `scope` option; this is the
+ * equivalent for the manually-fetched entity stores.
+ *
+ * Call it once inside a store's setup. The watcher is non-immediate, so it
+ * never races with the page's own initial fetch — it only reacts to a switch.
+ *
+ * @param refetch Reloads the store's data for the active org.
+ * @param reset   Optional: clears state before refetching (and on sign-out,
+ *                when the org becomes null).
+ */
+export function useOrgScopedRefetch(
+    refetch: () => void | Promise<void>,
+    reset?: () => void,
+) {
+    const organisationStore = useOrganisationStore()
+
+    watch(
+        () => organisationStore.organisation?.id,
+        (orgId) => {
+            reset?.()
+            if (orgId) refetch()
+        },
+    )
+}

--- a/packages/interloper-app/app/app/layouts/default.vue
+++ b/packages/interloper-app/app/app/layouts/default.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
-import type { NavigationMenuItem, DropdownMenuItem } from '@nuxt/ui'
-import type { Organisation } from '~/types/organisation'
+import type { NavigationMenuItem } from '@nuxt/ui'
 
 const route = useRoute()
 
@@ -10,18 +9,8 @@ const modeItems = computed<NavigationMenuItem[]>(() => [
     { label: 'Agent', icon: 'i-lucide-sparkles', to: '/agent' },
 ])
 
-const orgStore = useOrganisationStore()
 const catalogStore = useCatalogStore()
 const { open: commandPaletteOpen, groups: commandPaletteGroups } = useCommandPalette()
-
-const userOrgs = ref<Organisation[]>([])
-const orgsLoaded = ref(false)
-
-async function loadUserOrgs() {
-    if (orgsLoaded.value) return
-    userOrgs.value = await orgStore.fetchOrganisations()
-    orgsLoaded.value = true
-}
 
 /** Icons for resource kinds — fallback to generic box. */
 const RESOURCE_KIND_ICONS: Record<string, string> = {
@@ -106,38 +95,6 @@ const items = computed<NavigationMenuItem[]>(() => {
 
     return nav
 })
-
-const switchChildren = computed<DropdownMenuItem[][]>(() => {
-    if (!orgsLoaded.value) return [[{ label: 'Loading...', disabled: true }]]
-    if (userOrgs.value.length === 0) return [[{ label: 'No organisations', disabled: true }]]
-
-    const currentId = orgStore.organisation?.id
-    return [userOrgs.value.map(org => ({
-        label: org.name,
-        disabled: org.id === currentId,
-        onSelect: () => {
-            orgStore.switchOrg(org.id)
-            orgsLoaded.value = false
-        },
-    }))]
-})
-
-const orgMenuItems = computed<DropdownMenuItem[][]>(() => [
-    [
-        {
-            label: 'Manage',
-            icon: 'i-lucide-users',
-            onSelect: () => navigateTo('/organization'),
-        },
-    ],
-    [
-        {
-            label: 'Switch',
-            icon: 'i-lucide-arrow-left-right',
-            children: switchChildren.value,
-        },
-    ],
-])
 </script>
 
 <template>
@@ -188,30 +145,13 @@ const orgMenuItems = computed<DropdownMenuItem[][]>(() => [
                         <UNavigationMenu :collapsed="collapsed"
                                          :items="items"
                                          orientation="vertical" />
-
-                        <div class="mt-auto flex flex-col gap-1">
-                            <UDropdownMenu :items="orgMenuItems"
-                                           :content="{ align: 'start', side: 'right' }"
-                                           @update:open="(open: boolean) => { if (open) loadUserOrgs() }">
-                                <UButton :label="collapsed ? undefined : (orgStore.organisation?.name || 'Organization')"
-                                         icon="i-lucide-building-2"
-                                         class="w-full justify-start"
-                                         variant="ghost"
-                                         color="neutral"
-                                         :square="collapsed"
-                                         :class="{ 'text-highlighted': route.path === '/organization' }">
-                                    <template v-if="!collapsed"
-                                              #trailing>
-                                        <UIcon name="i-lucide-chevron-right"
-                                               class="size-4 ms-auto text-muted" />
-                                    </template>
-                                </UButton>
-                            </UDropdownMenu>
-                        </div>
                     </template>
 
                     <template #footer="{ collapsed }">
-                        <NavUser :collapsed="collapsed" />
+                        <div class="flex flex-col gap-1 w-full">
+                            <NavOrganisation :collapsed="collapsed" />
+                            <NavUser :collapsed="collapsed" />
+                        </div>
                     </template>
                 </UDashboardSidebar>
 

--- a/packages/interloper-app/app/app/middleware/auth.global.ts
+++ b/packages/interloper-app/app/app/middleware/auth.global.ts
@@ -29,9 +29,12 @@ export default defineNuxtRouteMiddleware(async (to) => {
 
     // Authenticated but no organisation:
     // - /invite/* and /welcome: allow through
+    // - /admin/*: allow super-admins through (they may belong to no org)
     // - All other routes: redirect to /welcome so user can create one
     if (!organisationStore.organisation) {
         if (to.path.startsWith('/invite/') || to.path === '/welcome')
+            return
+        if (to.path.startsWith('/admin') && userStore.isSuperAdmin)
             return
         return navigateTo('/welcome')
     }

--- a/packages/interloper-app/app/app/middleware/super-admin.ts
+++ b/packages/interloper-app/app/app/middleware/super-admin.ts
@@ -1,0 +1,11 @@
+export default defineNuxtRouteMiddleware(async () => {
+    const userStore = useUserStore()
+
+    if (!userStore.authenticated) {
+        await userStore.fetchMe()
+    }
+
+    if (!userStore.isSuperAdmin) {
+        return navigateTo('/')
+    }
+})

--- a/packages/interloper-app/app/app/pages/admin/index.vue
+++ b/packages/interloper-app/app/app/pages/admin/index.vue
@@ -1,0 +1,163 @@
+<script setup lang="ts">
+import { h } from 'vue'
+import type { TableColumn, DropdownMenuItem } from '@nuxt/ui'
+import type { AdminOrganisation } from '~/types/admin'
+
+definePageMeta({ title: 'Organisations', middleware: 'super-admin' })
+
+const adminStore = useAdminStore()
+const toast = useToast()
+
+const rows = ref<AdminOrganisation[]>([])
+const loading = ref(false)
+
+// Create / rename modal state
+const formOpen = ref(false)
+const formMode = ref<'create' | 'rename'>('create')
+const formName = ref('')
+const formTarget = ref<AdminOrganisation | null>(null)
+const submitting = ref(false)
+
+async function loadData() {
+    loading.value = true
+    try {
+        rows.value = await adminStore.listOrganisations()
+    }
+    catch (err) {
+        console.error('[Admin] Failed to load organisations', err)
+    }
+    finally {
+        loading.value = false
+    }
+}
+
+function openCreate() {
+    formMode.value = 'create'
+    formName.value = ''
+    formTarget.value = null
+    formOpen.value = true
+}
+
+function openRename(org: AdminOrganisation) {
+    formMode.value = 'rename'
+    formName.value = org.name
+    formTarget.value = org
+    formOpen.value = true
+}
+
+async function submitForm() {
+    const name = formName.value.trim()
+    if (!name) return
+
+    submitting.value = true
+    try {
+        if (formMode.value === 'create') {
+            await adminStore.createOrganisation(name)
+            toast.add({ title: `Organisation "${name}" created`, color: 'success' })
+        }
+        else if (formTarget.value) {
+            await adminStore.renameOrganisation(formTarget.value.id, name)
+            toast.add({ title: 'Organisation renamed', color: 'success' })
+        }
+        formOpen.value = false
+        await loadData()
+    }
+    catch (err: any) {
+        toast.add({ title: err?.data?.detail || 'Operation failed', color: 'error' })
+    }
+    finally {
+        submitting.value = false
+    }
+}
+
+function rowActions(org: AdminOrganisation): DropdownMenuItem[][] {
+    return [
+        [
+            {
+                label: 'Manage members',
+                icon: 'i-lucide-users',
+                onSelect: () => navigateTo(`/admin/organisations/${org.id}`),
+            },
+            {
+                label: 'Rename',
+                icon: 'i-lucide-pencil',
+                onSelect: () => openRename(org),
+            },
+        ],
+    ]
+}
+
+const columns: TableColumn<AdminOrganisation>[] = [
+    {
+        accessorKey: 'name',
+        header: 'Name',
+    },
+    {
+        accessorKey: 'member_count',
+        header: 'Members',
+        cell: ({ row }) => row.original.member_count,
+    },
+    {
+        accessorKey: 'created_at',
+        header: 'Created',
+        cell: ({ row }) => row.original.created_at
+            ? new Date(row.original.created_at).toLocaleDateString()
+            : '—',
+    },
+    {
+        id: 'open',
+        header: '',
+        cell: ({ row }) => h(resolveComponent('UButton'), {
+            icon: 'i-lucide-arrow-right',
+            color: 'neutral',
+            variant: 'ghost',
+            size: 'xs',
+            onClick: () => navigateTo(`/admin/organisations/${row.original.id}`),
+        }),
+        size: 50,
+        enableSorting: false,
+        enableGlobalFilter: false,
+    },
+]
+
+onMounted(loadData)
+</script>
+
+<template>
+    <div class="flex flex-col flex-1 min-h-0">
+        <DataTable :columns="columns"
+                   :data="rows"
+                   :loading="loading"
+                   :row-actions="rowActions"
+                   no-actions
+                   search-placeholder="Search organisations...">
+            <template #toolbar>
+                <UButton icon="i-lucide-plus"
+                         label="New organisation"
+                         @click="openCreate" />
+            </template>
+        </DataTable>
+
+        <UModal v-model:open="formOpen"
+                :title="formMode === 'create' ? 'New organisation' : 'Rename organisation'"
+                :ui="{ footer: 'justify-end' }">
+            <template #body>
+                <UInput v-model="formName"
+                        placeholder="Organisation name"
+                        autofocus
+                        class="w-full"
+                        @keydown.enter="submitForm" />
+            </template>
+            <template #footer>
+                <UButton label="Cancel"
+                         color="neutral"
+                         variant="outline"
+                         @click="formOpen = false" />
+                <UButton :label="formMode === 'create' ? 'Create' : 'Save'"
+                         :disabled="!formName.trim() || submitting"
+                         :loading="submitting"
+                         @click="submitForm" />
+            </template>
+        </UModal>
+    </div>
+</template>

--- a/packages/interloper-app/app/app/pages/admin/index.vue
+++ b/packages/interloper-app/app/app/pages/admin/index.vue
@@ -130,7 +130,7 @@ onMounted(loadData)
 
 <template>
     <div class="flex flex-col flex-1 min-h-0">
-        <div class="px-4 pt-4 shrink-0">
+        <div class="px-4 pt-4 pb-2 shrink-0">
             <UBreadcrumb :items="breadcrumbs" />
         </div>
         <DataTable :columns="columns"

--- a/packages/interloper-app/app/app/pages/admin/index.vue
+++ b/packages/interloper-app/app/app/pages/admin/index.vue
@@ -1,9 +1,14 @@
 <script setup lang="ts">
 import { h } from 'vue'
-import type { TableColumn, DropdownMenuItem } from '@nuxt/ui'
+import type { TableColumn, DropdownMenuItem, BreadcrumbItem } from '@nuxt/ui'
 import type { AdminOrganisation } from '~/types/admin'
 
 definePageMeta({ title: 'Organisations', middleware: 'super-admin' })
+
+const breadcrumbs: BreadcrumbItem[] = [
+    { label: 'Platform admin', icon: 'i-lucide-shield' },
+    { label: 'Organisations', icon: 'i-lucide-building-2' },
+]
 
 const adminStore = useAdminStore()
 const toast = useToast()
@@ -125,6 +130,9 @@ onMounted(loadData)
 
 <template>
     <div class="flex flex-col flex-1 min-h-0">
+        <div class="px-4 pt-4 shrink-0">
+            <UBreadcrumb :items="breadcrumbs" />
+        </div>
         <DataTable :columns="columns"
                    :data="rows"
                    :loading="loading"

--- a/packages/interloper-app/app/app/pages/admin/organisations/[id].vue
+++ b/packages/interloper-app/app/app/pages/admin/organisations/[id].vue
@@ -1,0 +1,116 @@
+<script setup lang="ts">
+import type { OrgMember } from '~/types/organisation'
+
+definePageMeta({ title: 'Manage organisation', middleware: 'super-admin' })
+
+const route = useRoute()
+const orgId = computed(() => route.params.id as string)
+
+const adminStore = useAdminStore()
+const toast = useToast()
+
+const rows = ref<OrgMember[]>([])
+const loading = ref(false)
+const inviteOpen = ref(false)
+
+const inviteEndpoint = computed(() => `/admin/organisations/${orgId.value}/invitations`)
+
+async function loadData() {
+    loading.value = true
+    try {
+        const [members, invitations] = await Promise.all([
+            adminStore.listMembers(orgId.value),
+            adminStore.listInvitations(orgId.value),
+        ])
+
+        const memberRows: OrgMember[] = members.map(m => ({
+            id: m.id,
+            email: m.email,
+            name: m.name,
+            avatar_url: m.avatar_url,
+            role: m.role,
+            status: 'active' as const,
+        }))
+
+        const inviteRows: OrgMember[] = invitations.map(i => ({
+            id: i.id,
+            email: i.email,
+            name: null,
+            avatar_url: null,
+            role: i.role,
+            status: 'invited' as const,
+        }))
+
+        rows.value = [...memberRows, ...inviteRows]
+    }
+    catch (err) {
+        console.error('[Admin] Failed to load members', err)
+    }
+    finally {
+        loading.value = false
+    }
+}
+
+async function removeMember(member: OrgMember) {
+    try {
+        await adminStore.removeMember(orgId.value, member.id)
+        toast.add({ title: `${member.name || member.email} removed`, color: 'success' })
+        await loadData()
+    }
+    catch (err: any) {
+        toast.add({ title: err?.data?.detail || 'Failed to remove member', color: 'error' })
+    }
+}
+
+async function cancelInvite(member: OrgMember) {
+    try {
+        await adminStore.cancelInvitation(orgId.value, member.id)
+        toast.add({ title: `Invitation to ${member.email} cancelled`, color: 'success' })
+        await loadData()
+    }
+    catch (err: any) {
+        toast.add({ title: err?.data?.detail || 'Failed to cancel invitation', color: 'error' })
+    }
+}
+
+async function resendInvite(member: OrgMember) {
+    try {
+        await adminStore.cancelInvitation(orgId.value, member.id)
+        await adminStore.inviteMember(orgId.value, member.email, member.role)
+        toast.add({ title: `Invitation resent to ${member.email}`, color: 'success' })
+        await loadData()
+    }
+    catch (err: any) {
+        toast.add({ title: err?.data?.detail || 'Failed to resend invitation', color: 'error' })
+    }
+}
+
+onMounted(loadData)
+watch(orgId, loadData)
+</script>
+
+<template>
+    <div class="flex flex-col flex-1 min-h-0">
+        <OrganizationMembersTable :members="rows"
+                                  :loading="loading"
+                                  is-admin
+                                  @remove-member="removeMember"
+                                  @cancel-invite="cancelInvite"
+                                  @resend-invite="resendInvite">
+            <template #toolbar>
+                <UButton icon="i-lucide-arrow-left"
+                         label="All organisations"
+                         color="neutral"
+                         variant="ghost"
+                         @click="navigateTo('/admin')" />
+                <UButton icon="i-lucide-user-plus"
+                         label="Invite"
+                         @click="inviteOpen = true" />
+            </template>
+        </OrganizationMembersTable>
+
+        <OrganizationInviteModal v-model:open="inviteOpen"
+                                 :endpoint="inviteEndpoint"
+                                 @invited="loadData" />
+    </div>
+</template>

--- a/packages/interloper-app/app/app/pages/admin/organisations/[id].vue
+++ b/packages/interloper-app/app/app/pages/admin/organisations/[id].vue
@@ -102,7 +102,7 @@ watch(orgId, loadData)
 
 <template>
     <div class="flex flex-col flex-1 min-h-0">
-        <div class="px-4 pt-4 shrink-0">
+        <div class="px-4 pt-4 pb-2 shrink-0">
             <UBreadcrumb :items="breadcrumbs" />
         </div>
         <OrganizationMembersTable :members="rows"

--- a/packages/interloper-app/app/app/pages/admin/organisations/[id].vue
+++ b/packages/interloper-app/app/app/pages/admin/organisations/[id].vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { BreadcrumbItem } from '@nuxt/ui'
 import type { OrgMember } from '~/types/organisation'
 
 definePageMeta({ title: 'Manage organisation', middleware: 'super-admin' })
@@ -10,18 +11,28 @@ const adminStore = useAdminStore()
 const toast = useToast()
 
 const rows = ref<OrgMember[]>([])
+const orgName = ref<string | null>(null)
 const loading = ref(false)
 const inviteOpen = ref(false)
 
 const inviteEndpoint = computed(() => `/admin/organisations/${orgId.value}/invitations`)
 
+const breadcrumbs = computed<BreadcrumbItem[]>(() => [
+    { label: 'Platform admin', icon: 'i-lucide-shield' },
+    { label: 'Organisations', icon: 'i-lucide-building-2', to: '/admin' },
+    { label: orgName.value ?? '…' },
+])
+
 async function loadData() {
     loading.value = true
     try {
-        const [members, invitations] = await Promise.all([
+        const [members, invitations, organisations] = await Promise.all([
             adminStore.listMembers(orgId.value),
             adminStore.listInvitations(orgId.value),
+            adminStore.listOrganisations(),
         ])
+
+        orgName.value = organisations.find(o => o.id === orgId.value)?.name ?? null
 
         const memberRows: OrgMember[] = members.map(m => ({
             id: m.id,
@@ -91,6 +102,9 @@ watch(orgId, loadData)
 
 <template>
     <div class="flex flex-col flex-1 min-h-0">
+        <div class="px-4 pt-4 shrink-0">
+            <UBreadcrumb :items="breadcrumbs" />
+        </div>
         <OrganizationMembersTable :members="rows"
                                   :loading="loading"
                                   is-admin
@@ -98,11 +112,6 @@ watch(orgId, loadData)
                                   @cancel-invite="cancelInvite"
                                   @resend-invite="resendInvite">
             <template #toolbar>
-                <UButton icon="i-lucide-arrow-left"
-                         label="All organisations"
-                         color="neutral"
-                         variant="ghost"
-                         @click="navigateTo('/admin')" />
                 <UButton icon="i-lucide-user-plus"
                          label="Invite"
                          @click="inviteOpen = true" />

--- a/packages/interloper-app/app/app/stores/admin.ts
+++ b/packages/interloper-app/app/app/stores/admin.ts
@@ -1,0 +1,86 @@
+import type { AdminOrganisation } from '~/types/admin'
+
+interface MemberResponse {
+    id: string
+    email: string
+    name: string | null
+    avatar_url: string | null
+    role: string
+}
+
+interface InvitationResponse {
+    id: string
+    email: string
+    role: string
+    created_at: string | null
+    expires_at: string
+}
+
+/** Cross-organisation management API, restricted to super-admins server-side. */
+export const useAdminStore = defineStore('admin', () => {
+    const { apiFetch } = useApi()
+
+    function listOrganisations() {
+        return apiFetch<AdminOrganisation[]>('/admin/organisations')
+    }
+
+    function createOrganisation(name: string) {
+        return apiFetch<AdminOrganisation>('/admin/organisations', {
+            method: 'POST',
+            body: { name },
+        })
+    }
+
+    function renameOrganisation(orgId: string, name: string) {
+        return apiFetch<AdminOrganisation>(`/admin/organisations/${orgId}`, {
+            method: 'PATCH',
+            body: { name },
+        })
+    }
+
+    function listMembers(orgId: string) {
+        return apiFetch<MemberResponse[]>(`/admin/organisations/${orgId}/members`)
+    }
+
+    function updateMemberRole(orgId: string, userId: string, role: string) {
+        return apiFetch(`/admin/organisations/${orgId}/members/${userId}`, {
+            method: 'PATCH',
+            body: { role },
+        })
+    }
+
+    function removeMember(orgId: string, userId: string) {
+        return apiFetch(`/admin/organisations/${orgId}/members/${userId}`, {
+            method: 'DELETE',
+        })
+    }
+
+    function listInvitations(orgId: string) {
+        return apiFetch<InvitationResponse[]>(`/admin/organisations/${orgId}/invitations`)
+    }
+
+    function inviteMember(orgId: string, email: string, role: string) {
+        return apiFetch<InvitationResponse>(`/admin/organisations/${orgId}/invitations`, {
+            method: 'POST',
+            body: { email, role },
+        })
+    }
+
+    function cancelInvitation(orgId: string, invitationId: string) {
+        return apiFetch(`/admin/organisations/${orgId}/invitations/${invitationId}`, {
+            method: 'DELETE',
+        })
+    }
+
+    return {
+        listOrganisations,
+        createOrganisation,
+        renameOrganisation,
+        listMembers,
+        updateMemberRole,
+        removeMember,
+        listInvitations,
+        inviteMember,
+        cancelInvitation,
+    }
+})

--- a/packages/interloper-app/app/app/stores/agent.ts
+++ b/packages/interloper-app/app/app/stores/agent.ts
@@ -59,6 +59,8 @@ export const useAgentStore = defineStore('agent', () => {
         error.value = null
     }
 
+    useOrgScopedRefetch(() => fetchSessions(), $reset)
+
     return {
         sessions,
         loading,

--- a/packages/interloper-app/app/app/stores/assets.ts
+++ b/packages/interloper-app/app/app/stores/assets.ts
@@ -126,6 +126,8 @@ export const useAssetsStore = defineStore('assets', () => {
         error.value = null
     }
 
+    useOrgScopedRefetch(() => fetch(), $reset)
+
     return {
         assets,
         standalone,

--- a/packages/interloper-app/app/app/stores/destinations.ts
+++ b/packages/interloper-app/app/app/stores/destinations.ts
@@ -86,6 +86,8 @@ export const useDestinationsStore = defineStore('destinations', () => {
         error.value = null
     }
 
+    useOrgScopedRefetch(() => fetch(), $reset)
+
     return {
         destinations,
         loading,

--- a/packages/interloper-app/app/app/stores/jobs.ts
+++ b/packages/interloper-app/app/app/stores/jobs.ts
@@ -109,6 +109,8 @@ export const useJobsStore = defineStore('jobs', () => {
         error.value = null
     }
 
+    useOrgScopedRefetch(() => fetch(), $reset)
+
     return {
         jobs,
         loading,

--- a/packages/interloper-app/app/app/stores/resources.ts
+++ b/packages/interloper-app/app/app/stores/resources.ts
@@ -96,6 +96,8 @@ export const useResourcesStore = defineStore('resources', () => {
         error.value = null
     }
 
+    useOrgScopedRefetch(() => fetch(), $reset)
+
     return {
         resources,
         loading,

--- a/packages/interloper-app/app/app/stores/sources.ts
+++ b/packages/interloper-app/app/app/stores/sources.ts
@@ -86,6 +86,8 @@ export const useSourcesStore = defineStore('sources', () => {
         error.value = null
     }
 
+    useOrgScopedRefetch(() => fetch(), $reset)
+
     return {
         sources,
         loading,

--- a/packages/interloper-app/app/app/stores/user.ts
+++ b/packages/interloper-app/app/app/stores/user.ts
@@ -10,6 +10,7 @@ export const useUserStore = defineStore('user', () => {
     const loading = ref(false)
     const error = ref<Error | null>(null)
     const authenticated = computed(() => !!user.value)
+    const isSuperAdmin = computed(() => !!user.value?.is_super_admin)
 
     /**********************
      * Actions
@@ -54,6 +55,7 @@ export const useUserStore = defineStore('user', () => {
         loading,
         error,
         authenticated,
+        isSuperAdmin,
         findProfile,
         requireProfile,
         fetchMe,

--- a/packages/interloper-app/app/app/types/admin.ts
+++ b/packages/interloper-app/app/app/types/admin.ts
@@ -1,0 +1,6 @@
+export interface AdminOrganisation {
+    id: string
+    name: string
+    member_count: number
+    created_at: string | null
+}

--- a/packages/interloper-app/app/app/types/user.ts
+++ b/packages/interloper-app/app/app/types/user.ts
@@ -6,6 +6,7 @@ export interface User {
     name: string | null
     avatar_url: string | null
     role: string
+    is_super_admin: boolean
     organisation: Organisation | null
     last_organisation_id: string | null
 }

--- a/packages/interloper-db/src/interloper_db/migrations/versions/005_super_admin.py
+++ b/packages/interloper-db/src/interloper_db/migrations/versions/005_super_admin.py
@@ -1,0 +1,30 @@
+"""Add is_super_admin flag to profiles.
+
+Grants a profile platform-wide super-admin privileges (cross-org management).
+The first super-admin is bootstrapped manually, e.g.::
+
+    UPDATE profiles SET is_super_admin = true WHERE email = '<you>';
+
+Revision ID: 005
+Revises: 004
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "005"
+down_revision: str | None = "004"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    """Add the is_super_admin column to the profiles table."""
+    op.execute("ALTER TABLE profiles ADD COLUMN IF NOT EXISTS is_super_admin BOOLEAN NOT NULL DEFAULT false;")
+
+
+def downgrade() -> None:
+    """Remove the is_super_admin column from the profiles table."""
+    op.execute("ALTER TABLE profiles DROP COLUMN IF EXISTS is_super_admin;")

--- a/packages/interloper-db/src/interloper_db/models.py
+++ b/packages/interloper-db/src/interloper_db/models.py
@@ -47,6 +47,7 @@ class Profile(SQLModel, table=True):
     name: str | None = None
     google_id: str = SQLField(index=True, unique=True)
     avatar_url: str | None = None
+    is_super_admin: bool = SQLField(default=False, sa_column_kwargs={"server_default": text("false")})
     last_organisation_id: UUID | None = SQLField(default=None, foreign_key="organisations.id")
     created_at: datetime | None = _ts()
 

--- a/packages/interloper-db/src/interloper_db/store/auth.py
+++ b/packages/interloper-db/src/interloper_db/store/auth.py
@@ -7,6 +7,7 @@ import secrets
 from datetime import datetime, timedelta, timezone
 from uuid import UUID
 
+from sqlalchemy import func
 from sqlmodel import Session, select
 
 from interloper_db.engine import get_engine
@@ -174,12 +175,14 @@ class AuthMixin:
 
     # -- Organisations --------------------------------------------------------
 
-    def create_organisation(self, name: str, creator_id: UUID) -> Organisation:
-        """Create an organisation and make the creator an admin.
+    def create_organisation(self, name: str, creator_id: UUID | None = None) -> Organisation:
+        """Create an organisation, optionally making the creator an admin.
 
         Args:
             name: Organisation name.
-            creator_id: Profile UUID of the creating user.
+            creator_id: Profile UUID of the creating user. When provided, the
+                user is added as an ``admin`` member. Pass ``None`` (e.g. for
+                super-admin provisioning) to create an org with no members.
 
         Returns:
             The created Organisation row.
@@ -189,14 +192,53 @@ class AuthMixin:
             session.add(db_organisation)
             session.flush()
 
-            session.add(UserOrganisation(
-                user_id=creator_id,
-                organisation_id=db_organisation.id,  # type: ignore[arg-type]
-                role="admin",
-            ))
+            if creator_id is not None:
+                session.add(UserOrganisation(
+                    user_id=creator_id,
+                    organisation_id=db_organisation.id,  # type: ignore[arg-type]
+                    role="admin",
+                ))
             session.commit()
             session.refresh(db_organisation)
             return db_organisation
+
+    def update_organisation(self, org_id: UUID, name: str) -> Organisation | None:
+        """Rename an organisation.
+
+        Args:
+            org_id: Organisation UUID.
+            name: New organisation name.
+
+        Returns:
+            The updated Organisation, or None if not found.
+        """
+        with Session(get_engine()) as session:
+            db_organisation = session.get(Organisation, org_id)
+            if not db_organisation:
+                return None
+            db_organisation.name = name
+            session.add(db_organisation)
+            session.commit()
+            session.refresh(db_organisation)
+            return db_organisation
+
+    def list_all_organisations(self) -> list[tuple[Organisation, int]]:
+        """List every organisation with its member count (super-admin only).
+
+        Returns:
+            List of ``(Organisation, member_count)`` tuples.
+        """
+        with Session(get_engine()) as session:
+            organisations = session.exec(select(Organisation)).all()
+            counts = dict(
+                session.exec(
+                    select(
+                        UserOrganisation.organisation_id,
+                        func.count(UserOrganisation.user_id),  # type: ignore[arg-type]
+                    ).group_by(UserOrganisation.organisation_id)  # type: ignore[arg-type]
+                ).all()
+            )
+            return [(org, counts.get(org.id, 0)) for org in organisations]  # type: ignore[arg-type]
 
     def get_organisation(self, org_id: UUID) -> Organisation | None:
         """Get an organisation by ID.
@@ -270,6 +312,31 @@ class AuthMixin:
                     session.expunge(db_profile)
                     results.append((db_profile, membership.role))
             return results
+
+    def update_member_role(self, org_id: UUID, user_id: UUID, role: str) -> bool:
+        """Update a member's role within an organisation.
+
+        Args:
+            org_id: Organisation UUID.
+            user_id: Profile UUID of the member.
+            role: New role to assign.
+
+        Returns:
+            True if updated, False if the user is not a member.
+        """
+        with Session(get_engine()) as session:
+            membership = session.exec(
+                select(UserOrganisation).where(
+                    UserOrganisation.user_id == user_id,
+                    UserOrganisation.organisation_id == org_id,
+                )
+            ).first()
+            if not membership:
+                return False
+            membership.role = role
+            session.add(membership)
+            session.commit()
+            return True
 
     def remove_org_member(self, org_id: UUID, user_id: UUID) -> bool:
         """Remove a member from an organisation.


### PR DESCRIPTION
## Summary

Introduces a platform-wide **super-admin** role that can manage all organisations through a dedicated settings area. Super-admin is a platform-level attribute, kept deliberately separate from the org-scoped `viewer`/`editor`/`admin` roles (which live on `UserOrganisation.role`). The change is almost entirely additive — existing role logic is untouched.

### Decisions baked in
- **Bootstrap: manual SQL** (no env allowlist). Promotion via UI deferred.
- **Manage orgs + members only** — `/admin` routes manage org metadata, members, and invitations across all orgs. **No org-data bypass**: `_check_role`/`get_org_id` are unchanged, so a super-admin gets no implicit access to another org's sources/jobs/runs.
- **No destructive ops** — org deletion is out of scope for this iteration.

## Backend
- `Profile.is_super_admin` flag + Alembic migration `005_super_admin.py`
- `require_super_admin` dependency — depends only on the current user, **not** the session's active org
- `routes/admin.py` (`/admin/*`): list/create/rename orgs, manage members (list, change role, remove) and invitations across all orgs; every route gated by `require_super_admin`
- `/auth/me` now returns `is_super_admin`
- Store helpers: `list_all_organisations` (with member counts), `update_organisation`, `update_member_role`; `create_organisation` takes an optional `creator_id`
- Tests: `tests/test_admin.py` — 403 gating for non-super-admins + happy paths

## Frontend
- `is_super_admin` on the `User` type, `isSuperAdmin` getter, new `stores/admin.ts`
- `/admin` pages: organisation list, and per-org member/invitation management reusing `MembersTable`/`InviteModal`
- Named `super-admin` route guard; global `auth.global.ts` lets orgless super-admins reach `/admin` (instead of redirecting to `/welcome`)
- Gated "Platform admin" entry in the user menu

## Bootstrapping the first super-admin
After running migration `005`:
```sql
UPDATE profiles SET is_super_admin = true WHERE email = '<you>';
```

## Verification
`make check` passes — ruff, pyright, full pytest (incl. new admin tests), frontend lint, and `nuxt typecheck`.