### PR TITLE
feat: gate org-bespoke content on the selected organisation

### DIFF
--- a/packages/interloper-api/src/interloper_api/dependencies.py
+++ b/packages/interloper-api/src/interloper_api/dependencies.py
@@ -217,6 +217,40 @@ def get_org_id(
 # -- RBAC dependencies -------------------------------------------------------
 
 
+def authorize_org_member(
+    user: Profile,
+    org_id: UUID,
+    store: Store,
+    *,
+    minimum: str = "viewer",
+    detail: str = "Not found",
+) -> None:
+    """Authorize access to a resource owned by ``org_id`` by membership.
+
+    Unlike the ``require_*`` dependencies, which bind to the session's *active*
+    organisation, this checks the user's role in the resource's organisation —
+    so ID-addressed endpoints work for members of the owning org regardless of
+    which org is currently selected. Non-members get a 404 carrying the same
+    ``detail`` as a missing resource, so IDs don't act as an existence oracle;
+    members with an insufficient role get a 403.
+
+    Args:
+        user: The authenticated user.
+        org_id: The organisation that owns the resource.
+        store: The Store instance.
+        minimum: Minimum role required (``viewer``, ``editor``, ``admin``).
+        detail: 404 detail, matching the route's missing-resource message.
+
+    Raises:
+        HTTPException: 404 if not a member, 403 if the role is insufficient.
+    """
+    role = store.get_user_role(user.id, org_id)
+    if role is None:
+        raise HTTPException(status_code=404, detail=detail)
+    if _ROLE_RANK.get(role, -1) < _ROLE_RANK[minimum]:
+        raise HTTPException(status_code=403, detail=f"Requires {minimum} role or higher")
+
+
 def _check_role(
     minimum: str,
     user: Profile,

--- a/packages/interloper-api/src/interloper_api/routes/assets.py
+++ b/packages/interloper-api/src/interloper_api/routes/assets.py
@@ -12,7 +12,14 @@ from interloper_db.models import Asset, AssetResource, Destination, DestinationR
 from pydantic import BaseModel
 from sqlmodel import Session, select
 
-from interloper_api.dependencies import get_org_id, get_store, require_editor, require_viewer
+from interloper_api.dependencies import (
+    authorize_org_member,
+    get_current_user,
+    get_org_id,
+    get_store,
+    require_editor,
+    require_viewer,
+)
 
 router = APIRouter()
 
@@ -116,6 +123,30 @@ def _dest_to_response(dest: Destination) -> DestinationResponse:
     )
 
 
+def _load_authorized_asset(asset_id: UUID, user: Profile, store: Store, *, minimum: str = "viewer") -> Asset:
+    """Load an asset and authorize the user by membership in its org.
+
+    Args:
+        asset_id: The asset UUID.
+        user: The authenticated user.
+        store: The Store instance.
+        minimum: Minimum role required in the asset's organisation.
+
+    Returns:
+        The Asset row.
+
+    Raises:
+        HTTPException: 404 if missing or the user is not a member of the
+            owning org, 403 if the role is insufficient.
+    """
+    try:
+        asset = store.get_asset(asset_id)
+    except NotFoundError:
+        raise HTTPException(status_code=404, detail=f"Asset {asset_id} not found")
+    authorize_org_member(user, asset.org_id, store, minimum=minimum, detail=f"Asset {asset_id} not found")
+    return asset
+
+
 def _asset_to_response(asset: Asset) -> AssetResponse:
     """Convert a DB Asset to an AssetResponse."""
     return AssetResponse(
@@ -183,14 +214,11 @@ def list_dependencies(
 @router.get("/{asset_id}")
 def get_asset(
     asset_id: UUID,
-    user: Profile = Depends(require_viewer),
+    user: Profile = Depends(get_current_user),
     store: Store = Depends(get_store),
 ) -> AssetResponse:
-    """Get a single asset by ID."""
-    try:
-        asset = store.get_asset(asset_id)
-    except NotFoundError:
-        raise HTTPException(status_code=404, detail=f"Asset {asset_id} not found")
+    """Get a single asset by ID. Authorized by membership in the asset's org."""
+    asset = _load_authorized_asset(asset_id, user, store)
     return _asset_to_response(asset)
 
 
@@ -198,10 +226,11 @@ def get_asset(
 def update_asset(
     asset_id: UUID,
     body: AssetUpdateRequest,
-    user: Profile = Depends(require_editor),
+    user: Profile = Depends(get_current_user),
     store: Store = Depends(get_store),
 ) -> AssetResponse:
     """Update an asset's configuration, resources, or destinations."""
+    _load_authorized_asset(asset_id, user, store, minimum="editor")
     try:
         asset = store.update_asset(
             asset_id,
@@ -218,10 +247,11 @@ def update_asset(
 @router.delete("/{asset_id}")
 def delete_asset(
     asset_id: UUID,
-    user: Profile = Depends(require_editor),
+    user: Profile = Depends(get_current_user),
     store: Store = Depends(get_store),
 ) -> dict[str, str]:
     """Delete a standalone asset."""
+    _load_authorized_asset(asset_id, user, store, minimum="editor")
     try:
         store.delete_asset(asset_id)
     except NotFoundError:
@@ -238,10 +268,14 @@ def delete_asset(
 def add_dependency(
     asset_id: UUID,
     body: AddDependencyRequest,
-    user: Profile = Depends(require_editor),
+    user: Profile = Depends(get_current_user),
     store: Store = Depends(get_store),
 ) -> DependencyResponse:
-    """Add a dependency between two assets."""
+    """Add a dependency between two assets. Both must belong to the same org."""
+    asset = _load_authorized_asset(asset_id, user, store, minimum="editor")
+    upstream = _load_authorized_asset(body.upstream_asset_id, user, store, minimum="editor")
+    if upstream.org_id != asset.org_id:
+        raise HTTPException(status_code=404, detail=f"Asset {body.upstream_asset_id} not found")
     try:
         dep = store.add_dependency(asset_id, body.upstream_asset_id, body.param_name)
     except NotFoundError as e:
@@ -256,10 +290,11 @@ def add_dependency(
 def remove_dependency(
     asset_id: UUID,
     upstream_asset_id: UUID,
-    user: Profile = Depends(require_editor),
+    user: Profile = Depends(get_current_user),
     store: Store = Depends(get_store),
 ) -> None:
     """Remove an asset dependency."""
+    _load_authorized_asset(asset_id, user, store, minimum="editor")
     try:
         store.remove_dependency(asset_id, upstream_asset_id)
     except NotFoundError as e:
@@ -272,11 +307,11 @@ def remove_dependency(
 @router.get("/{asset_id}/partition-row-counts")
 def get_partition_row_counts(
     asset_id: UUID,
-    user: Profile = Depends(require_viewer),
-    org_id: UUID = Depends(get_org_id),
+    user: Profile = Depends(get_current_user),
     store: Store = Depends(get_store),
 ) -> PartitionRowCountsResponse:
     """Get row counts grouped by partition for an asset."""
+    _load_authorized_asset(asset_id, user, store)
     try:
         il_asset = store.load_asset(asset_id)
     except NotFoundError as e:

--- a/packages/interloper-api/src/interloper_api/routes/backfills.py
+++ b/packages/interloper-api/src/interloper_api/routes/backfills.py
@@ -11,7 +11,7 @@ from interloper_db import Profile, Store
 from interloper_db.models import Backfill
 from pydantic import BaseModel
 
-from interloper_api.dependencies import get_org_id, get_store, require_viewer
+from interloper_api.dependencies import authorize_org_member, get_current_user, get_org_id, get_store, require_viewer
 
 router = APIRouter()
 
@@ -76,12 +76,13 @@ def list_backfills(
 @router.get("/{backfill_id}")
 def get_backfill(
     backfill_id: UUID,
-    user: Profile = Depends(require_viewer),
+    user: Profile = Depends(get_current_user),
     store: Store = Depends(get_store),
 ) -> BackfillResponse:
-    """Get a single backfill by ID."""
+    """Get a single backfill by ID. Authorized by membership in the backfill's org."""
     try:
         backfill = store.get_backfill(backfill_id)
     except NotFoundError:
         raise HTTPException(status_code=404, detail=f"Backfill {backfill_id} not found")
+    authorize_org_member(user, backfill.org_id, store, detail=f"Backfill {backfill_id} not found")
     return _backfill_to_response(backfill)

--- a/packages/interloper-api/src/interloper_api/routes/destinations.py
+++ b/packages/interloper-api/src/interloper_api/routes/destinations.py
@@ -7,11 +7,18 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
 from interloper.errors import NotFoundError
-from interloper_db import Store
+from interloper_db import Profile, Store
 from interloper_db.models import Destination, DestinationResource
 from pydantic import BaseModel
 
-from interloper_api.dependencies import get_org_id, get_store, require_editor, require_viewer
+from interloper_api.dependencies import (
+    authorize_org_member,
+    get_current_user,
+    get_org_id,
+    get_store,
+    require_editor,
+    require_viewer,
+)
 
 router = APIRouter()
 
@@ -87,14 +94,29 @@ def create_destination(
     return _to_response(dest)
 
 
+def _authorize_destination(destination_id: UUID, user: Profile, store: Store, *, minimum: str = "viewer") -> None:
+    """Authorize the user by membership in the destination's org.
+
+    Raises:
+        HTTPException: 404 if missing or the user is not a member of the
+            owning org, 403 if the role is insufficient.
+    """
+    try:
+        dest = store.get_destination(destination_id)
+    except NotFoundError:
+        raise HTTPException(status_code=404, detail=f"Destination {destination_id} not found")
+    authorize_org_member(user, dest.org_id, store, minimum=minimum, detail=f"Destination {destination_id} not found")
+
+
 @router.put("/{destination_id}")
 def update_destination(
     destination_id: UUID,
     body: DestinationCreateRequest,
-    user: object = Depends(require_editor),
+    user: Profile = Depends(get_current_user),
     store: Store = Depends(get_store),
 ) -> DestinationResponse:
     """Update a destination."""
+    _authorize_destination(destination_id, user, store, minimum="editor")
     try:
         dest = store.update_destination(
             destination_id,
@@ -110,9 +132,10 @@ def update_destination(
 @router.delete("/{destination_id}")
 def delete_destination(
     destination_id: UUID,
-    user: object = Depends(require_editor),
+    user: Profile = Depends(get_current_user),
     store: Store = Depends(get_store),
 ) -> dict[str, str]:
     """Delete a destination."""
+    _authorize_destination(destination_id, user, store, minimum="editor")
     store.delete_destination(destination_id)
     return {"status": "deleted"}

--- a/packages/interloper-api/src/interloper_api/routes/jobs.py
+++ b/packages/interloper-api/src/interloper_api/routes/jobs.py
@@ -11,7 +11,14 @@ from interloper_db import Profile, Store
 from interloper_db.models import Job
 from pydantic import BaseModel
 
-from interloper_api.dependencies import get_org_id, get_store, require_editor, require_viewer
+from interloper_api.dependencies import (
+    authorize_org_member,
+    get_current_user,
+    get_org_id,
+    get_store,
+    require_editor,
+    require_viewer,
+)
 
 router = APIRouter()
 
@@ -62,6 +69,30 @@ class BackfillRequest(BaseModel):
     fail_fast: bool = False
 
 
+def _load_authorized_job(job_id: UUID, user: Profile, store: Store, *, minimum: str = "viewer") -> Job:
+    """Load a job and authorize the user by membership in its org.
+
+    Args:
+        job_id: The job UUID.
+        user: The authenticated user.
+        store: The Store instance.
+        minimum: Minimum role required in the job's organisation.
+
+    Returns:
+        The Job row.
+
+    Raises:
+        HTTPException: 404 if missing or the user is not a member of the
+            owning org, 403 if the role is insufficient.
+    """
+    try:
+        job = store.get_job(job_id)
+    except NotFoundError:
+        raise HTTPException(status_code=404, detail=f"Job {job_id} not found")
+    authorize_org_member(user, job.org_id, store, minimum=minimum, detail=f"Job {job_id} not found")
+    return job
+
+
 def _job_to_response(job: Job) -> JobResponse:
     """Convert a DB Job to a JobResponse.
 
@@ -102,14 +133,11 @@ def list_jobs(
 @router.get("/{job_id}")
 def get_job(
     job_id: UUID,
-    user: Profile = Depends(require_viewer),
+    user: Profile = Depends(get_current_user),
     store: Store = Depends(get_store),
 ) -> JobResponse:
-    """Get a single job by ID."""
-    try:
-        job = store.get_job(job_id)
-    except NotFoundError:
-        raise HTTPException(status_code=404, detail=f"Job {job_id} not found")
+    """Get a single job by ID. Authorized by membership in the job's org."""
+    job = _load_authorized_job(job_id, user, store)
     return _job_to_response(job)
 
 
@@ -139,10 +167,11 @@ def create_job(
 def update_job(
     job_id: UUID,
     body: JobCreateRequest,
-    user: Profile = Depends(require_editor),
+    user: Profile = Depends(get_current_user),
     store: Store = Depends(get_store),
 ) -> JobResponse:
     """Update an existing job."""
+    _load_authorized_job(job_id, user, store, minimum="editor")
     try:
         job = store.update_job(
             job_id,
@@ -163,10 +192,11 @@ def update_job(
 @router.delete("/{job_id}")
 def delete_job(
     job_id: UUID,
-    user: Profile = Depends(require_editor),
+    user: Profile = Depends(get_current_user),
     store: Store = Depends(get_store),
 ) -> dict[str, str]:
     """Delete a job."""
+    _load_authorized_job(job_id, user, store, minimum="editor")
     store.delete_job(job_id)
     return {"status": "deleted"}
 
@@ -175,14 +205,11 @@ def delete_job(
 def queue_run(
     job_id: UUID,
     body: RunRequest | None = None,
-    user: Profile = Depends(require_editor),
+    user: Profile = Depends(get_current_user),
     store: Store = Depends(get_store),
 ) -> dict[str, str]:
     """Queue a single run for a job."""
-    try:
-        job = store.get_job(job_id)
-    except NotFoundError:
-        raise HTTPException(status_code=404, detail=f"Job {job_id} not found")
+    job = _load_authorized_job(job_id, user, store, minimum="editor")
 
     run = store.create_run(
         job.org_id,
@@ -196,14 +223,11 @@ def queue_run(
 def queue_backfill(
     job_id: UUID,
     body: BackfillRequest,
-    user: Profile = Depends(require_editor),
+    user: Profile = Depends(get_current_user),
     store: Store = Depends(get_store),
 ) -> dict[str, str]:
     """Queue a backfill for a job."""
-    try:
-        job = store.get_job(job_id)
-    except NotFoundError:
-        raise HTTPException(status_code=404, detail=f"Job {job_id} not found")
+    job = _load_authorized_job(job_id, user, store, minimum="editor")
 
     backfill = store.create_backfill(
         job.org_id,

--- a/packages/interloper-api/src/interloper_api/routes/organisations.py
+++ b/packages/interloper-api/src/interloper_api/routes/organisations.py
@@ -240,6 +240,9 @@ def cancel_invitation(
     store: Store = Depends(get_store),
 ) -> dict[str, str]:
     """Cancel a pending invitation. Requires admin role."""
+    invitations = store.list_invitations(org_id)
+    if not any(inv.id == invitation_id for inv in invitations):
+        raise HTTPException(status_code=404, detail="Invitation not found")
     if not store.delete_invitation(invitation_id):
         raise HTTPException(status_code=404, detail="Invitation not found")
 

--- a/packages/interloper-api/src/interloper_api/routes/resources.py
+++ b/packages/interloper-api/src/interloper_api/routes/resources.py
@@ -8,9 +8,18 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException
 from interloper.errors import NotFoundError
 from interloper_db import Profile, Store
+from interloper_db.models import Resource
 from pydantic import BaseModel
 
-from interloper_api.dependencies import get_catalog, get_org_id, get_store, require_editor, require_viewer
+from interloper_api.dependencies import (
+    authorize_org_member,
+    get_catalog,
+    get_current_user,
+    get_org_id,
+    get_store,
+    require_editor,
+    require_viewer,
+)
 
 router = APIRouter()
 
@@ -47,6 +56,30 @@ class ResourceDetailResponse(ResourceResponse):
     """Response body for a single resource, including its data payload."""
 
     data: dict[str, Any] = {}
+
+
+def _load_authorized_resource(resource_id: UUID, user: Profile, store: Store, *, minimum: str = "viewer") -> Resource:
+    """Load a resource and authorize the user by membership in its org.
+
+    Args:
+        resource_id: The resource UUID.
+        user: The authenticated user.
+        store: The Store instance.
+        minimum: Minimum role required in the resource's organisation.
+
+    Returns:
+        The Resource row.
+
+    Raises:
+        HTTPException: 404 if missing or the user is not a member of the
+            owning org, 403 if the role is insufficient.
+    """
+    try:
+        resource = store.load_resource(resource_id)
+    except NotFoundError:
+        raise HTTPException(status_code=404, detail=f"Resource {resource_id} not found")
+    authorize_org_member(user, resource.org_id, store, minimum=minimum, detail=f"Resource {resource_id} not found")
+    return resource
 
 
 @router.get("/kinds")
@@ -90,14 +123,14 @@ def list_resources(
 @router.get("/{resource_id}")
 def get_resource(
     resource_id: UUID,
-    user: Profile = Depends(require_viewer),
+    user: Profile = Depends(get_current_user),
     store: Store = Depends(get_store),
 ) -> ResourceDetailResponse:
-    """Get a single resource by ID, including its data payload."""
-    try:
-        r = store.load_resource(resource_id)
-    except NotFoundError:
-        raise HTTPException(status_code=404, detail=f"Resource {resource_id} not found")
+    """Get a single resource by ID, including its data payload.
+
+    Authorized by membership in the resource's org.
+    """
+    r = _load_authorized_resource(resource_id, user, store)
 
     return ResourceDetailResponse(
         id=r.id,
@@ -144,10 +177,11 @@ def create_resource(
 def update_resource(
     resource_id: UUID,
     body: ResourceCreateRequest,
-    user: Profile = Depends(require_editor),
+    user: Profile = Depends(get_current_user),
     store: Store = Depends(get_store),
 ) -> ResourceResponse:
     """Update an existing resource."""
+    _load_authorized_resource(resource_id, user, store, minimum="editor")
     try:
         resource = store.update_resource(
             resource_id,
@@ -174,9 +208,10 @@ def update_resource(
 @router.delete("/{resource_id}")
 def delete_resource(
     resource_id: UUID,
-    user: Profile = Depends(require_editor),
+    user: Profile = Depends(get_current_user),
     store: Store = Depends(get_store),
 ) -> dict[str, str]:
     """Delete a resource."""
+    _load_authorized_resource(resource_id, user, store, minimum="editor")
     store.delete_resource(resource_id)
     return {"status": "deleted"}

--- a/packages/interloper-api/src/interloper_api/routes/runs.py
+++ b/packages/interloper-api/src/interloper_api/routes/runs.py
@@ -12,7 +12,7 @@ from interloper_db import Profile, Store
 from interloper_db.models import Event, Run
 from pydantic import BaseModel
 
-from interloper_api.dependencies import get_org_id, get_store, require_editor, require_viewer
+from interloper_api.dependencies import authorize_org_member, get_current_user, get_org_id, get_store, require_viewer
 
 router = APIRouter()
 
@@ -100,6 +100,30 @@ def _run_to_response(run: Run) -> RunResponse:
     )
 
 
+def _load_authorized_run(run_id: UUID, user: Profile, store: Store, *, minimum: str = "viewer") -> Run:
+    """Load a run and authorize the user by membership in its org.
+
+    Args:
+        run_id: The run UUID.
+        user: The authenticated user.
+        store: The Store instance.
+        minimum: Minimum role required in the run's organisation.
+
+    Returns:
+        The Run row.
+
+    Raises:
+        HTTPException: 404 if missing or the user is not a member of the
+            owning org, 403 if the role is insufficient.
+    """
+    try:
+        run = store.get_run(run_id)
+    except NotFoundError:
+        raise HTTPException(status_code=404, detail=f"Run {run_id} not found")
+    authorize_org_member(user, run.org_id, store, minimum=minimum, detail=f"Run {run_id} not found")
+    return run
+
+
 def _event_to_response(event: Event) -> EventResponse:
     """Convert a DB Event to an EventResponse.
 
@@ -158,24 +182,22 @@ def list_runs(
 @router.get("/{run_id}")
 def get_run(
     run_id: UUID,
-    user: Profile = Depends(require_viewer),
+    user: Profile = Depends(get_current_user),
     store: Store = Depends(get_store),
 ) -> RunResponse:
-    """Get a single run by ID."""
-    try:
-        run = store.get_run(run_id)
-    except NotFoundError:
-        raise HTTPException(status_code=404, detail=f"Run {run_id} not found")
+    """Get a single run by ID. Authorized by membership in the run's org."""
+    run = _load_authorized_run(run_id, user, store)
     return _run_to_response(run)
 
 
 @router.get("/{run_id}/asset-executions")
 def list_asset_executions(
     run_id: UUID,
-    user: Profile = Depends(require_viewer),
+    user: Profile = Depends(get_current_user),
     store: Store = Depends(get_store),
 ) -> list[AssetExecutionResponse]:
     """List asset executions for a run."""
+    _load_authorized_run(run_id, user, store)
     rows = store.list_asset_executions(run_id)
     return [
         AssetExecutionResponse(
@@ -196,7 +218,7 @@ def list_asset_executions(
 def retry_run(
     run_id: UUID,
     body: RetryRequest | None = None,
-    user: Profile = Depends(require_editor),
+    user: Profile = Depends(get_current_user),
     store: Store = Depends(get_store),
 ) -> dict[str, str]:
     """Queue a retry of a failed run.
@@ -205,6 +227,7 @@ def retry_run(
     ``scope="all"`` the whole DAG re-runs; with ``scope="failed"`` only the
     previously failed/cancelled assets re-run.
     """
+    _load_authorized_run(run_id, user, store, minimum="editor")
     scope = body.scope if body else "all"
     try:
         run = store.retry_run(run_id, scope=scope)
@@ -222,7 +245,7 @@ def list_run_events(
     limit: int = 100,
     offset: int = 0,
     asset_id: UUID | None = None,
-    user: Profile = Depends(require_viewer),
+    user: Profile = Depends(get_current_user),
     store: Store = Depends(get_store),
 ) -> list[EventResponse]:
     """List events for a run, oldest first.
@@ -234,6 +257,7 @@ def list_run_events(
     through every event — including the terminal/outcome events
     (``asset_completed``, ``asset_failed``, ``run_failed``, …) that sort last.
     """
+    _load_authorized_run(run_id, user, store)
     limit = max(1, min(limit, MAX_EVENTS_PAGE_SIZE))
     offset = max(0, offset)
     total = store.count_events(run_id=run_id, asset_id=asset_id)

--- a/packages/interloper-api/src/interloper_api/routes/sources.py
+++ b/packages/interloper-api/src/interloper_api/routes/sources.py
@@ -13,7 +13,14 @@ from pydantic import BaseModel
 from sqlalchemy.orm import selectinload
 from sqlmodel import Session, select
 
-from interloper_api.dependencies import get_org_id, get_store, require_editor, require_viewer
+from interloper_api.dependencies import (
+    authorize_org_member,
+    get_current_user,
+    get_org_id,
+    get_store,
+    require_editor,
+    require_viewer,
+)
 
 router = APIRouter()
 
@@ -152,15 +159,29 @@ def create_source(
     return _load_source_for_response(source.id)
 
 
+def _authorize_source(source_id: UUID, user: Profile, store: Store, *, minimum: str = "viewer") -> None:
+    """Authorize the user by membership in the source's org.
+
+    Raises:
+        HTTPException: 404 if missing or the user is not a member of the
+            owning org, 403 if the role is insufficient.
+    """
+    try:
+        source = store.get_source(source_id)
+    except NotFoundError:
+        raise HTTPException(status_code=404, detail=f"Source {source_id} not found")
+    authorize_org_member(user, source.org_id, store, minimum=minimum, detail=f"Source {source_id} not found")
+
+
 @router.put("/{source_id}")
 def update_source(
     source_id: UUID,
     body: SourceCreateRequest,
-    user: Profile = Depends(require_editor),
-    org_id: UUID = Depends(get_org_id),
+    user: Profile = Depends(get_current_user),
     store: Store = Depends(get_store),
 ) -> SourceResponse:
     """Update a source."""
+    _authorize_source(source_id, user, store, minimum="editor")
     try:
         store.update_source(
             source_id,
@@ -179,9 +200,10 @@ def update_source(
 @router.delete("/{source_id}")
 def delete_source(
     source_id: UUID,
-    user: Profile = Depends(require_editor),
+    user: Profile = Depends(get_current_user),
     store: Store = Depends(get_store),
 ) -> dict[str, str]:
     """Delete a source. Assets cascade via FK."""
+    _authorize_source(source_id, user, store, minimum="editor")
     store.delete_source(source_id)
     return {"status": "deleted"}

--- a/packages/interloper-api/tests/test_run_events.py
+++ b/packages/interloper-api/tests/test_run_events.py
@@ -12,13 +12,14 @@ tests. The properties under test:
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from uuid import UUID, uuid4
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from interloper_api.dependencies import get_store, require_viewer
+from interloper_api.dependencies import get_current_user, get_store
 from interloper_api.routes import runs as runs_module
 from interloper_api.routes.runs import MAX_EVENTS_PAGE_SIZE
 
@@ -33,6 +34,12 @@ class FakeStore:
         self.total = total
         self.list_calls: list[tuple] = []
         self.count_calls: list[UUID | None] = []
+
+    def get_run(self, run_id: UUID):
+        return SimpleNamespace(id=run_id, org_id=_ORG_ID)
+
+    def get_user_role(self, user_id: UUID, org_id: UUID) -> str | None:
+        return "viewer"
 
     def count_events(
         self,
@@ -72,7 +79,7 @@ def _client(store: FakeStore) -> TestClient:
     app = FastAPI()
     app.include_router(runs_module.router)
     app.dependency_overrides[get_store] = lambda: store
-    app.dependency_overrides[require_viewer] = lambda: None
+    app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(id=uuid4())
     return TestClient(app)
 
 

--- a/packages/interloper-api/tests/test_runs.py
+++ b/packages/interloper-api/tests/test_runs.py
@@ -1,4 +1,4 @@
-"""Tests for ``interloper_api.routes.runs`` — focused on the retry endpoint.
+"""Tests for ``interloper_api.routes.runs`` — retry endpoint and org-membership scoping.
 
 A lightweight fake store stands in for persistence so these stay pure unit
 tests, matching the style of ``test_admin.py``.
@@ -14,22 +14,51 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from interloper.errors import RunNotFoundError
 
-from interloper_api.dependencies import get_store, require_editor
+from interloper_api.dependencies import get_current_user, get_store
 from interloper_api.routes import runs as runs_module
+
+_ORG_ID = uuid4()
+
+
+def _fake_run(run_id: UUID, org_id: UUID = _ORG_ID) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=run_id,
+        org_id=org_id,
+        job_id=None,
+        backfill_id=None,
+        partition_date=None,
+        status="failed",
+        retry_of=None,
+        attempt=1,
+        retry_scope=None,
+        started_at=None,
+        completed_at=None,
+        created_at=None,
+    )
 
 
 class FakeStore:
-    """In-memory stand-in implementing only what the retry route calls."""
+    """In-memory stand-in implementing only what the run routes call."""
 
     def __init__(self) -> None:
         self.retry_calls: list[tuple[UUID, str]] = []
         self.raise_not_found = False
         self.raise_value_error: str | None = None
+        #: Role the fake user holds in the run's org. None = not a member.
+        self.role: str | None = "editor"
+        #: Org owning every run this store returns.
+        self.run_org_id: UUID = _ORG_ID
+
+    def get_run(self, run_id: UUID):
+        if self.raise_not_found:
+            raise RunNotFoundError(f"Run {run_id} not found")
+        return _fake_run(run_id, self.run_org_id)
+
+    def get_user_role(self, user_id: UUID, org_id: UUID) -> str | None:
+        return self.role
 
     def retry_run(self, run_id: UUID, *, scope: str = "all"):
         self.retry_calls.append((run_id, scope))
-        if self.raise_not_found:
-            raise RunNotFoundError(f"Run {run_id} not found")
         if self.raise_value_error is not None:
             raise ValueError(self.raise_value_error)
         return SimpleNamespace(id=uuid4())
@@ -39,13 +68,16 @@ def _client(store: FakeStore) -> TestClient:
     app = FastAPI()
     app.include_router(runs_module.router)
     app.dependency_overrides[get_store] = lambda: store
-    app.dependency_overrides[require_editor] = lambda: SimpleNamespace(id=uuid4())
+    app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(id=uuid4())
     return TestClient(app)
 
 
 @pytest.fixture
 def store() -> FakeStore:
     return FakeStore()
+
+
+# -- Retry --------------------------------------------------------------------
 
 
 def test_retry_defaults_to_all_scope(store: FakeStore) -> None:
@@ -80,3 +112,51 @@ def test_retry_non_failed_run_returns_409(store: FakeStore) -> None:
     resp = _client(store).post(f"/{uuid4()}/retry")
     assert resp.status_code == 409
     assert "not failed" in resp.json()["detail"]
+
+
+def test_retry_requires_editor_in_owning_org(store: FakeStore) -> None:
+    store.role = "viewer"
+    resp = _client(store).post(f"/{uuid4()}/retry")
+    assert resp.status_code == 403
+    assert store.retry_calls == []
+
+
+# -- Org-membership scoping ---------------------------------------------------
+
+
+def test_get_run_allows_member_of_owning_org(store: FakeStore) -> None:
+    run_id = uuid4()
+    resp = _client(store).get(f"/{run_id}")
+    assert resp.status_code == 200
+    assert resp.json()["org_id"] == str(_ORG_ID)
+
+
+def test_get_run_returns_404_for_non_member(store: FakeStore) -> None:
+    store.role = None
+    run_id = uuid4()
+    resp = _client(store).get(f"/{run_id}")
+    assert resp.status_code == 404
+    # Identical detail to a missing run — IDs must not act as an existence oracle.
+    assert resp.json()["detail"] == f"Run {run_id} not found"
+
+
+def test_get_run_404_detail_matches_missing_run(store: FakeStore) -> None:
+    run_id = uuid4()
+    store.role = None
+    non_member = _client(store).get(f"/{run_id}").json()["detail"]
+    store.role = "viewer"
+    store.raise_not_found = True
+    missing = _client(store).get(f"/{run_id}").json()["detail"]
+    assert non_member == missing
+
+
+def test_run_events_return_404_for_non_member(store: FakeStore) -> None:
+    store.role = None
+    resp = _client(store).get(f"/{uuid4()}/events")
+    assert resp.status_code == 404
+
+
+def test_asset_executions_return_404_for_non_member(store: FakeStore) -> None:
+    store.role = None
+    resp = _client(store).get(f"/{uuid4()}/asset-executions")
+    assert resp.status_code == 404

--- a/packages/interloper-app/app/app/components/OrgGate.vue
+++ b/packages/interloper-app/app/app/components/OrgGate.vue
@@ -1,0 +1,87 @@
+<script setup lang="ts">
+import type { Organisation } from '~/types/organisation'
+
+/**
+ * Gates a resource detail page on the active organisation.
+ *
+ * The API authorizes detail reads by membership in the resource's org, so a
+ * link can load a resource from an org the user belongs to but doesn't have
+ * selected. Instead of rendering that content under the wrong org context,
+ * this shows an interstitial offering to switch to the owning org (or go back
+ * to the list). Non-member resources 404 server-side and render a not-found
+ * state here.
+ */
+const props = defineProps<{
+    /** Org that owns the displayed resource; undefined while it loads. */
+    orgId?: string | null
+    /** Error from fetching the resource, used to detect 404s. */
+    error?: unknown
+    /** Where "Back" navigates (the resource's list page). */
+    backTo: string
+    /** Human label for the resource kind, e.g. "run". */
+    resourceLabel: string
+}>()
+
+const orgStore = useOrganisationStore()
+
+const mismatch = computed(() =>
+    !!props.orgId && !!orgStore.organisation && props.orgId !== orgStore.organisation.id,
+)
+const notFound = computed(() => (props.error as { statusCode?: number } | null)?.statusCode === 404)
+
+const owningOrg = ref<Organisation | null>(null)
+watch(mismatch, async (value) => {
+    if (!value) return
+    const orgs = await orgStore.fetchOrganisations()
+    owningOrg.value = orgs.find(o => o.id === props.orgId) ?? null
+}, { immediate: true })
+
+const switching = ref(false)
+async function switchToOwningOrg() {
+    if (!props.orgId) return
+    switching.value = true
+    try {
+        await orgStore.switchOrg(props.orgId)
+    }
+    finally {
+        switching.value = false
+    }
+}
+</script>
+
+<template>
+    <div v-if="notFound"
+         class="flex flex-col items-center justify-center gap-3 py-24 text-center">
+        <UIcon name="i-lucide-search-x"
+               class="size-8 text-muted" />
+        <p class="text-sm text-muted">
+            This {{ resourceLabel }} wasn't found in your organisations.
+        </p>
+        <UButton :to="backTo"
+                 variant="outline"
+                 color="neutral"
+                 size="sm"
+                 label="Back" />
+    </div>
+    <div v-else-if="mismatch"
+         class="flex flex-col items-center justify-center gap-3 py-24 text-center">
+        <UIcon name="i-lucide-building-2"
+               class="size-8 text-muted" />
+        <p class="text-sm text-muted">
+            This {{ resourceLabel }} belongs to
+            <span class="font-medium text-default">{{ owningOrg?.name ?? 'another organisation' }}</span>.
+        </p>
+        <div class="flex items-center gap-2">
+            <UButton size="sm"
+                     :loading="switching"
+                     :label="`Switch to ${owningOrg?.name ?? 'that organisation'}`"
+                     @click="switchToOwningOrg" />
+            <UButton :to="backTo"
+                     variant="outline"
+                     color="neutral"
+                     size="sm"
+                     label="Back" />
+        </div>
+    </div>
+    <slot v-else />
+</template>

--- a/packages/interloper-app/app/app/components/nav/Organisation.vue
+++ b/packages/interloper-app/app/app/components/nav/Organisation.vue
@@ -18,6 +18,15 @@ async function loadUserOrgs() {
     orgsLoaded.value = true
 }
 
+async function selectOrg(org: Organisation) {
+    // Pages bespoke to one org's resource (run/backfill details) are
+    // meaningless in the new org — leave for their list page first.
+    const target = route.meta.orgSwitchTarget
+    if (typeof target === 'string') await navigateTo(target)
+    await orgStore.switchOrg(org.id)
+    orgsLoaded.value = false
+}
+
 const orgItems = computed<DropdownMenuItem[]>(() => {
     if (!orgsLoaded.value) return [{ label: 'Loading...', disabled: true }]
     if (userOrgs.value.length === 0) return [{ label: 'No organisations', disabled: true }]
@@ -35,10 +44,7 @@ const orgItems = computed<DropdownMenuItem[]>(() => {
         return {
             label: org.name,
             icon: 'i-lucide-building-2',
-            onSelect: () => {
-                orgStore.switchOrg(org.id)
-                orgsLoaded.value = false
-            },
+            onSelect: () => selectOrg(org),
         }
     })
 })

--- a/packages/interloper-app/app/app/pages/executions/backfills/[backfill].vue
+++ b/packages/interloper-app/app/app/pages/executions/backfills/[backfill].vue
@@ -4,7 +4,9 @@ import type { TableColumn } from '@nuxt/ui'
 import type { Run } from '~/types/run'
 import type { Backfill } from '~/types/backfill'
 
-definePageMeta({ title: 'Backfill' })
+// orgSwitchTarget: this page is bespoke to one org's backfill — switching org
+// from the nav lands on the backfills list instead.
+definePageMeta({ title: 'Backfill', orgSwitchTarget: '/executions?tab=backfills' })
 
 const UBadge = resolveComponent('UBadge')
 
@@ -23,16 +25,25 @@ const backfillJobName = computed(() =>
     backfill.value?.job?.name ?? jobsStore.findById(backfill.value?.job_id ?? '')?.name ?? 'Deleted job',
 )
 
+const fetchError = ref<unknown>(null)
+
 onMounted(async () => {
     runsLoading.value = true
     jobsStore.fetch()
-    const [fetchedBackfill, runs] = await Promise.all([
-        backfillsStore.fetchOne(backfillId),
-        apiFetch<Run[]>(`/runs?backfill_id=${backfillId}`),
-    ])
-    backfill.value = fetchedBackfill
-    backfillRuns.value = runs
-    runsLoading.value = false
+    try {
+        const [fetchedBackfill, runs] = await Promise.all([
+            backfillsStore.fetchOne(backfillId),
+            apiFetch<Run[]>(`/runs?backfill_id=${backfillId}`),
+        ])
+        backfill.value = fetchedBackfill
+        backfillRuns.value = runs
+    }
+    catch (e) {
+        fetchError.value = e
+    }
+    finally {
+        runsLoading.value = false
+    }
 })
 
 const columns: TableColumn<Run>[] = [
@@ -76,8 +87,12 @@ const columns: TableColumn<Run>[] = [
 </script>
 
 <template>
-    <div>
-        <div class="flex items-center gap-3 mb-4 shrink-0 px-4 pt-4">
+    <OrgGate :org-id="backfill?.org_id"
+             :error="fetchError"
+             back-to="/executions?tab=backfills"
+             resource-label="backfill">
+        <div>
+            <div class="flex items-center gap-3 mb-4 shrink-0 px-4 pt-4">
             <NuxtLink to="/executions?tab=backfills"
                       class="text-sm text-muted hover:text-default">
                 Backfills
@@ -123,5 +138,6 @@ const columns: TableColumn<Run>[] = [
                 sticky
                 class="flex-1"
                 @select="(_e: Event, row: any) => navigateTo(`/executions/runs/${row.original.id}`)" />
-    </div>
+        </div>
+    </OrgGate>
 </template>

--- a/packages/interloper-app/app/app/pages/executions/runs/[run].vue
+++ b/packages/interloper-app/app/app/pages/executions/runs/[run].vue
@@ -5,7 +5,9 @@ import type { Run } from '~/types/run'
 import type { ExecutionStatus } from '~/types/asset_execution'
 import { SplitterGroup, SplitterPanel, SplitterResizeHandle } from 'reka-ui'
 
-definePageMeta({ title: 'Run' })
+// orgSwitchTarget: this page is bespoke to one org's run — switching org from
+// the nav lands on the runs list instead.
+definePageMeta({ title: 'Run', orgSwitchTarget: '/executions?tab=runs' })
 
 const route = useRoute()
 const runId = route.params.run!.toString()
@@ -62,17 +64,24 @@ const retryItems = computed<DropdownMenuItem[]>(() => [
     },
 ])
 
+const fetchError = ref<unknown>(null)
+
 onMounted(async () => {
-    const [fetchedRun] = await Promise.all([
-        runsStore.fetchOne(runId),
-        eventsStore.fetchForRun(runId),
-        assetExecutionsStore.fetchForRun(runId),
-        sourcesStore.sources.length === 0 ? sourcesStore.fetch() : Promise.resolve(),
-        catalogStore.loaded ? Promise.resolve() : catalogStore.fetchCatalog(),
-    ])
-    initialRun.value = fetchedRun
-    // Seed the store so realtime updates can find and update it.
-    runsStore._upsert(fetchedRun)
+    try {
+        const [fetchedRun] = await Promise.all([
+            runsStore.fetchOne(runId),
+            eventsStore.fetchForRun(runId),
+            assetExecutionsStore.fetchForRun(runId),
+            sourcesStore.sources.length === 0 ? sourcesStore.fetch() : Promise.resolve(),
+            catalogStore.loaded ? Promise.resolve() : catalogStore.fetchCatalog(),
+        ])
+        initialRun.value = fetchedRun
+        // Seed the store so realtime updates can find and update it.
+        runsStore._upsert(fetchedRun)
+    }
+    catch (e) {
+        fetchError.value = e
+    }
 })
 
 onUnmounted(() => {
@@ -82,8 +91,12 @@ onUnmounted(() => {
 </script>
 
 <template>
-    <div>
-        <div class="flex items-center gap-3 mb-4 shrink-0 px-4 pt-4">
+    <OrgGate :org-id="run?.org_id"
+             :error="fetchError"
+             back-to="/executions?tab=runs"
+             resource-label="run">
+        <div>
+            <div class="flex items-center gap-3 mb-4 shrink-0 px-4 pt-4">
             <NuxtLink to="/executions?tab=runs"
                       class="text-sm text-muted hover:text-default">
                 Runs
@@ -155,5 +168,6 @@ onUnmounted(() => {
                 </div>
             </SplitterPanel>
         </SplitterGroup>
-    </div>
+        </div>
+    </OrgGate>
 </template>

--- a/packages/interloper-app/app/app/stores/backfills.ts
+++ b/packages/interloper-app/app/app/stores/backfills.ts
@@ -70,6 +70,8 @@ export const useBackfillsStore = defineStore('backfills', () => {
         error.value = null
     }
 
+    useOrgScopedRefetch(() => fetch(), $reset)
+
     return {
         backfills,
         loading,

--- a/packages/interloper-app/app/app/stores/organisation.ts
+++ b/packages/interloper-app/app/app/stores/organisation.ts
@@ -12,6 +12,22 @@ export const useOrganisationStore = defineStore('organisation', () => {
     const organisation = ref<Organisation | null>(null)
 
     /**********************
+     * Cross-tab sync
+     **********************/
+    // The active org lives in the shared session cookie, so a switch in one
+    // tab silently changes what every other tab's API calls return. Broadcast
+    // switches so other tabs re-sync their state; org-scoped stores and
+    // OrgGate react from there.
+    const channel = typeof BroadcastChannel !== 'undefined' ? new BroadcastChannel('interloper-org') : null
+    channel?.addEventListener('message', async (event: MessageEvent) => {
+        const orgId: unknown = event.data?.orgId
+        if (typeof orgId === 'string' && orgId !== organisation.value?.id) {
+            await userStore.fetchMe()
+            organisation.value = userStore.user?.organisation ?? null
+        }
+    })
+
+    /**********************
      * Actions
      **********************/
     async function fetchOrganisations(): Promise<Organisation[]> {
@@ -43,6 +59,7 @@ export const useOrganisationStore = defineStore('organisation', () => {
         })
         await userStore.fetchMe()
         organisation.value = created
+        channel?.postMessage({ orgId: created.id })
         return created
     }
 
@@ -53,6 +70,7 @@ export const useOrganisationStore = defineStore('organisation', () => {
         })
         await userStore.fetchMe()
         organisation.value = userStore.user?.organisation ?? null
+        channel?.postMessage({ orgId })
     }
 
     function findOrganisation(): Organisation | null {

--- a/packages/interloper-app/app/app/stores/runs.ts
+++ b/packages/interloper-app/app/app/stores/runs.ts
@@ -110,6 +110,8 @@ export const useRunsStore = defineStore('runs', () => {
         error.value = null
     }
 
+    useOrgScopedRefetch(() => fetch(), $reset)
+
     return {
         runs,
         total,

--- a/packages/interloper-db/src/interloper_db/store/sources.py
+++ b/packages/interloper-db/src/interloper_db/store/sources.py
@@ -98,6 +98,24 @@ class SourceMixin:
             session.refresh(db_source)
             return db_source
 
+    def get_source(self, source_id: UUID) -> Source:
+        """Load a source row by ID.
+
+        Args:
+            source_id: The source UUID.
+
+        Returns:
+            The Source row.
+
+        Raises:
+            SourceNotFoundError: If the source is not found.
+        """
+        with Session(get_engine()) as session:
+            db_source = session.get(Source, source_id)
+            if not db_source:
+                raise SourceNotFoundError(f"Source {source_id} not found")
+            return db_source
+
     def list_sources(self, org_id: UUID) -> list[Source]:
         """List all sources with assets and destinations loaded."""
         with Session(get_engine()) as session:


### PR DESCRIPTION
## What

When switching organisations while on an org-bespoke page (a run or backfill detail), the app stayed put and kept showing content that doesn't belong to the newly selected org. Worse, the API's ID-addressed endpoints performed no org check at all, so any authenticated user could read (and in places mutate) any org's resources by UUID.

This PR gates content on the selected org, end to end:

### API — membership-scoped authorization

- New `authorize_org_member()` dependency helper: authorizes ID-addressed endpoints by the caller's role in the **resource's** org, not the session's active org. Non-members get a 404 with the same detail as a missing ID (resource IDs don't act as an existence oracle); members with an insufficient role get a 403.
- Applied post-fetch across all ID-addressed routes: runs (detail / events / asset-executions / retry), backfills, jobs (get / update / delete / queue-run / queue-backfill), resources (incl. the decrypted-payload read), assets (CRUD + dependency edges, which are now also same-org enforced), sources, destinations.
- `cancel_invitation` is now scoped to the active org (it previously deleted any invitation by ID).
- List endpoints stay scoped to the active org. `/admin/*` (super-admin, intentionally cross-org) and agent sessions (user-scoped) are untouched.
- Added a `Store.get_source` row getter to support the source checks.

### App — "follow the resource" UX

- New `OrgGate` component wraps the run and backfill detail pages. Opening a link to a resource owned by another org you belong to shows an interstitial — *"This run belongs to Beta Org"* — with **Switch to Beta Org** (switches the active org and renders in place) and **Back**. Non-member resources 404 server-side and render a not-found state.
- The org switcher reads `route.meta.orgSwitchTarget`: bespoke pages navigate to their list (`/executions?tab=runs|backfills`) before the switch; generic pages stay put and refetch.
- Runs/backfills stores joined `useOrgScopedRefetch` — previously the `/executions` lists kept the old org's rows after a switch.
- Org switches broadcast on a `BroadcastChannel`, so other open tabs re-sync from the shared session and their gates/lists react.

## Why this design

The active org stays session-backed (no org in the URL): tenant isolation is enforced server-side by membership in the owning org, and the "active org" becomes purely a presentation lens. Shared links work for members of the owning org via the interstitial instead of silently breaking on the recipient's invisible active-org state.

## Verification

- `make check` green: ruff, ty, pytest (500 passed, incl. new membership-scoping tests for the run routes), frontend lint + `nuxt typecheck`.
- Live against the seeded dev instance with a real session cookie: own-org run **200**, run from another org the user belongs to **200**, non-member org's run and its sub-resources **404**, anonymous **401**.
- UI flows (interstitial switch, not-found state, switcher navigation, cross-tab sync) exercised manually against `make dev-up`.

## Notes for reviewers

- Detail endpoints switched from `require_viewer`/`require_editor` (active-org role) to `get_current_user` + post-fetch `authorize_org_member` — the role floor per endpoint is unchanged, only which org it's evaluated against.
- Known follow-up: agent chat sessions capture `org_id` in ADK state at creation, so an old chat keeps acting on the old org after a switch (user-scoped, lower stakes).