### PR TITLE
feat: write schema descriptions and partitioning to BigQuery tables

### DIFF
--- a/packages/interloper-core/src/interloper/schema/base.py
+++ b/packages/interloper-core/src/interloper/schema/base.py
@@ -34,6 +34,8 @@ class FieldSpec:
         nullable: Whether the field accepts ``None`` (declared as ``T | None``).
         repeated: Whether the field is a list of *type* (declared as ``list[T]``).
         fields: Sub-field specs when *type* is a nested model, else ``None``.
+        description: Human-readable field description (from ``Field(description=...)``),
+            else ``None``.
     """
 
     name: str
@@ -41,10 +43,11 @@ class FieldSpec:
     nullable: bool
     repeated: bool = False
     fields: tuple[FieldSpec, ...] | None = None
+    description: str | None = None
 
 
-def _field_spec(name: str, annotation: Any) -> FieldSpec:
-    """Build a FieldSpec from a field name and type annotation.
+def _field_spec(name: str, annotation: Any, description: str | None = None) -> FieldSpec:
+    """Build a FieldSpec from a field name, type annotation, and description.
 
     Returns:
         The extracted spec, with ``Optional``/``list`` wrappers unwrapped.
@@ -71,9 +74,11 @@ def _field_spec(name: str, annotation: Any) -> FieldSpec:
     # Nested model -> sub-field specs
     fields: tuple[FieldSpec, ...] | None = None
     if isinstance(annotation, type) and issubclass(annotation, BaseModel):
-        fields = tuple(_field_spec(n, f.annotation) for n, f in annotation.model_fields.items())
+        fields = tuple(_field_spec(n, f.annotation, f.description) for n, f in annotation.model_fields.items())
 
-    return FieldSpec(name=name, type=annotation, nullable=nullable, repeated=repeated, fields=fields)
+    return FieldSpec(
+        name=name, type=annotation, nullable=nullable, repeated=repeated, fields=fields, description=description
+    )
 
 
 class Schema(Component):
@@ -124,7 +129,9 @@ class Schema(Component):
         names = [n for n in cls.model_fields if n in data_fields]
         own_order = [n for n in cls.__dict__.get("__annotations__", {}) if n in data_fields]
         ordered = own_order + [n for n in names if n not in own_order]
-        return [_field_spec(name, cls.model_fields[name].annotation) for name in ordered]
+        return [
+            _field_spec(name, cls.model_fields[name].annotation, cls.model_fields[name].description) for name in ordered
+        ]
 
     @classmethod
     def infer(

--- a/packages/interloper-core/tests/schema/test_base.py
+++ b/packages/interloper-core/tests/schema/test_base.py
@@ -10,12 +10,12 @@ from interloper.schema import FieldSpec, Schema
 
 
 class Nested(BaseModel):
-    city: str
+    city: str = Field(description="City name")
     zip: str | None
 
 
 class FullSchema(Schema):
-    plain_int: int
+    plain_int: int = Field(description="A plain integer")
     nullable_float: float | None = Field(...)
     a_date: datetime.date | None
     a_datetime: datetime.datetime
@@ -82,6 +82,16 @@ class TestFieldSpecs:
 
     def test_any_type(self):
         assert spec_by_name(FullSchema, "untyped").type is Any
+
+    def test_description_extracted(self):
+        assert spec_by_name(FullSchema, "plain_int").description == "A plain integer"
+        assert spec_by_name(FullSchema, "nullable_float").description is None
+
+    def test_nested_description_extracted(self):
+        spec = spec_by_name(FullSchema, "nested")
+        assert spec.fields is not None
+        assert spec.fields[0].description == "City name"
+        assert spec.fields[1].description is None
 
     def test_component_fields_excluded(self):
         names = [s.name for s in FullSchema.field_specs()]

--- a/packages/interloper-google-cloud/src/interloper_google_cloud/bigquery/destination.py
+++ b/packages/interloper-google-cloud/src/interloper_google_cloud/bigquery/destination.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import datetime
+import inspect
 import json
 import math
 import warnings
+from collections.abc import Sequence
 from decimal import Decimal
 from functools import cached_property
 from typing import Any
@@ -18,6 +20,7 @@ from google.oauth2 import service_account
 from interloper.destination import IOContext, destination
 from interloper.destination.database import DatabaseDestination
 from interloper.errors import ConfigError, DataNotFoundError
+from interloper.partitioning import PartitionConfig, TimePartitionConfig
 from interloper.representation import representation_for
 from interloper.resource.fields import InputField, SelectField
 from interloper.schema import FieldSpec, Schema
@@ -104,6 +107,21 @@ class BigQueryDestination(DatabaseDestination):
         ds = self._resolve_dataset(schema)
         return f"{self.project}.{ds}.{table}"
 
+    def _get_table(self, table: str, schema: str | None) -> bigquery.Table | None:
+        """Fetch a BigQuery table.
+
+        Args:
+            table: Table name.
+            schema: Schema (dataset) override.
+
+        Returns:
+            The table, or ``None`` if it does not exist.
+        """
+        try:
+            return self.client.get_table(self._table_ref(table, schema))
+        except NotFound:
+            return None
+
     def _table_exists(self, table: str, schema: str | None) -> bool:
         """Check whether a BigQuery table exists.
 
@@ -114,22 +132,60 @@ class BigQueryDestination(DatabaseDestination):
         Returns:
             ``True`` if the table exists, ``False`` otherwise.
         """
-        try:
-            self.client.get_table(self._table_ref(table, schema))
-        except NotFound:
-            return False
-        return True
+        return self._get_table(table, schema) is not None
 
-    def _create_table(self, table: str, schema: str | None, bq_schema: list[bigquery.SchemaField]) -> None:
+    def _create_table(
+        self,
+        table: str,
+        schema: str | None,
+        bq_schema: list[bigquery.SchemaField],
+        time_partitioning: bigquery.TimePartitioning | None = None,
+        description: str | None = None,
+    ) -> None:
         """Create a BigQuery table with an explicit schema.
 
         Args:
             table: Target table name.
             schema: Database schema (dataset).
             bq_schema: BigQuery field definitions.
+            time_partitioning: Time partitioning spec, if the asset is partitioned.
+            description: Table description (the asset's description).
         """
         bq_table = bigquery.Table(self._table_ref(table, schema), schema=bq_schema)
+        bq_table.time_partitioning = time_partitioning
+        bq_table.description = description
         self.client.create_table(bq_table)
+
+    def _sync_table_metadata(
+        self,
+        bq_table: bigquery.Table,
+        bq_schema: list[bigquery.SchemaField] | None,
+        description: str | None,
+    ) -> None:
+        """Push field and table descriptions onto an existing table.
+
+        Keeps BigQuery metadata in sync when descriptions change on the asset
+        or its schema after the table was created.  Only descriptions are
+        updated (types, modes, and partitioning are immutable here), empty
+        descriptions never clear existing ones, and no API call is made when
+        nothing changed.
+
+        Args:
+            bq_table: The existing table.
+            bq_schema: Field definitions carrying the wanted descriptions.
+            description: Wanted table description (the asset's description).
+        """
+        update_fields = []
+        if bq_schema is not None:
+            merged, changed = _merge_field_descriptions(bq_table.schema, bq_schema)
+            if changed:
+                bq_table.schema = merged
+                update_fields.append("schema")
+        if description and bq_table.description != description:
+            bq_table.description = description
+            update_fields.append("description")
+        if update_fields:
+            self.client.update_table(bq_table, update_fields)
 
     def _ensure_dataset(self, schema: str | None) -> None:
         """Create the BigQuery dataset if it does not already exist.
@@ -163,6 +219,10 @@ class BigQueryDestination(DatabaseDestination):
         (``load_table_from_dataframe``); other data falls back to the
         JSON-rows path.
 
+        New tables are created with the asset's partitioning (daily time
+        partitioning on the partition column) and carry field and table
+        descriptions; on existing tables, descriptions are kept in sync.
+
         Args:
             table: Target table name.
             schema: Database schema (dataset).
@@ -170,27 +230,44 @@ class BigQueryDestination(DatabaseDestination):
             context: IO context carrying the asset and effective schema.
         """
         bq_schema = _schema_to_bq_fields(context.schema) if context.schema is not None else None
+        description = _asset_description(context.asset)
+        partitioning = context.asset.partitioning
 
-        if not self._table_exists(table, schema):
+        bq_table = self._get_table(table, schema)
+        creating = bq_table is None
+        if creating:
             self._ensure_dataset(schema)
             if bq_schema is not None:
-                self._create_table(table, schema, bq_schema)
+                tp = _time_partitioning(partitioning, bq_schema)
+                self._create_table(table, schema, bq_schema, time_partitioning=tp, description=description)
             elif not isinstance(data, pd.DataFrame):
                 rows = representation_for(data).to_records(data)
                 if not rows:
                     return
-                self._create_table(table, schema, _infer_bq_schema(rows))
-            # DataFrame without schema: the load job creates the table from dtypes.
+                inferred = _infer_bq_schema(rows)
+                tp = _time_partitioning(partitioning, inferred)
+                self._create_table(table, schema, inferred, time_partitioning=tp, description=description)
+            # DataFrame without schema: the load job creates the table from dtypes,
+            # with the partitioning spec passed on the job config below.
+        else:
+            self._sync_table_metadata(bq_table, bq_schema, description)
 
         ref = self._table_ref(table, schema)
         if isinstance(data, pd.DataFrame):
-            self._load_dataframe(ref, data, bq_schema)
+            tp = _time_partitioning(partitioning, bq_schema) if creating and bq_schema is None else None
+            self._load_dataframe(ref, data, bq_schema, time_partitioning=tp)
         else:
             rows = representation_for(data).to_records(data)
             if rows:
                 self._load_rows(ref, rows, bq_schema)
 
-    def _load_dataframe(self, ref: str, df: pd.DataFrame, bq_schema: list[bigquery.SchemaField] | None) -> None:
+    def _load_dataframe(
+        self,
+        ref: str,
+        df: pd.DataFrame,
+        bq_schema: list[bigquery.SchemaField] | None,
+        time_partitioning: bigquery.TimePartitioning | None = None,
+    ) -> None:
         """Load a DataFrame via a Parquet load job.
 
         When a schema is available, columns are aligned to it: extra columns
@@ -202,8 +279,12 @@ class BigQueryDestination(DatabaseDestination):
             ref: Fully-qualified table reference.
             df: The DataFrame to load.
             bq_schema: BigQuery field definitions, or ``None`` to autodetect.
+            time_partitioning: Partitioning spec for the table the load job is
+                about to create; ``None`` when the table already exists.
         """
         job_config = bigquery.LoadJobConfig(write_disposition=bigquery.WriteDisposition.WRITE_APPEND)
+        if time_partitioning is not None:
+            job_config.time_partitioning = time_partitioning
 
         if bq_schema is not None:
             schema_columns = [field.name for field in bq_schema]
@@ -275,13 +356,12 @@ class BigQueryDestination(DatabaseDestination):
             column: Partition column name.
             value: Partition value to match.
         """
-        if not self._table_exists(table, schema):
+        bq_table = self._get_table(table, schema)
+        if bq_table is None:
             return
         ref = self._table_ref(table, schema)
         query = f"DELETE FROM `{ref}` WHERE `{column}` = @partition_value"
-        job_config = bigquery.QueryJobConfig(
-            query_parameters=[bigquery.ScalarQueryParameter("partition_value", _bq_to_py_type(value), value)],
-        )
+        job_config = bigquery.QueryJobConfig(query_parameters=[_partition_param(bq_table, column, value)])
         self.client.query(query, job_config=job_config).result()
 
     def _select_all(self, table: str, schema: str | None) -> list[dict[str, Any]]:
@@ -325,14 +405,13 @@ class BigQueryDestination(DatabaseDestination):
         Raises:
             DataNotFoundError: If the table does not exist.
         """
-        if not self._table_exists(table, schema):
+        bq_table = self._get_table(table, schema)
+        if bq_table is None:
             qualified = self._table_ref(table, schema)
             raise DataNotFoundError(f"Table '{qualified}' does not exist. Has the asset been materialized?")
         ref = self._table_ref(table, schema)
         query = f"SELECT * FROM `{ref}` WHERE `{column}` = @partition_value"
-        job_config = bigquery.QueryJobConfig(
-            query_parameters=[bigquery.ScalarQueryParameter("partition_value", _bq_to_py_type(value), value)],
-        )
+        job_config = bigquery.QueryJobConfig(query_parameters=[_partition_param(bq_table, column, value)])
         rows = self.client.query(query, job_config=job_config).result()
         return [dict(row) for row in rows]
 
@@ -393,22 +472,175 @@ def _schema_to_bq_fields(schema: type[Schema]) -> list[bigquery.SchemaField]:
     """
     return _specs_to_bq_fields(schema.field_specs())
 
+
 def _specs_to_bq_fields(specs: list[FieldSpec] | tuple[FieldSpec, ...]) -> list[bigquery.SchemaField]:
     """Map field specs to BigQuery field definitions.
 
     Returns:
-        One ``SchemaField`` per spec.
+        One ``SchemaField`` per spec, carrying the spec's description.
     """
     fields = []
     for spec in specs:
         mode = "REPEATED" if spec.repeated else ("NULLABLE" if spec.nullable else "REQUIRED")
+        # SchemaField's description default is a sentinel, not None — only pass it when set.
+        described: dict[str, Any] = {"description": spec.description} if spec.description else {}
         if spec.fields is not None:
             fields.append(
-                bigquery.SchemaField(spec.name, "RECORD", mode=mode, fields=_specs_to_bq_fields(spec.fields))
+                bigquery.SchemaField(
+                    spec.name, "RECORD", mode=mode, fields=_specs_to_bq_fields(spec.fields), **described
+                )
             )
         else:
-            fields.append(bigquery.SchemaField(spec.name, _py_type_to_bq_type(spec.type), mode=mode))
+            fields.append(bigquery.SchemaField(spec.name, _py_type_to_bq_type(spec.type), mode=mode, **described))
     return fields
+
+
+def _asset_description(asset: Any) -> str | None:
+    """Return the asset's description (its class docstring), cleaned.
+
+    This mirrors how ``Component.definition()`` derives descriptions.
+
+    Returns:
+        The cleaned docstring, or ``None`` when the asset has none.
+    """
+    doc = type(asset).__doc__
+    return inspect.cleandoc(doc) if doc else None
+
+
+# BigQuery time partitioning only supports DATE / DATETIME / TIMESTAMP columns.
+_TIME_PARTITIONABLE_TYPES = {"DATE", "DATETIME", "TIMESTAMP"}
+
+
+def _time_partitioning(
+    config: PartitionConfig | None,
+    bq_schema: list[bigquery.SchemaField] | None,
+) -> bigquery.TimePartitioning | None:
+    """Resolve the asset's partition config into a BigQuery time partitioning spec.
+
+    Daily partitioning on the partition column, when BigQuery supports it:
+    the column must be DATE / DATETIME / TIMESTAMP.  When the column type is
+    known (from the schema) and is not time-partitionable, or the config is
+    not time-based and no schema is available, returns ``None`` — the table
+    is created unpartitioned, which is always valid.
+
+    Args:
+        config: The asset's partition config, if any.
+        bq_schema: The table's field definitions, when known.
+
+    Returns:
+        A daily ``TimePartitioning`` on the partition column, or ``None``.
+    """
+    if config is None:
+        return None
+
+    if bq_schema is not None:
+        field = next((f for f in bq_schema if f.name == config.column), None)
+        if field is None or field.field_type not in _TIME_PARTITIONABLE_TYPES:
+            if isinstance(config, TimePartitionConfig):
+                warnings.warn(
+                    f"Partition column '{config.column}' is "
+                    f"{'missing from the schema' if field is None else f'of type {field.field_type}'}; "
+                    "the BigQuery table will not be time-partitioned.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+            return None
+    elif not isinstance(config, TimePartitionConfig):
+        return None
+
+    return bigquery.TimePartitioning(type_=bigquery.TimePartitioningType.DAY, field=config.column)
+
+
+def _merge_field_descriptions(
+    existing: Sequence[bigquery.SchemaField],
+    desired: Sequence[bigquery.SchemaField],
+) -> tuple[list[bigquery.SchemaField], bool]:
+    """Overlay desired field descriptions onto an existing table schema.
+
+    Only descriptions are touched — types and modes stay as they are in the
+    table, so the result is always a valid ``update_table`` schema.  Empty
+    desired descriptions never clear an existing one (e.g. set manually in
+    the BigQuery console).
+
+    Args:
+        existing: The table's current field definitions.
+        desired: Field definitions carrying the wanted descriptions.
+
+    Returns:
+        The merged field list and whether anything changed.
+    """
+    desired_by_name = {f.name: f for f in desired}
+    merged: list[bigquery.SchemaField] = []
+    changed = False
+    for field in existing:
+        want = desired_by_name.get(field.name)
+        if want is None:
+            merged.append(field)
+            continue
+        api = field.to_api_repr()
+        if want.description and want.description != field.description:
+            api["description"] = want.description
+            changed = True
+        if field.field_type == "RECORD" and want.fields:
+            sub_fields, sub_changed = _merge_field_descriptions(field.fields, want.fields)
+            if sub_changed:
+                api["fields"] = [f.to_api_repr() for f in sub_fields]
+                changed = True
+        merged.append(bigquery.SchemaField.from_api_repr(api))
+    return merged, changed
+
+
+# BigQuery column type -> query parameter type, for partition predicates.
+_BQ_FIELD_TO_PARAM_TYPE = {
+    "BOOLEAN": "BOOL",
+    "BOOL": "BOOL",
+    "INTEGER": "INT64",
+    "INT64": "INT64",
+    "FLOAT": "FLOAT64",
+    "FLOAT64": "FLOAT64",
+    "NUMERIC": "NUMERIC",
+    "DATE": "DATE",
+    "DATETIME": "DATETIME",
+    "TIMESTAMP": "TIMESTAMP",
+    "BYTES": "BYTES",
+    "STRING": "STRING",
+}
+
+
+def _partition_param(
+    bq_table: bigquery.Table,
+    column: str,
+    value: Any,
+) -> bigquery.ScalarQueryParameter:
+    """Build the partition-predicate query parameter, typed from the table.
+
+    Partition values arrive as strings (``Partition.id``), but the column may
+    be DATE / TIMESTAMP / INTEGER — BigQuery does not coerce a STRING
+    parameter in an equality predicate, so the parameter type must match the
+    actual column type.  Falls back to inferring from the value when the
+    column is not in the table schema.
+
+    Args:
+        bq_table: The target table (for column type lookup).
+        column: Partition column name.
+        value: Partition value.
+
+    Returns:
+        A ``partition_value`` scalar parameter with the matching type.
+    """
+    field = next((f for f in bq_table.schema if f.name == column), None)
+    if field is not None:
+        param_type = _BQ_FIELD_TO_PARAM_TYPE.get(field.field_type, "STRING")
+    else:
+        param_type = _bq_to_py_type(value)
+    if param_type in ("TIMESTAMP", "DATETIME") and isinstance(value, str):
+        # The client serializes these from datetime objects; a date-only
+        # string like "2024-01-01" (a TimePartition id) fails to format.
+        try:
+            value = datetime.datetime.fromisoformat(value)
+        except ValueError:
+            pass
+    return bigquery.ScalarQueryParameter("partition_value", param_type, value)
 
 
 def _py_type_to_bq_type(py_type: Any) -> str:

--- a/packages/interloper-google-cloud/tests/test_bigquery.py
+++ b/packages/interloper-google-cloud/tests/test_bigquery.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 
 import interloper as il
 import pytest
+from google.cloud import bigquery
 from interloper.destination import IOContext
 from interloper.destination.database import WriteDisposition
 from interloper.errors import ConfigError
@@ -18,9 +19,12 @@ from interloper_google_cloud.bigquery.destination import (
     BigQueryDestination,
     _bq_to_py_type,
     _infer_bq_schema,
+    _merge_field_descriptions,
+    _partition_param,
     _py_to_bq_type,
     _replace_non_finite,
     _schema_to_bq_fields,
+    _time_partitioning,
 )
 from interloper_google_cloud.connection import GoogleCloudConnection
 
@@ -48,6 +52,11 @@ def _make_destination(**overrides: Any) -> tuple[BigQueryDestination, MagicMock]
         resources={"connection": conn},
     )
     object.__setattr__(dest, "client", mock_client)
+
+    # By default, the table "exists" with an empty schema and no description,
+    # so the metadata-sync path is a no-op unless a test configures otherwise.
+    mock_client.get_table.return_value.schema = []
+    mock_client.get_table.return_value.description = None
 
     return dest, mock_client
 
@@ -298,20 +307,20 @@ class TestDispose:
 
 
 class _RowSchema(Schema):
-    id: int | None = Field(...)
+    id: int | None = Field(..., description="Row id")
     cost: float | None = Field(...)
     day: datetime.date | None = Field(...)
 
 
 class _NestedModel(BaseModel):
-    city: str
+    city: str = Field(description="City name")
     zip: str | None
 
 
 class _NestedSchema(Schema):
     name: str
     tags: list[str]
-    address: _NestedModel | None
+    address: _NestedModel | None = Field(None, description="Postal address")
 
 
 def _ctx(asset: Any, schema: type[Schema] | None) -> IOContext:
@@ -320,6 +329,12 @@ def _ctx(asset: Any, schema: type[Schema] | None) -> IOContext:
 
 @il.asset
 def _plain_asset() -> list:
+    return []
+
+
+@il.asset(partitioning=il.TimePartitionConfig(column="day"))
+def _partitioned_asset() -> list:
+    """Daily rows."""
     return []
 
 
@@ -341,6 +356,17 @@ class TestSchemaToBqFields:
         assert fields["tags"].field_type == "STRING"
         assert fields["address"].field_type == "RECORD"
         assert [sub.name for sub in fields["address"].fields] == ["city", "zip"]
+
+    def test_descriptions_carried(self):
+        fields = {f.name: f for f in _schema_to_bq_fields(_RowSchema)}
+        assert fields["id"].description == "Row id"
+        assert fields["cost"].description is None
+
+    def test_nested_descriptions_carried(self):
+        fields = {f.name: f for f in _schema_to_bq_fields(_NestedSchema)}
+        assert fields["address"].description == "Postal address"
+        assert fields["address"].fields[0].description == "City name"
+        assert fields["address"].fields[1].description is None
 
 
 class TestInferBqSchema:
@@ -430,3 +456,223 @@ class TestInsertData:
         call = mock_client.load_table_from_json.call_args
         assert call.args[0] == [{"id": 1, "cost": None, "day": None}]  # NaN sanitized
         assert [f.name for f in call.kwargs["job_config"].schema] == ["id", "cost", "day"]
+
+
+# ------------------------------------------------------------------
+# Partitioning and table metadata
+# ------------------------------------------------------------------
+
+
+class TestTimePartitioning:
+    """Partition config → BigQuery time partitioning spec."""
+
+    def test_none_without_config(self):
+        assert _time_partitioning(None, None) is None
+
+    def test_time_config_with_date_column(self):
+        tp = _time_partitioning(il.TimePartitionConfig(column="day"), _schema_to_bq_fields(_RowSchema))
+        assert tp is not None
+        assert tp.type_ == "DAY"
+        assert tp.field == "day"
+
+    def test_time_config_without_schema(self):
+        tp = _time_partitioning(il.TimePartitionConfig(column="date"), None)
+        assert tp is not None
+        assert tp.field == "date"
+
+    def test_generic_config_with_date_column(self):
+        tp = _time_partitioning(il.PartitionConfig(column="day"), _schema_to_bq_fields(_RowSchema))
+        assert tp is not None
+        assert tp.field == "day"
+
+    def test_generic_config_without_schema(self):
+        assert _time_partitioning(il.PartitionConfig(column="x"), None) is None
+
+    def test_non_time_column_warns_and_skips(self):
+        with pytest.warns(UserWarning, match="not be time-partitioned"):
+            tp = _time_partitioning(il.TimePartitionConfig(column="id"), _schema_to_bq_fields(_RowSchema))
+        assert tp is None
+
+    def test_missing_column_warns_and_skips(self):
+        with pytest.warns(UserWarning, match="not be time-partitioned"):
+            tp = _time_partitioning(il.TimePartitionConfig(column="nope"), _schema_to_bq_fields(_RowSchema))
+        assert tp is None
+
+
+class TestCreateTableMetadata:
+    """New tables carry partitioning, field descriptions, and table description."""
+
+    def test_table_created_with_partitioning_and_descriptions(self):
+        from google.cloud.exceptions import NotFound
+
+        dest, mock_client = _make_destination(dataset="ds")
+        mock_client.get_table.side_effect = NotFound("nope")
+
+        dest._insert_data("tbl", "ds", [{"id": 1, "cost": 1.0, "day": None}], _ctx(_partitioned_asset(), _RowSchema))
+
+        created = mock_client.create_table.call_args.args[0]
+        assert created.time_partitioning is not None
+        assert created.time_partitioning.type_ == "DAY"
+        assert created.time_partitioning.field == "day"
+        assert created.description == "Daily rows."
+        assert {f.name: f.description for f in created.schema}["id"] == "Row id"
+
+    def test_unpartitioned_asset_creates_unpartitioned_table(self):
+        from google.cloud.exceptions import NotFound
+
+        dest, mock_client = _make_destination(dataset="ds")
+        mock_client.get_table.side_effect = NotFound("nope")
+
+        dest._insert_data("tbl", "ds", [{"id": 1, "cost": 1.0, "day": None}], _ctx(_plain_asset(), _RowSchema))
+
+        created = mock_client.create_table.call_args.args[0]
+        assert created.time_partitioning is None
+        assert created.description is None
+
+    def test_inferred_schema_table_partitioned_on_date_column(self):
+        from google.cloud.exceptions import NotFound
+
+        dest, mock_client = _make_destination(dataset="ds")
+        mock_client.get_table.side_effect = NotFound("nope")
+
+        rows = [{"id": 1, "day": datetime.date(2024, 1, 1)}]
+        dest._insert_data("tbl", "ds", rows, _ctx(_partitioned_asset(), None))
+
+        created = mock_client.create_table.call_args.args[0]
+        assert created.time_partitioning is not None
+        assert created.time_partitioning.field == "day"
+
+    def test_dataframe_without_schema_partitions_via_load_job(self):
+        import pandas as pd
+        from google.cloud.exceptions import NotFound
+
+        dest, mock_client = _make_destination(dataset="ds")
+        mock_client.get_table.side_effect = NotFound("nope")
+
+        df = pd.DataFrame([{"id": 1, "day": datetime.date(2024, 1, 1)}])
+        dest._insert_data("tbl", "ds", df, _ctx(_partitioned_asset(), None))
+
+        assert not mock_client.create_table.called
+        job_config = mock_client.load_table_from_dataframe.call_args.kwargs["job_config"]
+        assert job_config.time_partitioning is not None
+        assert job_config.time_partitioning.field == "day"
+
+    def test_load_job_into_existing_table_has_no_partitioning_spec(self):
+        import pandas as pd
+
+        dest, mock_client = _make_destination(dataset="ds")
+
+        df = pd.DataFrame([{"id": 1, "day": datetime.date(2024, 1, 1)}])
+        dest._insert_data("tbl", "ds", df, _ctx(_partitioned_asset(), None))
+
+        job_config = mock_client.load_table_from_dataframe.call_args.kwargs["job_config"]
+        assert job_config.time_partitioning is None
+
+
+class TestMergeFieldDescriptions:
+    """Overlaying schema descriptions onto an existing table schema."""
+
+    def test_sets_missing_description(self):
+        existing = [bigquery.SchemaField("id", "INTEGER", mode="NULLABLE")]
+        desired = [bigquery.SchemaField("id", "INTEGER", mode="NULLABLE", description="Row id")]
+        merged, changed = _merge_field_descriptions(existing, desired)
+        assert changed is True
+        assert merged[0].description == "Row id"
+        assert merged[0].field_type == "INTEGER"
+
+    def test_empty_desired_never_clears_existing(self):
+        existing = [bigquery.SchemaField("id", "INTEGER", description="Set in console")]
+        desired = [bigquery.SchemaField("id", "INTEGER")]
+        merged, changed = _merge_field_descriptions(existing, desired)
+        assert changed is False
+        assert merged[0].description == "Set in console"
+
+    def test_unknown_fields_kept_untouched(self):
+        existing = [bigquery.SchemaField("legacy", "STRING")]
+        desired = [bigquery.SchemaField("id", "INTEGER", description="Row id")]
+        merged, changed = _merge_field_descriptions(existing, desired)
+        assert changed is False
+        assert merged == existing
+
+    def test_nested_record_descriptions(self):
+        existing = [bigquery.SchemaField("address", "RECORD", fields=[bigquery.SchemaField("city", "STRING")])]
+        desired = [
+            bigquery.SchemaField(
+                "address",
+                "RECORD",
+                fields=[bigquery.SchemaField("city", "STRING", description="City name")],
+            )
+        ]
+        merged, changed = _merge_field_descriptions(existing, desired)
+        assert changed is True
+        assert merged[0].fields[0].description == "City name"
+
+    def test_existing_table_metadata_synced_on_write(self):
+        dest, mock_client = _make_destination(dataset="ds")
+        existing = mock_client.get_table.return_value
+        existing.schema = [
+            bigquery.SchemaField("id", "INTEGER", mode="NULLABLE"),
+            bigquery.SchemaField("cost", "FLOAT", mode="NULLABLE"),
+            bigquery.SchemaField("day", "DATE", mode="NULLABLE"),
+        ]
+
+        dest._insert_data("tbl", "ds", [{"id": 1, "cost": 1.0, "day": None}], _ctx(_partitioned_asset(), _RowSchema))
+
+        table, update_fields = mock_client.update_table.call_args.args
+        assert set(update_fields) == {"schema", "description"}
+        assert {f.name: f.description for f in table.schema}["id"] == "Row id"
+        assert table.description == "Daily rows."
+
+    def test_no_update_when_metadata_already_in_sync(self):
+        dest, mock_client = _make_destination(dataset="ds")
+        existing = mock_client.get_table.return_value
+        existing.schema = [
+            bigquery.SchemaField("id", "INTEGER", mode="NULLABLE", description="Row id"),
+            bigquery.SchemaField("cost", "FLOAT", mode="NULLABLE"),
+            bigquery.SchemaField("day", "DATE", mode="NULLABLE"),
+        ]
+        existing.description = "Daily rows."
+
+        dest._insert_data("tbl", "ds", [{"id": 1, "cost": 1.0, "day": None}], _ctx(_partitioned_asset(), _RowSchema))
+
+        assert not mock_client.update_table.called
+
+
+class TestPartitionParam:
+    """Partition predicates are typed from the table's column type."""
+
+    def test_param_typed_from_table_column(self):
+        table = MagicMock()
+        table.schema = [bigquery.SchemaField("day", "DATE")]
+        param = _partition_param(table, "day", "2024-01-01")
+        assert param.type_ == "DATE"
+        assert param.value == "2024-01-01"
+
+    def test_param_falls_back_to_value_type(self):
+        table = MagicMock()
+        table.schema = []
+        assert _partition_param(table, "day", "2024-01-01").type_ == "STRING"
+        assert _partition_param(table, "n", 3).type_ == "INT64"
+
+    def test_delete_partition_uses_column_type(self):
+        dest, mock_client = _make_destination(dataset="ds")
+        mock_client.get_table.return_value.schema = [bigquery.SchemaField("day", "DATE")]
+
+        dest._delete_partition("tbl", "ds", "day", "2024-01-01")
+
+        job_config = mock_client.query.call_args.kwargs["job_config"]
+        assert job_config.query_parameters[0].type_ == "DATE"
+
+    def test_select_partition_uses_column_type(self):
+        dest, mock_client = _make_destination(dataset="ds")
+        mock_client.get_table.return_value.schema = [bigquery.SchemaField("day", "TIMESTAMP")]
+        mock_client.query.return_value.result.return_value = []
+
+        dest._select_partition("tbl", "ds", "day", "2024-01-01")
+
+        job_config = mock_client.query.call_args.kwargs["job_config"]
+        param = job_config.query_parameters[0]
+        assert param.type_ == "TIMESTAMP"
+        # Date-only strings are coerced to datetime for client serialization
+        # (which normalizes them to UTC).
+        assert param.value == datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)


### PR DESCRIPTION
## What

The BigQuery destination now writes schema metadata and configures partitioning on the tables it creates, and keeps descriptions in sync afterwards:

- **Field descriptions** — `FieldSpec` (core) now carries the `description` from `Field(description=...)`, including nested models. The BigQuery destination maps it onto `SchemaField`, so columns and nested RECORD sub-fields get descriptions.
- **Table partitioning** — new tables are created with daily time partitioning on the asset's partition column, on all three creation paths (schema DDL, inferred-from-rows DDL, DataFrame-autodetect load job). Applied only when the column is DATE/DATETIME/TIMESTAMP (BigQuery rejects anything else), with a warning when a `TimePartitionConfig` column can't be partitioned. A generic `PartitionConfig` on a date-typed column is also partitioned.
- **Table description** — set from the asset's docstring at creation, mirroring how `Component.definition()` derives descriptions.
- **Metadata sync for existing tables** — field and table descriptions are pushed onto existing tables on write when they drift, reusing the `get_table` call already made per write. No API call when nothing changed; an empty desired description never clears one set manually in the console.

## Why

Schemas across `interloper-assets` already declare field descriptions, but they were silently dropped during `FieldSpec` extraction and never reached BigQuery. Partitioned assets got plain unpartitioned tables, losing pruning/cost benefits.

## Bug fix included

Partition predicates (`_delete_partition` / `_select_partition`) always sent the partition value as a `STRING` query parameter. Against a `DATE` column — which the schema-driven DDL creates for `dt.date` partition columns — BigQuery rejects the comparison (`No matching signature for operator =`), so partitioned REPLACE writes into schema-typed tables failed. The parameter type is now resolved from the table's actual column type, with date-only strings coerced to `datetime` for TIMESTAMP/DATETIME columns (the client can't serialize them otherwise).

## Notes for review

- Partitioning is immutable on existing BigQuery tables: tables created before this change stay unpartitioned unless dropped and re-materialized. Only descriptions are synced in place.
- `_table_exists` is now a thin wrapper over a new `_get_table`, so the sync and predicate paths reuse the table object instead of adding API calls.