### PR TITLE
refactor: runner registry via entry points

### DIFF
--- a/chart/interloper/README.md
+++ b/chart/interloper/README.md
@@ -25,7 +25,7 @@ ghcr.io/digitl-cloud/interloper-scheduler-k8s:<version>      # kubernetes launch
 ghcr.io/digitl-cloud/interloper-scheduler-docker:<version>   # docker launcher
 ghcr.io/digitl-cloud/interloper-api:<version>
 ghcr.io/digitl-cloud/interloper-frontend:<version>
-ghcr.io/digitl-cloud/interloper-worker:<version>             # k8s runner per-asset Job target
+ghcr.io/digitl-cloud/interloper-worker:<version>             # kubernetes runner per-asset Job target
 ```
 
 The chart picks the scheduler image suffix from `config.launcher.type`

--- a/chart/interloper/templates/configmap.yaml
+++ b/chart/interloper/templates/configmap.yaml
@@ -18,7 +18,7 @@ set them explicitly.
     {{- $_ := set $cfg.launcher.config "service_account_name" (include "interloper.serviceAccountName" .) -}}
   {{- end -}}
 {{- end -}}
-{{- if eq (default "" (dig "runner" "type" "" $cfg)) "k8s" -}}
+{{- if has (default "" (dig "runner" "type" "" $cfg)) (list "kubernetes" "k8s") -}}
   {{- if not (hasKey $cfg "runner") -}}{{- $_ := set $cfg "runner" dict -}}{{- end -}}
   {{- if not (hasKey $cfg.runner "config") -}}{{- $_ := set $cfg.runner "config" dict -}}{{- end -}}
   {{- if not $cfg.runner.config.image -}}

--- a/chart/interloper/values.yaml
+++ b/chart/interloper/values.yaml
@@ -41,7 +41,7 @@ scheduler:
   podAnnotations: {}
   extraEnv: []
 
-# ── Worker (per-asset Job target; only consumed when config.runner.type=k8s) ─
+# ── Worker (per-asset Job target; only consumed when config.runner.type=kubernetes (or legacy alias k8s)) ─
 # Not deployed as a workload — this image is referenced by the Kubernetes
 # runner as the per-asset Job target. Slimmer than scheduler: no DB, no
 # scheduler/launcher packages, just core + assets + destinations + pandas.

--- a/dockerfile
+++ b/dockerfile
@@ -6,7 +6,7 @@
 #
 #   core       interloper-core only (lightest)
 #   scheduler  core + db + scheduler + assets (cron + worker + reaper)
-#   worker     core + assets only (per-asset Job target for runner.type=k8s)
+#   worker     core + assets only (per-asset Job target for runner.type=kubernetes)
 #   api        core + db + api (assets installed; SDK extras skipped)
 #   frontend   pre-built Nuxt SPA served by nginx
 #
@@ -89,7 +89,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 
 # ── worker (leaf per-asset Job target) ────────────────────────
-# Used as runner.config.image when runner.type=k8s. Executes a single
+# Used as runner.config.image when runner.type=kubernetes. Executes a single
 # mini-DAG via `interloper run --format inline`. No DB, no scheduler,
 # no launcher — just core + assets + destinations + pandas.
 FROM base AS build-worker
@@ -148,7 +148,7 @@ COPY --from=build-scheduler --chown=app:app /interloper/.venv /interloper/.venv
 USER app
 CMD ["interloper", "app", "--no-api", "--cron", "--worker", "--reaper", "--no-create-tables"]
 
-# ── worker (per-asset Job target; runner.type=k8s only) ───────
+# ── worker (per-asset Job target; runner.type=kubernetes only) ───────
 FROM runtime AS worker
 COPY --from=build-worker --chown=app:app /interloper/.venv /interloper/.venv
 USER app

--- a/packages/interloper-core/pyproject.toml
+++ b/packages/interloper-core/pyproject.toml
@@ -25,6 +25,11 @@ dev = ["pytest>=8.0.0", "pytest-cov>=7.0.0"]
 [tool.uv.sources]
 interloper-google-cloud = { workspace = true }
 
+[project.entry-points."interloper.runners"]
+serial = "interloper.runner.serial:SerialRunner"
+multi_thread = "interloper.runner.multi_thread:MultiThreadRunner"
+multi_process = "interloper.runner.multi_process:MultiProcessRunner"
+
 [build-system]
 requires = ["uv_build>=0.11.5,<0.12"]
 build-backend = "uv_build"

--- a/packages/interloper-core/src/interloper/runner/base.py
+++ b/packages/interloper-core/src/interloper/runner/base.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from functools import cache
+from importlib.metadata import entry_points
 from typing import TYPE_CHECKING, Any
 
 from pydantic import Field, PrivateAttr
 
 from interloper.component import Component
-from interloper.errors import PartitionError, RunnerError
+from interloper.errors import ConfigError, PartitionError, RunnerError
 
 if TYPE_CHECKING:
     from interloper.dag.base import DAG
@@ -18,57 +20,47 @@ from interloper.partitioning.base import Partition, PartitionWindow
 from interloper.runner.results import ExecutionStatus, RunResult
 from interloper.runner.state import RunState
 
+_ENTRY_POINT_GROUP = "interloper.runners"
+
+
+@cache
+def runners() -> dict[str, type[SyncRunner]]:
+    """Load the runner registry from installed entry points.
+
+    Every runner — including the built-ins — registers through the
+    ``interloper.runners`` entry-point group; the entry name is the runner
+    type key used in ``RunnerSettings.type``. Installed means discovered: a
+    new runner is one new package with one entry point.
+
+    Returns:
+        Mapping of runner type key to runner class.
+    """
+    return {entry_point.name: entry_point.load() for entry_point in entry_points(group=_ENTRY_POINT_GROUP)}
+
 
 def build_runner(
     runner_type: str = "multi_thread",
     runner_config: dict[str, Any] | None = None,
 ) -> tuple[type[SyncRunner], dict[str, Any]]:
-    """Resolve a runner type string to a concrete class and forward its kwargs.
-
-    Supported types: ``serial``, ``multi_thread``, ``multi_process``, ``docker``.
-    ``docker`` requires the ``interloper-docker`` package to be installed.
+    """Resolve a runner type key to a concrete class and forward its kwargs.
 
     Args:
-        runner_type: Runner type name.
+        runner_type: Runner type key (an ``interloper.runners`` entry name).
         runner_config: Runner-specific kwargs forwarded to the constructor.
 
     Returns:
         A tuple of ``(runner_class, runner_kwargs)``.
 
     Raises:
-        ValueError: If ``runner_type`` is unknown or its package is missing.
+        ConfigError: If no runner is registered under ``runner_type``.
     """
-    cls: type[SyncRunner]
-    match runner_type:
-        case "serial":
-            from interloper.runner.serial import SerialRunner
-
-            cls = SerialRunner
-        case "multi_thread":
-            from interloper.runner.multi_thread import MultiThreadRunner
-
-            cls = MultiThreadRunner
-        case "multi_process":
-            from interloper.runner.multi_process import MultiProcessRunner
-
-            cls = MultiProcessRunner
-        case "docker":
-            try:
-                from interloper_docker import DockerRunner
-            except ImportError as exc:
-                raise ValueError("Runner 'docker' requires the 'interloper-docker' package to be installed.") from exc
-            cls = DockerRunner
-        case "k8s":
-            try:
-                from interloper_k8s import KubernetesRunner
-            except ImportError as exc:
-                raise ValueError("Runner 'k8s' requires the 'interloper-k8s' package to be installed.") from exc
-
-            cls = KubernetesRunner
-        case _:
-            raise ValueError(f"Unknown runner: {runner_type!r}. Available: serial, multi_thread, multi_process, docker")
-
-    return cls, dict(runner_config or {})
+    registry = runners()
+    if runner_type not in registry:
+        raise ConfigError(
+            f"Unknown runner: {runner_type!r} (available: {sorted(registry)}). "
+            f"Is the matching interloper package installed?"
+        )
+    return registry[runner_type], dict(runner_config or {})
 
 
 class Runner(Component):

--- a/packages/interloper-core/tests/runner/test_base.py
+++ b/packages/interloper-core/tests/runner/test_base.py
@@ -1,0 +1,44 @@
+"""Tests for ``interloper.runner.base``."""
+
+from __future__ import annotations
+
+import pytest
+
+from interloper.errors import ConfigError
+from interloper.runner import build_runner
+from interloper.runner.base import runners
+from interloper.runner.serial import SerialRunner
+
+
+class TestRegistry:
+    """Entry-point discovery of runners."""
+
+    def test_all_workspace_runners_are_discovered(self):
+        # Built-ins register through core's own pyproject; docker/k8s through
+        # theirs — asserting the discovery end to end.
+        assert {"serial", "multi_thread", "multi_process", "docker", "kubernetes"} <= set(runners())
+
+    def test_registry_maps_keys_to_classes(self):
+        registry = runners()
+        assert registry["serial"] is SerialRunner
+        assert registry["docker"].__name__ == "DockerRunner"
+        assert registry["kubernetes"].__name__ == "KubernetesRunner"
+
+    def test_k8s_is_a_compat_alias_for_kubernetes(self):
+        # Pre-existing configs use runner.type=k8s; both keys resolve to the
+        # same class so deployed values keep working.
+        registry = runners()
+        assert registry["k8s"] is registry["kubernetes"]
+
+
+class TestBuildRunner:
+    """Key resolution and kwargs forwarding."""
+
+    def test_resolves_class_and_forwards_kwargs(self):
+        cls, kwargs = build_runner("serial", {"fail_fast": True})
+        assert cls is SerialRunner
+        assert kwargs == {"fail_fast": True}
+
+    def test_unknown_type_raises_actionable_error(self):
+        with pytest.raises(ConfigError, match=r"Unknown runner: 'ray'.*available.*docker.*serial"):
+            build_runner("ray")

--- a/packages/interloper-docker/pyproject.toml
+++ b/packages/interloper-docker/pyproject.toml
@@ -10,6 +10,9 @@ authors = [{ name = "Guillaume Onfroy", email = "guillaume@digitlcloud.com" }]
 requires-python = ">=3.10"
 dependencies = ["docker>=7.1.0", "interloper-core", "interloper-scheduler"]
 
+[project.entry-points."interloper.runners"]
+docker = "interloper_docker.runner:DockerRunner"
+
 [project.entry-points."interloper.launchers"]
 docker = "interloper_docker.launcher:DockerLauncher"
 

--- a/packages/interloper-k8s/pyproject.toml
+++ b/packages/interloper-k8s/pyproject.toml
@@ -14,6 +14,12 @@ dependencies = [
     "interloper-scheduler",
 ]
 
+[project.entry-points."interloper.runners"]
+kubernetes = "interloper_k8s.runner:KubernetesRunner"
+# Deprecated alias — pre-existing configs use runner.type=k8s; the canonical
+# key matches the launcher ("kubernetes").
+k8s = "interloper_k8s.runner:KubernetesRunner"
+
 [project.entry-points."interloper.launchers"]
 kubernetes = "interloper_k8s.launcher:KubernetesLauncher"
 


### PR DESCRIPTION
## What

Recovers the runner-registry commit that was pushed to the #32 branch *after* it merged (so it never shipped). Cherry-picked onto current main, all checks green.

`build_runner` in **core** was the same match-statement shape as the launcher factory, and worse-placed: core hardcoded lazy imports of `interloper_docker`/`interloper_k8s` (a core → integration name reference, the smell the representation seam removed for pandas), and both the docstring and the `"Available: …"` error string had drifted — neither mentioned the `k8s` runner.

Runners now register through the **`interloper.runners`** entry-point group: core's own pyproject declares the built-ins (`serial`, `multi_thread`, `multi_process`); `interloper-docker` and `interloper-k8s` declare theirs. `build_runner` resolves by key and raises `ConfigError` (still a `ValueError`) listing the registered keys — which can no longer drift, because it *is* the registry. The `(class, kwargs)` return contract is unchanged.

### Naming inconsistency fixed

The runner key was `k8s` while the launcher key was `kubernetes`. Canonical is now **`kubernetes` for both**; `k8s` stays registered as a deprecated alias to the same class (asserted by test: `registry["k8s"] is registry["kubernetes"]`), so deployed configs using `runner.type: k8s` keep working. The chart's runner auto-fill condition accepts both keys, and the values/README/dockerfile docs now use the canonical name. Image names keep the `-k8s` suffix (the chart already maps `kubernetes → "-k8s"`).

This completes the four registry groups: `representations` (#31), `launchers` (#32), `components` (#33), `runners`.

## Verification

453 passed, ruff + ty clean. `tests/runner/test_base.py`: end-to-end discovery of all five runners, key→class mapping, kwargs forwarding, actionable unknown-key error.