### PR TITLE
ci: sync uv.lock with released versions and regenerate it on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,7 +72,10 @@ jobs:
         with:
           prerelease: ${{ inputs.release_type == 'release-candidate' }}
           prerelease_token: rc
-          build: false
+          # Runs the configured build_command (`uv lock`) so the release
+          # commit carries a lock file consistent with the stamped versions.
+          # The actual package build happens in the publish step below.
+          build: true
           changelog: ${{ inputs.release_type == 'stable' }}
           commit: true
           tag: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,13 @@ allow_zero_version = true
 # Stay on 0.x: a breaking change bumps the minor (0.2.0 → 0.3.0) instead of
 # graduating to 1.0.0. Flip to true (the default) when ready to commit to 1.0.
 major_on_zero = false
-build_command = "uv build --all-packages"
+# Runs between version stamping and the release commit. The package build
+# itself happens in the workflow's publish step; this only refreshes uv.lock
+# so the locked workspace versions match the ones just stamped — `assets`
+# then folds the regenerated lock into the release commit. The PSR GitHub
+# action runs in its own docker container without uv, hence the pip bootstrap.
+build_command = "python -m pip install uv && uv lock"
+assets = ["uv.lock"]
 commit_message = "chore(release): {version} [skip ci]"
 version_toml = [
     "pyproject.toml:project.version",

--- a/uv.lock
+++ b/uv.lock
@@ -1575,7 +1575,7 @@ wheels = [
 
 [[package]]
 name = "interloper-agent"
-version = "0.12.0"
+version = "0.14.0"
 source = { editable = "packages/interloper-agent" }
 dependencies = [
     { name = "google-adk" },
@@ -1594,7 +1594,7 @@ requires-dist = [
 
 [[package]]
 name = "interloper-api"
-version = "0.12.0"
+version = "0.14.0"
 source = { editable = "packages/interloper-api" }
 dependencies = [
     { name = "fastapi" },
@@ -1628,7 +1628,7 @@ provides-extras = ["agent"]
 
 [[package]]
 name = "interloper-app"
-version = "0.12.0"
+version = "0.14.0"
 source = { editable = "packages/interloper-app" }
 dependencies = [
     { name = "interloper-api" },
@@ -1645,7 +1645,7 @@ requires-dist = [
 
 [[package]]
 name = "interloper-assets"
-version = "0.12.0"
+version = "0.14.0"
 source = { editable = "packages/interloper-assets" }
 dependencies = [
     { name = "httpx" },
@@ -1681,7 +1681,7 @@ provides-extras = ["bing", "google", "facebook"]
 
 [[package]]
 name = "interloper-core"
-version = "0.12.0"
+version = "0.14.0"
 source = { editable = "packages/interloper-core" }
 dependencies = [
     { name = "httpx" },
@@ -1721,7 +1721,7 @@ dev = [
 
 [[package]]
 name = "interloper-db"
-version = "0.12.0"
+version = "0.14.0"
 source = { editable = "packages/interloper-db" }
 dependencies = [
     { name = "alembic" },
@@ -1744,7 +1744,7 @@ requires-dist = [
 
 [[package]]
 name = "interloper-docker"
-version = "0.12.0"
+version = "0.14.0"
 source = { editable = "packages/interloper-docker" }
 dependencies = [
     { name = "docker" },
@@ -1761,7 +1761,7 @@ requires-dist = [
 
 [[package]]
 name = "interloper-google-cloud"
-version = "0.12.0"
+version = "0.14.0"
 source = { editable = "packages/interloper-google-cloud" }
 dependencies = [
     { name = "db-dtypes" },
@@ -1782,7 +1782,7 @@ requires-dist = [
 
 [[package]]
 name = "interloper-k8s"
-version = "0.12.0"
+version = "0.14.0"
 source = { editable = "packages/interloper-k8s" }
 dependencies = [
     { name = "interloper-core" },
@@ -1799,7 +1799,7 @@ requires-dist = [
 
 [[package]]
 name = "interloper-pandas"
-version = "0.12.0"
+version = "0.14.0"
 source = { editable = "packages/interloper-pandas" }
 dependencies = [
     { name = "interloper-core" },
@@ -1815,7 +1815,7 @@ requires-dist = [
 
 [[package]]
 name = "interloper-scheduler"
-version = "0.12.0"
+version = "0.14.0"
 source = { editable = "packages/interloper-scheduler" }
 dependencies = [
     { name = "croniter" },
@@ -1843,7 +1843,7 @@ provides-extras = ["docker", "k8s"]
 
 [[package]]
 name = "interloper-workspace"
-version = "0.12.0"
+version = "0.14.0"
 source = { virtual = "." }
 dependencies = [
     { name = "interloper-agent" },


### PR DESCRIPTION
## What

- **Sync uv.lock with the released workspace versions.** `python-semantic-release` bumped all workspace packages to 0.14.0 (`chore(release): 0.14.0 [skip ci]`) but `uv.lock` still recorded them at 0.12.0. The diff is exactly the 12 `interloper-*` version entries, 0.12.0 → 0.14.0 — nothing else changed.
- **Make the release regenerate the lock so this doesn't recur.** Semantic-release stamps the new version into every workspace `pyproject.toml` via `version_toml`, but the workflow passed `build: false`, so nothing refreshed `uv.lock` before the release commit — every release left it stale.

## Why

A stale lock means any non-frozen `uv` invocation (`uv sync`, `uv run`, …) rewrites `uv.lock` as a side effect, causing churn in unrelated branches.

## How

Follows python-semantic-release's [uv integration guide](https://python-semantic-release.readthedocs.io/en/latest/configuration/configuration-guides/uv_integration.html):

- `build_command = "python -m pip install uv && uv lock"` — runs between version stamping and the release commit. The pip bootstrap is needed because the PSR GitHub Action runs in its own docker container (`python:3.14-slim`) that ships without uv (verified against the action's Dockerfile).
- `assets = ["uv.lock"]` folds the regenerated lock into the release commit.
- `build: true` in `release.yaml` so the build command actually runs. Repurposing `build_command` loses nothing — the actual package build still happens in the workflow's separate publish step (`uv build --all-packages`).

## Reviewer notes

- Verified locally: after the sync commit, `uv sync --all-packages --all-extras --dry-run` leaves the lock untouched.
- The new `build_command` path only executes during a real release, so it can't be exercised before merge — worth checking that the next release commit includes `uv.lock`.