### PR TITLE
fix: create missing runs/events indexes and bound migration lock waits

### DIFF
--- a/packages/interloper-db/src/interloper_db/migrations/env.py
+++ b/packages/interloper-db/src/interloper_db/migrations/env.py
@@ -22,6 +22,16 @@ def run_migrations_online() -> None:
     connectable = get_engine()
 
     with connectable.connect() as connection:
+        # Bound how long any migration will WAIT for a lock. Without this, a DDL
+        # statement (e.g. ALTER TABLE) that can't immediately acquire its lock on
+        # a busy table blocks indefinitely — and while it waits at the head of
+        # the lock queue it also blocks every new query on that table, taking the
+        # API down (504s) and wedging the db-init job forever. Failing fast turns
+        # that silent deadlock into a loud, retryable migration error.
+        #
+        # This caps lock *acquisition* only, not statement runtime, so long
+        # `CREATE INDEX CONCURRENTLY` builds (see migration 007) are unaffected.
+        connection.exec_driver_sql("SET lock_timeout = '10s'")
         context.configure(
             connection=connection,
             target_metadata=target_metadata,

--- a/packages/interloper-db/src/interloper_db/migrations/versions/007_runs_events_indexes.py
+++ b/packages/interloper-db/src/interloper_db/migrations/versions/007_runs_events_indexes.py
@@ -1,0 +1,57 @@
+"""Ensure the declared composite indexes exist on ``runs`` and ``events``.
+
+These indexes are declared on the SQLModel models (``__table_args__``) but were
+only ever materialised by ``SQLModel.metadata.create_all()`` when the tables
+were first created. ``create_all`` never ALTERs an existing table, so any
+database whose ``runs``/``events`` tables predate these declarations is missing
+them. The practical fallout:
+
+- ``GET /runs`` filters on ``org_id`` and sorts by ``created_at DESC`` and also
+  runs a ``count(*)`` — without ``ix_runs_org_id_created_at`` every request is a
+  full sequential scan + sort of the whole table, which times out (504) as the
+  table grows.
+- The run-events endpoint pages on ``(run_id, timestamp)`` and relies on
+  ``ix_events_run_id_timestamp``.
+
+Create them here so the fix reaches existing production tables. ``CONCURRENTLY``
+keeps reads and writes flowing during the build, and ``IF NOT EXISTS`` makes the
+migration a no-op on databases that already have them (e.g. freshly provisioned
+ones where ``create_all`` did create them).
+
+Revision ID: 007
+Revises: 006
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "007"
+down_revision: str | None = "006"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+# (index name, table, column list) — kept in sync with the models' __table_args__.
+_INDEXES: list[tuple[str, str, str]] = [
+    ("ix_runs_org_id_created_at", "runs", "(org_id, created_at)"),
+    ("ix_runs_backfill_id_status", "runs", "(backfill_id, status)"),
+    ("ix_events_run_id_timestamp", "events", "(run_id, timestamp)"),
+    ("ix_events_asset_lookup", "events", "(run_id, asset_key, event_type, timestamp)"),
+]
+
+
+def upgrade() -> None:
+    """Create the declared indexes if they're missing, without locking the tables."""
+    # CREATE INDEX CONCURRENTLY cannot run inside a transaction block, so step
+    # outside Alembic's surrounding transaction for these statements.
+    with op.get_context().autocommit_block():
+        for name, table, cols in _INDEXES:
+            op.execute(f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {name} ON {table} {cols}")
+
+
+def downgrade() -> None:
+    """Drop the indexes created by this migration."""
+    with op.get_context().autocommit_block():
+        for name, _table, _cols in _INDEXES:
+            op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {name}")


### PR DESCRIPTION
## Incident

`GET /runs` started returning **504 Gateway Timeout** in prod, and the `interloper-…-db-init` job pod hung indefinitely instead of completing.

## Root cause (two coupled bugs)

**1. Missing indexes on existing prod tables.** The composite indexes are declared only on the SQLModel models' `__table_args__`:

- `ix_runs_org_id_created_at` `(org_id, created_at)`
- `ix_runs_backfill_id_status` `(backfill_id, status)`
- `ix_events_run_id_timestamp` `(run_id, timestamp)`
- `ix_events_asset_lookup` `(run_id, asset_key, event_type, timestamp)`

They were never added by a migration (only `ix_runs_retry_of` was, in 006). `SQLModel.metadata.create_all()` materialises indexes **only as part of `CREATE TABLE`** — it never `ALTER`s an existing table. So any DB whose `runs`/`events` tables predate these declarations is missing them. Without `ix_runs_org_id_created_at`, `GET /runs` (filter on `org_id` + `ORDER BY created_at DESC` + a `count(*)`) is a **full seq-scan + sort of the whole table** → times out as the table grows.

**2. Migrations had no `lock_timeout`.** `env.py` ran every migration with no lock bound. A DDL statement that can't immediately acquire its lock on a busy table (e.g. an `ALTER TABLE runs …`) **waits forever**, and while it waits at the head of the lock queue it **blocks every new query** on that table. That's the mechanism behind both symptoms: the db-init migration wedges, and every `GET /runs` queued behind it 504s. The unindexed (therefore slow, long-lock-holding) `runs` table makes the collision far more likely.

## Fix

- **Migration 007** creates the four declared indexes with `CREATE INDEX CONCURRENTLY IF NOT EXISTS` — reaches existing prod tables **without locking** reads/writes, and is a no-op where they already exist (freshly-provisioned DBs). Runs inside an `autocommit_block` since `CONCURRENTLY` can't run in a transaction.
- **`env.py`** sets `lock_timeout = '10s'` for migrations, so a blocked DDL fails **loudly and retryably** instead of deadlocking the deploy and the table. It bounds lock *acquisition* only, not statement runtime, so the long `CONCURRENTLY` builds in 007 are unaffected.

## Validation

- Alembic revision graph verified: single linear head `007 → 006 → … → 001`.
- `ruff` / `pyright` / `pytest` (interloper-db, 19 passed) green.

## ⚠️ Production remediation (do this first — this PR only prevents recurrence)

The currently-hung db-init pod and the 504s need a manual unblock **now**; merging/deploying this PR can't run until the wedged migration clears. See the runbook in the incident thread:
1. Identify & terminate the lock blocker so the in-flight migration completes.
2. `CREATE INDEX CONCURRENTLY` the missing indexes manually (immediate `GET /runs` relief — migration 007 then no-ops).
3. Deploy this PR so the indexes + `lock_timeout` are codified and this can't recur.