### PR TITLE
ci: trigger publish on release published, not the tag push

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,8 +6,11 @@ name: Publish
 # release and skip everything).
 #
 # Triggers:
-#   - automatically when semantic-release pushes a `v*` tag (the tag is
-#     pushed with the GitHub App token, so the push event fires workflows);
+#   - automatically when semantic-release publishes the GitHub release
+#     (created with the GitHub App token, so the event fires workflows).
+#     Not the tag push: the release commit message carries `[skip ci]`,
+#     which suppresses the push event for the tag pointing at it — the
+#     `release` event is immune to skip instructions;
 #   - manually via workflow_dispatch with an existing tag, to re-publish
 #     after a transient failure.
 #
@@ -15,8 +18,8 @@ name: Publish
 # chart-releaser skips chart releases that already exist.
 
 on:
-  push:
-    tags: ["v*"]
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       tag:
@@ -27,6 +30,10 @@ on:
 jobs:
   resolve:
     name: Resolve tag
+    # chart-releaser publishes its per-chart releases with GITHUB_TOKEN, which
+    # never triggers workflows — but guard on the `v` prefix anyway so only
+    # semantic-release tags are published.
+    if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'v')
     runs-on: ubuntu-latest
 
     outputs:
@@ -38,7 +45,7 @@ jobs:
       - name: Resolve tag
         id: resolve
         run: |
-          tag="${{ inputs.tag || github.ref_name }}"
+          tag="${{ inputs.tag || github.event.release.tag_name }}"
           version="${tag#v}"
           case "$version" in
             *-rc*) stable=false ;;

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,8 +2,9 @@ name: Release
 
 # Cuts the release only: checks, semantic-release (version bump, tag,
 # changelog, GitHub release) and the PyPI publish. Docker images and the
-# Helm chart are published by the Publish workflow, which fires on the tag
-# semantic-release pushes — and can be re-run for that tag independently.
+# Helm chart are published by the Publish workflow, which fires on the
+# GitHub release semantic-release publishes — and can be re-run for that
+# tag independently.
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Problem

The Publish workflow introduced in #39 never fired automatically — `v0.13.0` was released ([run](https://github.com/digitl-cloud/interloper/actions/runs/27350481376)) with no Publish run.

Root cause: the semantic-release commit message is `chore(release): {version} [skip ci]` (pyproject.toml). GitHub applies skip instructions to the **head commit of any push event — including tag pushes**. The `v*` tag points at the release commit, so its push event was silently suppressed. The App token was never the issue.

## Fix

Trigger Publish on `release: types: [published]` instead of `push: tags`:

- skip instructions only apply to `push`/`pull_request` events — `release` is immune;
- semantic-release creates the GitHub release (`vcs_release: true`) with the App token, so the event triggers workflows;
- fires for prereleases (RCs) too, matching the previous tag-pattern behavior.

The `resolve` job now reads the tag from the release payload and is guarded to `v`-prefixed tags, keeping chart-releaser's per-chart releases out (those are created with `GITHUB_TOKEN` and wouldn't trigger anyway — belt and braces). The `workflow_dispatch` replay path is unchanged.

Dropping `[skip ci]` instead was considered and rejected: it would re-run Checks on every release commit, which the marker is there to prevent.

## Notes for review

- `v0.13.0` artifacts still need a backfill: dispatch Publish manually with `tag: v0.13.0` after this merges.
- Both workflows pass actionlint.