### PR TITLE
refactor: catalog discovery via entry points

### DIFF
--- a/packages/interloper-assets/pyproject.toml
+++ b/packages/interloper-assets/pyproject.toml
@@ -15,6 +15,9 @@ bing = ["bingads>=13.0.24.1"]
 google = ["google-api-python-client>=2.167.0", "google-ads>=29.2.0"]
 facebook = ["facebook-business>=20.0.0"]
 
+[project.entry-points."interloper.components"]
+assets = "interloper_assets"
+
 [build-system]
 requires = ["uv_build>=0.11.5,<0.12"]
 build-backend = "uv_build"

--- a/packages/interloper-core/src/interloper/catalog/base.py
+++ b/packages/interloper-core/src/interloper/catalog/base.py
@@ -3,20 +3,29 @@
 The catalog collects definitions from sources, their assets, resources,
 and destinations into a single ``dict[str, ComponentDefinition]``.
 
+Discovery vs enablement: installed packages declare the components they
+provide through the ``interloper.components`` entry-point group (the
+*available universe*); the ``AppSettings.catalog`` import paths select what a
+deployment actually exposes. When no paths are configured, the catalog is
+the full discovered universe.
+
 Usage::
 
     import interloper as il
 
-    # From settings (falls back to auto-discovery)
+    # From settings; falls back to entry-point discovery when unset
     catalog = il.Catalog.from_settings()
 
-    # Auto-discover from interloper_assets directly
-    catalog = il.Catalog.from_interloper_assets()
+    # The full discovered universe, regardless of settings
+    catalog = il.Catalog.discover()
 """
 
 from __future__ import annotations
 
 import logging
+from functools import cache
+from importlib.metadata import entry_points
+from types import ModuleType
 from typing import Any
 
 from pydantic import BaseModel, Field
@@ -31,6 +40,34 @@ from interloper.source.base import Source
 logger = logging.getLogger(__name__)
 
 COMPONENT_TYPES = (Source, Destination, Asset, Resource)
+
+_ENTRY_POINT_GROUP = "interloper.components"
+
+
+@cache
+def _discovered_paths() -> tuple[str, ...]:
+    """Collect component import paths from installed entry points.
+
+    Each entry under ``interloper.components`` names a module whose public
+    attributes are scanned for component classes (or a component class
+    directly).
+
+    Returns:
+        Import paths of every discovered component class.
+    """
+    from interloper.utils.imports import get_object_path
+
+    paths: list[str] = []
+    for entry_point in entry_points(group=_ENTRY_POINT_GROUP):
+        loaded = entry_point.load()
+        if isinstance(loaded, ModuleType):
+            for attr in dir(loaded):
+                obj = getattr(loaded, attr)
+                if isinstance(obj, type) and any(issubclass(obj, t) for t in COMPONENT_TYPES):
+                    paths.append(get_object_path(obj))
+        elif isinstance(loaded, type) and any(issubclass(loaded, t) for t in COMPONENT_TYPES):
+            paths.append(get_object_path(loaded))
+    return tuple(paths)
 
 
 class Catalog(BaseModel):
@@ -124,15 +161,17 @@ class Catalog(BaseModel):
     def from_settings(cls) -> Catalog:
         """Load catalog from the ``AppSettings.catalog`` import paths.
 
-        Falls back to :meth:`from_interloper_assets` when no paths are
-        configured.
+        The configured paths are the deployment's *enablement* list; when no
+        paths are configured, falls back to :meth:`discover` — everything the
+        installed packages declare.
 
         Returns:
             Catalog of all component definitions.
         """
         settings = AppSettings.get()
-
-        return cls.from_paths(settings.catalog)
+        if settings.catalog:
+            return cls.from_paths(settings.catalog)
+        return cls.discover()
 
     @classmethod
     def from_assets(cls, sources_or_assets: list[type[Source | Asset]]) -> Catalog:
@@ -146,24 +185,14 @@ class Catalog(BaseModel):
         )
 
     @classmethod
-    def from_interloper_assets(cls) -> Catalog:
-        """Load catalog from the ``interloper-assets`` package.
+    def discover(cls) -> Catalog:
+        """Load the catalog from installed ``interloper.components`` entry points.
+
+        The available universe: every component declared by every installed
+        package, discovered from package metadata — no hardcoded package
+        names, no import-order dependence.
 
         Returns:
-            Catalog of all component definitions.
+            Catalog of all discovered component definitions.
         """
-        from interloper.utils.imports import get_object_path
-
-        paths: list[str] = []
-
-        try:
-            import interloper_assets
-
-            for attr in dir(interloper_assets):
-                obj = getattr(interloper_assets, attr)
-                if isinstance(obj, type) and any(issubclass(obj, t) for t in COMPONENT_TYPES):
-                    paths.append(get_object_path(obj))
-        except ImportError:
-            pass
-
-        return cls.from_paths(paths)
+        return cls.from_paths(list(_discovered_paths()))

--- a/packages/interloper-core/tests/catalog/test_base.py
+++ b/packages/interloper-core/tests/catalog/test_base.py
@@ -1,0 +1,39 @@
+"""Tests for ``interloper.catalog.base``."""
+
+from __future__ import annotations
+
+from interloper.catalog.base import Catalog
+from interloper.settings import AppSettings
+
+
+class TestDiscovery:
+    """Entry-point discovery of the component universe."""
+
+    def test_discovers_components_from_installed_packages(self):
+        # interloper-assets and interloper-google-cloud declare themselves
+        # under the interloper.components group; this asserts the discovery
+        # end to end, with no package names hardcoded anywhere in core.
+        catalog = Catalog.discover()
+        assert "amazon_ads" in catalog.components
+        assert "bigquery_destination" in catalog.components
+
+    def test_discovers_nested_resources(self):
+        catalog = Catalog.discover()
+        assert "google_cloud_connection" in catalog.components
+
+
+class TestFromSettings:
+    """Explicit settings paths are the enablement list; discovery is the fallback."""
+
+    def test_explicit_paths_win(self, monkeypatch):
+        stub = AppSettings.model_construct(catalog=["interloper_assets.demo.source.DemoSource"])
+        monkeypatch.setattr(AppSettings, "get", classmethod(lambda cls: stub))
+        catalog = Catalog.from_settings()
+        assert "demo_source" in catalog.components
+        assert "amazon_ads" not in catalog.components  # not enabled
+
+    def test_empty_settings_fall_back_to_discovery(self, monkeypatch):
+        stub = AppSettings.model_construct(catalog=[])
+        monkeypatch.setattr(AppSettings, "get", classmethod(lambda cls: stub))
+        catalog = Catalog.from_settings()
+        assert "amazon_ads" in catalog.components

--- a/packages/interloper-google-cloud/pyproject.toml
+++ b/packages/interloper-google-cloud/pyproject.toml
@@ -16,6 +16,9 @@ dependencies = [
     "db-dtypes>=1.0",
 ]
 
+[project.entry-points."interloper.components"]
+google_cloud = "interloper_google_cloud"
+
 [build-system]
 requires = ["uv_build>=0.11.5,<0.12"]
 build-backend = "uv_build"


### PR DESCRIPTION
## What

Second Tier-A application of the entry-point registry pattern (#31 representations, #32 launchers): the component catalog.

### The bug it fixes on the way

`Catalog.from_settings` *documented* a fallback to `from_interloper_assets` that the code never performed — empty settings silently produced an empty catalog. And `from_interloper_assets` hardcoded the assets package name inside core (`import interloper_assets` + `dir()` scan) — the same smell the representation seam removed for pandas.

### Discovery vs enablement, made explicit

- **Discovery** — installed packages declare what they provide via the `interloper.components` entry-point group. An entry names a module whose public attributes are scanned for component classes (or a class directly). `Catalog.discover()` is the union: the *available universe*, resolved from package metadata, zero package names in core. `interloper-assets` and `interloper-google-cloud` declare themselves (58 components discovered in the workspace).
- **Enablement** — the `AppSettings.catalog` import paths stay exactly what they are: the deployment's explicit selection of what to expose. When configured they win, unchanged. When empty, `from_settings` falls back to `discover()` — the documented behavior, now real.

`from_interloper_assets` is retired. A future private source package (or `interloper-polars` shipping destinations) becomes catalog-visible by declaring one entry point — no core or config changes for the available universe; YAML still decides exposure.

## Verification

444 passed, ruff + ty clean. New `tests/catalog/test_base.py` asserts end-to-end discovery (amazon_ads, bigquery_destination, nested `google_cloud_connection` — no hardcoded names in core), explicit-paths-win enablement, and the empty-settings fallback.

## Note

Independent of #32 (disjoint files); both are based on main-with-#31.