### PR TITLE
fix: exclude framework resources field from asset schema

### DIFF
--- a/packages/interloper-core/src/interloper/asset/base.py
+++ b/packages/interloper-core/src/interloper/asset/base.py
@@ -226,8 +226,8 @@ class Asset(Component):
         """
         res_types: dict[str, type[Resource]] = cls.__dict__.get("resource_types", {})
         schema_dict: dict[str, Any] | None = None
-        if cls.schema is not None and hasattr(cls.schema, "model_json_schema"):
-            schema_dict = cls.schema.model_json_schema()
+        if cls.schema is not None and hasattr(cls.schema, "json_schema"):
+            schema_dict = cls.schema.json_schema()
 
         partitioning_dict: dict[str, Any] | None = None
         if cls.partitioning is not None:

--- a/packages/interloper-core/src/interloper/schema/base.py
+++ b/packages/interloper-core/src/interloper/schema/base.py
@@ -134,6 +134,31 @@ class Schema(Component):
         ]
 
     @classmethod
+    def json_schema(cls) -> dict[str, Any]:
+        """JSON Schema for this schema's data fields only.
+
+        Like :meth:`pydantic.BaseModel.model_json_schema` but excludes the
+        fields inherited from :class:`Component` (e.g. ``resources``), which are
+        framework plumbing rather than data columns, and orders ``properties``
+        by declaration order (see :meth:`field_specs`) so the column order
+        matches the author's intent rather than pydantic's parent-first layout.
+
+        Returns:
+            A JSON Schema dict whose ``properties`` are the data columns.
+        """
+        schema = cls.model_json_schema()
+        data_order = [spec.name for spec in cls.field_specs()]
+        properties = schema.get("properties", {})
+        schema["properties"] = {name: properties[name] for name in data_order if name in properties}
+        if "required" in schema:
+            required = [name for name in schema["required"] if name in properties]
+            if required:
+                schema["required"] = required
+            else:
+                del schema["required"]
+        return schema
+
+    @classmethod
     def infer(
         cls,
         rows: list[dict[str, Any]],

--- a/packages/interloper-core/tests/schema/test_base.py
+++ b/packages/interloper-core/tests/schema/test_base.py
@@ -106,3 +106,29 @@ class TestFieldSpecs:
         assert specs["a"].type is int
         assert specs["a"].nullable is True  # inferred fields are always optional
         assert specs["b"].type is str
+
+
+class TestJsonSchema:
+    """JSON Schema generation restricted to data fields."""
+
+    def test_component_fields_excluded(self):
+        # The inherited ``resources`` field is framework plumbing; raw pydantic
+        # leaks it (and at the parent's slot, first), json_schema() must not.
+        assert "resources" in FullSchema.model_json_schema()["properties"]
+        assert "resources" not in FullSchema.json_schema()["properties"]
+
+    def test_properties_in_declaration_order(self):
+        props = list(ShadowingSchema.json_schema()["properties"])
+        assert props == ["id", "cost", "name", "day"]
+
+    def test_required_excludes_component_fields(self):
+        assert "resources" not in FullSchema.json_schema().get("required", [])
+
+    def test_required_dropped_when_empty(self):
+        # A schema whose only required field is the inherited ``resources``
+        # must not surface a ``required`` key referencing it.
+        class AllOptional(Schema):
+            a: int | None = None
+            b: str | None = None
+
+        assert "required" not in AllOptional.json_schema()


### PR DESCRIPTION
## Problem

In the frontend asset side panel, the **Schema** section always showed `resources` as the first row, before the actual data columns.

## Root cause

`AssetDefinition.definition()` serialized the asset's output schema by dumping the raw Pydantic schema:

```python
schema_dict = cls.schema.model_json_schema()
```

Every asset `Schema` subclasses `Component`, which declares a framework field `resources: dict[str, Any]`. `model_json_schema()` includes it, and because Pydantic positions parent-declared fields *before* subclass fields, `resources` came out first in `properties` — so the UI ([`AssetPanel.vue`](packages/interloper-app/app/app/components/graph/AssetPanel.vue), which renders `asset_schema.properties` verbatim) listed it as the leading column.

`resources` is framework plumbing, not a data column — the rest of the schema layer already strips it (`Schema._data_fields()`, `Schema.field_specs()`), but `definition()` bypassed that.

## Fix

- Add `Schema.json_schema()` — like `model_json_schema()` but restricted to declared **data** fields, ordered by declaration order (reusing `field_specs()` ordering, which already corrects Pydantic's parent-first layout). Filters `resources` (and any other inherited `Component` field) out of both `properties` and `required`.
- `AssetDefinition.definition()` now calls `json_schema()` instead of `model_json_schema()`.

## Result

`asset_schema.properties` for the demo asset goes from `['resources', 'date', 'hello']` → `['date', 'hello']`.

## Tests

Added `TestJsonSchema` in `tests/schema/test_base.py` covering: `resources` exclusion, declaration-order properties, `required` filtering, and `required` dropped when empty. Full `ruff` / `ty` / schema + asset + catalog test suites pass.