### PR TITLE
refactor: one conform seam — Conformer resolved from the data's representation

### DIFF
--- a/packages/interloper-assets/tests/test_amazon_ads.py
+++ b/packages/interloper-assets/tests/test_amazon_ads.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from typing import Any
 
 import pandas as pd
+from interloper.conformer import conformer_for
 from interloper.dag.base import DAG
 from interloper.dag.spec import DAGSpec
 from interloper_pandas import DataFrameNormalizer
@@ -85,4 +86,4 @@ class TestSpecRoundtrip:
         normalizer = child_asset.normalizer
         assert normalizer is not None
         normalized = normalizer.normalize(df)
-        normalizer.validate_schema(normalized, schemas.ProductsCampaigns)  # must not raise
+        conformer_for(normalized).validate(normalized, schemas.ProductsCampaigns)  # must not raise

--- a/packages/interloper-core/src/interloper/asset/base.py
+++ b/packages/interloper-core/src/interloper/asset/base.py
@@ -13,6 +13,7 @@ from typing_extensions import Self
 
 from interloper.asset.context import ExecutionContext
 from interloper.component import Component, ComponentDefinition
+from interloper.conformer import Conformer, conformer_for
 from interloper.destination import Destination, IOContext
 from interloper.errors import AssetError, NormalizerError, PartitionError
 from interloper.events import EventBus, EventType
@@ -20,7 +21,7 @@ from interloper.normalizer import MaterializationStrategy, Normalizer
 from interloper.partitioning import Partition, PartitionConfig, PartitionWindow
 from interloper.resource import Resource
 from interloper.schema import Schema
-from interloper.utils.data import dataframe_to_records, is_dataframe, is_empty
+from interloper.utils.data import is_empty
 from interloper.utils.imports import get_object_path
 from interloper.utils.text import to_label
 
@@ -29,10 +30,6 @@ if TYPE_CHECKING:
     from interloper.source import Source
 
 _UNSET = object()
-
-# Shared coercer for the no-normalizer conform path; only `_coerce` is used,
-# so the instance's transformation config is irrelevant.
-_COERCER = Normalizer()
 
 
 warnings.filterwarnings("ignore", message='Field name "schema" in "AssetDefinition"')
@@ -616,16 +613,19 @@ class Asset(Component):
     def _conform(self, result: Any) -> Any:
         """Enforce the asset's schema according to the materialization strategy.
 
-        AUTO: validate each row when a schema is declared, infer one otherwise.
+        AUTO: validate when a schema is declared, infer one otherwise.
         STRICT: schema required; reject extra, missing, or mistyped fields.
         RECONCILE: schema required; align columns and coerce values.
 
-        The effective schema (declared, or inferred under AUTO) is stored on
-        the asset and carried to destinations via ``IOContext.schema``.
+        The schema operations come from a single :class:`Conformer`, resolved
+        once from the data's representation (rows or DataFrame). Tabular data
+        is canonicalized on the way in (dict / model / generator →
+        ``list[dict]``); non-tabular data without a schema passes through
+        untouched. The effective schema (declared, or inferred under AUTO) is
+        carried to destinations via ``IOContext.schema``.
 
         Returns:
-            The conformed result.  Tabular non-DataFrame data (single dict,
-            generator) is coerced to ``list[dict]`` when a schema is declared.
+            The conformed result.
 
         Raises:
             AssetError: If the strategy requires a schema but none is declared,
@@ -634,71 +634,53 @@ class Asset(Component):
         strategy = self.materialization_strategy
         schema = self.schema
 
-        if schema is None:
-            if strategy != MaterializationStrategy.AUTO:
-                raise AssetError(f"Asset '{type(self).key}': strategy='{strategy.value}' requires a schema.")
-            self._effective_schema = self._infer_schema(result)
-            return result
+        if schema is None and strategy != MaterializationStrategy.AUTO:
+            raise AssetError(f"Asset '{type(self).key}': strategy='{strategy.value}' requires a schema.")
 
-        self._effective_schema = schema
-
-        # A normalizer knows the data's native type — delegate to it.
-        if self.normalizer is not None:
-            if strategy == MaterializationStrategy.RECONCILE:
-                return self.normalizer.reconcile(result, schema)
-            self.normalizer.validate_schema(result, schema, strict=strategy == MaterializationStrategy.STRICT)
-            return result
-
-        # No normalizer: conform on a records view of the data.
-        if is_dataframe(result):
-            records = dataframe_to_records(result)
-            if strategy == MaterializationStrategy.RECONCILE:
-                import pandas as pd
-
-                return pd.DataFrame(schema.reconcile(records))
-            schema.validate_rows(records, strict=strategy == MaterializationStrategy.STRICT)
-            return result
-
+        conformer = conformer_for(result)
         try:
-            records = _COERCER._coerce(result)
+            result = conformer.prepare(result)
         except NormalizerError as e:
+            if schema is None:
+                # Non-tabular data without a contract (e.g. arbitrary objects
+                # bound for a FileDestination) passes through untouched.
+                self._effective_schema = None
+                return result
             raise AssetError(
                 f"Asset '{type(self).key}' declares a schema but returned data that cannot "
                 f"be checked against it: {e}"
             ) from e
 
-        if strategy == MaterializationStrategy.RECONCILE:
-            return schema.reconcile(records)
-        schema.validate_rows(records, strict=strategy == MaterializationStrategy.STRICT)
-        return records
+        if schema is None:
+            self._effective_schema = self._infer_schema(conformer, result)
+            return result
 
-    def _infer_schema(self, result: Any) -> type[Schema] | None:
+        self._effective_schema = schema
+        if strategy == MaterializationStrategy.RECONCILE:
+            return conformer.reconcile(result, schema)
+        conformer.validate(result, schema, strict=strategy == MaterializationStrategy.STRICT)
+        return result
+
+    def _infer_schema(self, conformer: Conformer, result: Any) -> type[Schema] | None:
         """Best-effort schema inference for the IO boundary (AUTO, no declared schema).
 
         Inference is metadata for destinations (DDL, typed loads) — it must
         never fail a materialization, so any inference error yields ``None``.
 
+        Args:
+            conformer: The conformer resolved for *result*.
+            result: The prepared (canonical) data.
+
         Returns:
-            The inferred schema, or ``None`` when inference is disabled,
-            impossible (non-tabular data, generators), or fails.
+            The inferred schema, or ``None`` when the data is empty or
+            inference fails.
         """
         if is_empty(result):
             return None
-        if self.normalizer is not None:
-            if not self.normalizer.infer:
-                return None
-            try:
-                return self.normalizer.infer_schema(result)
-            except Exception:  # noqa: BLE001 — inference is best-effort metadata
-                return None
-        if isinstance(result, list) and result and isinstance(result[0], dict):
-            try:
-                return Schema.infer(result)
-            except Exception:  # noqa: BLE001 — inference is best-effort metadata
-                return None
-        # DataFrames without a normalizer are left to the destination's native
-        # type handling; other shapes are not inferable.
-        return None
+        try:
+            return conformer.infer(result)
+        except Exception:  # noqa: BLE001 — inference is best-effort metadata
+            return None
 
     def _validate_partitioning(
         self,

--- a/packages/interloper-core/src/interloper/conformer/__init__.py
+++ b/packages/interloper-core/src/interloper/conformer/__init__.py
@@ -1,0 +1,3 @@
+from interloper.conformer.base import Conformer, RowsConformer, conformer_for
+
+__all__ = ["Conformer", "RowsConformer", "conformer_for"]

--- a/packages/interloper-core/src/interloper/conformer/base.py
+++ b/packages/interloper-core/src/interloper/conformer/base.py
@@ -1,0 +1,117 @@
+"""Conformer: schema enforcement resolved from the data's representation.
+
+The conform stage runs on every materialization, between normalization
+(optional reshaping) and the destination write. A :class:`Conformer` carries
+the schema operations — validate, reconcile, infer — for exactly one data
+representation, and :func:`conformer_for` resolves the right one from the
+data itself.
+
+Conformers are pure mechanism: stateless, never serialized, and not
+user-configurable. User-facing configuration lives on
+:class:`~interloper.normalizer.Normalizer` (reshaping) and the asset's
+``schema`` / ``materialization_strategy`` (the contract and how strictly to
+enforce it).
+
+Core ships the rows conformer; the DataFrame conformer lives in the
+``interloper-pandas`` package and is loaded lazily when DataFrame data
+appears.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+from interloper.errors import ConformerError
+from interloper.schema import Schema
+from interloper.utils.data import coerce_to_records, is_dataframe
+
+
+class Conformer(ABC):
+    """Schema operations for one data representation.
+
+    ``prepare`` canonicalizes raw asset output into the representation the
+    other operations expect; it is called once per materialization, before
+    any schema operation.
+    """
+
+    @abstractmethod
+    def prepare(self, data: Any) -> Any:
+        """Canonicalize *data* into this conformer's representation.
+
+        Raises:
+            NormalizerError: If the data cannot be represented as a table.
+        """
+
+    @abstractmethod
+    def validate(self, data: Any, schema: type[Schema], *, strict: bool = False) -> None:
+        """Validate *data* against *schema*; raise :class:`SchemaError` on mismatch."""
+
+    @abstractmethod
+    def reconcile(self, data: Any, schema: type[Schema]) -> Any:
+        """Align *data* to *schema* (drop extras, add missing) and coerce values."""
+
+    @abstractmethod
+    def infer(self, data: Any) -> type[Schema]:
+        """Infer a Schema from *data*."""
+
+
+class RowsConformer(Conformer):
+    """Schema operations on ``list[dict]`` records (pydantic row-wise)."""
+
+    def prepare(self, data: Any) -> list[dict[str, Any]]:
+        """Coerce dict / model / generator shapes to records.
+
+        Returns:
+            Data as a list of row dicts.
+        """
+        return coerce_to_records(data)
+
+    def validate(self, data: list[dict[str, Any]], schema: type[Schema], *, strict: bool = False) -> None:
+        """Validate each row against the schema."""
+        schema.validate_rows(data, strict=strict)
+
+    def reconcile(self, data: list[dict[str, Any]], schema: type[Schema]) -> list[dict[str, Any]]:
+        """Reconcile rows against the schema.
+
+        Returns:
+            Reconciled rows with columns aligned and values coerced.
+        """
+        return schema.reconcile(data)
+
+    def infer(self, data: list[dict[str, Any]]) -> type[Schema]:
+        """Infer a Schema by scanning row values.
+
+        Returns:
+            A dynamically created Schema subclass.
+        """
+        return Schema.infer(data)
+
+
+_ROWS_CONFORMER = RowsConformer()
+
+
+def conformer_for(data: Any) -> Conformer:
+    """Resolve the conformer matching the data's representation.
+
+    DataFrames resolve to the conformer shipped by ``interloper-pandas``,
+    imported lazily — core references the integration without depending on
+    it. Everything else resolves to the rows conformer, whose ``prepare``
+    rejects non-tabular data.
+
+    Returns:
+        The conformer for *data*.
+
+    Raises:
+        ConformerError: If *data* is a DataFrame but ``interloper-pandas``
+            is not installed.
+    """
+    if is_dataframe(data):
+        try:
+            from interloper_pandas.conformer import DATAFRAME_CONFORMER
+        except ImportError as e:
+            raise ConformerError(
+                "DataFrame data requires the 'interloper-pandas' package for schema operations."
+            ) from e
+        return DATAFRAME_CONFORMER
+    return _ROWS_CONFORMER

--- a/packages/interloper-core/src/interloper/errors.py
+++ b/packages/interloper-core/src/interloper/errors.py
@@ -90,6 +90,10 @@ class NormalizerError(InterloperError, TypeError):
     """The normalizer received data it cannot coerce to ``list[dict]``."""
 
 
+class ConformerError(InterloperError, TypeError):
+    """No conformer is available for the data's representation."""
+
+
 # ---------------------------------------------------------------------------
 # Destination
 # ---------------------------------------------------------------------------

--- a/packages/interloper-core/src/interloper/normalizer/base.py
+++ b/packages/interloper-core/src/interloper/normalizer/base.py
@@ -1,17 +1,14 @@
-"""Normalizer: type-native data normalization, transformation, and schema inference/validation."""
+"""Normalizer: data reshaping (coercion, flattening, column naming). Schema ops live in interloper.conformer."""
 
 from __future__ import annotations
 
 import re
-import types
-from collections.abc import Generator, Iterator
 from typing import Any, ClassVar
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from interloper.component import Component
-from interloper.errors import NormalizerError
-from interloper.schema import Schema
+from interloper.utils.data import coerce_to_records
 from interloper.utils.text import to_snake_case
 
 
@@ -41,8 +38,6 @@ class Normalizer(Component):
         flatten_separator: Separator for flattened key names.
         fill_missing: Fill missing keys across rows with ``None`` so every row
             has the same columns.
-        infer: When ``True`` and no schema is provided, infer a Pydantic model
-            from the data.
         replace_empty_dicts: Replace ``{}`` values with ``None``.
         replace_empty_strings: Replace ``""`` values with ``None``.
         drop_na_columns: Drop columns where every value is ``None``.
@@ -63,7 +58,6 @@ class Normalizer(Component):
     flatten_max_level: int | None = 0
     flatten_separator: str = "_"
     fill_missing: bool = True
-    infer: bool = True
     drop_na_columns: bool = False
     snake_case_digits: bool = False
     column_overrides: dict[str, str] = Field(default_factory=dict)
@@ -104,52 +98,6 @@ class Normalizer(Component):
 
         return rows
 
-    def infer_schema(self, data: list[dict[str, Any]]) -> type[Schema]:
-        """Infer a Schema subclass from normalized data.
-
-        Args:
-            data: Normalized list of row dicts (output of :meth:`normalize`).
-
-        Returns:
-            A dynamically created ``Schema`` subclass.
-        """
-        return Schema.infer(data)
-
-    def validate_schema(
-        self,
-        data: list[dict[str, Any]],
-        schema: type[Schema],
-        *,
-        strict: bool = False,
-    ) -> None:
-        """Validate normalized data against a Schema.
-
-        Args:
-            data: Normalized list of row dicts.
-            schema: Schema class to validate against.
-            strict: When ``True``, reject extra and missing required fields.
-        """
-        schema.validate_rows(data, strict=strict)
-
-    def reconcile(
-        self,
-        data: list[dict[str, Any]],
-        schema: type[Schema],
-    ) -> list[dict[str, Any]]:
-        """Reconcile normalized data against a Schema.
-
-        Aligns columns to the schema (drops extras, adds missing) and
-        coerces values to the schema's types via Pydantic ``model_validate``.
-
-        Args:
-            data: Normalized list of row dicts.
-            schema: Schema class describing the target shape.
-
-        Returns:
-            Reconciled list of row dicts.
-        """
-        return schema.reconcile(data)
-
     def column_name(self, name: str) -> str:
         """Transform a column name according to the normalizer's convention.
 
@@ -175,49 +123,12 @@ class Normalizer(Component):
     # ------------------------------------------------------------------
 
     def _coerce(self, data: Any) -> list[dict[str, Any]]:
-        """Coerce arbitrary data to ``list[dict]``.
-
-        Supported types: ``dict``, ``list[dict]``, ``BaseModel``,
-        ``list[BaseModel]``, ``Generator`` / ``Iterator``, ``None``.
+        """Coerce arbitrary data to ``list[dict]`` (raises ``NormalizerError`` when unsupported).
 
         Returns:
             The coerced list of row dicts.
-
-        Raises:
-            NormalizerError: If the data type is unsupported.
         """
-        if data is None:
-            return []
-
-        # Generator / Iterator -> consume then re-process
-        if isinstance(data, (Generator, Iterator, types.GeneratorType)):
-            return self._coerce(list(data))
-
-        # Single Pydantic model
-        if isinstance(data, BaseModel):
-            return [data.model_dump()]
-
-        # list
-        if isinstance(data, list):
-            if not data:
-                return []
-            first = data[0]
-            if isinstance(first, dict):
-                return data
-            if isinstance(first, BaseModel):
-                return [item.model_dump() for item in data]
-            raise NormalizerError(
-                f"Normalizer received list[{type(first).__name__}], expected list[dict] or list[BaseModel]."
-            )
-
-        # Single dict
-        if isinstance(data, dict):
-            return [data]
-
-        raise NormalizerError(
-            f"Normalizer does not support type {type(data).__name__}. "
-            "Supported: dict, list[dict], BaseModel, list[BaseModel], Generator."
-        )
+        return coerce_to_records(data)
 
     # ------------------------------------------------------------------
     # Transformations

--- a/packages/interloper-core/src/interloper/utils/data.py
+++ b/packages/interloper-core/src/interloper/utils/data.py
@@ -3,7 +3,59 @@
 from __future__ import annotations
 
 import sys
+import types
+from collections.abc import Generator, Iterator
 from typing import Any
+
+from pydantic import BaseModel
+
+from interloper.errors import NormalizerError
+
+
+def coerce_to_records(data: Any) -> list[dict[str, Any]]:
+    """Coerce tabular-ish data to ``list[dict]`` records.
+
+    Supported types: ``dict``, ``list[dict]``, ``BaseModel``,
+    ``list[BaseModel]``, ``Generator`` / ``Iterator``, ``None``.
+
+    Returns:
+        The coerced list of row dicts.
+
+    Raises:
+        NormalizerError: If the data type is unsupported.
+    """
+    if data is None:
+        return []
+
+    # Generator / Iterator -> consume then re-process
+    if isinstance(data, (Generator, Iterator, types.GeneratorType)):
+        return coerce_to_records(list(data))
+
+    # Single Pydantic model
+    if isinstance(data, BaseModel):
+        return [data.model_dump()]
+
+    # list
+    if isinstance(data, list):
+        if not data:
+            return []
+        first = data[0]
+        if isinstance(first, dict):
+            return data
+        if isinstance(first, BaseModel):
+            return [item.model_dump() for item in data]
+        raise NormalizerError(
+            f"Normalizer received list[{type(first).__name__}], expected list[dict] or list[BaseModel]."
+        )
+
+    # Single dict
+    if isinstance(data, dict):
+        return [data]
+
+    raise NormalizerError(
+        f"Normalizer does not support type {type(data).__name__}. "
+        "Supported: dict, list[dict], BaseModel, list[BaseModel], Generator."
+    )
 
 
 def is_dataframe(data: Any) -> bool:

--- a/packages/interloper-core/tests/conformer/test_base.py
+++ b/packages/interloper-core/tests/conformer/test_base.py
@@ -1,0 +1,68 @@
+"""Tests for ``interloper.conformer.base``."""
+
+import pytest
+from pydantic import BaseModel, Field
+
+from interloper.conformer import RowsConformer, conformer_for
+from interloper.errors import NormalizerError, SchemaError
+from interloper.schema import Schema
+
+
+class UserSchema(Schema):
+    user_id: int | None = Field(...)
+    name: str | None = Field(...)
+
+
+class TestConformerResolution:
+    """conformer_for resolves from the data's representation."""
+
+    def test_rows_for_lists(self):
+        assert isinstance(conformer_for([{"a": 1}]), RowsConformer)
+
+    def test_rows_for_non_tabular(self):
+        assert isinstance(conformer_for("anything"), RowsConformer)
+
+
+class TestRowsConformer:
+    """Row-wise schema operations and canonicalization."""
+
+    def test_prepare_passes_lists_through(self):
+        rows = [{"a": 1}]
+        assert RowsConformer().prepare(rows) is rows
+
+    def test_prepare_coerces_dict(self):
+        assert RowsConformer().prepare({"a": 1}) == [{"a": 1}]
+
+    def test_prepare_coerces_model(self):
+        class Row(BaseModel):
+            a: int
+
+        assert RowsConformer().prepare(Row(a=1)) == [{"a": 1}]
+
+    def test_prepare_consumes_generator(self):
+        def gen():
+            yield {"a": 1}
+            yield {"a": 2}
+
+        assert RowsConformer().prepare(gen()) == [{"a": 1}, {"a": 2}]
+
+    def test_prepare_rejects_non_tabular(self):
+        with pytest.raises(NormalizerError, match="does not support type"):
+            RowsConformer().prepare(42)
+
+    def test_validate_passes(self):
+        RowsConformer().validate([{"user_id": 1, "name": "a"}], UserSchema)
+
+    def test_validate_fails_on_missing_required(self):
+        with pytest.raises(SchemaError, match="Field required"):
+            RowsConformer().validate([{"user_id": 1}], UserSchema)
+
+    def test_reconcile_coerces_and_aligns(self):
+        rows = RowsConformer().reconcile([{"user_id": "1", "name": "a", "extra": True}], UserSchema)
+        assert rows == [{"user_id": 1, "name": "a"}]
+
+    def test_infer(self):
+        inferred = RowsConformer().infer([{"a": 1, "b": "x"}])
+        specs = {s.name: s for s in inferred.field_specs()}
+        assert specs["a"].type is int
+        assert specs["b"].type is str

--- a/packages/interloper-pandas/src/interloper_pandas/__init__.py
+++ b/packages/interloper-pandas/src/interloper_pandas/__init__.py
@@ -1,6 +1,7 @@
-"""Interloper pandas integration: DataFrame normalizer and IO adapter."""
+"""Interloper pandas integration: DataFrame normalizer, conformer, and IO adapter."""
 
 from interloper_pandas.adapter import DataFrameAdapter
+from interloper_pandas.conformer import DataFrameConformer
 from interloper_pandas.normalizer import DataFrameNormalizer
 
-__all__ = ["DataFrameAdapter", "DataFrameNormalizer"]
+__all__ = ["DataFrameAdapter", "DataFrameConformer", "DataFrameNormalizer"]

--- a/packages/interloper-pandas/src/interloper_pandas/conformer.py
+++ b/packages/interloper-pandas/src/interloper_pandas/conformer.py
@@ -1,0 +1,145 @@
+"""DataFrame conformer: vectorized schema operations over field specs."""
+
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+from typing import Any
+
+import pandas as pd
+from interloper.conformer import Conformer
+from interloper.errors import SchemaError
+from interloper.schema import FieldSpec, Schema
+from interloper.utils.data import dataframe_to_records
+from pydantic import create_model
+
+
+class DataFrameConformer(Conformer):
+    """Schema operations on pandas DataFrames, vectorized over field specs.
+
+    Resolved by :func:`interloper.conformer.conformer_for` whenever the
+    materialized data is a DataFrame.
+    """
+
+    def prepare(self, data: pd.DataFrame) -> pd.DataFrame:
+        """DataFrames are already canonical.
+
+        Returns:
+            The DataFrame unchanged.
+        """
+        return data
+
+    def validate(self, data: pd.DataFrame, schema: type[Schema], *, strict: bool = False) -> None:
+        """Validate via a null-safe records view (``NaN``/``NaT`` → ``None``).
+
+        Missing values in numeric columns validate correctly against
+        nullable fields instead of failing as ``nan`` floats.
+        """
+        schema.validate_rows(dataframe_to_records(data), strict=strict)
+
+    def reconcile(self, data: pd.DataFrame, schema: type[Schema]) -> pd.DataFrame:
+        """Reconcile using vectorized column-wise casts from the field specs.
+
+        No per-row pydantic validation — this scales to warehouse-sized
+        frames. Uses nullable pandas dtypes (``Int64``, ``Float64``,
+        ``boolean``, ``string``) so missing values survive as ``pd.NA``.
+
+        Returns:
+            Reconciled DataFrame.
+
+        Raises:
+            SchemaError: If a column cannot be cast to its declared type, or
+                a required non-nullable column is missing.
+        """
+        columns: dict[str, pd.Series] = {}
+        for spec in schema.field_specs():
+            if spec.name in data.columns:
+                series = data[spec.name]
+            elif spec.nullable:
+                series = pd.Series([None] * len(data), index=data.index, dtype=object)
+            else:
+                raise SchemaError(f"Reconciliation failed: required column '{spec.name}' is missing.")
+            columns[spec.name] = _cast_series(series, spec)
+        return pd.DataFrame(columns, index=data.index)
+
+    def infer(self, data: pd.DataFrame) -> type[Schema]:
+        """Infer a Schema from the DataFrame's dtypes (no row materialization).
+
+        ``object`` columns fall back to the type of the first non-null
+        value. All fields are optional, mirroring :meth:`Schema.infer`.
+
+        Returns:
+            A dynamically created Schema subclass.
+
+        Raises:
+            SchemaError: If the DataFrame has no columns.
+        """
+        if len(data.columns) == 0:
+            raise SchemaError("Cannot infer schema from a DataFrame with no columns.")
+
+        field_definitions: dict[str, Any] = {}
+        for column in data.columns:
+            py_type = _dtype_to_py_type(data[column])
+            field_definitions[str(column)] = (py_type | None if py_type is not Any else Any, None)
+        return create_model("InferredSchema", __base__=Schema, **field_definitions)
+
+
+DATAFRAME_CONFORMER = DataFrameConformer()
+
+
+def _dtype_to_py_type(series: pd.Series) -> Any:
+    """Map a Series' dtype to a Python type for schema inference.
+
+    Returns:
+        The resolved Python type, or ``Any`` when unknown (e.g. an all-null
+        object column).
+    """
+    dtype = series.dtype
+    if pd.api.types.is_bool_dtype(dtype):
+        return bool
+    if pd.api.types.is_integer_dtype(dtype):
+        return int
+    if pd.api.types.is_float_dtype(dtype):
+        return float
+    if pd.api.types.is_datetime64_any_dtype(dtype):
+        return datetime.datetime
+    if pd.api.types.is_string_dtype(dtype) and not pd.api.types.is_object_dtype(dtype):
+        return str
+    non_null = series.dropna()
+    if non_null.empty:
+        return Any
+    return type(non_null.iloc[0])
+
+
+def _cast_series(series: pd.Series, spec: FieldSpec) -> pd.Series:
+    """Cast a Series to the pandas dtype matching a field spec.
+
+    Returns:
+        The cast Series.
+
+    Raises:
+        SchemaError: If the values cannot be cast to the declared type.
+    """
+    # Nested / repeated / unknown types pass through untouched.
+    if spec.repeated or spec.fields is not None or spec.type is Any:
+        return series
+
+    try:
+        if spec.type is bool:
+            return series.astype("boolean")
+        if spec.type is int:
+            return pd.to_numeric(series, errors="raise").astype("Int64")
+        if spec.type is float:
+            return pd.to_numeric(series, errors="raise").astype("Float64")
+        if spec.type is str:
+            return series.astype("string")
+        if spec.type is datetime.datetime:
+            return pd.to_datetime(series, errors="raise")
+        if spec.type is datetime.date:
+            return pd.to_datetime(series, errors="raise").dt.date
+        if spec.type is Decimal:
+            return series.map(lambda v: v if isinstance(v, Decimal) or pd.isna(v) else Decimal(str(v)))
+    except (ValueError, TypeError) as e:
+        raise SchemaError(f"Reconciliation failed for column '{spec.name}': cannot cast to {spec.type}: {e}") from e
+
+    return series

--- a/packages/interloper-pandas/src/interloper_pandas/normalizer.py
+++ b/packages/interloper-pandas/src/interloper_pandas/normalizer.py
@@ -2,16 +2,10 @@
 
 from __future__ import annotations
 
-import datetime
-from decimal import Decimal
 from typing import Any
 
 import pandas as pd
-from interloper.errors import SchemaError
 from interloper.normalizer import Normalizer
-from interloper.schema import FieldSpec, Schema
-from interloper.utils.data import dataframe_to_records
-from pydantic import create_model
 
 
 class DataFrameNormalizer(Normalizer):
@@ -19,6 +13,9 @@ class DataFrameNormalizer(Normalizer):
 
     Accepts a ``DataFrame`` and returns a ``DataFrame`` — all transformations
     are performed using native pandas operations for efficiency.
+
+    Reshaping only: schema operations (validate, reconcile, infer) live in
+    :mod:`interloper.conformer`, resolved from the data type.
 
     Usage::
 
@@ -28,7 +25,7 @@ class DataFrameNormalizer(Normalizer):
 
     Inherits all configuration fields from :class:`Normalizer`:
     ``normalize_columns``, ``flatten_max_level``, ``flatten_separator``,
-    ``fill_missing``, ``infer``, ``snake_case_digits``.
+    ``fill_missing``, ``infer``, ``snake_case_digits``, ``column_overrides``.
     """
 
     def normalize(self, data: Any) -> pd.DataFrame:
@@ -66,84 +63,6 @@ class DataFrameNormalizer(Normalizer):
 
         return df
 
-    def infer_schema(self, data: pd.DataFrame) -> type[Schema]:
-        """Infer a Schema subclass from a ``DataFrame``'s dtypes.
-
-        Column types are read from the dtypes directly (no row materialization);
-        ``object`` columns fall back to the type of the first non-null value.
-        All fields are optional, mirroring :meth:`Schema.infer`.
-
-        Args:
-            data: Normalized ``DataFrame`` (output of :meth:`normalize`).
-
-        Returns:
-            A dynamically created ``Schema`` subclass.
-
-        Raises:
-            SchemaError: If *data* has no columns.
-        """
-        if len(data.columns) == 0:
-            raise SchemaError("Cannot infer schema from a DataFrame with no columns.")
-
-        field_definitions: dict[str, Any] = {}
-        for column in data.columns:
-            py_type = _dtype_to_py_type(data[column])
-            field_definitions[str(column)] = (py_type | None if py_type is not Any else Any, None)
-        return create_model("InferredSchema", __base__=Schema, **field_definitions)
-
-    def validate_schema(
-        self,
-        data: pd.DataFrame,
-        schema: type[Schema],
-        *,
-        strict: bool = False,
-    ) -> None:
-        """Validate a ``DataFrame`` against a Schema.
-
-        Uses a null-safe records view (``NaN``/``NaT`` → ``None``) so missing
-        values in numeric columns validate correctly against nullable fields.
-
-        Args:
-            data: Normalized ``DataFrame``.
-            schema: Schema class to validate against.
-            strict: When ``True``, reject extra and missing required fields.
-        """
-        rows = dataframe_to_records(data)
-        schema.validate_rows(rows, strict=strict)
-
-    def reconcile(
-        self,
-        data: pd.DataFrame,
-        schema: type[Schema],
-    ) -> pd.DataFrame:
-        """Reconcile a ``DataFrame`` against a Schema using vectorized casts.
-
-        Columns are aligned to the schema (extras dropped, missing added as
-        nulls) and cast column-wise from the schema's field specs — no per-row
-        Pydantic validation, so this scales to warehouse-sized frames.
-
-        Args:
-            data: Normalized ``DataFrame``.
-            schema: Schema class describing the target shape.
-
-        Returns:
-            Reconciled ``DataFrame`` with nullable pandas dtypes.
-
-        Raises:
-            SchemaError: If a column cannot be cast to its declared type, or a
-                required non-nullable column is missing.
-        """
-        columns: dict[str, pd.Series] = {}
-        for spec in schema.field_specs():
-            if spec.name in data.columns:
-                series = data[spec.name]
-            elif spec.nullable:
-                series = pd.Series([None] * len(data), index=data.index, dtype=object)
-            else:
-                raise SchemaError(f"Reconciliation failed: required column '{spec.name}' is missing.")
-            columns[spec.name] = _cast_series(series, spec)
-        return pd.DataFrame(columns, index=data.index)
-
     def _flatten_dataframe(self, df: pd.DataFrame) -> pd.DataFrame:
         """Flatten nested dicts in DataFrame cells using separator-joined keys.
 
@@ -162,67 +81,3 @@ class DataFrameNormalizer(Normalizer):
         rows = df.to_dict("records")
         flattened = [self._flatten_dict(row) for row in rows]
         return pd.DataFrame(flattened)
-
-
-def _dtype_to_py_type(series: pd.Series) -> Any:
-    """Map a Series' dtype to a Python type for schema inference.
-
-    ``object`` columns are resolved from the first non-null value; an all-null
-    column maps to ``Any``.
-
-    Returns:
-        The resolved Python type, or ``Any`` when unknown.
-    """
-    dtype = series.dtype
-    if pd.api.types.is_bool_dtype(dtype):
-        return bool
-    if pd.api.types.is_integer_dtype(dtype):
-        return int
-    if pd.api.types.is_float_dtype(dtype):
-        return float
-    if pd.api.types.is_datetime64_any_dtype(dtype):
-        return datetime.datetime
-    if pd.api.types.is_string_dtype(dtype) and not pd.api.types.is_object_dtype(dtype):
-        return str
-    non_null = series.dropna()
-    if non_null.empty:
-        return Any
-    return type(non_null.iloc[0])
-
-
-def _cast_series(series: pd.Series, spec: FieldSpec) -> pd.Series:
-    """Cast a Series to the pandas dtype matching a field spec.
-
-    Uses nullable pandas dtypes (``Int64``, ``Float64``, ``boolean``,
-    ``string``) so missing values survive as ``pd.NA`` instead of mutating
-    the column type.
-
-    Returns:
-        The cast Series.
-
-    Raises:
-        SchemaError: If the values cannot be cast to the declared type.
-    """
-    # Nested / repeated / unknown types pass through untouched.
-    if spec.repeated or spec.fields is not None or spec.type is Any:
-        return series
-
-    try:
-        if spec.type is bool:
-            return series.astype("boolean")
-        if spec.type is int:
-            return pd.to_numeric(series, errors="raise").astype("Int64")
-        if spec.type is float:
-            return pd.to_numeric(series, errors="raise").astype("Float64")
-        if spec.type is str:
-            return series.astype("string")
-        if spec.type is datetime.datetime:
-            return pd.to_datetime(series, errors="raise")
-        if spec.type is datetime.date:
-            return pd.to_datetime(series, errors="raise").dt.date
-        if spec.type is Decimal:
-            return series.map(lambda v: v if isinstance(v, Decimal) or pd.isna(v) else Decimal(str(v)))
-    except (ValueError, TypeError) as e:
-        raise SchemaError(f"Reconciliation failed for column '{spec.name}': cannot cast to {spec.type}: {e}") from e
-
-    return series

--- a/packages/interloper-pandas/tests/test_conformer.py
+++ b/packages/interloper-pandas/tests/test_conformer.py
@@ -1,0 +1,114 @@
+"""Tests for the DataFrame conformer."""
+
+import datetime
+
+import pandas as pd
+import pytest
+from interloper.conformer import conformer_for
+from interloper.errors import SchemaError
+from interloper.schema import Schema
+from pydantic import Field
+
+from interloper_pandas.conformer import DataFrameConformer
+
+
+class UserSchema(Schema):
+    user_id: int | None = Field(...)
+    name: str | None = Field(...)
+
+
+class TypedSchema(Schema):
+    id: int | None = Field(...)
+    cost: float | None = Field(...)
+    day: datetime.date | None = Field(...)
+    name: str | None = Field(...)
+
+
+class TestResolution:
+    """conformer_for resolves DataFrames to the pandas conformer."""
+
+    def test_dataframe_resolves_to_dataframe_conformer(self):
+        assert isinstance(conformer_for(pd.DataFrame()), DataFrameConformer)
+
+
+class TestDataFrameConformerValidate:
+    """Null-safe validation on DataFrames."""
+
+    def test_valid_data_passes(self):
+        DataFrameConformer().validate(pd.DataFrame({"user_id": [1], "name": ["a"]}), UserSchema)
+
+    def test_invalid_data_raises(self):
+        with pytest.raises(SchemaError, match="Schema validation failed"):
+            DataFrameConformer().validate(pd.DataFrame({"user_id": [1], "name": [123]}), UserSchema)
+
+    def test_nan_in_nullable_int_column_passes(self):
+        import numpy as np
+
+        class S(Schema):
+            id: int | None = Field(...)
+
+        # NaN forces float64 dtype; the records view must yield None, not nan
+        DataFrameConformer().validate(pd.DataFrame({"id": [1.0, np.nan]}), S)
+
+
+class TestDataFrameConformerReconcile:
+    """Spec-driven vectorized reconcile."""
+
+    def test_casts_to_nullable_dtypes(self):
+        import numpy as np
+
+        df = pd.DataFrame(
+            {"id": [1.0, np.nan], "cost": ["1.5", None], "day": ["2024-01-01", None], "name": ["x", None]}
+        )
+        out = DataFrameConformer().reconcile(df, TypedSchema)
+        assert str(out["id"].dtype) == "Int64"
+        assert out["id"].tolist()[0] == 1
+        assert out["cost"].tolist()[0] == 1.5
+        assert out["day"].tolist()[0] == datetime.date(2024, 1, 1)
+        assert out["name"].tolist()[0] == "x"
+
+    def test_missing_nullable_column_added_and_extra_dropped(self):
+        out = DataFrameConformer().reconcile(pd.DataFrame({"id": [1], "extra": ["drop"]}), TypedSchema)
+        assert list(out.columns) == ["id", "cost", "day", "name"]
+        assert out["cost"].isna().all()
+
+    def test_missing_required_column_raises(self):
+
+        class Req(Schema):
+            must: int
+
+        with pytest.raises(SchemaError, match="required column 'must' is missing"):
+            DataFrameConformer().reconcile(pd.DataFrame({"other": [1]}), Req)
+
+    def test_uncastable_value_raises(self):
+        df = pd.DataFrame({"id": ["abc"], "cost": [1.0], "day": ["2024-01-01"], "name": ["x"]})
+        with pytest.raises(SchemaError, match="cannot cast"):
+            DataFrameConformer().reconcile(df, TypedSchema)
+
+
+class TestDataFrameConformerInfer:
+    """Dtype-based inference, no row materialization."""
+
+    def test_dtype_mapping(self):
+        import numpy as np
+
+        df = pd.DataFrame(
+            {
+                "i": [1, 2],
+                "f": [1.0, np.nan],
+                "b": [True, False],
+                "t": pd.to_datetime(["2024-01-01", "2024-01-02"]),
+                "s": ["x", "y"],
+            }
+        )
+        specs = {s.name: s for s in DataFrameConformer().infer(df).field_specs()}
+        assert specs["i"].type is int
+        assert specs["f"].type is float
+        assert specs["b"].type is bool
+        assert specs["t"].type is datetime.datetime
+        assert specs["s"].type is str
+        assert all(s.nullable for s in specs.values())
+
+    def test_empty_dataframe_raises(self):
+        with pytest.raises(SchemaError, match="Cannot infer schema from a DataFrame with no columns"):
+            DataFrameConformer().infer(pd.DataFrame())

--- a/packages/interloper-pandas/tests/test_normalizer.py
+++ b/packages/interloper-pandas/tests/test_normalizer.py
@@ -11,7 +11,7 @@ class TestDataFrameNormalize:
     """Tests for DataFrameNormalizer.normalize()."""
 
     def test_dataframe_in_dataframe_out(self):
-        n = DataFrameNormalizer(normalize_columns_names=False, fill_missing=False, infer=False)
+        n = DataFrameNormalizer(normalize_columns_names=False, fill_missing=False)
         df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
         result = n.normalize(df)
         assert isinstance(result, pd.DataFrame)
@@ -19,14 +19,14 @@ class TestDataFrameNormalize:
         assert result["a"].tolist() == [1, 2]
 
     def test_columns_normalized(self):
-        n = DataFrameNormalizer(fill_missing=False, infer=False)
+        n = DataFrameNormalizer(fill_missing=False)
         df = pd.DataFrame({"UserName": ["alice"], "UserAge": [30]})
         result = n.normalize(df)
         assert isinstance(result, pd.DataFrame)
         assert list(result.columns) == ["user_name", "user_age"]
 
     def test_flatten_nested_dicts(self):
-        n = DataFrameNormalizer(flatten_max_level=None, infer=False)
+        n = DataFrameNormalizer(flatten_max_level=None)
         df = pd.DataFrame({"user": [{"name": "alice", "age": 30}]})
         result = n.normalize(df)
         assert isinstance(result, pd.DataFrame)
@@ -34,13 +34,13 @@ class TestDataFrameNormalize:
         assert "user_age" in result.columns
 
     def test_list_dict_coerced_to_dataframe(self):
-        n = DataFrameNormalizer(normalize_columns_names=False, fill_missing=False, infer=False)
+        n = DataFrameNormalizer(normalize_columns_names=False, fill_missing=False)
         result = n.normalize([{"a": 1}, {"a": 2}])
         assert isinstance(result, pd.DataFrame)
         assert result["a"].tolist() == [1, 2]
 
     def test_single_dict_coerced(self):
-        n = DataFrameNormalizer(normalize_columns_names=False, fill_missing=False, infer=False)
+        n = DataFrameNormalizer(normalize_columns_names=False, fill_missing=False)
         result = n.normalize({"a": 1, "b": 2})
         assert isinstance(result, pd.DataFrame)
         assert result["a"].tolist() == [1]
@@ -50,25 +50,25 @@ class TestDataFrameNormalize:
             name: str
             age: int
 
-        n = DataFrameNormalizer(normalize_columns_names=False, fill_missing=False, infer=False)
+        n = DataFrameNormalizer(normalize_columns_names=False, fill_missing=False)
         result = n.normalize(User(name="alice", age=30))
         assert isinstance(result, pd.DataFrame)
         assert result["name"].tolist() == ["alice"]
 
     def test_none_returns_empty_df(self):
-        n = DataFrameNormalizer(infer=False)
+        n = DataFrameNormalizer()
         result = n.normalize(None)
         assert isinstance(result, pd.DataFrame)
         assert result.empty
 
     def test_empty_list_returns_empty_df(self):
-        n = DataFrameNormalizer(infer=False)
+        n = DataFrameNormalizer()
         result = n.normalize([])
         assert isinstance(result, pd.DataFrame)
         assert result.empty
 
     def test_unsupported_type_raises(self):
-        n = DataFrameNormalizer(infer=False)
+        n = DataFrameNormalizer()
         with pytest.raises(TypeError, match="does not support type"):
             n.normalize(42)
 
@@ -76,203 +76,13 @@ class TestDataFrameNormalize:
         n = DataFrameNormalizer(
             normalize_columns_names=False,
             fill_missing=False,
-            infer=False,
         )
         df = pd.DataFrame({"A": [1], "B": [2]})
         result = n.normalize(df)
         assert list(result.columns) == ["A", "B"]
 
     def test_flatten_then_normalize(self):
-        n = DataFrameNormalizer(flatten_max_level=None, infer=False)
+        n = DataFrameNormalizer(flatten_max_level=None)
         df = pd.DataFrame({"userData": [{"firstName": "alice"}]})
         result = n.normalize(df)
         assert "user_data_first_name" in result.columns
-
-
-class TestDataFrameInferSchema:
-    """Tests for DataFrameNormalizer.infer_schema()."""
-
-    def test_infers_from_dataframe(self):
-        n = DataFrameNormalizer()
-        df = pd.DataFrame({"name": ["alice", "bob"], "age": [30, 25]})
-        schema = n.infer_schema(df)
-        assert issubclass(schema, BaseModel)
-        assert "name" in schema.model_fields
-        assert "age" in schema.model_fields
-
-    def test_empty_dataframe_raises(self):
-        n = DataFrameNormalizer()
-        df = pd.DataFrame()
-        with pytest.raises(ValueError, match="Cannot infer schema from a DataFrame with no columns"):
-            n.infer_schema(df)
-
-
-class TestDataFrameValidateSchema:
-    """Tests for DataFrameNormalizer.validate_schema()."""
-
-    def test_valid_data_passes(self):
-        from interloper.schema import Schema
-
-        class UserSchema(Schema):
-            name: str
-            age: int | None = None
-
-        n = DataFrameNormalizer()
-        df = pd.DataFrame({"name": ["alice"], "age": [30]})
-        n.validate_schema(df, UserSchema)  # should not raise
-
-    def test_invalid_data_raises(self):
-        from interloper.schema import Schema
-
-        class UserSchema(Schema):
-            name: str
-
-        n = DataFrameNormalizer()
-        df = pd.DataFrame({"name": [123]})
-        with pytest.raises(ValueError, match="Schema validation failed"):
-            n.validate_schema(df, UserSchema)
-
-
-class TestDataFrameReconcile:
-    """Tests for DataFrameNormalizer.reconcile()."""
-
-    def test_reconcile_returns_dataframe(self):
-        from interloper.schema import Schema
-
-        class UserSchema(Schema):
-            name: str
-            age: int | None = None
-
-        n = DataFrameNormalizer()
-        df = pd.DataFrame({"name": ["alice"], "age": [30]})
-        result = n.reconcile(df, UserSchema)
-        assert isinstance(result, pd.DataFrame)
-        assert "name" in result.columns
-        assert "age" in result.columns
-
-    def test_reconcile_coerces_types(self):
-        from interloper.schema import Schema
-
-        class ValueSchema(Schema):
-            value: int
-
-        n = DataFrameNormalizer()
-        df = pd.DataFrame({"value": ["123", "456"]})
-        result = n.reconcile(df, ValueSchema)
-        assert isinstance(result, pd.DataFrame)
-        assert result["value"].tolist() == [123, 456]
-
-    def test_reconcile_drops_extra_columns(self):
-        from interloper.schema import Schema
-
-        class NameSchema(Schema):
-            name: str
-
-        n = DataFrameNormalizer()
-        df = pd.DataFrame({"name": ["alice"], "extra": ["drop_me"]})
-        result = n.reconcile(df, NameSchema)
-        assert isinstance(result, pd.DataFrame)
-        assert "extra" not in result.columns
-
-
-class TestVectorizedReconcile:
-    """Spec-driven column-wise reconcile."""
-
-    def _schema(self):
-        import datetime
-
-        from interloper.schema import Schema
-        from pydantic import Field
-
-        class S(Schema):
-            id: int | None = Field(...)
-            cost: float | None = Field(...)
-            day: datetime.date | None = Field(...)
-            name: str | None = Field(...)
-
-        return S
-
-    def test_casts_to_nullable_dtypes(self):
-        import numpy as np
-
-        n = DataFrameNormalizer()
-        df = pd.DataFrame(
-            {"id": [1.0, np.nan], "cost": ["1.5", None], "day": ["2024-01-01", None], "name": ["x", None]}
-        )
-        out = n.reconcile(df, self._schema())
-        assert str(out["id"].dtype) == "Int64"
-        assert out["id"].tolist()[0] == 1
-        assert out["cost"].tolist()[0] == 1.5
-        import datetime
-
-        assert out["day"].tolist()[0] == datetime.date(2024, 1, 1)
-        assert out["name"].tolist()[0] == "x"
-
-    def test_missing_nullable_column_added(self):
-        n = DataFrameNormalizer()
-        df = pd.DataFrame({"id": [1]})
-        out = n.reconcile(df, self._schema())
-        assert list(out.columns) == ["id", "cost", "day", "name"]
-        assert out["cost"].isna().all()
-
-    def test_missing_required_column_raises(self):
-        from interloper.errors import SchemaError
-        from interloper.schema import Schema
-
-        class Req(Schema):
-            must: int
-
-        n = DataFrameNormalizer()
-        with pytest.raises(SchemaError, match="required column 'must' is missing"):
-            n.reconcile(pd.DataFrame({"other": [1]}), Req)
-
-    def test_uncastable_value_raises(self):
-        from interloper.errors import SchemaError
-
-        n = DataFrameNormalizer()
-        df = pd.DataFrame({"id": ["abc"], "cost": [1.0], "day": ["2024-01-01"], "name": ["x"]})
-        with pytest.raises(SchemaError, match="cannot cast"):
-            n.reconcile(df, self._schema())
-
-
-class TestDtypeInference:
-    """infer_schema reads dtypes, not rows."""
-
-    def test_dtype_mapping(self):
-        import datetime
-
-        import numpy as np
-
-        n = DataFrameNormalizer()
-        df = pd.DataFrame(
-            {
-                "i": [1, 2],
-                "f": [1.0, np.nan],
-                "b": [True, False],
-                "t": pd.to_datetime(["2024-01-01", "2024-01-02"]),
-                "s": ["x", "y"],
-            }
-        )
-        specs = {s.name: s for s in n.infer_schema(df).field_specs()}
-        assert specs["i"].type is int
-        assert specs["f"].type is float
-        assert specs["b"].type is bool
-        assert specs["t"].type is datetime.datetime
-        assert specs["s"].type is str
-        assert all(s.nullable for s in specs.values())
-
-
-class TestNullSafeValidate:
-    """validate_schema tolerates NaN in nullable numeric columns."""
-
-    def test_nan_in_nullable_int_column_passes(self):
-        import numpy as np
-        from interloper.schema import Schema
-        from pydantic import Field
-
-        class S(Schema):
-            id: int | None = Field(...)
-
-        n = DataFrameNormalizer()
-        # NaN forces float64 dtype; the records view must yield None, not nan
-        n.validate_schema(pd.DataFrame({"id": [1.0, np.nan]}), S)


### PR DESCRIPTION
## What

Tier-1 refactor from the cleanliness audit: replaces the three parallel conform paths in `Asset._conform` with a single seam — a **`Conformer`** carrying the schema operations (`validate` / `reconcile` / `infer`) for exactly one data representation, resolved once per materialization by `conformer_for(data)`.

```
before: if normalizer → its methods | elif DataFrame → guarded records round-trip | else → _COERCER records path
after:  conformer = conformer_for(result) → prepare → apply strategy
```

### The pieces

- **`interloper.conformer`** (new package, `conformer/base.py` per repo convention): `Conformer` ABC + `RowsConformer` (pydantic row-wise). Conformers are pure mechanism — stateless, never serialized, not user-configurable. Naming: the actor is named after the *stage* (conform), its methods after the *modes* (validate/reconcile/infer), so `MaterializationStrategy.RECONCILE` reads naturally against it.
- **`DataFrameConformer` lives in `interloper-pandas`** (vectorized over `field_specs`, plain top-level `import pandas` — the dependency is honest and declared). `conformer_for` loads it lazily only when the data *is* a DataFrame, so core references the integration without depending on it; if DataFrame data flows without `interloper-pandas` installed, a clear `ConformerError` says exactly what to install. No registry machinery — one well-known integration, one lazy import; a registry becomes worth it the day a third representation (polars, arrow) appears.
- **`Normalizer` is now purely a reshaper** (coerce / flatten / rename / fill). Its `infer_schema`/`validate_schema`/`reconcile` thin delegations — which existed only so one branch of `_conform` had something to call — are gone. One class, one responsibility.
- **`Normalizer.infer` removed** — a leftover from when the normalizer owned inference. Its only consumer was a gate in `Asset._infer_schema` that was incoherent anyway (only effective when a normalizer happened to be configured). Inference is best-effort conformer mechanism with a destination-side fallback; if a kill switch is ever needed it belongs on the Asset, next to `materialization_strategy`.
- **One coercion implementation**: raw→records moves to `utils.data.coerce_to_records`, shared by `Normalizer` and `RowsConformer`; the module-level `_COERCER` hack in `asset/base` is deleted.
- **`DataFrameNormalizer` shrinks** to normalize + flatten; its vectorized reconcile / dtype-inference code moves to the core conformer.

### Behavioral refinements (deliberate, both toward consistency)

1. **Tabular data is canonicalized even without a schema**: single dicts become `[dict]`, generators are materialized. Destinations stop receiving shapes they can't store (a dict-returning asset previously crashed `DatabaseDestination._to_rows`; a generator would pickle as garbage). Non-tabular data without a schema still passes through untouched.
2. **Schema-less DataFrame assets now get a dtype-inferred effective schema** on `IOContext` (previously only normalizer-equipped assets did) — destinations get deterministic DDL instead of BigQuery load-job autodetection.

## Verification

- **427 passed**, ruff + ty clean. The suite passed on the first complete run after the rewrite — the conform behavior tests and the AmazonAds prod-chain regression (live source → spec JSON → child asset → normalize + validate) are design-agnostic and held unchanged.
- Schema-op test coverage moved from `interloper-pandas/tests/test_normalizer.py` to `interloper-core/tests/test_conform.py` (where the code now lives), with new `RowsConformer` and resolution coverage; the pandas tests keep reshaping coverage only.