### PR TITLE
ci: split docker/helm publishing into a tag-triggered publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,166 @@
+name: Publish
+
+# Publishes the artifacts for a released tag: Docker images and the Helm
+# chart. Decoupled from the Release workflow so a failed publish can be
+# replayed without re-running semantic-release (which would find nothing to
+# release and skip everything).
+#
+# Triggers:
+#   - automatically when semantic-release pushes a `v*` tag (the tag is
+#     pushed with the GitHub App token, so the push event fires workflows);
+#   - manually via workflow_dispatch with an existing tag, to re-publish
+#     after a transient failure.
+#
+# Every job is idempotent: Docker re-pushes the same image tags and
+# chart-releaser skips chart releases that already exist.
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to (re)publish"
+        required: true
+        type: string
+
+jobs:
+  resolve:
+    name: Resolve tag
+    runs-on: ubuntu-latest
+
+    outputs:
+      tag: ${{ steps.resolve.outputs.tag }}
+      version: ${{ steps.resolve.outputs.version }}
+      stable: ${{ steps.resolve.outputs.stable }}
+
+    steps:
+      - name: Resolve tag
+        id: resolve
+        run: |
+          tag="${{ inputs.tag || github.ref_name }}"
+          version="${tag#v}"
+          case "$version" in
+            *-rc*) stable=false ;;
+            *)     stable=true ;;
+          esac
+          {
+            echo "tag=${tag}"
+            echo "version=${version}"
+            echo "stable=${stable}"
+          } >> "$GITHUB_OUTPUT"
+
+  # ────────────────────────────────────────────────────────────────────
+  # Docker images → GitHub Container Registry (ghcr.io)
+  #
+  # One image per component, tagged with the released version (plus `latest`
+  # on stable releases only). The matrix mirrors the image catalog in the
+  # Makefile (ROLES + ROLES_LAUNCHER_AWARE) — keep the two in sync.
+  # ────────────────────────────────────────────────────────────────────
+  docker:
+    name: Docker (${{ matrix.image }})
+    needs: resolve
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: "read"
+      packages: "write"
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { target: api,       image: interloper-api,              scheduler_extras: "" }
+          - { target: frontend,  image: interloper-frontend,         scheduler_extras: "" }
+          - { target: worker,    image: interloper-worker,           scheduler_extras: "" }
+          - { target: scheduler, image: interloper-scheduler,        scheduler_extras: "" }
+          - { target: scheduler, image: interloper-scheduler-k8s,    scheduler_extras: "k8s" }
+          - { target: scheduler, image: interloper-scheduler-docker, scheduler_extras: "docker" }
+
+    steps:
+      - name: Checkout (released tag)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve.outputs.tag }}
+
+      - name: Setup QEMU
+        # Registers binfmt handlers so the amd64 runner can build the
+        # linux/arm64 image via emulation.
+        uses: docker/setup-qemu-action@v3
+
+      - name: Setup Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute tags
+        id: tags
+        run: |
+          owner="$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
+          repo="ghcr.io/${owner}/${{ matrix.image }}"
+          tags="${repo}:${{ needs.resolve.outputs.version }}"
+          if [ "${{ needs.resolve.outputs.stable }}" = "true" ]; then
+            tags="${tags},${repo}:latest"
+          fi
+          echo "tags=${tags}" >> "$GITHUB_OUTPUT"
+
+      - name: Build & Push (${{ matrix.target }})
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: dockerfile
+          target: ${{ matrix.target }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          build-args: |
+            CORE_EXTRAS=google-cloud
+            ASSETS_EXTRAS=bing,facebook,google
+            SCHEDULER_EXTRAS=${{ matrix.scheduler_extras }}
+          cache-from: type=gha,scope=docker-${{ matrix.image }}
+          cache-to: type=gha,scope=docker-${{ matrix.image }},mode=max
+
+  # ────────────────────────────────────────────────────────────────────
+  # Helm chart → GitHub Pages (chart-releaser)
+  #
+  # Packages chart/interloper and publishes it to the gh-pages Helm repo,
+  # creating a per-chart GitHub release. Stable releases only — RC chart
+  # versions would clutter the public repo. Chart `version`/`appVersion`
+  # are bumped by semantic-release, so the checked-out tag is ready to ship.
+  # ────────────────────────────────────────────────────────────────────
+  helm:
+    name: Helm chart release
+    needs: resolve
+    if: needs.resolve.outputs.stable == 'true'
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: "write"
+
+    steps:
+      - name: Checkout (released tag)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve.outputs.tag }}
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+
+      - name: Release chart
+        uses: helm/chart-releaser-action@v1
+        with:
+          charts_dir: chart
+          config: cr.yaml
+        env:
+          CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,10 @@
 name: Release
 
+# Cuts the release only: checks, semantic-release (version bump, tag,
+# changelog, GitHub release) and the PyPI publish. Docker images and the
+# Helm chart are published by the Publish workflow, which fires on the tag
+# semantic-release pushes — and can be re-run for that tag independently.
+
 on:
   workflow_dispatch:
     inputs:
@@ -16,11 +21,6 @@ jobs:
     name: Release (${{ inputs.release_type }})
     if: github.ref_name == 'main'
     runs-on: ubuntu-latest
-
-    outputs:
-      released: ${{ steps.release.outputs.released }}
-      version: ${{ steps.release.outputs.version }}
-      tag: ${{ steps.release.outputs.tag }}
 
     permissions:
       contents: "write"
@@ -85,119 +85,3 @@ jobs:
         run: |
           uv build --all-packages
           uv publish --trusted-publishing always
-
-  # ────────────────────────────────────────────────────────────────────
-  # Docker images → GitHub Container Registry (ghcr.io)
-  #
-  # One image per component, tagged with the released version (plus `latest`
-  # on stable releases only). The matrix mirrors the image catalog in the
-  # Makefile (ROLES + ROLES_LAUNCHER_AWARE) — keep the two in sync.
-  # ────────────────────────────────────────────────────────────────────
-  docker:
-    name: Docker (${{ matrix.image }})
-    needs: release
-    if: needs.release.outputs.released == 'true'
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: "read"
-      packages: "write"
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - { target: api,       image: interloper-api,              scheduler_extras: "" }
-          - { target: frontend,  image: interloper-frontend,         scheduler_extras: "" }
-          - { target: worker,    image: interloper-worker,           scheduler_extras: "" }
-          - { target: scheduler, image: interloper-scheduler,        scheduler_extras: "" }
-          - { target: scheduler, image: interloper-scheduler-k8s,    scheduler_extras: "k8s" }
-          - { target: scheduler, image: interloper-scheduler-docker, scheduler_extras: "docker" }
-
-    steps:
-      - name: Checkout (released tag)
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.release.outputs.tag }}
-
-      - name: Setup QEMU
-        # Registers binfmt handlers so the amd64 runner can build the
-        # linux/arm64 image via emulation.
-        uses: docker/setup-qemu-action@v3
-
-      - name: Setup Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Compute tags
-        id: tags
-        run: |
-          owner="$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
-          repo="ghcr.io/${owner}/${{ matrix.image }}"
-          tags="${repo}:${{ needs.release.outputs.version }}"
-          if [ "${{ inputs.release_type }}" = "stable" ]; then
-            tags="${tags},${repo}:latest"
-          fi
-          echo "tags=${tags}" >> "$GITHUB_OUTPUT"
-
-      - name: Build & Push (${{ matrix.target }})
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: dockerfile
-          target: ${{ matrix.target }}
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.tags.outputs.tags }}
-          build-args: |
-            CORE_EXTRAS=google-cloud
-            ASSETS_EXTRAS=bing,facebook,google
-            SCHEDULER_EXTRAS=${{ matrix.scheduler_extras }}
-          cache-from: type=gha,scope=docker-${{ matrix.image }}
-          cache-to: type=gha,scope=docker-${{ matrix.image }},mode=max
-
-  # ────────────────────────────────────────────────────────────────────
-  # Helm chart → GitHub Pages (chart-releaser)
-  #
-  # Packages chart/interloper and publishes it to the gh-pages Helm repo,
-  # creating a per-chart GitHub release. Stable releases only — RC chart
-  # versions would clutter the public repo. Chart `version`/`appVersion`
-  # are bumped by semantic-release, so the checked-out tag is ready to ship.
-  # ────────────────────────────────────────────────────────────────────
-  helm:
-    name: Helm chart release
-    needs: release
-    if: needs.release.outputs.released == 'true' && inputs.release_type == 'stable'
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: "write"
-
-    steps:
-      - name: Checkout (released tag)
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.release.outputs.tag }}
-          fetch-depth: 0
-
-      - name: Configure Git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-      - name: Setup Helm
-        uses: azure/setup-helm@v4
-
-      - name: Release chart
-        uses: helm/chart-releaser-action@v1
-        with:
-          charts_dir: chart
-          config: cr.yaml
-        env:
-          CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

The Release workflow conflated two things with different idempotency: cutting a release (one-shot) and publishing its artifacts (safely repeatable). If the `release` job succeeded but `docker` or `helm` failed transiently, the release was stuck: re-dispatching the workflow made semantic-release find nothing new to release, so `released` stayed `false` and the publish jobs were skipped — with no way to ship the missing artifacts for the already-created tag.

## What changed

- **New `publish.yaml`** owning the `docker` and `helm` jobs (unchanged in substance). Two triggers:
  - `on: push: tags: ["v*"]` — fires automatically when semantic-release pushes the tag. This works because the tag is pushed with the GitHub App token, not `GITHUB_TOKEN` (which suppresses workflow triggering).
  - `workflow_dispatch` with a required `tag` input — the recovery path: re-publish any existing tag without involving semantic-release.

  A small `resolve` job normalizes both trigger shapes into `tag` / `version` / `stable` outputs.
- **Stable vs RC is derived from the tag name** (`-rc` ⇒ prerelease) instead of the dispatch `release_type` input, so a manual replay can't accidentally tag an RC image as `latest` or publish an RC chart.
- **`release.yaml`** is now release-cutting only: checks → semantic-release → PyPI publish.

## Notes for review

- Both publish jobs are idempotent: docker re-pushes the same image tags; chart-releaser skips chart releases that already exist.
- Existing tags (e.g. `v0.12.0`) never fired the tag-push trigger — if a past release is missing images or the chart, dispatch Publish once with that tag to backfill.
- Both workflows pass actionlint.