### PR TITLE
fix: paginate run events so outcome events are reachable

### DIFF
--- a/packages/interloper-api/src/interloper_api/routes/runs.py
+++ b/packages/interloper-api/src/interloper_api/routes/runs.py
@@ -16,6 +16,11 @@ from interloper_api.dependencies import get_org_id, get_store, require_editor, r
 
 router = APIRouter()
 
+#: Hard cap on the number of events returned in a single page, regardless of
+#: the requested ``limit``. Keeps a pathological ``?limit=1000000`` from loading
+#: an entire run's history into memory at once.
+MAX_EVENTS_PAGE_SIZE = 1000
+
 
 class RunResponse(BaseModel):
     """Response body for a run."""
@@ -211,10 +216,23 @@ def retry_run(
 @router.get("/{run_id}/events")
 def list_run_events(
     run_id: UUID,
+    response: Response,
     limit: int = 100,
+    offset: int = 0,
     user: Profile = Depends(require_viewer),
     store: Store = Depends(get_store),
 ) -> list[EventResponse]:
-    """List events for a run."""
-    events = store.list_events(run_id=run_id, limit=limit)
+    """List events for a run, oldest first.
+
+    Events are ordered ``timestamp ASC`` and paged with ``limit``/``offset``.
+    The total number of events for the run (ignoring ``limit``/``offset``) is
+    returned in the ``X-Total-Count`` response header so clients can page
+    through every event — including the terminal/outcome events
+    (``asset_completed``, ``asset_failed``, ``run_failed``, …) that sort last.
+    """
+    limit = max(1, min(limit, MAX_EVENTS_PAGE_SIZE))
+    offset = max(0, offset)
+    total = store.count_events(run_id=run_id)
+    response.headers["X-Total-Count"] = str(total)
+    events = store.list_events(run_id=run_id, limit=limit, offset=offset)
     return [_event_to_response(e) for e in events]

--- a/packages/interloper-api/tests/test_run_events.py
+++ b/packages/interloper-api/tests/test_run_events.py
@@ -1,0 +1,104 @@
+"""Tests for the ``GET /{run_id}/events`` pagination contract.
+
+A lightweight fake store stands in for persistence so these stay pure unit
+tests. The properties under test:
+
+- ``limit``/``offset`` are forwarded to the store,
+- ``limit`` is clamped to ``[1, MAX_EVENTS_PAGE_SIZE]`` and ``offset`` to ``>= 0``,
+- the total event count is surfaced in the ``X-Total-Count`` header so the
+  client can page through every event (including terminal/outcome events).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from interloper_api.dependencies import get_store, require_viewer
+from interloper_api.routes import runs as runs_module
+from interloper_api.routes.runs import MAX_EVENTS_PAGE_SIZE
+
+_RUN_ID = UUID("99c018d6-98fe-4de5-a867-1f1a9a545a38")
+_ORG_ID = uuid4()
+
+
+class FakeStore:
+    """Records the pagination args it was called with and returns fakes."""
+
+    def __init__(self, total: int = 777) -> None:
+        self.total = total
+        self.list_calls: list[tuple] = []
+
+    def count_events(self, *, run_id: UUID | None = None, org_id: UUID | None = None) -> int:
+        return self.total
+
+    def list_events(
+        self,
+        *,
+        run_id: UUID | None = None,
+        org_id: UUID | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list:
+        self.list_calls.append((run_id, limit, offset))
+        # Return as many fake events as the page would hold, capped at the total.
+        n = max(0, min(limit, self.total - offset))
+        return [
+            runs_module.Event(
+                id=uuid4(),
+                org_id=_ORG_ID,
+                run_id=run_id,
+                event_type="asset_completed",
+                timestamp=datetime.now(timezone.utc),
+            )
+            for _ in range(n)
+        ]
+
+
+def _client(store: FakeStore) -> TestClient:
+    app = FastAPI()
+    app.include_router(runs_module.router)
+    app.dependency_overrides[get_store] = lambda: store
+    app.dependency_overrides[require_viewer] = lambda: None
+    return TestClient(app)
+
+
+@pytest.fixture
+def store() -> FakeStore:
+    return FakeStore()
+
+
+def test_returns_total_count_header(store: FakeStore) -> None:
+    resp = _client(store).get(f"/{_RUN_ID}/events")
+    assert resp.status_code == 200
+    assert resp.headers["X-Total-Count"] == "777"
+
+
+def test_forwards_limit_and_offset(store: FakeStore) -> None:
+    resp = _client(store).get(f"/{_RUN_ID}/events?limit=100&offset=200")
+    assert resp.status_code == 200
+    assert store.list_calls[-1] == (_RUN_ID, 100, 200)
+
+
+def test_limit_is_clamped_to_max_page_size(store: FakeStore) -> None:
+    _client(store).get(f"/{_RUN_ID}/events?limit=1000000")
+    assert store.list_calls[-1][1] == MAX_EVENTS_PAGE_SIZE
+
+
+def test_limit_and_offset_are_clamped_to_lower_bounds(store: FakeStore) -> None:
+    _client(store).get(f"/{_RUN_ID}/events?limit=0&offset=-5")
+    _, limit, offset = store.list_calls[-1]
+    assert limit == 1
+    assert offset == 0
+
+
+def test_tail_page_reaches_terminal_events(store: FakeStore) -> None:
+    # Paging to the final offset returns the outcome events that sort last.
+    resp = _client(store).get(f"/{_RUN_ID}/events?limit=100&offset=700")
+    body = resp.json()
+    assert len(body) == 77
+    assert all(e["event_type"] == "asset_completed" for e in body)

--- a/packages/interloper-app/app/app/components/executions/EventsTable.vue
+++ b/packages/interloper-app/app/app/components/executions/EventsTable.vue
@@ -11,11 +11,35 @@ const UButton = resolveComponent('UButton')
 const props = defineProps<{
     events: RunEvent[]
     loading?: boolean
+    loadingMore?: boolean
+    hasMore?: boolean
+}>()
+
+const emit = defineEmits<{
+    loadMore: []
 }>()
 
 const selectedAsset = defineModel<string | null>('selectedAsset', { default: null })
 const eventInFocus = defineModel<RunEvent | null>('eventInFocus', { default: null })
 const assetDisplayName = useAssetDisplayName()
+
+// UTable exposes its `<table>` element; its parent is the scrolling container
+// the sticky header sticks to. We attach infinite scroll to that element so
+// reaching the bottom pulls the next page (including the terminal events).
+const table = useTemplateRef('table')
+const scrollEl = computed<HTMLElement | null>(() => {
+    const el = unref(table.value?.tableRef) as HTMLTableElement | null | undefined
+    return el?.parentElement ?? null
+})
+
+useInfiniteScroll(
+    scrollEl,
+    () => emit('loadMore'),
+    {
+        distance: 200,
+        canLoadMore: () => !!props.hasMore && !props.loading && !props.loadingMore,
+    },
+)
 
 const overlay = useOverlay()
 
@@ -105,11 +129,21 @@ const columns: TableColumn<RunEvent>[] = [
 </script>
 
 <template>
-    <UTable :data="filteredEvents"
+    <UTable ref="table"
+            :data="filteredEvents"
             :columns="columns"
             :loading="loading"
             sticky
             :ui="{ tr: 'h-10' }"
             class="h-full"
-            :on-hover="onRowHover" />
+            :on-hover="onRowHover">
+        <template #body-bottom>
+            <div v-if="loadingMore"
+                 class="flex items-center justify-center gap-2 py-3 text-xs text-muted">
+                <UIcon name="i-lucide-loader-circle"
+                       class="size-4 animate-spin" />
+                Loading more events…
+            </div>
+        </template>
+    </UTable>
 </template>

--- a/packages/interloper-app/app/app/pages/executions/runs/[run].vue
+++ b/packages/interloper-app/app/app/pages/executions/runs/[run].vue
@@ -130,11 +130,26 @@ onUnmounted(() => {
             </SplitterResizeHandle>
 
             <SplitterPanel :default-size="60"
-                           :min-size="20">
-                <ExecutionsEventsTable v-model:selected-asset="selectedAsset"
-                                       v-model:event-in-focus="eventInFocus"
-                                       :events="eventsStore.events"
-                                       :loading="eventsStore.loading" />
+                           :min-size="20"
+                           class="flex flex-col min-h-0">
+                <div class="flex items-center gap-2 px-4 py-2 shrink-0">
+                    <span class="text-xs font-medium uppercase tracking-wide text-muted">Events</span>
+                    <UBadge v-if="!eventsStore.loading"
+                            color="neutral"
+                            variant="subtle"
+                            size="sm">
+                        {{ eventsStore.hasMore ? `${eventsStore.events.length} / ${eventsStore.total}` : eventsStore.events.length }}
+                    </UBadge>
+                </div>
+                <div class="flex-1 min-h-0">
+                    <ExecutionsEventsTable v-model:selected-asset="selectedAsset"
+                                           v-model:event-in-focus="eventInFocus"
+                                           :events="eventsStore.events"
+                                           :loading="eventsStore.loading"
+                                           :loading-more="eventsStore.loadingMore"
+                                           :has-more="eventsStore.hasMore"
+                                           @load-more="eventsStore.loadMore()" />
+                </div>
             </SplitterPanel>
         </SplitterGroup>
     </div>

--- a/packages/interloper-app/app/app/stores/events.ts
+++ b/packages/interloper-app/app/app/stores/events.ts
@@ -14,8 +14,11 @@ export interface RunEvent {
     timestamp: string
 }
 
+/** How many events to request per page while infinite-scrolling a run. */
+const EVENTS_PAGE_SIZE = 100
+
 export const useEventsStore = defineStore('events', () => {
-    const { apiFetch } = useApi()
+    const { apiFetchRaw } = useApi()
     const orgStore = useOrganisationStore()
 
     /**********************
@@ -23,12 +26,28 @@ export const useEventsStore = defineStore('events', () => {
      **********************/
     const runId = ref<string | null>(null)
     const events = ref<RunEvent[]>([])
-    const loading = ref(false)
+    const total = ref(0)
+    const loading = ref(false) // initial page load
+    const loadingMore = ref(false) // subsequent pages (infinite scroll)
     const error = ref<Error | null>(null)
+
+    // Offset of the next page to request. Tracks rows pulled from the server
+    // only — realtime tail-inserts append to `events` but never advance this.
+    let nextOffset = 0
+
+    /**********************
+     * Getters
+     **********************/
+    /** Whether more events remain on the server beyond what's been fetched. */
+    const hasMore = computed(() => nextOffset < total.value)
 
     /**********************
      * Internals
      **********************/
+    function _sort() {
+        events.value.sort((a, b) => a.timestamp.localeCompare(b.timestamp) || a.id.localeCompare(b.id))
+    }
+
     function _upsert(event: RunEvent) {
         const idx = events.value.findIndex(e => e.id === event.id)
         if (idx >= 0) {
@@ -36,8 +55,35 @@ export const useEventsStore = defineStore('events', () => {
         }
         else {
             events.value.push(event)
-            events.value.sort((a, b) => a.timestamp.localeCompare(b.timestamp))
+            _sort()
+            total.value++
         }
+    }
+
+    /** Append a freshly fetched page, skipping rows already present (e.g. via realtime). */
+    function _mergePage(rows: RunEvent[]) {
+        const seen = new Set(events.value.map(e => e.id))
+        const fresh = rows.filter(r => !seen.has(r.id))
+        if (!fresh.length) return
+        events.value.push(...fresh)
+        _sort()
+    }
+
+    /** Fetch the page at `nextOffset` and merge it in. Caller owns loading flags. */
+    async function _loadPage() {
+        const id = runId.value
+        if (!id) return
+        const params = new URLSearchParams({
+            limit: String(EVENTS_PAGE_SIZE),
+            offset: String(nextOffset),
+        })
+        const res = await apiFetchRaw<RunEvent[]>(`/runs/${id}/events?${params}`)
+        const page = res._data ?? []
+        total.value = Number(res.headers.get('X-Total-Count') ?? nextOffset + page.length)
+        // A short/empty page means the server has nothing more; pin the offset
+        // to the total so `hasMore` settles false and we never loop forever.
+        nextOffset = page.length < EVENTS_PAGE_SIZE ? total.value : nextOffset + page.length
+        _mergePage(page)
     }
 
     /**********************
@@ -53,18 +99,44 @@ export const useEventsStore = defineStore('events', () => {
     /**********************
      * Actions
      **********************/
+    /**
+     * Load the first page of events for a run.
+     *
+     * Events are ordered oldest-first, so the terminal/outcome events
+     * (`asset_completed`, `asset_failed`, `run_failed`, …) live at the end.
+     * The table reaches them by infinite-scrolling — see `loadMore` — rather
+     * than loading the whole history up front.
+     */
     async function fetchForRun(id: string) {
         runId.value = id
-        loading.value = true
+        events.value = []
+        total.value = 0
+        nextOffset = 0
         error.value = null
+        loading.value = true
         try {
-            events.value = await apiFetch<RunEvent[]>(`/runs/${id}/events`)
+            await _loadPage()
         }
         catch (e) {
             error.value = e as Error
         }
         finally {
             loading.value = false
+        }
+    }
+
+    /** Load the next page of events. Safe to call repeatedly (infinite scroll). */
+    async function loadMore() {
+        if (loading.value || loadingMore.value || !hasMore.value) return
+        loadingMore.value = true
+        try {
+            await _loadPage()
+        }
+        catch (e) {
+            error.value = e as Error
+        }
+        finally {
+            loadingMore.value = false
         }
     }
 
@@ -82,16 +154,23 @@ export const useEventsStore = defineStore('events', () => {
     function $reset() {
         runId.value = null
         events.value = []
+        total.value = 0
+        nextOffset = 0
         loading.value = false
+        loadingMore.value = false
         error.value = null
     }
 
     return {
         runId,
         events,
+        total,
         loading,
+        loadingMore,
+        hasMore,
         error,
         fetchForRun,
+        loadMore,
         findById,
         byAssetKey,
         _upsert,

--- a/packages/interloper-db/src/interloper_db/store/runs.py
+++ b/packages/interloper-db/src/interloper_db/store/runs.py
@@ -58,13 +58,19 @@ class RunMixin:
         run_id: UUID | None = None,
         org_id: UUID | None = None,
         limit: int = 100,
+        offset: int = 0,
     ) -> list[Event]:
         """List events, optionally filtered by run.
+
+        Ordering is ``timestamp ASC, id ASC`` — stable and deterministic so
+        ``offset``/``limit`` paging never skips or repeats a row when several
+        events share a timestamp.
 
         Args:
             run_id: Optional run filter.
             org_id: Optional org filter.
             limit: Max results (default 100).
+            offset: Pagination offset.
 
         Returns:
             List of Event rows.
@@ -75,8 +81,33 @@ class RunMixin:
                 statement = statement.where(Event.run_id == run_id)
             if org_id:
                 statement = statement.where(Event.org_id == org_id)
-            statement = statement.order_by(col(Event.timestamp).asc()).limit(limit)
+            statement = (
+                statement.order_by(col(Event.timestamp).asc(), col(Event.id).asc()).offset(offset).limit(limit)
+            )
             return list(session.exec(statement).all())
+
+    def count_events(
+        self,
+        *,
+        run_id: UUID | None = None,
+        org_id: UUID | None = None,
+    ) -> int:
+        """Count events matching the same filters as :meth:`list_events`.
+
+        Args:
+            run_id: Optional run filter.
+            org_id: Optional org filter.
+
+        Returns:
+            Total number of matching events (ignoring limit/offset).
+        """
+        with Session(get_engine()) as session:
+            statement = select(func.count()).select_from(Event)
+            if run_id:
+                statement = statement.where(Event.run_id == run_id)
+            if org_id:
+                statement = statement.where(Event.org_id == org_id)
+            return session.exec(statement).one()
 
     def list_asset_executions(self, run_id: UUID) -> list[dict]:
         """List asset executions for a run from the ``asset_executions`` view.

--- a/packages/interloper-db/tests/test_run_events.py
+++ b/packages/interloper-db/tests/test_run_events.py
@@ -1,0 +1,131 @@
+"""Tests for event pagination in ``RunMixin`` (``list_events`` / ``count_events``).
+
+These run against an in-memory SQLite database so the offset/limit/ordering
+behaviour is exercised end-to-end against real SQL, not a stubbed query.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import datetime, timedelta, timezone
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy.pool import StaticPool
+from sqlmodel import Session
+
+from interloper_db import engine as engine_module
+from interloper_db.models import Event
+from interloper_db.store.runs import RunMixin
+
+_RUN_ID = UUID("99c018d6-98fe-4de5-a867-1f1a9a545a38")
+_OTHER_RUN_ID = uuid4()
+_ORG_ID = uuid4()
+_BASE_TS = datetime(2026, 6, 4, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def store() -> Iterator[RunMixin]:
+    """A RunMixin wired to a fresh in-memory SQLite database."""
+    eng = engine_module.init_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    # Only the events table is exercised here; creating the full schema would
+    # pull in Postgres-only column types (e.g. ARRAY) that SQLite can't render.
+    Event.__table__.create(eng)  # type: ignore[attr-defined]
+    try:
+        yield RunMixin()
+    finally:
+        eng.dispose()
+        engine_module._engine = None
+
+
+def _seed(events: list[Event]) -> None:
+    with Session(engine_module.get_engine()) as session:
+        session.add_all(events)
+        session.commit()
+
+
+def _make_events(n: int, *, run_id: UUID = _RUN_ID, start: int = 0) -> list[Event]:
+    """Build ``n`` events for a run, one second apart, oldest first."""
+    return [
+        Event(
+            id=uuid4(),
+            org_id=_ORG_ID,
+            run_id=run_id,
+            event_type="asset_materializing" if i < n - 1 else "asset_completed",
+            timestamp=_BASE_TS + timedelta(seconds=start + i),
+        )
+        for i in range(n)
+    ]
+
+
+def test_list_events_defaults_to_oldest_first(store: RunMixin) -> None:
+    _seed(_make_events(3))
+    events = store.list_events(run_id=_RUN_ID)
+    timestamps = [e.timestamp for e in events]
+    assert timestamps == sorted(timestamps)
+
+
+def test_offset_and_limit_page_without_gaps_or_repeats(store: RunMixin) -> None:
+    _seed(_make_events(250))
+
+    page1 = store.list_events(run_id=_RUN_ID, limit=100, offset=0)
+    page2 = store.list_events(run_id=_RUN_ID, limit=100, offset=100)
+    page3 = store.list_events(run_id=_RUN_ID, limit=100, offset=200)
+
+    assert [len(page1), len(page2), len(page3)] == [100, 100, 50]
+
+    ids = [e.id for p in (page1, page2, page3) for e in p]
+    assert len(ids) == 250
+    assert len(set(ids)) == 250  # no row repeated across pages
+
+
+def test_terminal_event_is_reachable_via_offset(store: RunMixin) -> None:
+    # The outcome event sorts last; the default first page hides it, but
+    # paging to the tail must surface it.
+    _seed(_make_events(150))
+
+    first_page = store.list_events(run_id=_RUN_ID, limit=100, offset=0)
+    assert all(e.event_type != "asset_completed" for e in first_page)
+
+    last_page = store.list_events(run_id=_RUN_ID, limit=100, offset=100)
+    assert last_page[-1].event_type == "asset_completed"
+
+
+def test_ordering_is_stable_for_equal_timestamps(store: RunMixin) -> None:
+    # All events share a timestamp; paging must still be deterministic
+    # (tie-broken by id) so no row is skipped or repeated.
+    shared = [
+        Event(
+            id=uuid4(),
+            org_id=_ORG_ID,
+            run_id=_RUN_ID,
+            event_type="asset_materializing",
+            timestamp=_BASE_TS,
+        )
+        for _ in range(20)
+    ]
+    _seed(shared)
+
+    page1 = store.list_events(run_id=_RUN_ID, limit=10, offset=0)
+    page2 = store.list_events(run_id=_RUN_ID, limit=10, offset=10)
+    ids = [e.id for e in page1 + page2]
+    assert len(set(ids)) == 20
+
+
+def test_count_events_ignores_limit_and_offset(store: RunMixin) -> None:
+    _seed(_make_events(777))
+    assert store.count_events(run_id=_RUN_ID) == 777
+    # A capped page does not change the reported total.
+    assert len(store.list_events(run_id=_RUN_ID, limit=100)) == 100
+
+
+def test_filters_isolate_runs(store: RunMixin) -> None:
+    _seed(_make_events(5, run_id=_RUN_ID))
+    _seed(_make_events(3, run_id=_OTHER_RUN_ID))
+    assert store.count_events(run_id=_RUN_ID) == 5
+    assert store.count_events(run_id=_OTHER_RUN_ID) == 3
+    assert len(store.list_events(run_id=_RUN_ID)) == 5


### PR DESCRIPTION
## The bug

The run executions page (`/executions/runs/<run_id>`) calls `GET /{run_id}/events`, which defaulted to `limit=100`, ordered `timestamp ASC`, and had **no offset/cursor**. Runs commonly have many hundreds of events (one prod run, `99c018d6-98fe-4de5-a867-1f1a9a545a38`, has 777). So the table only ever showed the **earliest 100** events and silently hid the rest — including every outcome event (`asset_failed`, `asset_completed`, `dest_write_*`, `run_failed`), all of which sort to the end. Users read this as "events missing from the table".

## The fix

**Store** (`interloper-db`, `store/runs.py`)
- `list_events`: added an `offset` parameter and changed ordering to `timestamp ASC, id ASC` so paging is stable and deterministic even when several events share a timestamp.
- Added `count_events(...)` returning the total for the same filters (mirrors `count_runs`).

**API** (`interloper-api`, `routes/runs.py`)
- `GET /{run_id}/events` now accepts bounded `limit`/`offset` (clamped to `[1, MAX_EVENTS_PAGE_SIZE=1000]`, offset `>= 0`) and returns the total in the `X-Total-Count` header — the same pagination contract already used by `GET /runs`.

**Frontend** (`interloper-app`, `stores/events.ts`, `components/executions/EventsTable.vue`, `pages/executions/runs/[run].vue`) — **infinite scroll**
- The events store loads the first page on open and exposes `loadMore()` / `hasMore` / `loadingMore`. `EventsTable` attaches VueUse `useInfiniteScroll` to the `UTable` scroll container; reaching the bottom pulls the next page (100 at a time) until the whole history is loaded, so the terminal events are reachable by scrolling down.
- Pages are merged with id-dedup, so realtime inserts (live runs) never duplicate a row, and the offset only advances for server-fetched rows.
- A "Loading more events…" row shows while a page is in flight; the panel header shows `loaded / total` while more remain.

## Default view / reachability decision

The default ordering stays **oldest-first**, consistent with the execution timeline and the realtime ordering. Outcome events become reachable by **scrolling to the bottom** (infinite scroll), not by reordering.

Note: the execution **timeline** is driven by `asset_executions` and the currently-hovered event — it does **not** consume the events list — so lazy-loading the table has no effect on it.

## Tests

- `interloper-db/tests/test_run_events.py` (SQLite-backed): oldest-first default, gap/repeat-free paging across 250 events, terminal event reachable via offset, stable ordering for equal timestamps, `count_events` ignoring limit/offset, per-run isolation.
- `interloper-api/tests/test_run_events.py`: `X-Total-Count` header, `limit`/`offset` forwarding, clamping to the max page size and lower bounds, tail page reaching the outcome events.

## Validation

`uv run ruff check`, `uv run pyright`, `uv run pytest` (db + api, 39 passed) all green; frontend `pnpm run lint` (0 errors) and `nuxt typecheck` (exit 0).

## Scope

Events pagination / loading only — the separate event-ingest hardening effort is untouched.