### PR TITLE
fix: stop infinite-scroll flicker at the end of the events list

### DIFF
--- a/packages/interloper-app/app/app/components/executions/EventsTable.vue
+++ b/packages/interloper-app/app/app/components/executions/EventsTable.vue
@@ -13,10 +13,8 @@ const props = defineProps<{
     loading?: boolean
     loadingMore?: boolean
     hasMore?: boolean
-}>()
-
-const emit = defineEmits<{
-    loadMore: []
+    /** Loads the next page; returns the in-flight promise so infinite scroll awaits it. */
+    loadMore?: () => Promise<void>
 }>()
 
 const selectedAsset = defineModel<string | null>('selectedAsset', { default: null })
@@ -34,7 +32,7 @@ const scrollEl = computed<HTMLElement | null>(() => {
 
 useInfiniteScroll(
     scrollEl,
-    () => emit('loadMore'),
+    () => props.loadMore?.(),
     {
         distance: 200,
         canLoadMore: () => !!props.hasMore && !props.loading && !props.loadingMore,

--- a/packages/interloper-app/app/app/pages/executions/runs/[run].vue
+++ b/packages/interloper-app/app/app/pages/executions/runs/[run].vue
@@ -148,7 +148,7 @@ onUnmounted(() => {
                                            :loading="eventsStore.loading"
                                            :loading-more="eventsStore.loadingMore"
                                            :has-more="eventsStore.hasMore"
-                                           @load-more="eventsStore.loadMore()" />
+                                           :load-more="eventsStore.loadMore" />
                 </div>
             </SplitterPanel>
         </SplitterGroup>

--- a/packages/interloper-app/app/app/stores/events.ts
+++ b/packages/interloper-app/app/app/stores/events.ts
@@ -33,13 +33,17 @@ export const useEventsStore = defineStore('events', () => {
 
     // Offset of the next page to request. Tracks rows pulled from the server
     // only — realtime tail-inserts append to `events` but never advance this.
-    let nextOffset = 0
+    // Must be a ref: `hasMore` reads it inside a computed, so a plain variable
+    // would leave `hasMore` stale once `total` stops changing (the last page
+    // sets `total` to its existing value, firing no recompute) — which makes
+    // infinite scroll re-fire loadMore forever at the end of the list.
+    const nextOffset = ref(0)
 
     /**********************
      * Getters
      **********************/
     /** Whether more events remain on the server beyond what's been fetched. */
-    const hasMore = computed(() => nextOffset < total.value)
+    const hasMore = computed(() => nextOffset.value < total.value)
 
     /**********************
      * Internals
@@ -75,14 +79,14 @@ export const useEventsStore = defineStore('events', () => {
         if (!id) return
         const params = new URLSearchParams({
             limit: String(EVENTS_PAGE_SIZE),
-            offset: String(nextOffset),
+            offset: String(nextOffset.value),
         })
         const res = await apiFetchRaw<RunEvent[]>(`/runs/${id}/events?${params}`)
         const page = res._data ?? []
-        total.value = Number(res.headers.get('X-Total-Count') ?? nextOffset + page.length)
+        total.value = Number(res.headers.get('X-Total-Count') ?? nextOffset.value + page.length)
         // A short/empty page means the server has nothing more; pin the offset
         // to the total so `hasMore` settles false and we never loop forever.
-        nextOffset = page.length < EVENTS_PAGE_SIZE ? total.value : nextOffset + page.length
+        nextOffset.value = page.length < EVENTS_PAGE_SIZE ? total.value : nextOffset.value + page.length
         _mergePage(page)
     }
 
@@ -111,7 +115,7 @@ export const useEventsStore = defineStore('events', () => {
         runId.value = id
         events.value = []
         total.value = 0
-        nextOffset = 0
+        nextOffset.value = 0
         error.value = null
         loading.value = true
         try {
@@ -155,7 +159,7 @@ export const useEventsStore = defineStore('events', () => {
         runId.value = null
         events.value = []
         total.value = 0
-        nextOffset = 0
+        nextOffset.value = 0
         loading.value = false
         loadingMore.value = false
         error.value = null


### PR DESCRIPTION
## Bug

On the run executions page, the events table's infinite scroll **flickers and keeps re-fetching forever** once the table reaches the end — either because the loaded events only partially fill the panel, or because every event is already loaded.

This also explains a second reported symptom: **clicking an asset in the timeline stopped filtering the events table.** Same root cause — see below.

Follow-up to #19 (events pagination), which introduced the infinite scroll.

## Root cause

In `stores/events.ts`:

```js
let nextOffset = 0                                   // ❌ plain, non-reactive variable
const hasMore = computed(() => nextOffset < total.value)
```

`hasMore` reads `nextOffset` inside a `computed`, but `nextOffset` was a plain variable, so Vue couldn't track it — the computed only re-evaluated when `total.value` changed. On the **final** page the API returns `X-Total-Count` equal to the value `total` already held, so setting `total.value` fires no reactive update, while `nextOffset` advances to it. `hasMore` therefore stayed stuck at its cached `true`, and `useInfiniteScroll` re-fired `loadMore` on every tick — each call fetching an empty tail page.

That runaway loop produces **both** symptoms:
- **Flicker / endless fetching** — the visible one.
- **Asset click stops filtering** — each `loadMore` toggles `loadingMore`, which `[run].vue` binds as a prop, so the whole run page re-renders ~10×/second. That patch storm next to the ECharts timeline disrupts its canvas click handling, so clicking an asset appeared to do nothing. (The filter itself was never broken — the old fetch-all version had no `loadingMore` loop, which is why it only regressed with infinite scroll.)

## Fix

- Make `nextOffset` a `ref(0)` so `hasMore` recomputes when it advances → `hasMore` correctly settles `false` at the end and the loop stops.
- Pass `loadMore` as a function prop that returns the in-flight promise (instead of a fire-and-forget `@load-more` event), so `useInfiniteScroll` awaits the actual fetch before re-checking rather than re-polling on its internal 100 ms timer.

## Validation

`nuxt typecheck` (exit 0) and `pnpm run lint` (0 errors). Single commit off `main`.

Please verify on a real run that (a) the flicker is gone at the end of the list and (b) clicking a timeline asset filters the table again.