### PR TITLE
refactor: launcher and runner registries via entry points

### DIFF
--- a/packages/interloper-docker/pyproject.toml
+++ b/packages/interloper-docker/pyproject.toml
@@ -10,6 +10,9 @@ authors = [{ name = "Guillaume Onfroy", email = "guillaume@digitlcloud.com" }]
 requires-python = ">=3.10"
 dependencies = ["docker>=7.1.0", "interloper-core", "interloper-scheduler"]
 
+[project.entry-points."interloper.launchers"]
+docker = "interloper_docker.launcher:DockerLauncher"
+
 [build-system]
 requires = ["uv_build>=0.11.5,<0.12"]
 build-backend = "uv_build"

--- a/packages/interloper-docker/src/interloper_docker/launcher.py
+++ b/packages/interloper-docker/src/interloper_docker/launcher.py
@@ -5,11 +5,15 @@ from __future__ import annotations
 import json
 import logging
 import os
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
 import docker
 from interloper.catalog.base import Catalog
+from interloper.errors import ConfigError
+
+if TYPE_CHECKING:
+    from interloper.settings import LauncherSettings, PostgresSettings, RunnerSettings
 from interloper_scheduler.launcher import Launcher, RunState, RunStatus
 
 logger = logging.getLogger(__name__)
@@ -31,6 +35,43 @@ class DockerLauncher(Launcher):
     (``_build_launcher``) injects the app-level defaults; any overrides
     from the launcher YAML config take precedence.
     """
+
+    @classmethod
+    def from_settings(
+        cls,
+        settings: LauncherSettings,
+        *,
+        postgres: PostgresSettings,
+        runner: RunnerSettings,
+        catalog: Catalog | None,
+        store: Any | None = None,
+    ) -> DockerLauncher:
+        """Construct from scheduler settings (registry construction hook).
+
+        Postgres credentials and the catalog are forwarded into the spawned
+        environment; ``settings.config`` supplies the launcher-specific
+        keyword arguments.
+
+        Returns:
+            The configured launcher.
+
+        Raises:
+            ConfigError: If no catalog is provided — this launcher spawns
+                isolated processes and must reproduce the catalog there.
+        """
+        if catalog is None:
+            raise ConfigError("The 'docker' launcher requires a catalog.")
+        return cls(
+            catalog=catalog,
+            postgres_host=postgres.host,
+            postgres_port=postgres.port,
+            postgres_user=postgres.user,
+            postgres_password=postgres.password,
+            postgres_database=postgres.database,
+            runner_type=runner.type,
+            runner_config=runner.config,
+            **settings.config,
+        )
 
     def __init__(
         self,

--- a/packages/interloper-k8s/pyproject.toml
+++ b/packages/interloper-k8s/pyproject.toml
@@ -14,6 +14,9 @@ dependencies = [
     "interloper-scheduler",
 ]
 
+[project.entry-points."interloper.launchers"]
+kubernetes = "interloper_k8s.launcher:KubernetesLauncher"
+
 [build-system]
 requires = ["uv_build>=0.11.5,<0.12"]
 build-backend = "uv_build"

--- a/packages/interloper-k8s/src/interloper_k8s/launcher.py
+++ b/packages/interloper-k8s/src/interloper_k8s/launcher.py
@@ -5,10 +5,14 @@ from __future__ import annotations
 import json
 import logging
 import os
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
 from interloper.catalog.base import Catalog
+from interloper.errors import ConfigError
+
+if TYPE_CHECKING:
+    from interloper.settings import LauncherSettings, PostgresSettings, RunnerSettings
 from interloper_scheduler.launcher import Launcher, RunState, RunStatus
 from kubernetes import client, config
 
@@ -27,6 +31,43 @@ class KubernetesLauncher(Launcher):
     the app-level defaults; any overrides from the launcher YAML
     config take precedence.
     """
+
+    @classmethod
+    def from_settings(
+        cls,
+        settings: LauncherSettings,
+        *,
+        postgres: PostgresSettings,
+        runner: RunnerSettings,
+        catalog: Catalog | None,
+        store: Any | None = None,
+    ) -> KubernetesLauncher:
+        """Construct from scheduler settings (registry construction hook).
+
+        Postgres credentials and the catalog are forwarded into the spawned
+        environment; ``settings.config`` supplies the launcher-specific
+        keyword arguments.
+
+        Returns:
+            The configured launcher.
+
+        Raises:
+            ConfigError: If no catalog is provided — this launcher spawns
+                isolated processes and must reproduce the catalog there.
+        """
+        if catalog is None:
+            raise ConfigError("The 'kubernetes' launcher requires a catalog.")
+        return cls(
+            catalog=catalog,
+            postgres_host=postgres.host,
+            postgres_port=postgres.port,
+            postgres_user=postgres.user,
+            postgres_password=postgres.password,
+            postgres_database=postgres.database,
+            runner_type=runner.type,
+            runner_config=runner.config,
+            **settings.config,
+        )
 
     def __init__(
         self,

--- a/packages/interloper-scheduler/pyproject.toml
+++ b/packages/interloper-scheduler/pyproject.toml
@@ -18,6 +18,9 @@ dependencies = [
 docker = ["interloper-docker"]
 k8s = ["interloper-k8s"]
 
+[project.entry-points."interloper.launchers"]
+in_process = "interloper_scheduler.launcher:InProcessLauncher"
+
 [build-system]
 requires = ["uv_build>=0.11.5,<0.12"]
 build-backend = "uv_build"

--- a/packages/interloper-scheduler/src/interloper_scheduler/launcher.py
+++ b/packages/interloper-scheduler/src/interloper_scheduler/launcher.py
@@ -1,4 +1,4 @@
-"""Launcher interface and in-process implementation."""
+"""Launcher interface, in-process implementation, and the launcher registry."""
 
 from __future__ import annotations
 
@@ -7,9 +7,12 @@ import threading
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
+from functools import cache
+from importlib.metadata import entry_points
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
+from interloper.errors import ConfigError
 from interloper_db import Store
 
 if TYPE_CHECKING:
@@ -36,18 +39,38 @@ class RunState:
     error: str | None = None
 
 
+_ENTRY_POINT_GROUP = "interloper.launchers"
+
+
+@cache
+def launchers() -> dict[str, type[Launcher]]:
+    """Load the launcher registry from installed entry points.
+
+    Every launcher — including the built-in in-process one — registers
+    through the ``interloper.launchers`` entry-point group; the entry name
+    is the launcher type key used in ``LauncherSettings.type``. Installed
+    means discovered: no import-order dependence, and a new launcher is one
+    new package with one entry point.
+
+    Returns:
+        Mapping of launcher type key to launcher class.
+    """
+    return {entry_point.name: entry_point.load() for entry_point in entry_points(group=_ENTRY_POINT_GROUP)}
+
+
 def build_launcher(
     launcher: LauncherSettings,
     *,
     postgres: PostgresSettings,
     runner: RunnerSettings,
-    catalog: Catalog,
+    catalog: Catalog | None,
     store: Any | None = None,
-) -> Any:
+) -> Launcher:
     """Build a launcher instance from settings.
 
-    The runner configuration is always forwarded so every launcher type
-    respects ``RunnerSettings`` uniformly.
+    Resolves the launcher class from the registry by ``launcher.type`` and
+    delegates construction to the class's own :meth:`Launcher.from_settings`
+    — each integration package owns its construction recipe.
 
     Args:
         launcher: Launcher settings (type + type-specific config).
@@ -55,65 +78,25 @@ def build_launcher(
             isolated processes (e.g. Docker).
         runner: Runner settings forwarded to every launcher.
         catalog: Catalog forwarded to launchers that spawn isolated
-            processes so they can reproduce an identical catalog.
+            processes so they can reproduce an identical catalog
+            (``None`` is accepted by launchers that don't consume it).
         store: Optional Store instance shared with in-process launchers.
 
     Returns:
         A scheduler ``Launcher`` instance.
 
     Raises:
-        ValueError: If the launcher type is unknown.
+        ConfigError: If no launcher is registered under ``launcher.type``.
     """
-    match launcher.type:
-        case "in_process":
-            from interloper_scheduler import InProcessLauncher
-
-            return InProcessLauncher(
-                store=store,
-                runner_type=runner.type,
-                runner_config=runner.config,
-            )
-        case "docker":
-            from interloper_docker import DockerLauncher
-
-            postgres_kwargs = {
-                "postgres_host": postgres.host,
-                "postgres_port": postgres.port,
-                "postgres_user": postgres.user,
-                "postgres_password": postgres.password,
-                "postgres_database": postgres.database,
-            }
-            kwargs = {**postgres_kwargs, **launcher.config}
-            return DockerLauncher(
-                catalog=catalog,
-                runner_type=runner.type,
-                runner_config=runner.config,
-                **kwargs,  # ty: ignore[invalid-argument-type]
-            )
-        case "kubernetes":
-            try:
-                from interloper_k8s import KubernetesLauncher
-            except ImportError as exc:
-                raise ValueError(
-                    "Launcher 'kubernetes' requires the 'interloper-k8s' package to be installed."
-                ) from exc
-
-            postgres_kwargs = {
-                "postgres_host": postgres.host,
-                "postgres_port": postgres.port,
-                "postgres_user": postgres.user,
-                "postgres_password": postgres.password,
-                "postgres_database": postgres.database,
-            }
-            kwargs = {**postgres_kwargs, **launcher.config}
-            return KubernetesLauncher(
-                catalog=catalog,
-                runner_type=runner.type,
-                runner_config=runner.config,
-                **kwargs,  # ty: ignore[invalid-argument-type]
-            )
-        case _:
-            raise ValueError(f"Unknown launcher: {launcher.type!r}. Available: in_process, docker, kubernetes")
+    registry = launchers()
+    if launcher.type not in registry:
+        raise ConfigError(
+            f"Unknown launcher: {launcher.type!r} (available: {sorted(registry)}). "
+            f"Is the matching interloper package installed?"
+        )
+    return registry[launcher.type].from_settings(
+        launcher, postgres=postgres, runner=runner, catalog=catalog, store=store
+    )
 
 
 class Launcher(ABC):
@@ -123,6 +106,24 @@ class Launcher(ABC):
     Every launcher carries a runner configuration that determines *how* the
     DAG is executed once it reaches the execution environment.
     """
+
+    @classmethod
+    @abstractmethod
+    def from_settings(
+        cls,
+        settings: LauncherSettings,
+        *,
+        postgres: PostgresSettings,
+        runner: RunnerSettings,
+        catalog: Catalog | None,
+        store: Any | None = None,
+    ) -> Launcher:
+        """Construct this launcher from scheduler settings.
+
+        The registry construction hook: each launcher owns its recipe
+        (which settings it consumes, how ``settings.config`` maps to its
+        constructor).
+        """
 
     def __init__(
         self,
@@ -181,6 +182,23 @@ class InProcessLauncher(Launcher):
         """
         super().__init__(runner_type=runner_type, runner_config=runner_config)
         self._store = store
+
+    @classmethod
+    def from_settings(
+        cls,
+        settings: LauncherSettings,
+        *,
+        postgres: PostgresSettings,
+        runner: RunnerSettings,
+        catalog: Catalog | None,
+        store: Any | None = None,
+    ) -> InProcessLauncher:
+        """Construct from settings; uses only the runner config and the shared store.
+
+        Returns:
+            The configured in-process launcher.
+        """
+        return cls(runner_type=runner.type, runner_config=runner.config, store=store)
 
     def launch(self, run_id: UUID) -> None:
         """Launch a run in a background thread.

--- a/packages/interloper-scheduler/tests/test_launcher.py
+++ b/packages/interloper-scheduler/tests/test_launcher.py
@@ -1,0 +1,48 @@
+"""Tests for the launcher registry."""
+
+from __future__ import annotations
+
+import pytest
+from interloper.errors import ConfigError
+from interloper.settings import LauncherSettings, PostgresSettings, RunnerSettings
+
+from interloper_scheduler.launcher import InProcessLauncher, build_launcher, launchers
+
+
+class TestRegistry:
+    """Entry-point discovery of launchers."""
+
+    def test_all_workspace_launchers_are_discovered(self):
+        # Every launcher — including the built-in — registers through the
+        # entry-point group; this asserts discovery end to end.
+        registry = launchers()
+        assert {"in_process", "docker", "kubernetes"} <= set(registry)
+
+    def test_registry_maps_keys_to_classes(self):
+        registry = launchers()
+        assert registry["in_process"] is InProcessLauncher
+        assert registry["docker"].__name__ == "DockerLauncher"
+        assert registry["kubernetes"].__name__ == "KubernetesLauncher"
+
+
+class TestBuildLauncher:
+    """Settings-driven construction through the registry."""
+
+    def test_builds_in_process_launcher(self):
+        launcher = build_launcher(
+            LauncherSettings(type="in_process"),
+            postgres=PostgresSettings(),
+            runner=RunnerSettings(type="serial"),
+            catalog=None,  # in-process launcher does not consume the catalog
+        )
+        assert isinstance(launcher, InProcessLauncher)
+        assert launcher._runner_type == "serial"
+
+    def test_unknown_type_raises_actionable_error(self):
+        with pytest.raises(ConfigError, match=r"Unknown launcher: 'nomad'.*available.*docker.*in_process.*kubernetes"):
+            build_launcher(
+                LauncherSettings(type="nomad"),
+                postgres=PostgresSettings(),
+                runner=RunnerSettings(),
+                catalog=None,
+            )


### PR DESCRIPTION
## What

Applies the entry-point registry pattern (established for data representations in #31) to launchers — the purest remaining fit, since `interloper_scheduler/launcher.py` had a literal `match launcher.type:` hardcoding lazy imports of `interloper_docker`/`interloper_k8s`, each branch embedding that launcher's construction recipe, ending in a hand-maintained `"Available: in_process, docker, kubernetes"` string.

### The shape

- **`interloper.launchers` entry-point group** — every launcher registers, *including the built-in*: `interloper-scheduler`'s own pyproject declares `in_process`, `interloper-docker` declares `docker`, `interloper-k8s` declares `kubernetes`. The entry name is the type key used in `LauncherSettings.type`. Installed ⇒ discovered; a new launcher (Nomad, ECS…) is one new package with one metadata line, scheduler untouched.
- **Construction inverted** — `Launcher` gains an abstract `from_settings(settings, *, postgres, runner, catalog, store)` classmethod, so each integration package owns its recipe (the postgres-kwargs plumbing moved out of the scheduler into the launchers that need it). `build_launcher` reduces to: resolve by key, delegate.
- **Errors** — unknown keys raise `ConfigError` (still a `ValueError`, preserving the documented contract) listing the registered keys and hinting at the missing package; this subsumes the old kubernetes-only `ImportError` special case.
- **Honesty fix** — `catalog` is now `Catalog | None` in the factory signature (the in-process launcher never consumed it); docker/kubernetes guard explicitly with a clear `ConfigError` since they must reproduce the catalog in spawned environments.

## Verification


444 passed, ruff + ty clean. New `interloper-scheduler/tests/test_launcher.py` asserts end-to-end entry-point discovery of all three launchers (no explicit imports), key→class mapping, settings-driven construction of the in-process launcher, and the actionable unknown-key error.