### PR TITLE
fix: decorators build through the metaclass; Normalizer becomes a Component

### DIFF
--- a/packages/interloper-assets/tests/test_amazon_ads.py
+++ b/packages/interloper-assets/tests/test_amazon_ads.py
@@ -1,0 +1,88 @@
+"""Regression tests for the AmazonAds source configuration.
+
+Prod incident (run d0aebe6d, 2026-06-10): the source-level
+``DataFrameNormalizer`` never reached asset instances, so raw camelCase
+report rows hit schema validation and every report asset failed with
+"Field required" errors. Two distinct defects were involved:
+
+1. ``@il.source(normalizer=...)`` field args were silently dropped on
+   class-based sources (``build_component_class`` setattr on a built
+   pydantic class).
+2. The host→child DAG-spec round-trip dumped the normalizer as a bare
+   dict, degrading ``DataFrameNormalizer`` to the base ``Normalizer``.
+
+These tests pin the whole chain: live instance → spec JSON → reconstructed
+child asset → normalize+validate a camelCase report row.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+from interloper.dag.base import DAG
+from interloper.dag.spec import DAGSpec
+from interloper_pandas import DataFrameNormalizer
+
+from interloper_assets.amazon_ads import constants, schemas
+from interloper_assets.amazon_ads.source import AmazonAds
+
+
+def _source() -> Any:
+    return AmazonAds(id="src-1", profile_id="123")  # ty: ignore[unknown-argument]
+
+
+class TestSourceNormalizer:
+    """The decorator-configured normalizer must reach every asset instance."""
+
+    def test_source_instance_has_dataframe_normalizer(self):
+        src = _source()
+        assert isinstance(src.normalizer, DataFrameNormalizer)
+        assert src.normalizer.snake_case_digits is True
+        assert src.normalizer.flatten_max_level == 1
+
+    def test_all_assets_inherit_the_normalizer(self):
+        src = _source()
+        for asset in src.assets:
+            assert isinstance(asset.normalizer, DataFrameNormalizer), type(asset).key
+
+
+class TestSpecRoundtrip:
+    """The host→child spec round-trip must preserve the normalizer subclass."""
+
+    def test_child_asset_keeps_dataframe_normalizer(self):
+        src = _source()
+        asset = next(a for a in src.assets if type(a).key == "products_campaigns")
+
+        # Exactly what the k8s runner ships to the child pod.
+        spec_json = DAG(src).mini_dag(asset.id).to_spec().model_dump(mode="json")
+        child_dag = DAGSpec(**spec_json).reconstruct()
+        child_asset = next(a for a in child_dag.assets if type(a).key == "products_campaigns")
+
+        normalizer = child_asset.normalizer
+        assert isinstance(normalizer, DataFrameNormalizer)
+        assert normalizer.snake_case_digits is True
+        assert normalizer.flatten_max_level == 1
+        assert normalizer.column_overrides == {
+            "eCPAddToCart": "ecp_add_to_cart",
+            "eCPBrandSearch": "ecp_brand_search",
+        }
+
+    def test_camelcase_report_row_conforms_after_roundtrip(self):
+        """A raw API-shaped row must normalize and validate against the schema."""
+        src = _source()
+        asset = next(a for a in src.assets if type(a).key == "products_campaigns")
+        spec_json = DAG(src).mini_dag(asset.id).to_spec().model_dump(mode="json")
+        child_dag = DAGSpec(**spec_json).reconstruct()
+        child_asset = next(a for a in child_dag.assets if type(a).key == "products_campaigns")
+
+        # One row with every requested report column, as Amazon returns them.
+        # All schema fields are required-nullable, so None is valid everywhere.
+        row: dict[str, object] = {col: None for col in constants.PRODUCTS_CAMPAIGN_METRICS}
+        row["date"] = "2026-06-10"
+        df = pd.DataFrame([row])
+
+        normalizer = child_asset.normalizer
+        assert normalizer is not None
+        normalized = normalizer.normalize(df)
+        normalizer.validate_schema(normalized, schemas.ProductsCampaigns)  # must not raise

--- a/packages/interloper-core/src/interloper/component/base.py
+++ b/packages/interloper-core/src/interloper/component/base.py
@@ -23,6 +23,27 @@ class ComponentDescriptor:
     """
 
 
+def dump_spec_value(value: Any) -> Any:
+    """Serialize a component field value for a :class:`ComponentSpec` init payload.
+
+    The wire format is uniform: **anything with class identity is a
+    Component** and serializes via its own spec; lists and dicts are walked;
+    everything else must be a JSON-able scalar.
+
+    Returns:
+        A JSON-able value understood by ``ComponentSpec.reconstruct``.
+    """
+    from pydantic_core import to_jsonable_python
+
+    if isinstance(value, Component):
+        return value.to_spec().model_dump(mode="json")
+    if isinstance(value, (list, tuple)):
+        return [dump_spec_value(v) for v in value]
+    if isinstance(value, dict):
+        return {k: dump_spec_value(v) for k, v in value.items()}
+    return to_jsonable_python(value)
+
+
 class ComponentDefinition(BaseModel):
     """Read-only view of a Component class's metadata.
 
@@ -226,17 +247,6 @@ class Component(BaseModel):
         Returns:
             A ComponentSpec capturing this instance's state.
         """
-        from pydantic_core import to_jsonable_python
-
-        def dump(value: Any) -> Any:
-            if isinstance(value, Component):
-                return value.to_spec().model_dump(mode="json")
-            if isinstance(value, (list, tuple)):
-                return [dump(v) for v in value]
-            if isinstance(value, dict):
-                return {k: dump(v) for k, v in value.items()}
-            return to_jsonable_python(value)
-
         init: dict[str, Any] = {}
         for name in type(self).model_fields:
             if name == "id":
@@ -244,7 +254,7 @@ class Component(BaseModel):
             value = getattr(self, name)
             if value is None:
                 continue
-            init[name] = dump(value)
+            init[name] = dump_spec_value(value)
 
         return ComponentSpec(path=self.path(), id=self.id, init=init or None)
 

--- a/packages/interloper-core/src/interloper/component/build.py
+++ b/packages/interloper-core/src/interloper/component/build.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any, ClassVar, TypeVar, cast
 
+from pydantic import create_model
+
 from interloper.component.base import Component
 
 C = TypeVar("C", bound=Component)
@@ -18,39 +20,60 @@ def build_component_class(
 ) -> type[C]:
     """Build a Component subclass from a decorated class.
 
-    When the decorated class already extends the target base (or a subclass
-    of it), the decorator only needs to stamp ClassVars onto the existing
-    class — no rebuild required.  This preserves Pydantic field descriptors,
-    JSON Schema metadata, validators, and everything else the metaclass set
-    up during original class creation.
+    The invariant: **decorators build classes, they never mutate finalized
+    ones.**  Field defaults always pass through the Pydantic metaclass so
+    they become real field definitions — a plain ``setattr`` on a built
+    pydantic class would leave ``model_fields`` (and therefore every
+    instance) on the old default.
 
-    When the decorated class does **not** extend the base, a new class is
-    created via ``type()`` that inherits from *base* and carries over the
-    decorated class's members and annotations.
+    Two construction paths:
+
+    - The decorated class already extends *base*: field defaults (when
+      present) produce a new subclass via :func:`pydantic.create_model`
+      with the parent's annotations; ClassVars are stamped on the result
+      (plain class attributes — no pydantic machinery involved).
+    - The decorated class does **not** extend *base*: a new class is
+      created via ``type()`` that inherits from *base* and carries over the
+      decorated class's members and annotations, with decorator fields
+      annotated from the base's field definitions.
 
     Args:
         cls: The decorated class to transform.
         base: The Component subclass to inherit from.
         classvars: Class-level attributes (key, name, tags, …).
-        fields: Instance-level field defaults (dataset, normalizer, …).
+        fields: Field default overrides (dataset, normalizer, …); every key
+            must be an existing field on *base*.
 
     Returns:
         A Component subclass.
+
+    Raises:
+        TypeError: If a decorator field is not a field of *base*.
     """
-    already_subclass = any(
-        isinstance(b, type) and issubclass(b, base) for b in cls.__bases__
-    )
+    for field_name in fields or {}:
+        if field_name not in base.model_fields:
+            raise TypeError(f"Decorator field '{field_name}' is not a field of {base.__name__}.")
+
+    already_subclass = any(isinstance(b, type) and issubclass(b, base) for b in cls.__bases__)
 
     if already_subclass:
-        # The class is already properly constructed by Pydantic's metaclass.
-        # Just stamp the decorator-provided classvars and fields.
+        result_cls = cast(type[C], cls)
+        if fields:
+            field_definitions: dict[str, Any] = {
+                name: (result_cls.model_fields[name].annotation, value) for name, value in fields.items()
+            }
+            result_cls = create_model(
+                cls.__name__,
+                __base__=result_cls,
+                __module__=cls.__module__,
+                **field_definitions,
+            )
+            result_cls.__qualname__ = cls.__qualname__
+            result_cls.__doc__ = cls.__doc__
         if classvars:
             for name, value in classvars.items():
-                setattr(cls, name, value)
-        if fields:
-            for name, value in fields.items():
-                setattr(cls, name, value)
-        return cast(type[C], cls)
+                setattr(result_cls, name, value)
+        return result_cls
 
     # Plain class — build a new class that inherits from base.
     namespace: dict[str, Any] = {}
@@ -72,6 +95,14 @@ def build_component_class(
     if "__annotations__" in cls.__dict__:
         namespace.setdefault("__annotations__", {}).update(cls.__dict__["__annotations__"])
 
+    # Annotate decorator fields from the base's field definitions so the
+    # metaclass registers them as field default overrides.
+    if fields:
+        annotations = namespace.setdefault("__annotations__", {})
+        for field_name in fields:
+            if field_name not in annotations:
+                annotations[field_name] = base.model_fields[field_name].annotation
+
     # Annotate classvars as ClassVar so Pydantic doesn't treat them as
     # model fields.  Without this, a bare `tags = ["Cloud"]` in the
     # namespace triggers a PydanticUserError for non-annotated attributes.
@@ -86,4 +117,4 @@ def build_component_class(
     if cls.__doc__:
         result_cls.__doc__ = cls.__doc__
 
-    return cast(type[C], result_cls)
+    return cast("type[C]", result_cls)

--- a/packages/interloper-core/src/interloper/normalizer/base.py
+++ b/packages/interloper-core/src/interloper/normalizer/base.py
@@ -5,24 +5,27 @@ from __future__ import annotations
 import re
 import types
 from collections.abc import Generator, Iterator
-from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, ClassVar
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
+from interloper.component import Component
 from interloper.errors import NormalizerError
 from interloper.schema import Schema
 from interloper.utils.text import to_snake_case
 
 
-@dataclass
-class Normalizer:
+class Normalizer(Component):
     """Type-native normalizer for ``list[dict]`` asset data.
 
     Accepts arbitrary return types (``dict``, ``list[dict]``, ``BaseModel``,
     ``list[BaseModel]``, ``Generator``), coerces to ``list[dict]``, then
     applies optional transformations (column-name normalization, nested-dict
     flattening, missing-column fill).
+
+    Normalizer is a :class:`Component` so configured instances round-trip
+    through ``ComponentSpec`` with their concrete subclass intact — e.g.
+    across the host → child-pod DAG-spec boundary.
 
     Usage::
 
@@ -52,6 +55,10 @@ class Normalizer:
             rule can handle (``eCPAddToCart`` → ``ecp_add_to_cart``).
     """
 
+    # Shadow Component.id — normalizers are pure configuration, not runtime
+    # instances that need identity. (Same pattern as Schema.)
+    id: ClassVar[str] = ""
+
     normalize_columns_names: bool = True
     flatten_max_level: int | None = 0
     flatten_separator: str = "_"
@@ -59,7 +66,11 @@ class Normalizer:
     infer: bool = True
     drop_na_columns: bool = False
     snake_case_digits: bool = False
-    column_overrides: dict[str, str] = field(default_factory=dict)
+    column_overrides: dict[str, str] = Field(default_factory=dict)
+
+    # Override Component.model_post_init to avoid setting an instance id.
+    def model_post_init(self, context: Any) -> None:
+        """No-op: normalizers don't need instance identity."""
 
     # ------------------------------------------------------------------
     # Public API

--- a/packages/interloper-core/src/interloper/source/base.py
+++ b/packages/interloper-core/src/interloper/source/base.py
@@ -11,7 +11,7 @@ from typing_extensions import Self
 from interloper.asset import Asset
 from interloper.asset.base import AssetDefinition
 from interloper.component import Component, ComponentDefinition
-from interloper.component.base import ComponentDescriptor, ComponentSpec
+from interloper.component.base import ComponentDescriptor, ComponentSpec, dump_spec_value
 from interloper.destination import Destination
 from interloper.normalizer import MaterializationStrategy, Normalizer
 from interloper.resource import Resource
@@ -107,7 +107,7 @@ class Source(Component):
     assets: list[Asset] = Field(default_factory=list)
 
     # Exposed fields
-    dataset: str = InputField(default="")
+    dataset: str = InputField(default="", description="Defaults to the source key when left empty")
     default_destination_key: str = SelectField(
         title="Default Destination",
         default="",
@@ -125,7 +125,6 @@ class Source(Component):
         level and the live instance at instance level.
         """
         super().__init_subclass__(**kwargs)
-        cls._init_defaults()
         cls._collect_asset_types()
         cls._infer_all_requires()
 
@@ -183,17 +182,6 @@ class Source(Component):
         Returns:
             A ``ComponentSpec`` capturing this source and its assets.
         """
-        from pydantic_core import to_jsonable_python
-
-        def dump(value: Any) -> Any:
-            if isinstance(value, Component):
-                return value.to_spec().model_dump(mode="json")
-            if isinstance(value, (list, tuple)):
-                return [dump(v) for v in value]
-            if isinstance(value, dict):
-                return {k: dump(v) for k, v in value.items()}
-            return to_jsonable_python(value)
-
         init: dict[str, Any] = {}
         for name in type(self).model_fields:
             if name == "id":
@@ -213,17 +201,9 @@ class Source(Component):
                 if overrides:
                     init["assets"] = overrides
                 continue
-            init[name] = dump(value)
+            init[name] = dump_spec_value(value)
 
         return ComponentSpec(path=self.path(), id=self.id, init=init or None)
-
-    @classmethod
-    def _init_defaults(cls) -> None:
-        """Initialize default values for the source's fields."""
-        if "dataset" not in cls.__dict__:
-            cls.model_fields["dataset"].default = cls.key
-
-        cls.model_rebuild()
 
     @classmethod
     def _collect_asset_types(cls) -> None:
@@ -347,12 +327,15 @@ class Source(Component):
 
     def _resolve(self) -> None:
         """Apply source-level defaults to assets that don't define their own."""
+        if not self.dataset:
+            self.dataset = self.key
+
         siblings: dict[str, Asset] = {type(a).key: a for a in self.assets}
 
         for asset in self.assets:
             asset._source = self
             if not asset.dataset:
-                asset.dataset = self.dataset or self.key
+                asset.dataset = self.dataset
             if not asset.default_destination_key and self.default_destination_key:
                 asset.default_destination_key = self.default_destination_key
             if asset.destination is None and self.destination is not None:

--- a/packages/interloper-core/src/interloper/source/decorator.py
+++ b/packages/interloper-core/src/interloper/source/decorator.py
@@ -203,24 +203,12 @@ def _build_source_from_class(
 
     Asset subclasses defined in the class body (via ``@asset`` on methods)
     are auto-collected by ``Source.__init_subclass__._collect_asset_types()``.
+    Field annotations are handled by ``build_component_class``.
 
     Returns:
         A dynamically created Source subclass.
     """
-    merged_classvars = dict(classvars)
-
-    annotations: dict[str, Any] = {}
-    for attr in fields:
-        if attr in Source.model_fields:
-            annotations[attr] = Source.model_fields[attr].annotation
-
-    # We need to inject field annotations; build_component_class merges
-    # cls.__dict__["__annotations__"], but we also need the field-type
-    # annotations.  Easiest to add them to classvars as __annotations__.
-    if annotations:
-        merged_classvars.setdefault("__annotations__", {}).update(annotations)
-
-    source_cls = build_component_class(cls, base=Source, classvars=merged_classvars, fields=fields)
+    source_cls = build_component_class(cls, base=Source, classvars=classvars, fields=fields)
 
     # Set _source_type backref on each asset.
     for asset_cls in source_cls.asset_types:

--- a/packages/interloper-core/tests/component/test_build.py
+++ b/packages/interloper-core/tests/component/test_build.py
@@ -1,0 +1,86 @@
+"""Tests for ``interloper.component.build``."""
+
+from typing import Any
+
+import interloper as il
+from interloper.component.base import ComponentSpec, dump_spec_value
+from interloper.normalizer import Normalizer
+from interloper.source.base import Source
+
+
+@il.source(normalizer=Normalizer(snake_case_digits=True), dataset="custom_ds")
+class DecoratedSource(il.Source):
+    """Class-based source with decorator-provided field defaults."""
+
+    @il.asset
+    def my_asset(self) -> list:
+        return []
+
+
+class TestClassBasedDecoratorFields:
+    """Decorator field args must become real pydantic field defaults.
+
+    Regression: ``build_component_class`` used a plain ``setattr`` on
+    already-built pydantic classes, which left ``model_fields`` (and every
+    instance) on the old default — source-level normalizers silently never
+    applied in production.
+    """
+
+    def test_field_defaults_reach_instances(self):
+        src = DecoratedSource(id="s")
+        assert src.normalizer is not None
+        assert src.normalizer.snake_case_digits is True
+        assert src.dataset == "custom_ds"
+
+    def test_assets_inherit_source_normalizer(self):
+        src = DecoratedSource(id="s")
+        assert src.assets[0].normalizer is src.normalizer
+
+    def test_model_fields_default_updated(self):
+        assert DecoratedSource.model_fields["normalizer"].default is not None
+
+    def test_parent_class_default_untouched(self):
+        """The FieldInfo is copied — the base Source default must stay None."""
+        assert Source.model_fields["normalizer"].default is None
+
+    def test_explicit_instance_value_still_wins(self):
+        override = Normalizer(snake_case_digits=False)
+        src = DecoratedSource(id="s", normalizer=override)
+        assert src.normalizer is override
+
+
+class TestDumpSpecValue:
+    """Configured component values must survive the spec round-trip with their class.
+
+    Regression: normalizers (then dataclasses) were dumped as bare dicts, so
+    reconstruction coerced them into the field's base annotation type, losing
+    the concrete subclass (``DataFrameNormalizer`` degraded to ``Normalizer``
+    across the host → child-pod boundary). Normalizer is a Component now, so
+    it serializes as a reconstructible spec like everything else.
+    """
+
+    def test_normalizer_dumps_as_reconstructible_spec(self):
+        n = Normalizer(snake_case_digits=True, column_overrides={"rawName": "raw_name"})
+        dumped = dump_spec_value(n)
+        assert dumped["path"].endswith("Normalizer")
+        assert dumped["init"]["snake_case_digits"] is True
+
+    def test_normalizer_roundtrip_preserves_class_and_config(self):
+        n = Normalizer(snake_case_digits=True, flatten_max_level=2)
+        dumped = dump_spec_value(n)
+        rebuilt: Any = ComponentSpec(path=dumped["path"], init=dumped["init"]).reconstruct()
+        assert type(rebuilt) is Normalizer
+        assert rebuilt.snake_case_digits is True
+        assert rebuilt.flatten_max_level == 2
+
+    def test_scalars_and_containers_unchanged(self):
+        assert dump_spec_value([1, "a", {"k": 2}]) == [1, "a", {"k": 2}]
+
+    def test_component_dumps_as_spec(self):
+        @il.asset
+        def some_asset() -> list:
+            return []
+
+        dumped = dump_spec_value(some_asset(id="a1"))
+        assert dumped["id"] == "a1"
+        assert "path" in dumped

--- a/packages/interloper-core/tests/source/test_base.py
+++ b/packages/interloper-core/tests/source/test_base.py
@@ -80,8 +80,8 @@ class TestIdentity:
         assert FakeSource.kind == "source"
 
     def test_dataset_default_equals_source_key(self):
-        # ``_init_defaults`` sets the default of the ``dataset`` field to ``cls.key``
-        # unless the subclass declares its own.
+        # ``_resolve`` fills an empty ``dataset`` with the source key at
+        # instance init — no class-level field mutation involved.
         assert FakeSource().dataset == FakeSource.key
 
     def test_explicit_dataset_default_is_preserved(self):

--- a/packages/interloper-k8s/src/interloper_k8s/runner.py
+++ b/packages/interloper-k8s/src/interloper_k8s/runner.py
@@ -20,6 +20,7 @@ from interloper.events import EventBus, EventType
 from interloper.events.event import parse_event_from_log_line
 from interloper.partitioning.base import Partition, PartitionWindow
 from interloper.partitioning.time import TimePartition, TimePartitionWindow
+from interloper.runner.results import ExecutionStatus
 from interloper.runner.sync_runner import SyncRunner
 from kubernetes import client, config
 from kubernetes.client import V1Job
@@ -219,21 +220,34 @@ class KubernetesRunner(SyncRunner):
 
         The log thread is joined with a longer timeout first so a child terminal
         that is still in flight wins the race.
+
+        When the run aborts on a failure, the raised error carries the asset's
+        terminal error (the child's rich report when available) rather than the
+        bare Job status — it becomes the run-level error shown in the UI.
+
+        Raises:
+            RunnerError: When the asset failed and fail-fast is enabled.
         """
         job_name = self._job_map.pop(future, None)
         if job_name is not None:
             self._stop_job_log_streaming(job_name, timeout=5.0)
 
         info = self.state.asset_executions.get(asset.id)
-        if not (info and info.is_terminal):
-            try:
-                future.result()
-            except Exception as e:
-                self.state.mark_asset_failed(asset, str(e), emit=True)
-                if self.fail_fast or self.reraise:
-                    raise
-            else:
-                self.state.mark_asset_completed(asset, emit=True)
+        if info and info.is_terminal:
+            # Child streamed its own terminal. If it failed, fail-fast must
+            # still abort the run — with the child's error as the cause.
+            if info.status == ExecutionStatus.FAILED and (self.fail_fast or self.reraise):
+                raise RunnerError(f"Asset '{type(asset).key}' failed: {info.error}")
+            return
+
+        try:
+            future.result()
+        except Exception as e:
+            self.state.mark_asset_failed(asset, str(e), emit=True)
+            if self.fail_fast or self.reraise:
+                raise RunnerError(f"Asset '{type(asset).key}' failed: {e}") from e
+        else:
+            self.state.mark_asset_completed(asset, emit=True)
 
     def _handle_flushed_future(self, future: Future[Any], asset: Asset) -> None:
         """Clean up job after flush, authoring the terminal event.

--- a/packages/interloper-k8s/tests/test_runner_terminal_events.py
+++ b/packages/interloper-k8s/tests/test_runner_terminal_events.py
@@ -81,3 +81,54 @@ def test_host_does_not_reauthor_when_asset_already_terminal() -> None:
         runner._handle_completed(future, asset)
 
     assert not [e for e in events if e.type in (EventType.ASSET_COMPLETED, EventType.ASSET_FAILED)]
+
+
+def test_fail_fast_surfaces_child_error_when_child_reported_terminal() -> None:
+    """The run-level error must carry the child's rich error, not the bare Job status.
+
+    Regression: when the child streamed its own ``asset_failed`` (rich
+    SchemaError etc.), the host returned quietly and the run error ended up
+    being some other job's generic "Job ... failed" string.
+    """
+    runner, asset = _runner_with_asset("asset-4", "run-1")
+    runner.fail_fast = True
+    runner.state.mark_asset_failed(asset, "Schema validation failed on row 0: 41 errors", emit=False)
+    future: Future[None] = Future()
+    future.set_exception(RunnerError("Job interloper-run-x failed"))
+
+    try:
+        runner._handle_completed(future, asset)
+    except RunnerError as e:
+        assert "Schema validation failed on row 0" in str(e)
+        assert "_Asset".lower() in str(e).lower() or "asset" in str(e).lower()
+    else:
+        raise AssertionError("fail_fast must abort the run on a child-reported failure")
+
+
+def test_fail_fast_wraps_job_error_with_asset_key() -> None:
+    """The host fallback error names the asset, not just the Job."""
+    runner, asset = _runner_with_asset("asset-5", "run-1")
+    runner.fail_fast = True
+    future: Future[None] = Future()
+    future.set_exception(RunnerError("Job interloper-run-x failed"))
+
+    try:
+        runner._handle_completed(future, asset)
+    except RunnerError as e:
+        assert "Job interloper-run-x failed" in str(e)
+        assert "failed:" in str(e)
+    else:
+        raise AssertionError("fail_fast must re-raise on job failure")
+
+
+def test_no_fail_fast_keeps_quiet_on_child_reported_failure() -> None:
+    """Without fail-fast, a child-reported terminal needs no host action."""
+    runner, asset = _runner_with_asset("asset-6", "run-1")
+    runner.state.mark_asset_failed(asset, "child error", emit=False)
+    future: Future[None] = Future()
+    future.set_exception(RunnerError("Job interloper-run-x failed"))
+
+    with _capture() as events:
+        runner._handle_completed(future, asset)  # must not raise
+
+    assert not [e for e in events if e.type == EventType.ASSET_FAILED]

--- a/packages/interloper-pandas/src/interloper_pandas/normalizer.py
+++ b/packages/interloper-pandas/src/interloper_pandas/normalizer.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import datetime
-from dataclasses import dataclass
 from decimal import Decimal
 from typing import Any
 
@@ -15,7 +14,6 @@ from interloper.utils.data import dataframe_to_records
 from pydantic import create_model
 
 
-@dataclass
 class DataFrameNormalizer(Normalizer):
     """Type-native normalizer for pandas ``DataFrame`` asset data.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,12 +74,19 @@ unused-type-ignore-comment = "ignore"
 replace-imports-with-any = ["bingads.**", "googleapiclient.**", "google.ads.**"]
 
 [[tool.ty.overrides]]
-# Schema definitions intentionally redeclare the `id`/`name` identity attributes
-# inherited from Component as typed data columns (Component models them as class
-# metadata; a Schema subclass models them as instance fields). The runtime handles
-# this shadow deliberately (see schema/base.py). Scope the override here so the rule
-# still guards genuine incompatible attribute overrides elsewhere.
-include = ["**/schemas/**", "packages/interloper-core/src/interloper/schema/base.py", "**/tests/**"]
+# Schema and Normalizer intentionally shadow the `id` identity attribute
+# inherited from Component as a ClassVar — they are pure structural/config
+# components, not runtime instances that need identity. Schema subclasses
+# additionally redeclare `id`/`name` as typed data columns. The runtime handles
+# this shadow deliberately (see schema/base.py, normalizer/base.py). Scope the
+# override here so the rule still guards genuine incompatible attribute
+# overrides elsewhere.
+include = [
+    "**/schemas/**",
+    "packages/interloper-core/src/interloper/schema/base.py",
+    "packages/interloper-core/src/interloper/normalizer/base.py",
+    "**/tests/**",
+]
 
 [tool.ty.overrides.rules]
 invalid-attribute-override = "ignore"


### PR DESCRIPTION
## What

Root-cause redesign for the prod incident (run `d0aebe6d`, 2026-06-10) where the AmazonAds normalizer never reached asset instances and every report asset failed schema validation on raw camelCase columns. This replaces the earlier surgical hotfix on this branch with two invariants instead of two patches.

### Invariant 1 — decorators *build* classes, they never mutate finalized ones

`build_component_class` previously applied decorator field args (`normalizer`, `dataset`, …) with a plain `setattr` on already-built pydantic classes — which never updates `model_fields`, so every `class X(il.Source)` source silently lost its decorator field config (LinkedIn's normalizers were equally dead in prod). Field defaults now always pass through the pydantic metaclass:

- class-based components → a new subclass via `create_model(__base__=cls)` with the parent's annotations;
- plain classes → namespace annotations derived from the base's field definitions (this also retires the annotation pre-merging hack in `_build_source_from_class`);
- unknown field names fail fast with a `TypeError` instead of silently sticking a dead attribute on the class.

Verified hazards of the wrapper-subclass approach: `asset_types` collection is namespace-scoped and inherits correctly, `key`/`kind` derivation is idempotent for a same-named subclass, `AssetRef` class-level access, docstrings, qualnames, and explicit instance overrides all preserved (covered by tests).

### Invariant 2 — everything serializable is a Component

`Normalizer` was a plain dataclass — the one value crossing the ComponentSpec wire without class identity. `to_spec` dumped it as a bare dict and child-pod reconstruction coerced it through the field annotation, degrading `DataFrameNormalizer` to base `Normalizer`. It now extends `Component` (identity shadowed via ClassVar, the same documented pattern as `Schema`), so configured instances round-trip with their concrete subclass intact:

```json
{"path": "interloper_pandas.normalizer.DataFrameNormalizer", "init": {"snake_case_digits": true, ...}}
```

The spec dump is one shared `dump_spec_value` helper (deduplicating the previously copy-pasted closures in `Component.to_spec` / `Source.to_spec`) that handles exactly **Components, containers, and scalars** — no per-type special cases.

### Invariant 1 follow-through

`Source._init_defaults` — the last remaining class mutation in the codebase — is retired in the same commit: the dataset-defaults-to-key rule now resolves at instance init in `_resolve`, next to the sibling fallbacks. The instance contract (`source.dataset == key`) is unchanged and still covered by the existing test; the `dataset` config field gains a "defaults to the source key when left empty" description since the class-level schema default is gone.

### Also included (unchanged from before)

- k8s runner: run-level errors carry the asset's terminal error (the child's rich SchemaError) instead of the bare `Job … failed` poller string; fail-fast now also aborts when the child streamed its own failure.

## Verification

- Regression test pins the full prod chain: live `AmazonAds` → mini-DAG spec JSON → reconstructed child asset → normalize + validate a camelCase report row (new `interloper-assets` test package).
- Decorator-default tests: instance fields, parent-class isolation, explicit-override precedence, `asset_types` survival through the wrapper.
- 419 passed, ruff + ty clean (the `invalid-attribute-override` ty scope gains `normalizer/base.py`, same rationale as `schema/base.py`).

## Deploy note

After this deploys, AmazonAds (and LinkedIn) write snake_case columns — the existing PascalCase tables still need the planned drop + re-materialization.