### PR TITLE
refactor: partition dispatch as a destination base-class template

### DIFF
--- a/packages/interloper-core/src/interloper/__init__.py
+++ b/packages/interloper-core/src/interloper/__init__.py
@@ -11,6 +11,7 @@ from interloper.destination import (
     FileDestination,
     IOContext,
     MemoryDestination,
+    PartitionedDestination,
     destination,
 )
 from interloper.events import Event, EventBus, EventType
@@ -74,6 +75,7 @@ __all__ = [
     "Partition",
     "PartitionConfig",
     "PartitionWindow",
+    "PartitionedDestination",
     "RESTClient",
     "Resource",
     "ResourceDefinition",

--- a/packages/interloper-core/src/interloper/asset/base.py
+++ b/packages/interloper-core/src/interloper/asset/base.py
@@ -163,6 +163,18 @@ class Asset(Component):
         """The source this asset belongs to, if any."""
         return self._source
 
+    def effective_partition(
+        self, partition_or_window: Partition | PartitionWindow | None
+    ) -> Partition | PartitionWindow | None:
+        """Return the partition scope this asset actually consumes.
+
+        Unpartitioned assets ignore any requested scope.
+
+        Returns:
+            The scope unchanged for partitioned assets, ``None`` otherwise.
+        """
+        return partition_or_window if self.partitioning is not None else None
+
     @property
     def qualified_key(self) -> str:
         """The fully qualified asset key: ``source_key.asset_key``."""
@@ -512,7 +524,7 @@ class Asset(Component):
 
         dest_context = IOContext(
             asset=self,
-            partition_or_window=partition_or_window if self.partitioning is not None else None,
+            partition_or_window=self.effective_partition(partition_or_window),
             metadata=metadata,
             schema=self._effective_schema or self.schema,
         )
@@ -562,7 +574,7 @@ class Asset(Component):
             raise AssetError(f"No destination found for upstream asset '{upstream_asset.key}'")
         dest = dests[0]
 
-        effective_partition = partition_or_window if upstream_asset.partitioning is not None else None
+        effective_partition = upstream_asset.effective_partition(partition_or_window)
         dest_context = IOContext(
             asset=upstream_asset,
             partition_or_window=effective_partition,

--- a/packages/interloper-core/src/interloper/destination/__init__.py
+++ b/packages/interloper-core/src/interloper/destination/__init__.py
@@ -5,6 +5,7 @@ from interloper.destination.database import DatabaseDestination, WriteDispositio
 from interloper.destination.decorator import destination
 from interloper.destination.file import FileDestination
 from interloper.destination.memory import MemoryDestination
+from interloper.destination.partitioned import PartitionedDestination
 
 __all__ = [
     "CSVDestination",
@@ -14,6 +15,7 @@ __all__ = [
     "FileDestination",
     "IOContext",
     "MemoryDestination",
+    "PartitionedDestination",
     "WriteDisposition",
     "destination",
 ]

--- a/packages/interloper-core/src/interloper/destination/csv.py
+++ b/packages/interloper-core/src/interloper/destination/csv.py
@@ -6,20 +6,22 @@ import csv
 from pathlib import Path
 from typing import Any
 
-from interloper.destination.base import Destination
 from interloper.destination.context import IOContext
 from interloper.destination.decorator import destination
-from interloper.partitioning.base import Partition, PartitionWindow
+from interloper.destination.partitioned import PartitionedDestination
+from interloper.partitioning.base import Partition
 from interloper.representation import representation_for
 
 
 @destination(name="CSV")
-class CSVDestination(Destination):
+class CSVDestination(PartitionedDestination):
     """Destination that reads and writes CSV files on the local filesystem.
 
     Data is stored under ``{base_path}/{dataset}/{asset_key}/data.csv``
     (or ``{base_path}/{asset_key}/data.csv`` when no dataset is set).
-    Partitioned assets add a ``{column}={id}`` subdirectory.
+    Partitioned assets add a ``{column}={id}`` subdirectory; the partition
+    dispatch (including window splitting) comes from
+    :class:`PartitionedDestination`.
 
     Data is viewed as ``list[dict]`` records through its registered
     representation on write (each dict is a row; the keys of the first dict
@@ -34,6 +36,32 @@ class CSVDestination(Destination):
     def _asset_path(self, context: IOContext) -> Path:
         """Return the base directory for an asset."""
         return Path(self.base_path) / (context.asset.dataset or "") / type(context.asset).key
+
+    def _scope_path(self, context: IOContext, partition: Partition | None) -> Path:
+        """Return the data file path for a scope.
+
+        Returns:
+            ``.../data.csv``, inside a ``{column}={id}`` subdirectory for
+            partition scopes.
+        """
+        base = self._asset_path(context)
+        if partition is None:
+            return base / "data.csv"
+        assert context.asset.partitioning
+        return base / f"{context.asset.partitioning.column}={partition.id}" / "data.csv"
+
+    def _write_scope(self, context: IOContext, partition: Partition | None, data: Any) -> None:
+        """Write one scope's data as CSV (converted to records through its representation)."""
+        rows = representation_for(data).to_records(data)
+        self._write_csv(self._scope_path(context, partition), rows)
+
+    def _read_scope(self, context: IOContext, partition: Partition | None) -> list[dict[str, Any]]:
+        """Read one scope's CSV file.
+
+        Returns:
+            Rows as a list of dicts (typed via the context schema when set).
+        """
+        return self._read_csv(self._scope_path(context, partition), context)
 
     def _write_csv(self, file_path: Path, data: list[dict[str, Any]]) -> None:
         """Write a list of row dicts to a CSV file."""
@@ -69,67 +97,6 @@ class CSVDestination(Destination):
             rows = [{k: (None if v == "" else v) for k, v in row.items()} for row in rows]
             rows = context.schema.reconcile(rows)
         return rows
-
-    @staticmethod
-    def _rows_for_partition(data: list[dict[str, Any]], column: str, partition: Partition) -> list[dict[str, Any]]:
-        """Return the subset of rows belonging to a partition.
-
-        Returns:
-            Rows whose partition column matches the partition id (compared as
-            strings, since partition ids stringify on disk).
-        """
-        return [row for row in data if str(row.get(column)) == str(partition.id)]
-
-    def write(self, context: IOContext, data: Any) -> None:
-        """Write row data to a CSV file, creating partition subdirectories as needed.
-
-        Data is converted to records through its representation.  Partition
-        windows are split by the partition column so each partition directory
-        only receives its own rows.
-        """
-        data = representation_for(data).to_records(data)
-        base = self._asset_path(context)
-
-        if context.partition_or_window is None:
-            self._write_csv(base / "data.csv", data)
-
-        elif isinstance(context.partition_or_window, PartitionWindow):
-            assert context.asset.partitioning
-            column = context.asset.partitioning.column
-            for partition in context.partition_or_window:
-                partition_path = base / f"{column}={partition.id}"
-                self._write_csv(partition_path / "data.csv", self._rows_for_partition(data, column, partition))
-
-        else:
-            assert isinstance(context.partition_or_window, Partition)
-            assert context.asset.partitioning
-            partition_path = base / f"{context.asset.partitioning.column}={context.partition_or_window.id}"
-            self._write_csv(partition_path / "data.csv", data)
-
-    def read(self, context: IOContext) -> list[dict[str, Any]] | list[list[dict[str, Any]]]:
-        """Read row data from a CSV file.
-
-        Returns:
-            A list of row dicts, or a list of lists for partition windows.
-        """
-        base = self._asset_path(context)
-
-        if context.partition_or_window is None:
-            return self._read_csv(base / "data.csv", context)
-
-        elif isinstance(context.partition_or_window, PartitionWindow):
-            assert context.asset.partitioning
-            return [
-                self._read_csv(base / f"{context.asset.partitioning.column}={p.id}" / "data.csv", context)
-                for p in context.partition_or_window
-            ]
-
-        else:
-            assert isinstance(context.partition_or_window, Partition)
-            assert context.asset.partitioning
-            return self._read_csv(
-                base / f"{context.asset.partitioning.column}={context.partition_or_window.id}" / "data.csv", context
-            )
 
     def partition_row_counts(self, context: IOContext) -> dict[str, int]:
         """Return row counts grouped by partition by scanning CSV files on disk."""

--- a/packages/interloper-core/src/interloper/destination/database.py
+++ b/packages/interloper-core/src/interloper/destination/database.py
@@ -9,8 +9,8 @@ from contextlib import contextmanager
 from enum import Enum
 from typing import Any
 
-from interloper.destination.base import Destination
 from interloper.destination.context import IOContext
+from interloper.destination.partitioned import PartitionedDestination
 from interloper.partitioning.base import Partition, PartitionWindow
 from interloper.representation import representation, representation_for
 from interloper.utils.data import is_empty
@@ -29,7 +29,7 @@ class WriteDisposition(str, Enum):
     APPEND = "append"
 
 
-class DatabaseDestination(Destination):
+class DatabaseDestination(PartitionedDestination):
     """Abstract base class for database-backed destination implementations.
 
     Provides the partition-aware write/read dispatch logic that is common to any
@@ -153,8 +153,12 @@ class DatabaseDestination(Destination):
     def write(self, context: IOContext, data: Any) -> None:
         """Write data to the database table.
 
-        With ``REPLACE``, deletes matching rows before inserting.
-        With ``APPEND``, rows are inserted without any prior deletion.
+        Overrides the :class:`PartitionedDestination` template: database
+        backends delete per scope but insert the whole batch once (rows
+        carry the partition column), instead of storing per-partition
+        slices.  With ``REPLACE``, matching rows are deleted before
+        inserting; with ``APPEND``, rows are inserted without any prior
+        deletion.
         """
         table = type(context.asset).key
         schema = context.asset.dataset or None
@@ -197,26 +201,16 @@ class DatabaseDestination(Destination):
 
             self._insert_data(table, schema, data, context)
 
-    def read(self, context: IOContext) -> Any:
-        """Read data from the database table.
+    def _read_scope(self, context: IOContext, partition: Partition | None) -> Any:
+        """Load one scope from the database table.
 
         Returns:
-            A list of results for partition windows, single result otherwise.
+            The scope's rows, materialized into the read representation.
         """
         table = type(context.asset).key
         schema = context.asset.dataset or None
-
-        if context.partition_or_window is None:
+        if partition is None:
             return self._from_rows(self._select_all(table, schema))
-
-        if isinstance(context.partition_or_window, PartitionWindow):
-            assert context.asset.partitioning
-            col = context.asset.partitioning.column
-            return [
-                self._from_rows(self._select_partition(table, schema, col, p.id)) for p in context.partition_or_window
-            ]
-
-        assert isinstance(context.partition_or_window, Partition)
         assert context.asset.partitioning
-        col = context.asset.partitioning.column
-        return self._from_rows(self._select_partition(table, schema, col, context.partition_or_window.id))
+        column = context.asset.partitioning.column
+        return self._from_rows(self._select_partition(table, schema, column, partition.id))

--- a/packages/interloper-core/src/interloper/destination/database.py
+++ b/packages/interloper-core/src/interloper/destination/database.py
@@ -7,7 +7,7 @@ from abc import abstractmethod
 from collections.abc import Iterator
 from contextlib import contextmanager
 from enum import Enum
-from typing import Any
+from typing import Any, ClassVar
 
 from interloper.destination.context import IOContext
 from interloper.destination.partitioned import PartitionedDestination
@@ -47,8 +47,10 @@ class DatabaseDestination(PartitionedDestination):
     (``"rows"`` by default; e.g. ``"dataframe"`` for pandas-native backends).
     """
 
-    write_disposition: WriteDisposition = WriteDisposition.REPLACE
-    read_representation: str = "rows"
+    # Backend traits, not instance configuration: class-level so they never
+    # appear in the destination's config schema (the UI form) or its specs.
+    write_disposition: ClassVar[WriteDisposition] = WriteDisposition.REPLACE
+    read_representation: ClassVar[str] = "rows"
 
     # ------------------------------------------------------------------
     # Transaction hook

--- a/packages/interloper-core/src/interloper/destination/decorator.py
+++ b/packages/interloper-core/src/interloper/destination/decorator.py
@@ -28,6 +28,7 @@ def destination(
     tags: list[str] = ...,
     name: str = ...,
     icon: str = ...,
+    read_representation: str = ...,
 ) -> Callable[[type[DestinationT]], type[DestinationT]]: ...
 def destination(
     cls: type | None = None,
@@ -38,6 +39,7 @@ def destination(
     tags: list[str] | None = None,
     name: str | None = None,
     icon: str | None = None,
+    read_representation: str | None = None,
 ) -> type[Destination] | Callable[[type], type[Destination]]:
     """Create a Destination subclass from a decorated class.
 
@@ -67,6 +69,8 @@ def destination(
     classvars: dict[str, Any] = {}
     if resources is not None:
         classvars["resource_types"] = resources
+    if read_representation is not None:
+        classvars["read_representation"] = read_representation
     if tags is not None:
         classvars["tags"] = tags
     if key is not None:

--- a/packages/interloper-core/src/interloper/destination/memory.py
+++ b/packages/interloper-core/src/interloper/destination/memory.py
@@ -4,100 +4,50 @@ from __future__ import annotations
 
 from typing import Any, ClassVar
 
-from interloper.destination.base import Destination
 from interloper.destination.context import IOContext
 from interloper.destination.decorator import destination
+from interloper.destination.partitioned import PartitionedDestination
 from interloper.errors import DataNotFoundError
-from interloper.partitioning.base import Partition, PartitionConfig, PartitionWindow
-from interloper.representation import representation_for
-
-
-def _slice_for_partition(data: Any, column: str, partition: Partition) -> Any:
-    """Return the subset of tabular data belonging to a partition.
-
-    Data recognized by a registered representation is filtered on the
-    partition column (compared as strings); other shapes are stored as-is
-    since they cannot be split.
-
-    Returns:
-        The partition's slice of the data.
-    """
-    rep = representation_for(data)
-    if rep.matches(data):
-        return rep.filter_eq(data, column, partition.id)
-    return data
+from interloper.partitioning.base import Partition, PartitionConfig
 
 
 @destination(name="Memory")
-class MemoryDestination(Destination):
+class MemoryDestination(PartitionedDestination):
     """Destination that stores data in a class-level dict keyed by ``{dataset}/{key}/{partition}``.
 
     All instances share a single ``_storage`` dict so data written by one
-    asset is visible to others.  Call :meth:`clear` between test runs.
+    asset is visible to others.  The partition dispatch (including window
+    splitting) comes from :class:`PartitionedDestination`.  Call
+    :meth:`clear` between test runs.
     """
 
     _storage: ClassVar[dict[str, Any]] = {}
 
-    def write(self, context: IOContext, data: Any) -> None:
-        """Store data in memory under a path-style key.
+    def _write_scope(self, context: IOContext, partition: Partition | None, data: Any) -> None:
+        """Store one scope's data under its path-style key."""
+        self._storage[self._scope_key(context, partition)] = data
 
-        Partition windows are split by the partition column so each partition
-        key only stores its own rows.
-        """
-        if context.partition_or_window is None:
-            key = self._build_key(type(context.asset).key, context.asset.dataset, context.asset.partitioning, None)
-            self._storage[key] = data
-
-        elif isinstance(context.partition_or_window, PartitionWindow):
-            assert context.asset.partitioning
-            column = context.asset.partitioning.column
-            for partition in context.partition_or_window:
-                key = self._build_key(
-                    type(context.asset).key, context.asset.dataset, context.asset.partitioning, partition
-                )
-                self._storage[key] = _slice_for_partition(data, column, partition)
-
-        else:
-            assert isinstance(context.partition_or_window, Partition)
-            key = self._build_key(
-                type(context.asset).key, context.asset.dataset, context.asset.partitioning, context.partition_or_window
-            )
-            self._storage[key] = data
-
-    def read(self, context: IOContext) -> Any:
-        """Retrieve data from memory.
+    def _read_scope(self, context: IOContext, partition: Partition | None) -> Any:
+        """Retrieve one scope's data.
 
         Returns:
-            The stored data, or a list of results for partition windows.
+            The stored data.
 
         Raises:
             DataNotFoundError: If no data exists for the resolved key.
         """
-        if context.partition_or_window is None:
-            key = self._build_key(type(context.asset).key, context.asset.dataset, context.asset.partitioning, None)
-            if key not in self._storage:
-                raise DataNotFoundError(f"No data found in memory for: {key}")
-            return self._storage[key]
+        key = self._scope_key(context, partition)
+        if key not in self._storage:
+            raise DataNotFoundError(f"No data found in memory for: {key}")
+        return self._storage[key]
 
-        elif isinstance(context.partition_or_window, PartitionWindow):
-            results = []
-            for partition in context.partition_or_window:
-                key = self._build_key(
-                    type(context.asset).key, context.asset.dataset, context.asset.partitioning, partition
-                )
-                if key not in self._storage:
-                    raise DataNotFoundError(f"No data found in memory for: {key}")
-                results.append(self._storage[key])
-            return results
+    def _scope_key(self, context: IOContext, partition: Partition | None) -> str:
+        """Build the storage key for a scope.
 
-        else:
-            assert isinstance(context.partition_or_window, Partition)
-            key = self._build_key(
-                type(context.asset).key, context.asset.dataset, context.asset.partitioning, context.partition_or_window
-            )
-            if key not in self._storage:
-                raise DataNotFoundError(f"No data found in memory for: {key}")
-            return self._storage[key]
+        Returns:
+            The constructed storage key string.
+        """
+        return self._build_key(type(context.asset).key, context.asset.dataset, context.asset.partitioning, partition)
 
     def _build_key(
         self,

--- a/packages/interloper-core/src/interloper/destination/partitioned.py
+++ b/packages/interloper-core/src/interloper/destination/partitioned.py
@@ -1,0 +1,96 @@
+"""Partition-aware destination template: the three-way scope dispatch, once."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from interloper.destination.base import Destination
+from interloper.destination.context import IOContext
+from interloper.partitioning.base import Partition, PartitionWindow
+from interloper.representation import representation_for
+
+
+class PartitionedDestination(Destination):
+    """Destination base implementing the partition dispatch once.
+
+    The ``None / Partition / PartitionWindow`` branching used to be
+    hand-rolled by every destination — the source of the window-duplication
+    bug where each partition directory received the *full* dataset.
+    Subclasses implement two scope hooks and are partition-correct by
+    construction:
+
+    - :meth:`_write_scope` — store data for one scope (``partition=None``
+      means the unpartitioned whole).
+    - :meth:`_read_scope` — load one scope.
+
+    Window writes are split per partition through the data's registered
+    representation; window reads return one result per partition. Data whose
+    representation cannot be recognized is passed to the write hook as-is
+    (it cannot be split).
+
+    Backends whose scoping semantics differ from per-scope storage may
+    override :meth:`write` or :meth:`read` wholesale instead of implementing
+    the corresponding hook — :class:`DatabaseDestination` does this for
+    writes (scoped deletes followed by a single insert).
+    """
+
+    def _write_scope(self, context: IOContext, partition: Partition | None, data: Any) -> None:
+        """Store *data* for a single scope.
+
+        Raises:
+            NotImplementedError: Subclasses implement this or override ``write``.
+        """
+        raise NotImplementedError(f"{type(self).__name__} must implement _write_scope() or override write().")
+
+    def _read_scope(self, context: IOContext, partition: Partition | None) -> Any:
+        """Load a single scope.
+
+        Raises:
+            NotImplementedError: Subclasses implement this or override ``read``.
+        """
+        raise NotImplementedError(f"{type(self).__name__} must implement _read_scope() or override read().")
+
+    def write(self, context: IOContext, data: Any) -> None:
+        """Write data, splitting partition windows per partition."""
+        scope = context.partition_or_window
+        if scope is None:
+            self._write_scope(context, None, data)
+        elif isinstance(scope, PartitionWindow):
+            assert context.asset.partitioning
+            column = context.asset.partitioning.column
+            for partition in scope:
+                self._write_scope(context, partition, _partition_slice(data, column, partition))
+        else:
+            assert isinstance(scope, Partition)
+            self._write_scope(context, scope, data)
+
+    def read(self, context: IOContext) -> Any:
+        """Read data for the context's scope.
+
+        Returns:
+            The scope's data; partition windows return one result per
+            partition, in window order.
+        """
+        scope = context.partition_or_window
+        if scope is None:
+            return self._read_scope(context, None)
+        if isinstance(scope, PartitionWindow):
+            return [self._read_scope(context, partition) for partition in scope]
+        assert isinstance(scope, Partition)
+        return self._read_scope(context, scope)
+
+
+def _partition_slice(data: Any, column: str, partition: Partition) -> Any:
+    """Return the partition's slice of *data*.
+
+    Data recognized by a registered representation is filtered on the
+    partition column (compared as strings); other shapes pass through
+    unchanged since they cannot be split.
+
+    Returns:
+        The partition's slice of the data.
+    """
+    rep = representation_for(data)
+    if rep.matches(data):
+        return rep.filter_eq(data, column, partition.id)
+    return data

--- a/packages/interloper-core/src/interloper/runner/async_runner.py
+++ b/packages/interloper-core/src/interloper/runner/async_runner.py
@@ -175,7 +175,7 @@ class AsyncRunner(Runner):
         self.state.mark_asset_running(asset)
 
         try:
-            effective_partition = partition_or_window if asset.partitioning is not None else None
+            effective_partition = asset.effective_partition(partition_or_window)
             result = await asset.materialize(
                 partition_or_window=effective_partition,
                 dag=self.state.dag,

--- a/packages/interloper-core/src/interloper/runner/sync_runner.py
+++ b/packages/interloper-core/src/interloper/runner/sync_runner.py
@@ -151,7 +151,7 @@ class SyncRunner(Runner):
         Returns:
             The materialization result.
         """
-        effective_partition = partition_or_window if asset.partitioning is not None else None
+        effective_partition = asset.effective_partition(partition_or_window)
         return asyncio.run(
             asset.materialize(
                 partition_or_window=effective_partition,

--- a/packages/interloper-core/tests/destination/test_database.py
+++ b/packages/interloper-core/tests/destination/test_database.py
@@ -65,7 +65,10 @@ class TestWrite:
         assert dest.calls[1][1][2] == rows
 
     def test_append_skips_deletes(self):
-        dest = RecordingDB(id="db", write_disposition=WriteDisposition.APPEND)
+        class AppendDB(RecordingDB):
+            write_disposition = WriteDisposition.APPEND
+
+        dest = AppendDB(id="db")
         dest.write(make_ctx(plain_asset()), [{"a": 1}])
         assert [c[0] for c in dest.calls] == ["insert"]
 
@@ -134,6 +137,30 @@ class TestInsertDataHook:
         assert captured["schema"] is MySchema
 
 
+class TestClassLevelTraits:
+    """write_disposition / read_representation are backend traits, not config."""
+
+    def test_traits_are_not_config_schema_fields(self):
+        # Regression: as pydantic fields they leaked into the UI config form.
+        properties = RecordingDB.definition().config_schema.get("properties", {})
+        assert "read_representation" not in properties
+        assert "write_disposition" not in properties
+
+    def test_traits_are_not_model_fields(self):
+        assert "read_representation" not in RecordingDB.model_fields
+        assert "write_disposition" not in RecordingDB.model_fields
+
+    def test_read_representation_via_decorator(self):
+        from interloper.destination import destination
+
+        @destination(name="Traited", read_representation="dataframe")
+        class TraitedDB(RecordingDB):
+            pass
+
+        assert TraitedDB.read_representation == "dataframe"
+        assert "read_representation" not in TraitedDB.definition().config_schema.get("properties", {})
+
+
 class TestRecordsConversion:
     """Data converts to records through its representation."""
 
@@ -158,7 +185,7 @@ class TestRecordsConversion:
         pd = pytest.importorskip("pandas")
 
         class DataFrameReadDB(RecordingDB):
-            read_representation: str = "dataframe"
+            read_representation = "dataframe"
 
         out = DataFrameReadDB(id="db")._from_rows([{"a": 1}])
         assert isinstance(out, pd.DataFrame)

--- a/packages/interloper-core/tests/destination/test_partitioned.py
+++ b/packages/interloper-core/tests/destination/test_partitioned.py
@@ -1,0 +1,117 @@
+"""Tests for ``interloper.destination.partitioned``."""
+
+import datetime
+from typing import Any, ClassVar
+
+import pytest
+
+import interloper as il
+from interloper.destination import IOContext, PartitionedDestination
+from interloper.partitioning.base import Partition
+from interloper.partitioning.time import TimePartition, TimePartitionWindow
+
+
+class RecordingScopes(PartitionedDestination):
+    """Destination capturing every scope-hook call."""
+
+    calls: ClassVar[list[tuple[str, Any, Any]]] = []
+
+    def model_post_init(self, context: Any) -> None:
+        super().model_post_init(context)
+        object.__setattr__(self, "calls", [])
+
+    def _write_scope(self, context: IOContext, partition: Partition | None, data: Any) -> None:
+        self.calls.append(("write", partition.id if partition else None, data))
+
+    def _read_scope(self, context: IOContext, partition: Partition | None) -> Any:
+        self.calls.append(("read", partition.id if partition else None, None))
+        return {"scope": partition.id if partition else None}
+
+
+@il.asset(partitioning=il.TimePartitionConfig(column="date"))
+def partitioned_asset(context: il.ExecutionContext) -> list:  # noqa: D103
+    return []
+
+
+@il.asset
+def plain_asset() -> list:  # noqa: D103
+    return []
+
+
+def ctx(asset: il.Asset, scope=None) -> IOContext:  # noqa: D103
+    return IOContext(asset=asset, partition_or_window=scope)
+
+
+class TestWriteDispatch:
+    """The three-way write dispatch with window splitting."""
+
+    def test_unpartitioned_write_is_one_scope(self):
+        dest = RecordingScopes(id="d")
+        dest.write(ctx(plain_asset()), [{"a": 1}])
+        assert dest.calls == [("write", None, [{"a": 1}])]
+
+    def test_partition_write_passes_data_unsplit(self):
+        dest = RecordingScopes(id="d")
+        rows = [{"date": "2024-01-01"}, {"date": "2024-01-02"}]
+        dest.write(ctx(partitioned_asset(), TimePartition(datetime.date(2024, 1, 1))), rows)
+        assert dest.calls == [("write", "2024-01-01", rows)]
+
+    def test_window_write_splits_per_partition(self):
+        dest = RecordingScopes(id="d")
+        rows = [
+            {"date": "2024-01-01", "v": 1},
+            {"date": "2024-01-02", "v": 2},
+            {"date": "2024-01-02", "v": 3},
+        ]
+        window = TimePartitionWindow(datetime.date(2024, 1, 1), datetime.date(2024, 1, 2))
+        dest.write(ctx(partitioned_asset(), window), rows)
+        by_scope = {scope: data for kind, scope, data in dest.calls}
+        assert by_scope["2024-01-01"] == [{"date": "2024-01-01", "v": 1}]
+        assert by_scope["2024-01-02"] == [{"date": "2024-01-02", "v": 2}, {"date": "2024-01-02", "v": 3}]
+
+    def test_window_write_splits_dataframes_natively(self):
+        pd = pytest.importorskip("pandas")
+
+        dest = RecordingScopes(id="d")
+        df = pd.DataFrame([{"date": "2024-01-01", "v": 1}, {"date": "2024-01-02", "v": 2}])
+        window = TimePartitionWindow(datetime.date(2024, 1, 1), datetime.date(2024, 1, 2))
+        dest.write(ctx(partitioned_asset(), window), df)
+        for _, _, data in dest.calls:
+            assert isinstance(data, pd.DataFrame)
+            assert len(data) == 1
+
+    def test_window_write_passes_unsplittable_data_as_is(self):
+        dest = RecordingScopes(id="d")
+        sentinel = object()
+        window = TimePartitionWindow(datetime.date(2024, 1, 1), datetime.date(2024, 1, 1))
+        dest.write(ctx(partitioned_asset(), window), sentinel)
+        assert dest.calls == [("write", "2024-01-01", sentinel)]
+
+
+class TestReadDispatch:
+    """The three-way read dispatch."""
+
+    def test_unpartitioned_read(self):
+        assert RecordingScopes(id="d").read(ctx(plain_asset())) == {"scope": None}
+
+    def test_partition_read(self):
+        result = RecordingScopes(id="d").read(ctx(partitioned_asset(), TimePartition(datetime.date(2024, 1, 2))))
+        assert result == {"scope": "2024-01-02"}
+
+    def test_window_read_returns_one_result_per_partition(self):
+        window = TimePartitionWindow(datetime.date(2024, 1, 1), datetime.date(2024, 1, 2))
+        result = RecordingScopes(id="d").read(ctx(partitioned_asset(), window))
+        assert {r["scope"] for r in result} == {"2024-01-01", "2024-01-02"}
+
+
+class TestHookContract:
+    """Hooks are required unless the corresponding template is overridden."""
+
+    def test_missing_hooks_raise_with_guidance(self):
+        class Bare(PartitionedDestination):
+            pass
+
+        with pytest.raises(NotImplementedError, match="_write_scope.*or override write"):
+            Bare(id="b").write(ctx(plain_asset()), [])
+        with pytest.raises(NotImplementedError, match="_read_scope.*or override read"):
+            Bare(id="b").read(ctx(plain_asset()))

--- a/packages/interloper-google-cloud/src/interloper_google_cloud/bigquery/destination.py
+++ b/packages/interloper-google-cloud/src/interloper_google_cloud/bigquery/destination.py
@@ -10,7 +10,7 @@ import warnings
 from collections.abc import Sequence
 from decimal import Decimal
 from functools import cached_property
-from typing import Any
+from typing import Any, ClassVar
 
 import google.auth
 import pandas as pd
@@ -40,7 +40,7 @@ class BigQueryDestination(DatabaseDestination):
     connection: GoogleCloudConnection
 
     # Reads materialize as DataFrames for downstream assets.
-    read_representation: str = "dataframe"
+    read_representation: ClassVar[str] = "dataframe"
 
     # Config fields (previously on BigQueryConfig)
     project: str = InputField(description="Google Cloud project ID")

--- a/packages/interloper-google-cloud/tests/test_bigquery.py
+++ b/packages/interloper-google-cloud/tests/test_bigquery.py
@@ -10,7 +10,6 @@ import interloper as il
 import pytest
 from google.cloud import bigquery
 from interloper.destination import IOContext
-from interloper.destination.database import WriteDisposition
 from interloper.errors import ConfigError
 from interloper.schema import Schema
 from pydantic import BaseModel, Field
@@ -48,7 +47,6 @@ def _make_destination(**overrides: Any) -> tuple[BigQueryDestination, MagicMock]
         project=project,
         location="EU",
         default_dataset=overrides.get("dataset", None),
-        write_disposition=overrides.get("write_disposition", WriteDisposition.REPLACE),
         resources={"connection": conn},
     )
     object.__setattr__(dest, "client", mock_client)


### PR DESCRIPTION
## What

Tier-1 item #2 from the cleanliness audit: the `None / Partition / PartitionWindow` three-way branch was hand-rolled **~10 times** across `DatabaseDestination`, CSV, and Memory (write *and* read) — the duplication that originally caused the window-splitting bug where every partition directory received the full dataset. Plus 4 more `partition_or_window if partitioning else None` ternaries in asset/runner code.

### `PartitionedDestination`

One template, two scope hooks — subclasses are partition-correct by construction:

```python
class PartitionedDestination(Destination):
    def _write_scope(self, context, partition: Partition | None, data) -> None: ...
    def _read_scope(self, context, partition: Partition | None) -> Any: ...
    # write(): None → one scope; Partition → one scope; Window → split per partition
    # read():  None → one scope; Partition → one scope; Window → [one result per partition]
```

Window writes split through the data's registered representation (`filter_eq`) — DataFrames slice natively before any records conversion, unrecognized shapes pass through unsplit. This also unifies the two previously-duplicated slicing helpers (CSV's `_rows_for_partition`, Memory's `_slice_for_partition`).

### Adoption

- **CSV / Memory** collapse onto the hooks; their window loops and scope-path/key plumbing unify (`_scope_path` / `_scope_key`).
- **DatabaseDestination** adopts the **read** template (hand-rolled `read()` deleted) and keeps `write()` overridden *deliberately*: database backends delete per scope but insert the whole batch once — per-partition writes would turn one BigQuery load job into N. This is why the hooks are `NotImplementedError`-defaults rather than abstract: a backend can adopt one template and override the other, and the error message names exactly that choice.
- **Plain `Destination`** remains the escape hatch for genuinely unpartitioned stores (`FileDestination`, user destinations) — no contract change for them.
- **`Asset.effective_partition()`** replaces the four scattered ternaries in asset/runner code.

## Verification

488 passed, ruff + ty clean. The existing CSV/Memory/Database behavior tests pass **unchanged** (parity through the template). New `test_partitioned.py` covers the dispatch matrix: all three scopes both directions, native DataFrame window slicing, unsplittable passthrough, and the hook-contract guidance errors.

### Second commit: backend traits are class-level, not instance config

`read_representation` and `write_disposition` were pydantic instance fields, so they leaked into `config_schema` and rendered as user-editable fields in the UI. They're backend *traits*: toggling `read_representation` would change the data type downstream assets receive, and disposition semantics belong to the integration author. Both move to `ClassVar` (the `Schema.id` pattern) — gone from `model_fields`, the config schema, and spec serialization automatically. BigQuery's UI form now shows exactly `project / location / default_dataset`. Subclasses override at class level, and `@destination(read_representation=...)` is supported for plain-class/function-style destinations. Regression tests pin the exclusion.
