### PR TITLE
feat: persist and display log event level

### DIFF
--- a/packages/interloper-api/src/interloper_api/routes/runs.py
+++ b/packages/interloper-api/src/interloper_api/routes/runs.py
@@ -71,6 +71,7 @@ class EventResponse(BaseModel):
     error: str | None
     traceback: str | None
     message: str | None
+    level: str | None
     timestamp: str
 
 
@@ -119,6 +120,7 @@ def _event_to_response(event: Event) -> EventResponse:
         error=event.error,
         traceback=event.traceback,
         message=event.message,
+        level=event.level,
         timestamp=str(event.timestamp),
     )
 

--- a/packages/interloper-app/app/app/components/executions/EventsTable.vue
+++ b/packages/interloper-app/app/app/components/executions/EventsTable.vue
@@ -89,11 +89,17 @@ const columns: TableColumn<RunEvent>[] = [
         header: 'Event',
         cell: ({ row }) => {
             const et = row.getValue<EventType>('event_type')
-            return h(UBadge, {
+            const badge = h(UBadge, {
                 color: eventTypeColor(et),
                 variant: 'subtle',
                 icon: eventTypeIcon(et),
             }, () => eventTypeLabel(et))
+            const level = row.original.level
+            if (et !== 'log' || !level) return badge
+            return h('div', { class: 'flex items-center gap-1.5' }, [
+                badge,
+                h(UBadge, { color: logLevelColor(level), variant: 'subtle' }, () => level),
+            ])
         },
     },
     {

--- a/packages/interloper-app/app/app/stores/events.ts
+++ b/packages/interloper-app/app/app/stores/events.ts
@@ -11,6 +11,7 @@ export interface RunEvent {
     error: string | null
     traceback: string | null
     message: string | null
+    level: string | null
     timestamp: string
 }
 

--- a/packages/interloper-app/app/app/utils/events.ts
+++ b/packages/interloper-app/app/app/utils/events.ts
@@ -62,6 +62,18 @@ export function eventTypeLabel(eventType: EventType): string {
     return labelMap[eventType] ?? eventType
 }
 
+const levelColorMap: Record<string, BadgeColor> = {
+    DEBUG: 'neutral',
+    INFO: 'info',
+    WARNING: 'warning',
+    ERROR: 'error',
+    CRITICAL: 'error',
+}
+
+export function logLevelColor(level: string): BadgeColor {
+    return levelColorMap[level.toUpperCase()] ?? 'neutral'
+}
+
 export function eventTypeColor(eventType: EventType): BadgeColor {
     if (eventType.includes('failed')) return 'error'
     if (eventType.includes('completed')) return 'success'

--- a/packages/interloper-db/src/interloper_db/migrations/versions/008_event_level.py
+++ b/packages/interloper-db/src/interloper_db/migrations/versions/008_event_level.py
@@ -1,0 +1,28 @@
+"""Add level column to events table.
+
+Stores the log level (DEBUG/INFO/WARNING/ERROR) carried by ``log``
+events so the UI can display it; NULL for all other event types.
+
+Revision ID: 008
+Revises: 007
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "008"
+down_revision: str | None = "007"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    """Add the level column to the events table."""
+    op.execute("ALTER TABLE events ADD COLUMN IF NOT EXISTS level TEXT;")
+
+
+def downgrade() -> None:
+    """Remove the level column from the events table."""
+    op.execute("ALTER TABLE events DROP COLUMN IF EXISTS level;")

--- a/packages/interloper-db/src/interloper_db/models.py
+++ b/packages/interloper-db/src/interloper_db/models.py
@@ -494,4 +494,5 @@ class Event(SQLModel, table=True):
     asset_id: UUID | None = SQLField(default=None)
     asset_key: str | None = None
     message: str | None = None
+    level: str | None = None
     timestamp: datetime = SQLField(sa_column=Column(TZDateTime))

--- a/packages/interloper-db/src/interloper_db/store/runs.py
+++ b/packages/interloper-db/src/interloper_db/store/runs.py
@@ -81,6 +81,7 @@ class RunMixin:
             "error": _sanitize_text(meta.get("error")),
             "traceback": _sanitize_text(meta.get("traceback")),
             "message": _sanitize_text(meta.get("message")),
+            "level": _sanitize_text(meta.get("level")),
             "timestamp": event.timestamp,
         }
 


### PR DESCRIPTION
## What

Log events in the run events table now display their level (`DEBUG`/`INFO`/`WARNING`/`ERROR`) as a colored badge next to the existing **Log** badge — neutral, info, warning, and error colors respectively.

## Why

`EventLogger` (`context.logger.info(...)` etc.) already carries the level in the event metadata, but it was dropped when the event was persisted, so the UI had no way to distinguish a warning from an info line.

## How

- **DB**: nullable `level` column on `Event` + migration `008_event_level`; `save_event` now persists `metadata["level"]` (sanitized like the other free-text fields).
- **API**: `level` added to `EventResponse` on `GET /runs/{run_id}/events`.
- **Frontend**: `level` on the `RunEvent` interface, a `logLevelColor` helper (DEBUG → neutral, INFO → info, WARNING → warning, ERROR/CRITICAL → error), and the badge rendering in `EventsTable.vue`.

## Notes for review

- The realtime path needs no change: the `table_changes` NOTIFY trigger forwards `row_to_json` of the row, so the new column flows to websocket clients automatically.
- Events persisted before the migration have `level = NULL` and render exactly as before (no extra badge).
- Verified: ruff, ty, db + api pytest suites, frontend eslint and `nuxt typecheck` all green.