### PR TITLE
fix: attribute LOG events to their asset so they filter and label correctly

### DIFF
--- a/packages/interloper-core/src/interloper/asset/base.py
+++ b/packages/interloper-core/src/interloper/asset/base.py
@@ -296,6 +296,8 @@ class Asset(Component):
             partition_or_window=partition_or_window,
             partitioning=self.partitioning,
             metadata=metadata,
+            asset_id=self.id,
+            source_id=self._source.id if self._source is not None else None,
         )
 
         kwargs = await self._build_kwargs(context, partition_or_window, dag)

--- a/packages/interloper-core/src/interloper/asset/context.py
+++ b/packages/interloper-core/src/interloper/asset/context.py
@@ -23,6 +23,8 @@ class ExecutionContext:
         partitioning: PartitionConfig | None = None,
         partition_or_window: Partition | PartitionWindow | None = None,
         metadata: dict[str, Any] | None = None,
+        asset_id: str | None = None,
+        source_id: str | None = None,
     ) -> None:
         """Initialize the execution context.
 
@@ -31,11 +33,15 @@ class ExecutionContext:
             partitioning: The partitioning configuration for the asset.
             partition_or_window: The partition or partition window for the asset.
             metadata: Arbitrary metadata dict (e.g. run_id, backfill_id).
+            asset_id: Id of the current asset, propagated onto ``LOG`` events.
+            source_id: Id of the source the asset belongs to, if any.
         """
         self._asset_key = asset_key
         self._partitioning = partitioning
         self._partition_or_window = partition_or_window
         self._metadata = metadata or {}
+        self._asset_id = asset_id
+        self._source_id = source_id
         self._logger: EventLogger | None = None
 
     @property
@@ -52,7 +58,12 @@ class ExecutionContext:
     def logger(self) -> EventLogger:
         """Logger that emits messages as events on the event bus."""
         if self._logger is None:
-            self._logger = EventLogger(self._asset_key, self._metadata)
+            self._logger = EventLogger(
+                self._asset_key,
+                self._metadata,
+                asset_id=self._asset_id,
+                source_id=self._source_id,
+            )
         return self._logger
 
     @property

--- a/packages/interloper-core/src/interloper/events/logger.py
+++ b/packages/interloper-core/src/interloper/events/logger.py
@@ -22,24 +22,41 @@ class EventLogger:
         context.logger.warning("Rate limited, retrying...")
     """
 
-    def __init__(self, asset_key: str, metadata: dict[str, Any]) -> None:
+    def __init__(
+        self,
+        asset_key: str,
+        metadata: dict[str, Any],
+        asset_id: str | None = None,
+        source_id: str | None = None,
+    ) -> None:
         """Initialize the logger.
 
         Args:
             asset_key: Qualified key of the asset that owns this logger.
             metadata: Run metadata included in every emitted ``LOG`` event.
+            asset_id: Id of the asset that owns this logger. Carried on every
+                emitted ``LOG`` event so it can be attributed to the asset
+                (e.g. filtered alongside its lifecycle events).
+            source_id: Id of the source the asset belongs to, if any.
         """
         self._asset_key = asset_key
         self._metadata = metadata
+        self._asset_id = asset_id
+        self._source_id = source_id
 
     def _emit(self, level: int, message: str) -> None:
         """Emit a ``LOG`` event with the given level and message."""
-        EventBus.emit(EventType.LOG, metadata={
+        metadata: dict[str, Any] = {
             **self._metadata,
             "asset_key": self._asset_key,
             "message": message,
             "level": logging.getLevelName(level),
-        })
+        }
+        if self._asset_id is not None:
+            metadata["asset_id"] = self._asset_id
+        if self._source_id is not None:
+            metadata["source_id"] = self._source_id
+        EventBus.emit(EventType.LOG, metadata=metadata)
 
     def debug(self, message: str) -> None:
         """Emit a debug-level log event."""

--- a/packages/interloper-core/tests/events/test_logger.py
+++ b/packages/interloper-core/tests/events/test_logger.py
@@ -1,0 +1,53 @@
+"""Tests for :class:`EventLogger` event attribution."""
+
+from __future__ import annotations
+
+from interloper.events import Event, EventBus, EventType
+from interloper.events.logger import EventLogger
+
+
+def _capture(emit: object) -> list[Event]:  # type: ignore[no-untyped-def]
+    captured: list[Event] = []
+
+    def handler(event: Event) -> None:
+        captured.append(event)
+
+    EventBus.subscribe(handler)
+    try:
+        emit()  # type: ignore[operator]
+        EventBus.flush(timeout=5.0)
+    finally:
+        EventBus.unsubscribe(handler)
+    return [e for e in captured if e.type == EventType.LOG]
+
+
+def test_log_event_carries_asset_and_source_id() -> None:
+    """``LOG`` events inherit the asset/source identity so they can be filtered by asset."""
+    logger = EventLogger(
+        "demo.a",
+        {"run_id": "run-1"},
+        asset_id="asset-1",
+        source_id="source-1",
+    )
+
+    events = _capture(lambda: logger.info("hello"))
+
+    assert len(events) == 1
+    meta = events[0].metadata
+    assert meta["asset_id"] == "asset-1"
+    assert meta["source_id"] == "source-1"
+    assert meta["asset_key"] == "demo.a"
+    assert meta["message"] == "hello"
+    assert meta["run_id"] == "run-1"
+
+
+def test_log_event_omits_ids_when_unset() -> None:
+    """Without an asset/source id, no null keys leak into the metadata."""
+    logger = EventLogger("demo.a", {"run_id": "run-1"})
+
+    events = _capture(lambda: logger.warning("careful"))
+
+    assert len(events) == 1
+    meta = events[0].metadata
+    assert "asset_id" not in meta
+    assert "source_id" not in meta


### PR DESCRIPTION
## Problem

For `log` events, the events table showed the raw event **key** instead of **Source name → Asset Name**, and those log events were **filtered out** when filtering events for a specific asset.

## Root cause

`LOG` events carried only `asset_key` (a bare string) and never `asset_id`/`source_id` — unlike every other asset event (lifecycle events in `runner/state.py` and exec events in `asset/base.py`, both of which set `asset_id`). The `EventLogger` was constructed with just the asset key plus run-level metadata.

Downstream consequences in the UI (`EventsTable.vue`):
- The display lookup `assetDisplayName.get(event.asset_id)` misses, so it falls back to showing `event.asset_key` instead of "Source → Asset".
- The filter `e.asset_id === selectedAsset` excludes log events entirely, since their `asset_id` is `NULL`.

The frontend logic was correct — the event data was simply incomplete.

## Fix

Thread `asset_id`/`source_id` from the asset, through `ExecutionContext`, into `EventLogger`, so every emitted `LOG` event carries the same identity its sibling events already do. The ids are only added to metadata when set, so ad-hoc loggers don't leak `null` keys.

## Tests

- New `packages/interloper-core/tests/events/test_logger.py` covering both the populated and unset cases.
- Full `interloper-core` suite green (212 passed); `ruff` + `pyright` clean.

## Note

This fixes attribution for **new** log events. Rows already persisted with `asset_id = NULL` stay unattributed — they'd need a backfill, but since these are observability records I left them as-is.
