### PR TITLE
fix: load filtered events from the server when a timeline asset is selected

### DIFF
--- a/packages/interloper-api/src/interloper_api/routes/runs.py
+++ b/packages/interloper-api/src/interloper_api/routes/runs.py
@@ -219,20 +219,22 @@ def list_run_events(
     response: Response,
     limit: int = 100,
     offset: int = 0,
+    asset_id: UUID | None = None,
     user: Profile = Depends(require_viewer),
     store: Store = Depends(get_store),
 ) -> list[EventResponse]:
     """List events for a run, oldest first.
 
     Events are ordered ``timestamp ASC`` and paged with ``limit``/``offset``.
-    The total number of events for the run (ignoring ``limit``/``offset``) is
-    returned in the ``X-Total-Count`` response header so clients can page
+    ``asset_id`` narrows the listing to one asset's events. The total number
+    of matching events (ignoring ``limit``/``offset``, honouring ``asset_id``)
+    is returned in the ``X-Total-Count`` response header so clients can page
     through every event — including the terminal/outcome events
     (``asset_completed``, ``asset_failed``, ``run_failed``, …) that sort last.
     """
     limit = max(1, min(limit, MAX_EVENTS_PAGE_SIZE))
     offset = max(0, offset)
-    total = store.count_events(run_id=run_id)
+    total = store.count_events(run_id=run_id, asset_id=asset_id)
     response.headers["X-Total-Count"] = str(total)
-    events = store.list_events(run_id=run_id, limit=limit, offset=offset)
+    events = store.list_events(run_id=run_id, asset_id=asset_id, limit=limit, offset=offset)
     return [_event_to_response(e) for e in events]

--- a/packages/interloper-api/tests/test_run_events.py
+++ b/packages/interloper-api/tests/test_run_events.py
@@ -32,8 +32,16 @@ class FakeStore:
     def __init__(self, total: int = 777) -> None:
         self.total = total
         self.list_calls: list[tuple] = []
+        self.count_calls: list[UUID | None] = []
 
-    def count_events(self, *, run_id: UUID | None = None, org_id: UUID | None = None) -> int:
+    def count_events(
+        self,
+        *,
+        run_id: UUID | None = None,
+        org_id: UUID | None = None,
+        asset_id: UUID | None = None,
+    ) -> int:
+        self.count_calls.append(asset_id)
         return self.total
 
     def list_events(
@@ -41,10 +49,11 @@ class FakeStore:
         *,
         run_id: UUID | None = None,
         org_id: UUID | None = None,
+        asset_id: UUID | None = None,
         limit: int = 100,
         offset: int = 0,
     ) -> list:
-        self.list_calls.append((run_id, limit, offset))
+        self.list_calls.append((run_id, limit, offset, asset_id))
         # Return as many fake events as the page would hold, capped at the total.
         n = max(0, min(limit, self.total - offset))
         return [
@@ -81,7 +90,7 @@ def test_returns_total_count_header(store: FakeStore) -> None:
 def test_forwards_limit_and_offset(store: FakeStore) -> None:
     resp = _client(store).get(f"/{_RUN_ID}/events?limit=100&offset=200")
     assert resp.status_code == 200
-    assert store.list_calls[-1] == (_RUN_ID, 100, 200)
+    assert store.list_calls[-1] == (_RUN_ID, 100, 200, None)
 
 
 def test_limit_is_clamped_to_max_page_size(store: FakeStore) -> None:
@@ -89,9 +98,23 @@ def test_limit_is_clamped_to_max_page_size(store: FakeStore) -> None:
     assert store.list_calls[-1][1] == MAX_EVENTS_PAGE_SIZE
 
 
+def test_forwards_asset_filter_to_list_and_count(store: FakeStore) -> None:
+    asset_id = uuid4()
+    resp = _client(store).get(f"/{_RUN_ID}/events?asset_id={asset_id}")
+    assert resp.status_code == 200
+    assert store.list_calls[-1] == (_RUN_ID, 100, 0, asset_id)
+    # X-Total-Count must reflect the same filter the listing used.
+    assert store.count_calls[-1] == asset_id
+
+
+def test_invalid_asset_filter_is_rejected(store: FakeStore) -> None:
+    resp = _client(store).get(f"/{_RUN_ID}/events?asset_id=not-a-uuid")
+    assert resp.status_code == 422
+
+
 def test_limit_and_offset_are_clamped_to_lower_bounds(store: FakeStore) -> None:
     _client(store).get(f"/{_RUN_ID}/events?limit=0&offset=-5")
-    _, limit, offset = store.list_calls[-1]
+    _, limit, offset, _ = store.list_calls[-1]
     assert limit == 1
     assert offset == 0
 

--- a/packages/interloper-app/app/app/components/executions/EventsTable.vue
+++ b/packages/interloper-app/app/app/components/executions/EventsTable.vue
@@ -17,7 +17,6 @@ const props = defineProps<{
     loadMore?: () => Promise<void>
 }>()
 
-const selectedAsset = defineModel<string | null>('selectedAsset', { default: null })
 const eventInFocus = defineModel<RunEvent | null>('eventInFocus', { default: null })
 const assetDisplayName = useAssetDisplayName()
 
@@ -52,11 +51,6 @@ function showErrorDetail(event: RunEvent) {
     })
     modal.open()
 }
-
-const filteredEvents = computed(() => {
-    if (!selectedAsset.value) return props.events
-    return props.events.filter(e => e.asset_id === selectedAsset.value)
-})
 
 function formatTimestamp(value: string): string {
     const date = new Date(value)
@@ -128,7 +122,7 @@ const columns: TableColumn<RunEvent>[] = [
 
 <template>
     <UTable ref="table"
-            :data="filteredEvents"
+            :data="events"
             :columns="columns"
             :loading="loading"
             sticky

--- a/packages/interloper-app/app/app/pages/executions/runs/[run].vue
+++ b/packages/interloper-app/app/app/pages/executions/runs/[run].vue
@@ -25,6 +25,10 @@ const run = computed(() => runsStore.findById(runId) ?? initialRun.value)
 
 const selectedAsset = ref<string | null>(null)
 const eventInFocus = ref<RunEvent | null>(null)
+
+// The events table is paged from the server, so the asset filter is applied
+// there (re-paged from offset 0) rather than over the loaded pages only.
+watch(selectedAsset, asset => eventsStore.filterByAsset(asset))
 const markerTime = computed(() => eventInFocus.value?.timestamp ? new Date(eventInFocus.value.timestamp) : null)
 const highlightedAsset = computed(() => eventInFocus.value?.asset_id ?? null)
 
@@ -142,8 +146,7 @@ onUnmounted(() => {
                     </UBadge>
                 </div>
                 <div class="flex-1 min-h-0">
-                    <ExecutionsEventsTable v-model:selected-asset="selectedAsset"
-                                           v-model:event-in-focus="eventInFocus"
+                    <ExecutionsEventsTable v-model:event-in-focus="eventInFocus"
                                            :events="eventsStore.events"
                                            :loading="eventsStore.loading"
                                            :loading-more="eventsStore.loadingMore"

--- a/packages/interloper-app/app/app/stores/events.ts
+++ b/packages/interloper-app/app/app/stores/events.ts
@@ -25,11 +25,20 @@ export const useEventsStore = defineStore('events', () => {
      * State
      **********************/
     const runId = ref<string | null>(null)
+    // Server-side asset filter. Events are paged from the server, so filtering
+    // must happen there too — filtering only the loaded pages client-side would
+    // hide every matching event that hasn't been scrolled into view yet.
+    const assetId = ref<string | null>(null)
     const events = ref<RunEvent[]>([])
     const total = ref(0)
     const loading = ref(false) // initial page load
     const loadingMore = ref(false) // subsequent pages (infinite scroll)
     const error = ref<Error | null>(null)
+
+    // Bumped on every reset (run change, filter change, $reset) so a page
+    // response that was in flight across the reset is dropped instead of
+    // merging stale rows and clobbering total/nextOffset.
+    let fetchEpoch = 0
 
     // Offset of the next page to request. Tracks rows pulled from the server
     // only — realtime tail-inserts append to `events` but never advance this.
@@ -77,11 +86,14 @@ export const useEventsStore = defineStore('events', () => {
     async function _loadPage() {
         const id = runId.value
         if (!id) return
+        const epoch = fetchEpoch
         const params = new URLSearchParams({
             limit: String(EVENTS_PAGE_SIZE),
             offset: String(nextOffset.value),
         })
+        if (assetId.value) params.set('asset_id', assetId.value)
         const res = await apiFetchRaw<RunEvent[]>(`/runs/${id}/events?${params}`)
+        if (epoch !== fetchEpoch) return // state was reset while in flight
         const page = res._data ?? []
         total.value = Number(res.headers.get('X-Total-Count') ?? nextOffset.value + page.length)
         // A short/empty page means the server has nothing more; pin the offset
@@ -96,7 +108,8 @@ export const useEventsStore = defineStore('events', () => {
     useRealtimeSubscription({
         table: 'events',
         scope: () => runId.value ? orgStore.organisation?.id : null,
-        shouldHandle: (record: Record<string, any>) => record.run_id === runId.value,
+        shouldHandle: (record: Record<string, any>) =>
+            record.run_id === runId.value && (!assetId.value || record.asset_id === assetId.value),
         onInsert: (record: Record<string, any>) => _upsert(record as RunEvent),
     })
 
@@ -104,15 +117,17 @@ export const useEventsStore = defineStore('events', () => {
      * Actions
      **********************/
     /**
-     * Load the first page of events for a run.
+     * Load the first page of events for a run, optionally filtered to one asset.
      *
      * Events are ordered oldest-first, so the terminal/outcome events
      * (`asset_completed`, `asset_failed`, `run_failed`, …) live at the end.
      * The table reaches them by infinite-scrolling — see `loadMore` — rather
      * than loading the whole history up front.
      */
-    async function fetchForRun(id: string) {
+    async function fetchForRun(id: string, asset: string | null = null) {
         runId.value = id
+        assetId.value = asset
+        fetchEpoch++
         events.value = []
         total.value = 0
         nextOffset.value = 0
@@ -127,6 +142,12 @@ export const useEventsStore = defineStore('events', () => {
         finally {
             loading.value = false
         }
+    }
+
+    /** Re-page from the start with an asset filter (`null` clears it). */
+    async function filterByAsset(asset: string | null) {
+        if (!runId.value || asset === assetId.value) return
+        await fetchForRun(runId.value, asset)
     }
 
     /** Load the next page of events. Safe to call repeatedly (infinite scroll). */
@@ -157,6 +178,8 @@ export const useEventsStore = defineStore('events', () => {
 
     function $reset() {
         runId.value = null
+        assetId.value = null
+        fetchEpoch++
         events.value = []
         total.value = 0
         nextOffset.value = 0
@@ -167,6 +190,7 @@ export const useEventsStore = defineStore('events', () => {
 
     return {
         runId,
+        assetId,
         events,
         total,
         loading,
@@ -174,6 +198,7 @@ export const useEventsStore = defineStore('events', () => {
         hasMore,
         error,
         fetchForRun,
+        filterByAsset,
         loadMore,
         findById,
         byAssetKey,

--- a/packages/interloper-db/src/interloper_db/store/runs.py
+++ b/packages/interloper-db/src/interloper_db/store/runs.py
@@ -98,10 +98,11 @@ class RunMixin:
         *,
         run_id: UUID | None = None,
         org_id: UUID | None = None,
+        asset_id: UUID | None = None,
         limit: int = 100,
         offset: int = 0,
     ) -> list[Event]:
-        """List events, optionally filtered by run.
+        """List events, optionally filtered by run and/or asset.
 
         Ordering is ``timestamp ASC, id ASC`` — stable and deterministic so
         ``offset``/``limit`` paging never skips or repeats a row when several
@@ -110,6 +111,7 @@ class RunMixin:
         Args:
             run_id: Optional run filter.
             org_id: Optional org filter.
+            asset_id: Optional asset filter.
             limit: Max results (default 100).
             offset: Pagination offset.
 
@@ -122,6 +124,8 @@ class RunMixin:
                 statement = statement.where(Event.run_id == run_id)
             if org_id:
                 statement = statement.where(Event.org_id == org_id)
+            if asset_id:
+                statement = statement.where(Event.asset_id == asset_id)
             statement = (
                 statement.order_by(col(Event.timestamp).asc(), col(Event.id).asc()).offset(offset).limit(limit)
             )
@@ -132,12 +136,14 @@ class RunMixin:
         *,
         run_id: UUID | None = None,
         org_id: UUID | None = None,
+        asset_id: UUID | None = None,
     ) -> int:
         """Count events matching the same filters as :meth:`list_events`.
 
         Args:
             run_id: Optional run filter.
             org_id: Optional org filter.
+            asset_id: Optional asset filter.
 
         Returns:
             Total number of matching events (ignoring limit/offset).
@@ -148,6 +154,8 @@ class RunMixin:
                 statement = statement.where(Event.run_id == run_id)
             if org_id:
                 statement = statement.where(Event.org_id == org_id)
+            if asset_id:
+                statement = statement.where(Event.asset_id == asset_id)
             return session.exec(statement).one()
 
     def list_asset_executions(self, run_id: UUID) -> list[dict]:

--- a/packages/interloper-db/tests/test_run_events.py
+++ b/packages/interloper-db/tests/test_run_events.py
@@ -48,13 +48,14 @@ def _seed(events: list[Event]) -> None:
         session.commit()
 
 
-def _make_events(n: int, *, run_id: UUID = _RUN_ID, start: int = 0) -> list[Event]:
+def _make_events(n: int, *, run_id: UUID = _RUN_ID, start: int = 0, asset_id: UUID | None = None) -> list[Event]:
     """Build ``n`` events for a run, one second apart, oldest first."""
     return [
         Event(
             id=uuid4(),
             org_id=_ORG_ID,
             run_id=run_id,
+            asset_id=asset_id,
             event_type="asset_materializing" if i < n - 1 else "asset_completed",
             timestamp=_BASE_TS + timedelta(seconds=start + i),
         )
@@ -129,3 +130,24 @@ def test_filters_isolate_runs(store: RunMixin) -> None:
     assert store.count_events(run_id=_RUN_ID) == 5
     assert store.count_events(run_id=_OTHER_RUN_ID) == 3
     assert len(store.list_events(run_id=_RUN_ID)) == 5
+
+
+def test_asset_filter_lists_and_counts_only_that_asset(store: RunMixin) -> None:
+    asset_a, asset_b = uuid4(), uuid4()
+    _seed(_make_events(150, asset_id=asset_a))
+    _seed(_make_events(30, start=150, asset_id=asset_b))
+
+    assert store.count_events(run_id=_RUN_ID, asset_id=asset_a) == 150
+    assert store.count_events(run_id=_RUN_ID, asset_id=asset_b) == 30
+
+    # Paging honours the filter: asset_a events past the first unfiltered
+    # page are reachable through the filtered offsets.
+    page2 = store.list_events(run_id=_RUN_ID, asset_id=asset_a, limit=100, offset=100)
+    assert len(page2) == 50
+    assert all(e.asset_id == asset_a for e in page2)
+
+    # asset_b's events all live beyond the first 150 rows of the run, yet its
+    # filtered first page surfaces them.
+    page_b = store.list_events(run_id=_RUN_ID, asset_id=asset_b, limit=100, offset=0)
+    assert len(page_b) == 30
+    assert all(e.asset_id == asset_b for e in page_b)


### PR DESCRIPTION
## What

Follow-up to #28. With the timeline clicks fixed, the asset filter itself had a coverage hole: the events table pages from the server 100 rows at a time, but the filter only ran client-side over the pages already loaded. Selecting an asset hid every matching event that hadn't been scrolled into view yet — and the shrunken filtered list never re-triggered the infinite scroll to fetch the rest.

## How

Filter server-side through the whole stack:

- `Store.list_events` / `count_events` accept an optional `asset_id` filter
- `GET /runs/{run_id}/events` takes an `asset_id` query param, honoured by both the listing and the `X-Total-Count` header
- the events store re-pages from offset 0 when the selection changes (`filterByAsset`), keeps infinite scroll working within the filter, and gates realtime inserts by the active filter
- a fetch epoch drops in-flight page responses that resolve after a reset (filter switch, run switch, unmount) so stale rows can't clobber the pagination bookkeeping
- the client-side `filteredEvents` computed in `EventsTable` is gone — the table renders what the store holds

The events count badge now reflects the filtered total when a filter is active, which also makes it honest ("14" instead of "1 of the rows you happen to have loaded").

## Verification

Driven end-to-end on the dev instance against a run with 204 events where asset E's 14 events sit almost entirely beyond the first page:

- selecting E surfaced all 14 events (13 of them previously unreachable), badge `14`
- blank-space click restored the unfiltered view (`100 / 204`)
- selecting an asset with 158 events showed the first filtered page (`100 / 158`), and scrolling paged the rest in (`158`)
- the mid-run click scenario from #28 was re-run against the new code and still passes (filter applies while `running`, clears, reapplies)