### PR TITLE
fix: timeline asset clicks not filtering events while a run is live

### DIFF
--- a/packages/interloper-app/app/app/components/chart/ExecutionTimeline.vue
+++ b/packages/interloper-app/app/app/components/chart/ExecutionTimeline.vue
@@ -357,12 +357,16 @@ function resize() {
 /**********************
  * Handlers
  **********************/
-function onAssetClick(params: any) {
+// Selection listens on mousedown, not click: while the run is live, `tick()`
+// rebuilds the series every `refreshRate` ms, so the element under the cursor
+// at mousedown no longer exists at mouseup and zrender suppresses the
+// synthetic click entirely. Mousedown carries no such down/up identity check.
+function onAssetMouseDown(params: any) {
     selectedAsset.value = params.data.id
 }
 
-function onBlankSpaceClick() {
-    selectedAsset.value = null
+function onBlankSpaceMouseDown(e: { target?: unknown }) {
+    if (!e.target) selectedAsset.value = null
 }
 
 /**********************
@@ -373,7 +377,7 @@ onMounted(() => {
     if (isRunning.value) {
         runInterval.value = setInterval(tick, props.refreshRate)
     }
-    chart.value?.chart?.getZr().on('click', onBlankSpaceClick)
+    chart.value?.chart?.getZr().on('mousedown', onBlankSpaceMouseDown)
 })
 
 onUnmounted(() => {
@@ -412,6 +416,6 @@ defineExpose({ tick, stop, resize })
          :style="{ height: chartHeight + 'px' }">
         <VChart ref="chart"
                 :manual-update="true"
-                @click="onAssetClick" />
+                @mousedown="onAssetMouseDown" />
     </div>
 </template>


### PR DESCRIPTION
## What

On the run detail page, clicking an asset in the execution timeline did nothing while the run was still `running` — the events table only filtered once the run finished.

## Why

While a run is live, the timeline's `tick()` loop redraws the chart every `refreshRate` (10 ms) with `setOption(..., { replaceMerge: ['series'] })`, recreating every bar element on each tick. zrender only synthesizes a `click` when the element under the cursor at mousedown is the *same object* at mouseup — a human click always spans a rebuild, so the click was discarded entirely and neither the asset handler nor the blank-space handler ever ran.

## How

Selection now listens on `mousedown`, which fires against whatever element is currently under the cursor with no down/up identity check:

- chart binding `@click="onAssetClick"` → `@mousedown="onAssetMouseDown"` (same `params.data.id` payload)
- blank-space clear moved from a zr `click` listener to a zr `mousedown` listener guarded by `if (!e.target)`, so it only clears on genuine empty-space presses (the old version fired on every click and relied on echarts' internal `zrEventfulCallAtLast` listener ordering to let the asset click win)

Only user-visible difference: selection happens on press instead of release; the chart has no drag interactions so this is imperceptible.

## Verification

Verified end-to-end on the dev instance (`make dev-up`, demo source run driven via headless Chrome with human-paced down→hold→up clicks):

- mid-run click on the running asset's bar → events table filtered to that asset only
- mid-run blank-space click → filter cleared; re-click → re-filtered
- finished-run click → still filters (previously-working path intact)
- control: identical mid-run click on the pre-fix component → no filtering (reproduces the bug)