### PR TITLE
feat: skip destination writes when an asset produces no data

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,7 @@ Override extras at `make` time: `CORE_EXTRAS`, `ASSETS_EXTRAS`, `SCHEDULER_EXTRA
 - Branch names use the same type prefix with a slash: `feat/xxx`, `fix/xxx`, `chore/xxx`, …
 - PR titles follow Conventional Commits (`feat: …`, `fix: …`); every commit that lands on `main` feeds `python-semantic-release`.
 - Python ≥3.10, ruff line length 120, pyright `basic` mode.
+- Test files mirror the package layout one-to-one: a test for `src/interloper/<pkg>/<module>.py` lives in `tests/<pkg>/test_<module>.py`. Don't add standalone `test_<feature>.py` files — fold tests for an existing module into that module's test file (e.g. tests for `asset/base.py` go in `tests/asset/test_base.py`, not a new `test_<feature>.py`).
 - Pre-commit runs ruff + pyright + pytest on every commit ([.pre-commit-config.yaml](.pre-commit-config.yaml)).
 - All workspace packages share `version = "0.2.0"`, bumped by `python-semantic-release` from commit history.
 

--- a/packages/interloper-core/src/interloper/asset/base.py
+++ b/packages/interloper-core/src/interloper/asset/base.py
@@ -20,6 +20,7 @@ from interloper.normalizer import MaterializationStrategy, Normalizer
 from interloper.partitioning import Partition, PartitionConfig, PartitionWindow
 from interloper.resource import Resource
 from interloper.schema import Schema
+from interloper.utils.data import is_empty
 from interloper.utils.imports import get_object_path
 from interloper.utils.text import to_label
 
@@ -489,6 +490,20 @@ class Asset(Component):
         """Write the execution result to all configured destinations."""
         dests = self._resolve_destinations()
         if not dests:
+            return
+
+        if is_empty(result):
+            EventBus.emit(
+                EventType.LOG,
+                metadata={
+                    **self._event_metadata(metadata, partition_or_window),
+                    "level": "WARNING",
+                    "message": (
+                        f"Asset '{type(self).key}' produced no data; "
+                        f"skipping write to {len(dests)} destination(s)"
+                    ),
+                },
+            )
             return
 
         dest_context = IOContext(

--- a/packages/interloper-core/src/interloper/utils/__init__.py
+++ b/packages/interloper-core/src/interloper/utils/__init__.py
@@ -1,6 +1,15 @@
-"""Shared utility helpers for imports and text processing."""
+"""Shared utility helpers for data, imports, and text processing."""
 
+from interloper.utils.data import is_empty
 from interloper.utils.imports import get_object_path, import_from_path
 from interloper.utils.text import to_label, to_slug_case, to_snake_case, validate_key
 
-__all__ = ["get_object_path", "import_from_path", "to_label", "to_slug_case", "to_snake_case", "validate_key"]
+__all__ = [
+    "get_object_path",
+    "import_from_path",
+    "is_empty",
+    "to_label",
+    "to_slug_case",
+    "to_snake_case",
+    "validate_key",
+]

--- a/packages/interloper-core/src/interloper/utils/data.py
+++ b/packages/interloper-core/src/interloper/utils/data.py
@@ -1,0 +1,27 @@
+"""Data utility helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def is_empty(data: Any) -> bool:
+    """Return whether a value carries no data.
+
+    Kept deliberately conservative: only values we can *positively* confirm
+    are empty count as empty, so callers never skip work on a value they don't
+    understand. ``None`` is empty; objects exposing a boolean ``empty`` (pandas
+    / polars DataFrames and Series — whose own ``bool()`` raises) defer to it;
+    sized containers (lists, dicts, ...) are empty when their length is zero.
+    Anything else (e.g. a lazy generator we must not consume) is treated as
+    non-empty.
+    """
+    if data is None:
+        return True
+    empty = getattr(data, "empty", None)
+    if isinstance(empty, bool):
+        return empty
+    try:
+        return len(data) == 0
+    except TypeError:
+        return False

--- a/packages/interloper-core/tests/asset/test_base.py
+++ b/packages/interloper-core/tests/asset/test_base.py
@@ -4,6 +4,7 @@
 # reads parameter annotations via ``inspect.signature`` and needs them as real
 # classes (not lazily-evaluated strings).
 
+import asyncio
 from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Any
@@ -14,6 +15,7 @@ import interloper as il
 from interloper.asset.base import AssetDefinition
 from interloper.component.base import Component, ComponentSpec
 from interloper.errors import AssetError, DestinationError, PartitionError
+from interloper.events import Event, EventBus, EventType
 from interloper.partitioning.base import Partition, PartitionConfig, PartitionWindow
 
 # ---------------------------------------------------------------------------
@@ -482,3 +484,63 @@ class TestSerialization:
         assert restored.dataset == "ds"
         assert isinstance(restored.destination, list)
         assert isinstance(restored.resources["config"], FakeResource)
+
+
+# ---------------------------------------------------------------------------
+# Destination write — empty-result handling
+# ---------------------------------------------------------------------------
+
+
+def _capture_log_events(run: Any) -> list[Event]:
+    captured: list[Event] = []
+
+    def handler(event: Event) -> None:
+        captured.append(event)
+
+    EventBus.subscribe(handler)
+    try:
+        run()
+        EventBus.flush(timeout=5.0)
+    finally:
+        EventBus.unsubscribe(handler)
+    return [e for e in captured if e.type == EventType.LOG]
+
+
+class TestDestinationWrite:
+    def test_empty_result_skips_write_and_warns(self):
+        il.MemoryDestination.clear()
+        mem = il.MemoryDestination()
+
+        @il.asset()
+        def empty() -> list[dict[str, Any]]:
+            return []
+
+        asset = empty(id="empty", destination=mem)
+        logs = _capture_log_events(lambda: asyncio.run(asset.materialize()))
+
+        # Nothing was written.
+        assert mem._storage == {}
+
+        warnings = [
+            e
+            for e in logs
+            if e.metadata.get("level") == "WARNING" and "produced no data" in (e.metadata.get("message") or "")
+        ]
+        assert len(warnings) == 1
+        # The warning is attributed to the asset so it filters/labels in the UI.
+        assert warnings[0].metadata.get("asset_id") == asset.id
+
+    def test_non_empty_result_is_written(self):
+        il.MemoryDestination.clear()
+        mem = il.MemoryDestination()
+
+        @il.asset()
+        def full() -> list[dict[str, Any]]:
+            return [{"a": 1}]
+
+        asset = full(id="full", destination=mem)
+        logs = _capture_log_events(lambda: asyncio.run(asset.materialize()))
+
+        # Data was written and no "no data" warning was emitted.
+        assert mem._storage
+        assert not [e for e in logs if "produced no data" in (e.metadata.get("message") or "")]

--- a/packages/interloper-core/tests/utils/test_data.py
+++ b/packages/interloper-core/tests/utils/test_data.py
@@ -1,0 +1,48 @@
+"""Tests for ``interloper.utils.data``."""
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from interloper.utils.data import is_empty
+
+
+class _FrameLike:
+    """Stand-in for a pandas/polars frame: boolean ``.empty``, ambiguous ``bool()``."""
+
+    def __init__(self, empty: bool) -> None:
+        self.empty = empty
+
+    def __bool__(self) -> bool:  # pragma: no cover - must never be called by is_empty
+        raise ValueError("The truth value of a frame is ambiguous")
+
+
+class TestIsEmpty:
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            (None, True),
+            ([], True),
+            ({}, True),
+            ("", True),
+            ([{"a": 1}], False),
+            ({"a": 1}, False),
+            ("x", False),
+            (0, False),  # not None, no len → can't confirm empty, treat as non-empty
+        ],
+    )
+    def test_confirms_only_known_empties(self, value: Any, expected: bool):
+        assert is_empty(value) is expected
+
+    def test_defers_to_frame_empty_flag(self):
+        assert is_empty(_FrameLike(empty=True)) is True
+        assert is_empty(_FrameLike(empty=False)) is False
+
+    def test_does_not_consume_generator(self):
+        def gen() -> Iterator[int]:
+            yield 1
+
+        g = gen()
+        assert is_empty(g) is False
+        assert next(g) == 1  # generator left intact


### PR DESCRIPTION
## What

When an asset produces **no data**, skip writing to its destinations and emit a `WARNING` log event explaining why, instead of silently no-opping or materialising an empty artifact (e.g. an empty CSV/pickle).

## Where — "is there a smart way to do this at the base class level?"

Yes, but **not** in the `Destination` base class. The smart single choke point is `Asset._destination_write` — every destination write for a materialization funnels through there.

A `Destination`-base template-method (rename abstract `write` → `_write`, wrap with an emptiness check) was rejected: it's a **breaking change** to the documented extension point, would emit **N warnings** (one per destination), and "the *asset* produced no data" is an asset-level fact. The asset-level guard is non-breaking, fires once, and reuses the existing `EventBus` + `_event_metadata` idiom — so the warning shows in the events table attributed to the asset (`asset_id`/`source_id`), alongside its sibling `dest_write_*` events.

## How

- `Asset._destination_write`: after resolving destinations, if the result is empty, emit a `LOG` event at `WARNING` level and return before writing.
- `interloper.utils.data.is_empty(data)`: conservative emptiness detection — `None`, frame-like objects with a boolean `.empty` (pandas/polars, whose `bool()` raises `ValueError`), and zero-length sized containers count as empty. Anything we can't positively confirm (e.g. a lazy generator we must not consume) is treated as non-empty and written as before — no behavior change for those.

## Notes

- `DatabaseDestination.write` already early-returned on empty rows; this generalizes that to all destinations and makes it observable rather than silent.
- Skips the write entirely on empty, matching the project's existing "empty = no-op" semantics.
- Documents a test-layout convention in `AGENTS.md`: test files mirror the package layout one-to-one (no standalone `test_<feature>.py`).

## Tests

Following the layout convention, tests live next to the code they exercise:
- `tests/utils/test_data.py` — `is_empty` unit table (None / `[]` / `{}` / `""` / frame-like `.empty` / non-empty / generator-not-consumed).
- `tests/asset/test_base.py` (`TestDestinationWrite`) — empty result → no write + single attributed `WARNING`; non-empty result → written, no warning.

Full `interloper-core` suite green (224 passed); `ruff` + `pyright` clean.
