### PR TITLE
feat: add retry for failed runs

### DIFF
--- a/packages/interloper-api/src/interloper_api/routes/runs.py
+++ b/packages/interloper-api/src/interloper_api/routes/runs.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime as dt
+from typing import Literal
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Response
@@ -11,7 +12,7 @@ from interloper_db import Profile, Store
 from interloper_db.models import Event, Run
 from pydantic import BaseModel
 
-from interloper_api.dependencies import get_org_id, get_store, require_viewer
+from interloper_api.dependencies import get_org_id, get_store, require_editor, require_viewer
 
 router = APIRouter()
 
@@ -25,9 +26,18 @@ class RunResponse(BaseModel):
     backfill_id: UUID | None
     partition_date: dt.date | None
     status: str
+    retry_of: UUID | None = None
+    attempt: int = 1
+    retry_scope: str | None = None
     started_at: str | None = None
     completed_at: str | None = None
     created_at: str | None = None
+
+
+class RetryRequest(BaseModel):
+    """Request body for retrying a failed run."""
+
+    scope: Literal["all", "failed"] = "all"
 
 
 class AssetExecutionResponse(BaseModel):
@@ -75,6 +85,9 @@ def _run_to_response(run: Run) -> RunResponse:
         backfill_id=run.backfill_id,
         partition_date=run.partition_date,
         status=run.status,
+        retry_of=run.retry_of,
+        attempt=run.attempt,
+        retry_scope=run.retry_scope,
         started_at=str(run.started_at) if run.started_at else None,
         completed_at=str(run.completed_at) if run.completed_at else None,
         created_at=str(run.created_at) if run.created_at else None,
@@ -170,6 +183,29 @@ def list_asset_executions(
         )
         for row in rows
     ]
+
+
+@router.post("/{run_id}/retry")
+def retry_run(
+    run_id: UUID,
+    body: RetryRequest | None = None,
+    user: Profile = Depends(require_editor),
+    store: Store = Depends(get_store),
+) -> dict[str, str]:
+    """Queue a retry of a failed run.
+
+    Creates a new run linked to the original via ``retry_of``. With
+    ``scope="all"`` the whole DAG re-runs; with ``scope="failed"`` only the
+    previously failed/cancelled assets re-run.
+    """
+    scope = body.scope if body else "all"
+    try:
+        run = store.retry_run(run_id, scope=scope)
+    except NotFoundError:
+        raise HTTPException(status_code=404, detail=f"Run {run_id} not found")
+    except ValueError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+    return {"status": "queued", "run_id": str(run.id)}
 
 
 @router.get("/{run_id}/events")

--- a/packages/interloper-api/tests/test_runs.py
+++ b/packages/interloper-api/tests/test_runs.py
@@ -1,0 +1,82 @@
+"""Tests for ``interloper_api.routes.runs`` — focused on the retry endpoint.
+
+A lightweight fake store stands in for persistence so these stay pure unit
+tests, matching the style of ``test_admin.py``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from interloper.errors import RunNotFoundError
+
+from interloper_api.dependencies import get_store, require_editor
+from interloper_api.routes import runs as runs_module
+
+
+class FakeStore:
+    """In-memory stand-in implementing only what the retry route calls."""
+
+    def __init__(self) -> None:
+        self.retry_calls: list[tuple[UUID, str]] = []
+        self.raise_not_found = False
+        self.raise_value_error: str | None = None
+
+    def retry_run(self, run_id: UUID, *, scope: str = "all"):
+        self.retry_calls.append((run_id, scope))
+        if self.raise_not_found:
+            raise RunNotFoundError(f"Run {run_id} not found")
+        if self.raise_value_error is not None:
+            raise ValueError(self.raise_value_error)
+        return SimpleNamespace(id=uuid4())
+
+
+def _client(store: FakeStore) -> TestClient:
+    app = FastAPI()
+    app.include_router(runs_module.router)
+    app.dependency_overrides[get_store] = lambda: store
+    app.dependency_overrides[require_editor] = lambda: SimpleNamespace(id=uuid4())
+    return TestClient(app)
+
+
+@pytest.fixture
+def store() -> FakeStore:
+    return FakeStore()
+
+
+def test_retry_defaults_to_all_scope(store: FakeStore) -> None:
+    run_id = uuid4()
+    resp = _client(store).post(f"/{run_id}/retry")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "queued"
+    assert store.retry_calls == [(run_id, "all")]
+
+
+def test_retry_passes_failed_scope(store: FakeStore) -> None:
+    run_id = uuid4()
+    resp = _client(store).post(f"/{run_id}/retry", json={"scope": "failed"})
+    assert resp.status_code == 200
+    assert store.retry_calls[0][1] == "failed"
+
+
+def test_retry_rejects_unknown_scope(store: FakeStore) -> None:
+    resp = _client(store).post(f"/{uuid4()}/retry", json={"scope": "partial"})
+    assert resp.status_code == 422
+    assert store.retry_calls == []
+
+
+def test_retry_missing_run_returns_404(store: FakeStore) -> None:
+    store.raise_not_found = True
+    resp = _client(store).post(f"/{uuid4()}/retry")
+    assert resp.status_code == 404
+
+
+def test_retry_non_failed_run_returns_409(store: FakeStore) -> None:
+    store.raise_value_error = "Run is not failed"
+    resp = _client(store).post(f"/{uuid4()}/retry")
+    assert resp.status_code == 409
+    assert "not failed" in resp.json()["detail"]

--- a/packages/interloper-app/app/app/pages/executions/runs/[run].vue
+++ b/packages/interloper-app/app/app/pages/executions/runs/[run].vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { DropdownMenuItem } from '@nuxt/ui'
 import type { RunEvent } from '~/stores/events'
 import type { Run } from '~/types/run'
 import type { ExecutionStatus } from '~/types/asset_execution'
@@ -14,6 +15,7 @@ const eventsStore = useEventsStore()
 const assetExecutionsStore = useAssetExecutionsStore()
 const sourcesStore = useSourcesStore()
 const catalogStore = useCatalogStore()
+const toast = useToast()
 
 const initialRun = ref<Run | null>(null)
 const assetExecutions = computed(() => assetExecutionsStore.assetExecutions)
@@ -25,6 +27,36 @@ const selectedAsset = ref<string | null>(null)
 const eventInFocus = ref<RunEvent | null>(null)
 const markerTime = computed(() => eventInFocus.value?.timestamp ? new Date(eventInFocus.value.timestamp) : null)
 const highlightedAsset = computed(() => eventInFocus.value?.asset_id ?? null)
+
+const retrying = ref(false)
+
+async function onRetry(scope: 'all' | 'failed') {
+    retrying.value = true
+    try {
+        const newRunId = await runsStore.retryRun(runId, scope)
+        toast.add({ title: `Retry queued (${newRunId.slice(0, 8)})`, color: 'success' })
+        await navigateTo(`/executions/runs/${newRunId}`)
+    }
+    catch {
+        toast.add({ title: 'Failed to queue retry', color: 'error' })
+    }
+    finally {
+        retrying.value = false
+    }
+}
+
+const retryItems = computed<DropdownMenuItem[]>(() => [
+    {
+        label: 'Retry failed assets only',
+        icon: 'i-lucide-list-restart',
+        onSelect: () => onRetry('failed'),
+    },
+    {
+        label: 'Retry all assets',
+        icon: 'i-lucide-rotate-ccw',
+        onSelect: () => onRetry('all'),
+    },
+])
 
 onMounted(async () => {
     const [fetchedRun] = await Promise.all([
@@ -58,6 +90,17 @@ onUnmounted(() => {
                     :color="statusColor(run.status)">
                 {{ statusLabel(run.status) }}
             </UBadge>
+            <UDropdownMenu v-if="run?.status === 'failed'"
+                           :items="retryItems"
+                           class="ml-auto">
+                <UButton icon="i-lucide-rotate-ccw"
+                         label="Retry"
+                         color="neutral"
+                         variant="outline"
+                         size="sm"
+                         trailing-icon="i-lucide-chevron-down"
+                         :loading="retrying" />
+            </UDropdownMenu>
         </div>
 
         <SplitterGroup direction="vertical"

--- a/packages/interloper-app/app/app/stores/runs.ts
+++ b/packages/interloper-app/app/app/stores/runs.ts
@@ -82,6 +82,14 @@ export const useRunsStore = defineStore('runs', () => {
         return apiFetch<Run>(`/runs/${id}`)
     }
 
+    async function retryRun(id: string, scope: 'all' | 'failed'): Promise<string> {
+        const res = await apiFetch<{ run_id: string }>(`/runs/${id}/retry`, {
+            method: 'POST',
+            body: { scope },
+        })
+        return res.run_id
+    }
+
     async function goToPage(page: number) {
         pageIndex.value = page
         await fetch()
@@ -112,6 +120,7 @@ export const useRunsStore = defineStore('runs', () => {
         error,
         fetch,
         fetchOne,
+        retryRun,
         goToPage,
         findById,
         _upsert,

--- a/packages/interloper-app/app/app/types/run.ts
+++ b/packages/interloper-app/app/app/types/run.ts
@@ -5,6 +5,9 @@ export interface Run {
     backfill_id: string | null
     partition_date: string | null
     status: string
+    retry_of: string | null
+    attempt: number
+    retry_scope: string | null
     started_at: string | null
     completed_at: string | null
     created_at: string | null

--- a/packages/interloper-db/src/interloper_db/migrations/versions/006_run_retry.py
+++ b/packages/interloper-db/src/interloper_db/migrations/versions/006_run_retry.py
@@ -1,0 +1,36 @@
+"""Add retry lineage columns to runs.
+
+A failed run can be retried by creating a new run that points back to its
+predecessor via ``retry_of`` and carries an incremented ``attempt`` count.
+``retry_scope`` records whether the retry re-runs the whole DAG (``"all"``)
+or only the previously failed assets (``"failed"``).
+
+Revision ID: 006
+Revises: 005
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "006"
+down_revision: str | None = "005"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    """Add retry_of, attempt, and retry_scope columns to the runs table."""
+    op.execute('ALTER TABLE runs ADD COLUMN IF NOT EXISTS retry_of UUID REFERENCES runs(id) ON DELETE SET NULL;')
+    op.execute('ALTER TABLE runs ADD COLUMN IF NOT EXISTS attempt INTEGER NOT NULL DEFAULT 1;')
+    op.execute('ALTER TABLE runs ADD COLUMN IF NOT EXISTS retry_scope VARCHAR;')
+    op.execute('CREATE INDEX IF NOT EXISTS ix_runs_retry_of ON runs (retry_of);')
+
+
+def downgrade() -> None:
+    """Remove the retry lineage columns from the runs table."""
+    op.execute('DROP INDEX IF EXISTS ix_runs_retry_of;')
+    op.execute('ALTER TABLE runs DROP COLUMN IF EXISTS retry_scope;')
+    op.execute('ALTER TABLE runs DROP COLUMN IF EXISTS attempt;')
+    op.execute('ALTER TABLE runs DROP COLUMN IF EXISTS retry_of;')

--- a/packages/interloper-db/src/interloper_db/models.py
+++ b/packages/interloper-db/src/interloper_db/models.py
@@ -456,6 +456,12 @@ class Run(SQLModel, table=True):
     backfill_id: UUID | None = SQLField(default=None, foreign_key="backfills.id")
     partition_date: dt.date | None = None
     status: str = "queued"
+    retry_of: UUID | None = SQLField(
+        default=None,
+        sa_column=Column(ForeignKey("runs.id", ondelete="SET NULL"), index=True),
+    )
+    attempt: int = 1
+    retry_scope: str | None = None
     started_at: datetime | None = SQLField(default=None, sa_column=Column(TZDateTime))
     completed_at: datetime | None = SQLField(default=None, sa_column=Column(TZDateTime))
     created_at: datetime | None = _ts()

--- a/packages/interloper-db/src/interloper_db/store/runs.py
+++ b/packages/interloper-db/src/interloper_db/store/runs.py
@@ -236,6 +236,49 @@ class RunMixin:
             session.refresh(db_run)
             return db_run
 
+    def retry_run(self, run_id: UUID, *, scope: str = "all") -> Run:
+        """Queue a new run that retries a failed one.
+
+        Each retry is a fresh ``Run`` row linked to its predecessor via
+        ``retry_of`` with an incremented ``attempt``. The new run is created
+        outside any backfill so backfill accounting is unaffected.
+
+        Args:
+            run_id: The failed run to retry.
+            scope: ``"all"`` to re-run the whole DAG, or ``"failed"`` to
+                re-run only the previously failed/cancelled assets.
+
+        Returns:
+            The newly created, queued Run row.
+
+        Raises:
+            RunNotFoundError: If the run is not found.
+            ValueError: If the run is not in a failed state or ``scope`` is invalid.
+        """
+        if scope not in ("all", "failed"):
+            raise ValueError(f"Invalid retry scope: {scope!r} (expected 'all' or 'failed')")
+
+        with Session(get_engine()) as session:
+            src = session.get(Run, run_id)
+            if not src:
+                raise RunNotFoundError(f"Run {run_id} not found")
+            if src.status != "failed":
+                raise ValueError(f"Run {run_id} is not failed (status={src.status!r}); only failed runs can be retried")
+
+            db_run = Run(
+                org_id=src.org_id,
+                job_id=src.job_id,
+                partition_date=src.partition_date,
+                status="queued",
+                retry_of=run_id,
+                attempt=src.attempt + 1,
+                retry_scope=scope,
+            )
+            session.add(db_run)
+            session.commit()
+            session.refresh(db_run)
+            return db_run
+
     # -- Backfills ------------------------------------------------------------
 
     def create_backfill(

--- a/packages/interloper-scheduler/src/interloper_scheduler/executor.py
+++ b/packages/interloper-scheduler/src/interloper_scheduler/executor.py
@@ -73,6 +73,9 @@ class RunExecutor:
 
                 self._resolve_upstream_deps(db_run.job, assets)
 
+                if db_run.retry_scope == "failed" and db_run.retry_of:
+                    self._skip_succeeded_assets(db_run, assets)
+
                 dag = il.DAG(*assets)
                 partition = il.TimePartition(db_run.partition_date) if db_run.partition_date else None
 
@@ -140,6 +143,31 @@ class RunExecutor:
             assets.append(self._store.load_asset(db_asset.id))
 
         return assets
+
+    def _skip_succeeded_assets(self, db_run: Run, assets: list[il.Asset]) -> None:
+        """Mark assets that already succeeded in the retry lineage as non-materializable.
+
+        For a ``"failed"``-scope retry, assets that completed successfully in an
+        earlier attempt are read from their destination instead of recomputed;
+        only the previously failed/cancelled assets re-execute. Successes are
+        resolved by walking the ``retry_of`` chain back to the root attempt so
+        that assets skipped by an intermediate failed-only retry (which emit no
+        events) still carry their earlier success forward.
+        """
+        statuses: dict[str, str] = {}
+        parent_id: UUID | None = db_run.retry_of
+        with Session(get_engine()) as session:
+            while parent_id:
+                for row in self._store.list_asset_executions(parent_id):
+                    # Closest ancestor wins: only record a key the first time we see it.
+                    statuses.setdefault(row["asset_key"], row["status"])
+                parent = session.get(Run, parent_id)
+                parent_id = parent.retry_of if parent else None
+
+        success_keys = {key for key, status in statuses.items() if status == "success"}
+        for asset in assets:
+            if type(asset).key in success_keys:
+                asset.materializable = False
 
     def _resolve_upstream_deps(self, db_job: Job, assets: list[il.Asset]) -> None:
         """Add transitive upstream deps to *assets* as non-materializable."""

--- a/packages/interloper-scheduler/tests/test_executor_retry.py
+++ b/packages/interloper-scheduler/tests/test_executor_retry.py
@@ -1,0 +1,132 @@
+"""Unit tests for ``RunExecutor`` retry skip logic.
+
+These avoid a live database by faking the store's asset-execution lookups and
+the lineage-walk session, so they stay pure unit tests.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+
+from interloper_scheduler import executor as executor_module
+from interloper_scheduler.executor import RunExecutor
+
+
+class _FakeStore:
+    """Returns canned asset_executions per run_id."""
+
+    def __init__(self, executions: dict[UUID, list[dict[str, str]]]) -> None:
+        self._executions = executions
+
+    def list_asset_executions(self, run_id: UUID) -> list[dict[str, str]]:
+        return self._executions.get(run_id, [])
+
+
+class _FakeSession:
+    """Context-manager session whose ``get`` resolves runs by id."""
+
+    def __init__(self, runs: dict[UUID, Any]) -> None:
+        self._runs = runs
+
+    def __enter__(self) -> _FakeSession:
+        return self
+
+    def __exit__(self, *exc: object) -> bool:
+        return False
+
+    def get(self, _model: Any, run_id: UUID) -> Any:
+        return self._runs.get(run_id)
+
+
+def _patch_session(monkeypatch: pytest.MonkeyPatch, runs: dict[UUID, Any]) -> None:
+    monkeypatch.setattr(executor_module, "get_engine", lambda: None)
+    monkeypatch.setattr(executor_module, "Session", lambda _engine: _FakeSession(runs))
+
+
+class _AssetA:
+    key = "a"
+
+    def __init__(self) -> None:
+        self.materializable = True
+
+
+class _AssetB:
+    key = "b"
+
+    def __init__(self) -> None:
+        self.materializable = True
+
+
+def test_succeeded_assets_are_marked_non_materializable(monkeypatch: pytest.MonkeyPatch) -> None:
+    parent_id = uuid4()
+    store = _FakeStore(
+        {parent_id: [{"asset_key": "a", "status": "success"}, {"asset_key": "b", "status": "failed"}]}
+    )
+    _patch_session(monkeypatch, {parent_id: SimpleNamespace(retry_of=None)})
+
+    executor = RunExecutor(store=store)  # type: ignore[arg-type]
+    db_run = SimpleNamespace(retry_of=parent_id, retry_scope="failed")
+    assets = [_AssetA(), _AssetB()]
+
+    executor._skip_succeeded_assets(db_run, assets)  # type: ignore[arg-type]
+
+    by_key = {type(a).key: a for a in assets}
+    assert by_key["a"].materializable is False  # succeeded → skipped
+    assert by_key["b"].materializable is True  # failed → re-runs
+
+
+def test_success_carries_forward_across_the_lineage_chain(monkeypatch: pytest.MonkeyPatch) -> None:
+    # attempt1: a succeeded, b failed.  attempt2 (failed-only) re-ran only b,
+    # which failed again — so attempt2 has no event for the skipped 'a'.
+    # Retrying attempt2 must still skip 'a' by walking back to attempt1.
+    root_id = uuid4()
+    mid_id = uuid4()
+    store = _FakeStore(
+        {
+            mid_id: [{"asset_key": "b", "status": "failed"}],
+            root_id: [{"asset_key": "a", "status": "success"}, {"asset_key": "b", "status": "failed"}],
+        }
+    )
+    _patch_session(
+        monkeypatch,
+        {mid_id: SimpleNamespace(retry_of=root_id), root_id: SimpleNamespace(retry_of=None)},
+    )
+
+    executor = RunExecutor(store=store)  # type: ignore[arg-type]
+    db_run = SimpleNamespace(retry_of=mid_id, retry_scope="failed")
+    assets = [_AssetA(), _AssetB()]
+
+    executor._skip_succeeded_assets(db_run, assets)  # type: ignore[arg-type]
+
+    by_key = {type(a).key: a for a in assets}
+    assert by_key["a"].materializable is False
+    assert by_key["b"].materializable is True
+
+
+def test_closest_ancestor_status_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    # If an asset failed in the root but succeeded in a later attempt, the
+    # most-recent (closest) success should win and the asset should be skipped.
+    root_id = uuid4()
+    mid_id = uuid4()
+    store = _FakeStore(
+        {
+            mid_id: [{"asset_key": "a", "status": "success"}],
+            root_id: [{"asset_key": "a", "status": "failed"}],
+        }
+    )
+    _patch_session(
+        monkeypatch,
+        {mid_id: SimpleNamespace(retry_of=root_id), root_id: SimpleNamespace(retry_of=None)},
+    )
+
+    executor = RunExecutor(store=store)  # type: ignore[arg-type]
+    db_run = SimpleNamespace(retry_of=mid_id, retry_scope="failed")
+    assets = [_AssetA()]
+
+    executor._skip_succeeded_assets(db_run, assets)  # type: ignore[arg-type]
+
+    assert assets[0].materializable is False


### PR DESCRIPTION
## Summary

Adds **manual retry of failed runs**, triggered from the run detail page. Each retry is a **new `Run` row** linked to its predecessor via `retry_of` (with an incremented `attempt` and a `retry_scope`), so per-attempt event history stays clean and the new `queued` run flows through the existing queue/launcher/reaper pipeline unchanged.

Two scopes are offered:
- **Failed assets only** — re-run only the previously failed/cancelled assets; already-succeeded assets are read from their destination.
- **All assets** — re-run the whole job DAG.

## Changes

- **db** — `Run` gains `retry_of` / `attempt` / `retry_scope` (migration `006_run_retry.py`). `Store.retry_run(run_id, scope)` clones a failed run into a fresh `queued` run; rejects non-failed runs. Created with `backfill_id=None` so backfill accounting (`_advance_backfill`) is unaffected.
- **scheduler** — for `scope="failed"`, `RunExecutor._skip_succeeded_assets` marks already-succeeded assets `materializable=False` (reusing the existing upstream-dependency mechanism), walking the `retry_of` lineage chain so successes carry forward across chained failed-only retries.
- **api** — `POST /runs/{run_id}/retry` (`require_editor`, `409` if the run isn't failed, `404` if missing). `RunResponse` now exposes `retry_of` / `attempt` / `retry_scope`.
- **app** — a Retry dropdown on the run detail page (shown only for failed runs) offering "Retry failed assets only" and "Retry all assets", then navigates to the newly queued run.

## Deliberately out of scope (follow-ups)

- **Backfill retries** — retry runs sit outside the backfill (`backfill_id=None`); wiring them into backfill accounting is deferred.
- **Automatic retry** — backoff / max-attempts / transient-error classification. Note the launch-failure path in `queue.py` sets `status="failed"` directly, bypassing `complete_run` — that should be centralized before adding auto-retry.

## Testing

- `make check-python` — ruff, pyright, pytest (287 passed) incl. new `test_runs.py` (API retry endpoint) and `test_executor_retry.py` (failed-only skip + lineage walk).
- Frontend `pnpm run lint` (no new warnings) and `nuxt typecheck` (no errors).