### PR TITLE
feat: manifest resources/destinations registry with refs and auto-use

### DIFF
--- a/examples/manifest.yaml
+++ b/examples/manifest.yaml
@@ -14,15 +14,20 @@ name: demo-manifest
 runner:
   type: serial
 
-destination:
-  type: interloper.destination.file.FileDestination
-  config:
-    base_path: /tmp/interloper-demo
+# `resources` and `destinations` declare reusable components by alias;
+# `{ref: <alias>}` references one anywhere a component is expected, reusing a
+# single instance.
+destinations:
+  files:
+    type: interloper.destination.file.FileDestination
+    config:
+      base_path: /tmp/interloper-demo
 
 assets:
   - source: interloper_assets.demo.source.DemoSource
     config:
       hello: manifest
+    destinations: [{ref: files}] # one or more destinations; writes fan out
     select: [a, b] # subset of the a -> b,c,d -> e DAG; omit to run all assets
 
 partition:

--- a/packages/interloper-core/src/interloper/__init__.py
+++ b/packages/interloper-core/src/interloper/__init__.py
@@ -1,5 +1,6 @@
 from interloper.asset import Asset, AssetDefinition, ExecutionContext, asset
 from interloper.catalog import Catalog
+from interloper.cli.manifest import RunManifest, RunPlan
 from interloper.component import Component, ComponentDefinition, ComponentSpec
 from interloper.config import Config, config
 from interloper.connection import Connection, OAuthConnection, connection
@@ -15,7 +16,6 @@ from interloper.destination import (
     destination,
 )
 from interloper.events import Event, EventBus, EventType
-from interloper.manifest import RunManifest, RunPlan
 from interloper.normalizer import MaterializationStrategy, Normalizer
 from interloper.oauth import OAuthConfig, OAuthProvider
 from interloper.partitioning import (

--- a/packages/interloper-core/src/interloper/cli/commands/run.py
+++ b/packages/interloper-core/src/interloper/cli/commands/run.py
@@ -8,7 +8,7 @@ Input formats
 -------------
 
 * ``--file/-f <manifest.yaml>`` — a declarative run manifest
-  (:class:`~interloper.manifest.RunManifest`): sources/assets with their
+  (:class:`~interloper.cli.manifest.RunManifest`): sources/assets with their
   config, destinations, an optional runner override, and a partition.
 * ``--format inline <json>`` — a serialized :class:`DAGSpec` as JSON.
   This is the mode used by the ``DockerRunner`` to pass a mini-DAG to a
@@ -171,8 +171,8 @@ def _cmd_run(args: argparse.Namespace) -> None:
         if args.file is not None:
             if args.target:
                 raise SystemExit("Error: --file cannot be combined with positional targets.")
+            from interloper.cli.manifest import RunManifest
             from interloper.errors import ManifestError
-            from interloper.manifest import RunManifest
 
             try:
                 plan = RunManifest.from_yaml_file(args.file).compile()

--- a/packages/interloper-core/src/interloper/cli/manifest.py
+++ b/packages/interloper-core/src/interloper/cli/manifest.py
@@ -20,29 +20,54 @@ Example::
       config:
         max_concurrency: 4
 
-    destination:                  # default destination for all items
-      type: file_destination      # catalog key or dotted import path
-      config:
-        base_path: /tmp/data
+    resources:                    # reusable Resources (connections, …), by alias
+      gcp:
+        type: google_cloud_connection
+        config:
+          service_account_key: ${GCP_KEY}
+
+    destinations:                 # reusable Destinations, by alias
+      bq:
+        type: bigquery_destination
+        auto: true                # used by any item that declares no destinations
+        config:
+          connection: {ref: gcp}  # refs may nest
 
     assets:
       - source: facebook_ads      # catalog key or dotted import path
         config:                   # init kwargs for the source
           dataset: raw_facebook
-        select: [campaigns, ads]  # subset of assets; omit for all
+        select: [campaigns, ads]  # no destinations → writes to the auto 'bq'
       - asset: demo_asset         # standalone assets work too
+        destinations: [{ref: bq}] # explicit (one or more; writes fan out)
 
     partition:
       date: 2026-06-01            # or start/end for a window
 
+Auto-use
+--------
+
+A ``resources``/``destinations`` entry marked ``auto: true`` is applied to
+every source/standalone asset that does not provide its own: an auto
+destination becomes the item's destination when it declares none, and an auto
+resource fills any empty resource slot it satisfies by type.  Explicit
+``destinations`` and ``config`` resources always take precedence.
+
 Component references
 --------------------
 
-Wherever a component instance is expected (``destination`` blocks, or any
-value nested inside a ``config`` block), a mapping of the shape
-``{type: <ref>, config: {...}}`` is recognized and instantiated.  The
-``type`` reference is resolved against the catalog when it is a bare key
-(no dots), or imported directly when it is a dotted/composite path.
+Wherever a component instance is expected (a ``destinations`` entry, or any
+value nested inside a ``config`` block), two forms are recognized:
+
+* ``{type: <ref>, config: {...}}`` — an inline definition.  The ``type`` is
+  resolved against the catalog when it is a bare key (no dots), or imported
+  directly when it is a dotted/composite path.
+* ``{ref: <alias>}`` — a reference to a component declared in the top-level
+  ``resources`` or ``destinations`` block.  Each alias is instantiated once
+  and the *same instance* is reused everywhere it is referenced, so a single
+  client or auth token is shared across sources.  (Sharing is in-process:
+  runners that serialize a per-asset sub-DAG to a child process rebuild their
+  own instances there.)
 
 Environment interpolation
 -------------------------
@@ -66,9 +91,12 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from interloper.errors import ManifestError
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from interloper.asset.base import Asset
     from interloper.component import Component
     from interloper.dag.base import DAG
+    from interloper.destination import Destination
     from interloper.partitioning import Partition, PartitionWindow
     from interloper.source.base import Source
 
@@ -118,16 +146,111 @@ def _is_component_ref(value: Any) -> bool:
     )
 
 
+def _is_ref(value: Any) -> bool:
+    """Check whether a value references a ``resources``/``destinations`` component.
+
+    Returns:
+        True for mappings shaped like ``{ref: <alias>}``.
+    """
+    return isinstance(value, dict) and set(value) == {"ref"} and isinstance(value.get("ref"), str)
+
+
 class _Resolver:
     """Resolve component type references to classes and build instances.
 
     Bare keys (no ``.`` or ``:``) are looked up in the catalog built from
     ``AppSettings.catalog`` (loaded lazily, at most once); dotted or
     composite paths are imported directly.
+
+    The named ``resources`` and ``destinations`` blocks share a single alias
+    namespace, resolved on demand via :meth:`resolve_ref`; each alias is built
+    at most once and the instance is cached, so every ``{ref: <alias>}``
+    returns the same object.  An entry must satisfy the kind of the block it is
+    declared under (``resources`` → :class:`Resource`, ``destinations`` →
+    :class:`Destination`).
     """
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        resources: Mapping[str, ComponentManifest] | None = None,
+        destinations: Mapping[str, ComponentManifest] | None = None,
+    ) -> None:
         self._catalog: Any = None
+        self._instances: dict[str, Component] = {}
+        self._resolving: set[str] = set()
+        # Merge the two named blocks into one alias namespace, recording the
+        # block each alias came from so its built instance can be kind-checked.
+        self._registry: dict[str, ComponentManifest] = {}
+        self._kinds: dict[str, str] = {}
+        for block, entries in (("resources", resources or {}), ("destinations", destinations or {})):
+            for alias, manifest in entries.items():
+                if alias in self._registry:
+                    raise ManifestError(
+                        f"Alias '{alias}' is declared in both 'resources' and 'destinations'"
+                    )
+                self._registry[alias] = manifest
+                self._kinds[alias] = block
+
+    def resolve_ref(self, alias: str) -> Component:
+        """Resolve an alias to its (cached) component instance.
+
+        Returns:
+            The referenced component instance, built once and memoized.
+
+        Raises:
+            ManifestError: If the alias is undefined, part of a reference cycle,
+                or does not match the kind of its declaring block.
+        """
+        if alias in self._instances:
+            return self._instances[alias]
+        if alias not in self._registry:
+            raise ManifestError(f"Unknown reference '{alias}'. Declared: {sorted(self._registry) or 'none'}")
+        if alias in self._resolving:
+            raise ManifestError(f"Circular reference involving '{alias}'")
+        self._resolving.add(alias)
+        try:
+            instance = self.build_component(self._registry[alias])
+        finally:
+            self._resolving.discard(alias)
+        self._check_kind(alias, instance)
+        self._instances[alias] = instance
+        return instance
+
+    def _check_kind(self, alias: str, instance: Component) -> None:
+        """Ensure a resolved alias matches the kind of its declaring block.
+
+        Raises:
+            ManifestError: If a ``resources`` alias is not a ``Resource`` or a
+                ``destinations`` alias is not a ``Destination``.
+        """
+        from interloper.destination import Destination
+        from interloper.resource import Resource
+
+        if self._kinds[alias] == "resources" and not isinstance(instance, Resource):
+            raise ManifestError(f"'{alias}' is declared under 'resources' but is not a Resource")
+        if self._kinds[alias] == "destinations" and not isinstance(instance, Destination):
+            raise ManifestError(f"'{alias}' is declared under 'destinations' but is not a Destination")
+
+    def build_destination(self, entry: RefManifest | ComponentManifest) -> Destination:
+        """Resolve a ``destinations`` entry (ref or inline) to a Destination.
+
+        Returns:
+            The destination instance.
+
+        Raises:
+            ManifestError: If the entry does not resolve to a ``Destination``.
+        """
+        from interloper.destination import Destination
+
+        if isinstance(entry, RefManifest):
+            instance: Component = self.resolve_ref(entry.ref)
+            label = f"reference '{entry.ref}'"
+        else:
+            instance = self.build_component(entry)
+            label = f"'{entry.type}'"
+        if not isinstance(instance, Destination):
+            raise ManifestError(f"{label} is not a Destination")
+        return instance
 
     def resolve(self, ref: str) -> type:
         """Resolve a type reference to a class.
@@ -194,6 +317,8 @@ class _Resolver:
         return {k: self._build_value(v) for k, v in config.items()}
 
     def _build_value(self, value: Any) -> Any:
+        if _is_ref(value):
+            return self.resolve_ref(value["ref"])
         if _is_component_ref(value):
             return self.build_component(ComponentManifest.model_validate(value))
         if isinstance(value, dict):
@@ -215,6 +340,23 @@ class ComponentManifest(_ManifestModel):
     type: str
     config: dict[str, Any] = Field(default_factory=dict)
     id: str = ""
+
+
+class RegistryEntryManifest(ComponentManifest):
+    """A ``resources``/``destinations`` registry entry.
+
+    ``auto`` opts the component into automatic use: an auto destination becomes
+    the destination of any item that declares none, and an auto resource fills
+    any empty resource slot it satisfies by type. Explicit references always win.
+    """
+
+    auto: bool = False
+
+
+class RefManifest(_ManifestModel):
+    """Reference to a component declared in the manifest's ``resources``/``destinations`` blocks."""
+
+    ref: str
 
 
 class RunnerManifest(_ManifestModel):
@@ -262,7 +404,7 @@ class AssetItemManifest(_ManifestModel):
     source: str | None = None
     asset: str | None = None
     config: dict[str, Any] = Field(default_factory=dict)
-    destination: ComponentManifest | None = None
+    destinations: list[RefManifest | ComponentManifest] | None = None
     select: list[str] | None = None
 
     @model_validator(mode="after")
@@ -293,7 +435,8 @@ class RunManifest(_ManifestModel):
 
     name: str = ""
     runner: RunnerManifest | None = None
-    destination: ComponentManifest | None = None
+    resources: dict[str, RegistryEntryManifest] = Field(default_factory=dict)
+    destinations: dict[str, RegistryEntryManifest] = Field(default_factory=dict)
     assets: list[AssetItemManifest] = Field(min_length=1)
     partition: PartitionManifest | None = None
 
@@ -366,10 +509,12 @@ class RunManifest(_ManifestModel):
         from interloper.dag.base import DAG
         from interloper.source.base import Source
 
-        resolver = _Resolver()
-        default_destination = (
-            resolver.build_component(self.destination) if self.destination is not None else None
-        )
+        resolver = _Resolver(resources=self.resources, destinations=self.destinations)
+
+        # Components opted into automatic use. resolve_ref kind-checks them, so
+        # auto_resources are Resources and auto_destinations are Destinations.
+        auto_resources = [resolver.resolve_ref(alias) for alias, entry in self.resources.items() if entry.auto]
+        auto_destinations = [resolver.resolve_ref(alias) for alias, entry in self.destinations.items() if entry.auto]
 
         items: list[Source | Asset] = []
         for item in self.assets:
@@ -381,11 +526,17 @@ class RunManifest(_ManifestModel):
                 raise ManifestError(f"'{ref}' is not a {expected.__name__} subclass")
 
             kwargs = resolver.build_init(item.config)
-            if "destination" not in kwargs:
-                if item.destination is not None:
-                    kwargs["destination"] = resolver.build_component(item.destination)
-                elif default_destination is not None:
-                    kwargs["destination"] = default_destination
+            if item.destinations is not None:
+                if "destination" in kwargs:
+                    raise ManifestError(
+                        f"'{ref}' sets a destination in both 'config' and the 'destinations' field"
+                    )
+                kwargs["destination"] = [resolver.build_destination(d) for d in item.destinations]
+            elif "destination" not in kwargs and auto_destinations:
+                kwargs["destination"] = list(auto_destinations)
+
+            if auto_resources:
+                _apply_auto_resources(cls, kwargs, auto_resources)
 
             try:
                 instance = cls(**kwargs)
@@ -407,6 +558,28 @@ class RunManifest(_ManifestModel):
             runner=self.runner,
             name=self.name,
         )
+
+
+def _apply_auto_resources(cls: type, kwargs: dict[str, Any], auto_resources: list[Component]) -> None:
+    """Fill *cls*'s empty resource slots in *kwargs* from auto-use resources.
+
+    A slot is left untouched when already provided (via ``resources`` or a
+    slot-named kwarg from ``config``); otherwise it is filled by the first
+    auto resource that satisfies the slot's declared type. Mutates *kwargs*.
+    """
+    resource_types: dict[str, type] = getattr(cls, "resource_types", {})
+    provided = set(kwargs.get("resources") or {}) | (set(kwargs) & set(resource_types))
+
+    additions: dict[str, Component] = {}
+    for name, res_type in resource_types.items():
+        if name in provided:
+            continue
+        match = next((res for res in auto_resources if isinstance(res, res_type)), None)
+        if match is not None:
+            additions[name] = match
+
+    if additions:
+        kwargs["resources"] = {**(kwargs.get("resources") or {}), **additions}
 
 
 def _select_assets(source: Source, select: list[str]) -> list[Asset]:

--- a/packages/interloper-core/tests/cli/commands/test_run.py
+++ b/packages/interloper-core/tests/cli/commands/test_run.py
@@ -148,11 +148,11 @@ class TestRunManifestMode:
             f"""
             runner:
               type: serial
-            destination:
-              type: interloper.destination.file.FileDestination
-              config:
-                base_path: {tmp_path}/data
             assets:
               - source: {SOURCE_PATH}
+                destinations:
+                  - type: interloper.destination.file.FileDestination
+                    config:
+                      base_path: {tmp_path}/data
             """,
         )

--- a/packages/interloper-core/tests/cli/test_manifest.py
+++ b/packages/interloper-core/tests/cli/test_manifest.py
@@ -1,4 +1,4 @@
-"""Tests for ``interloper.manifest``."""
+"""Tests for ``interloper.cli.manifest``."""
 
 # Note: no ``from __future__ import annotations`` — the fixtures below define
 # methods whose parameter annotations must be real classes (not lazy strings)
@@ -12,12 +12,12 @@ import pytest
 
 import interloper as il
 from interloper.catalog import Catalog
-from interloper.errors import ManifestError
-from interloper.manifest import (
+from interloper.cli.manifest import (
     AssetItemManifest,
     PartitionManifest,
     RunManifest,
 )
+from interloper.errors import ManifestError
 from interloper.partitioning import TimePartition, TimePartitionWindow
 
 # ---------------------------------------------------------------------------
@@ -51,8 +51,28 @@ class FakeStandaloneAsset(il.Asset):
         return [{"x": 1}]
 
 
+class FakeManifestResource(il.Resource):
+    """Resource fixture (no required fields) for auto-use tests."""
+
+    token: str = ""
+
+
+class FakeResourceSource(il.Source):
+    """Source with a ``conn`` resource slot, for auto-resource tests."""
+
+    conn: FakeManifestResource
+
+    class Solo(il.Asset):
+        """Single asset."""
+
+        def data(self) -> Any:  # pragma: no cover
+            return [{"x": 1}]
+
+
 SOURCE_PATH = f"{FakeManifestSource.__module__}.FakeManifestSource"
 ASSET_PATH = f"{FakeStandaloneAsset.__module__}.FakeStandaloneAsset"
+RESOURCE_SOURCE_PATH = f"{FakeResourceSource.__module__}.FakeResourceSource"
+RESOURCE_PATH = f"{FakeManifestResource.__module__}.FakeManifestResource"
 MEMORY_DESTINATION_PATH = "interloper.destination.memory.MemoryDestination"
 FILE_DESTINATION_PATH = "interloper.destination.file.FileDestination"
 
@@ -171,16 +191,16 @@ class TestAssetItemManifest:
 class TestCompile:
     """Manifest compilation into a run plan."""
 
-    def test_source_with_config_and_default_destination(self) -> None:
+    def test_source_with_config_and_destination(self) -> None:
         plan = _manifest(
             f"""
             name: test-run
-            destination:
-              type: {MEMORY_DESTINATION_PATH}
             assets:
               - source: {SOURCE_PATH}
                 config:
                   greeting: hi
+                destinations:
+                  - type: {MEMORY_DESTINATION_PATH}
             """
         ).compile()
 
@@ -189,7 +209,8 @@ class TestCompile:
         for asset in plan.dag.assets:
             assert asset.source is not None
             assert asset.source.greeting == "hi"
-            assert isinstance(asset.destination, il.MemoryDestination)
+            assert isinstance(asset.destination, list)
+            assert isinstance(asset.destination[0], il.MemoryDestination)
 
     def test_select_marks_unselected_non_materializable(self) -> None:
         plan = _manifest(
@@ -221,33 +242,197 @@ class TestCompile:
     def test_standalone_asset(self) -> None:
         plan = _manifest(
             f"""
-            destination:
-              type: {MEMORY_DESTINATION_PATH}
             assets:
               - asset: {ASSET_PATH}
+                destinations:
+                  - type: {MEMORY_DESTINATION_PATH}
             """
         ).compile()
 
         assert len(plan.dag.assets) == 1
         assert type(plan.dag.assets[0]).key == "fake_standalone_asset"
-        assert isinstance(plan.dag.assets[0].destination, il.MemoryDestination)
+        assert isinstance(plan.dag.assets[0].destination, list)
+        assert isinstance(plan.dag.assets[0].destination[0], il.MemoryDestination)
 
-    def test_item_destination_overrides_default(self, tmp_path: Any) -> None:
+    def test_multiple_destinations_fan_out(self, tmp_path: Any) -> None:
         plan = _manifest(
             f"""
-            destination:
-              type: {MEMORY_DESTINATION_PATH}
+            destinations:
+              mem: {{type: {MEMORY_DESTINATION_PATH}}}
             assets:
               - source: {SOURCE_PATH}
-                destination:
-                  type: {FILE_DESTINATION_PATH}
-                  config:
-                    base_path: {tmp_path}
+                destinations:
+                  - {{ref: mem}}
+                  - type: {FILE_DESTINATION_PATH}
+                    config:
+                      base_path: {tmp_path}
             """
         ).compile()
 
         for asset in plan.dag.assets:
-            assert isinstance(asset.destination, il.FileDestination)
+            assert isinstance(asset.destination, list)
+            types = {type(d) for d in asset.destination}
+            assert types == {il.MemoryDestination, il.FileDestination}
+
+    def test_ref_reuses_one_instance(self) -> None:
+        plan = _manifest(
+            f"""
+            destinations:
+              mem: {{type: {MEMORY_DESTINATION_PATH}}}
+            assets:
+              - source: {SOURCE_PATH}
+                destinations: [{{ref: mem}}]
+              - asset: {ASSET_PATH}
+                destinations: [{{ref: mem}}]
+            """
+        ).compile()
+
+        instances = set()
+        for a in plan.dag.assets:
+            assert isinstance(a.destination, list)
+            instances.add(id(a.destination[0]))
+        assert len(instances) == 1  # same instance across both items and all assets
+
+    def test_ref_resolved_inside_config(self) -> None:
+        plan = _manifest(
+            f"""
+            destinations:
+              mem: {{type: {MEMORY_DESTINATION_PATH}}}
+            assets:
+              - source: {SOURCE_PATH}
+                config:
+                  destination: {{ref: mem}}
+            """
+        ).compile()
+
+        for asset in plan.dag.assets:
+            assert isinstance(asset.destination, il.MemoryDestination)
+
+    def test_unknown_ref_raises(self) -> None:
+        with pytest.raises(ManifestError, match="Unknown reference 'nope'"):
+            _manifest(
+                f"""
+                assets:
+                  - source: {SOURCE_PATH}
+                    destinations: [{{ref: nope}}]
+                """
+            ).compile()
+
+    def test_resources_alias_must_be_a_resource(self) -> None:
+        # A Destination declared under 'resources' is rejected when referenced.
+        with pytest.raises(ManifestError, match="is not a Resource"):
+            _manifest(
+                f"""
+                resources:
+                  mem: {{type: {MEMORY_DESTINATION_PATH}}}
+                assets:
+                  - source: {SOURCE_PATH}
+                    destinations: [{{ref: mem}}]
+                """
+            ).compile()
+
+    def test_duplicate_alias_across_blocks_raises(self) -> None:
+        with pytest.raises(ManifestError, match="declared in both 'resources' and 'destinations'"):
+            _manifest(
+                f"""
+                resources:
+                  dup: {{type: {MEMORY_DESTINATION_PATH}}}
+                destinations:
+                  dup: {{type: {MEMORY_DESTINATION_PATH}}}
+                assets:
+                  - source: {SOURCE_PATH}
+                    destinations: [{{ref: dup}}]
+                """
+            ).compile()
+
+    def test_auto_destination_used_when_item_declares_none(self) -> None:
+        plan = _manifest(
+            f"""
+            destinations:
+              mem:
+                type: {MEMORY_DESTINATION_PATH}
+                auto: true
+            assets:
+              - source: {SOURCE_PATH}
+            """
+        ).compile()
+
+        for asset in plan.dag.assets:
+            assert isinstance(asset.destination, list)
+            assert isinstance(asset.destination[0], il.MemoryDestination)
+
+    def test_explicit_destinations_override_auto(self, tmp_path: Any) -> None:
+        plan = _manifest(
+            f"""
+            destinations:
+              mem:
+                type: {MEMORY_DESTINATION_PATH}
+                auto: true
+            assets:
+              - source: {SOURCE_PATH}
+                destinations:
+                  - type: {FILE_DESTINATION_PATH}
+                    config:
+                      base_path: {tmp_path}
+            """
+        ).compile()
+
+        for asset in plan.dag.assets:
+            assert isinstance(asset.destination, list)
+            assert {type(d) for d in asset.destination} == {il.FileDestination}  # auto 'mem' not applied
+
+    def test_auto_resource_fills_empty_slot(self) -> None:
+        plan = _manifest(
+            f"""
+            resources:
+              tok:
+                type: {RESOURCE_PATH}
+                auto: true
+            assets:
+              - source: {RESOURCE_SOURCE_PATH}
+            """
+        ).compile()
+
+        source = plan.dag.assets[0].source
+        assert source is not None
+        assert isinstance(source.resources["conn"], FakeManifestResource)
+
+    def test_explicit_resource_overrides_auto(self) -> None:
+        plan = _manifest(
+            f"""
+            resources:
+              auto_tok:
+                type: {RESOURCE_PATH}
+                auto: true
+                config: {{token: auto}}
+              explicit_tok:
+                type: {RESOURCE_PATH}
+                config: {{token: explicit}}
+            assets:
+              - source: {RESOURCE_SOURCE_PATH}
+                config:
+                  resources:
+                    conn: {{ref: explicit_tok}}
+            """
+        ).compile()
+
+        source = plan.dag.assets[0].source
+        assert source is not None
+        assert source.resources["conn"].token == "explicit"
+
+    def test_destinations_and_config_destination_conflict_raises(self, tmp_path: Any) -> None:
+        with pytest.raises(ManifestError, match="both 'config' and the 'destinations' field"):
+            _manifest(
+                f"""
+                assets:
+                  - source: {SOURCE_PATH}
+                    config:
+                      destination:
+                        type: {MEMORY_DESTINATION_PATH}
+                    destinations:
+                      - type: {MEMORY_DESTINATION_PATH}
+                """
+            ).compile()
 
     def test_nested_component_ref_in_config(self, tmp_path: Any) -> None:
         plan = _manifest(
@@ -300,10 +485,22 @@ class TestCompile:
         with pytest.raises(ManifestError, match="not an interloper component"):
             _manifest(
                 f"""
-                destination:
-                  type: interloper.manifest.RunManifest
                 assets:
                   - source: {SOURCE_PATH}
+                    destinations:
+                      - type: interloper.cli.manifest.RunManifest
+                """
+            ).compile()
+
+    def test_destination_must_be_a_destination(self) -> None:
+        # A real Component that is not a Destination (a Source) is rejected.
+        with pytest.raises(ManifestError, match="is not a Destination"):
+            _manifest(
+                f"""
+                assets:
+                  - source: {SOURCE_PATH}
+                    destinations:
+                      - type: {SOURCE_PATH}
                 """
             ).compile()
 


### PR DESCRIPTION
## Summary

Adds named, reusable component registries to declarative run manifests, replacing the single root `destination` default with a more general and explicit model.

- **Two root blocks** — `resources:` (Resources/connections) and `destinations:` (Destinations) — declare components by alias.
- **`{ref: <alias>}`** references a registry component anywhere a component is expected: a `destinations` entry, or any value nested in a `config` block (refs may nest, e.g. a destination referencing a connection). Aliases share one namespace; declaring the same alias in both blocks is an error.
- **Build-once sharing** — each alias is instantiated once and the same instance is reused everywhere it's referenced, so a single client/auth token is shared across sources (in-process; runners that serialize a per-asset sub-DAG rebuild their own there).
- **Kind validation** — a `resources:` alias must resolve to a `Resource`, a `destinations:` alias to a `Destination`.
- **`auto: true`** — opts a registry entry into automatic use: an auto destination becomes the destination of any item that declares none; an auto resource fills any empty resource slot it satisfies by type. Explicit references always win. Applies to the DAG items (sources / standalone assets).
- **Multiple destinations** — a source's `destinations: [...]` is now a list; writes fan out (the framework already supported `list[Destination]`).
- **Relocation** — `interloper.manifest` → `interloper.cli.manifest` (it backs `interloper run`); test moved to mirror.

```yaml
resources:
  gcp:  { type: google_cloud_connection, config: { service_account_key: ${KEY} } }
  bing: { type: bing_ads_connection, auto: true, config: { ... } }
destinations:
  bq:   { type: bigquery_destination, auto: true, config: { connection: { ref: gcp } } }
assets:
  - source: bing_ads          # connection (auto bing) + destination (auto bq) applied automatically
    select: [ads]
```

## Migration

Run manifests are a recent pre-1.0 feature, so this ships as a normal feature rather than a breaking release. Manifests that used the old shape need a small update:

- The root `destination:` block is replaced by the `destinations:` registry; reference it per source via `destinations: [{ref: ...}]`, or mark an entry `auto: true` to apply it by default.
- The per-item `destination` field becomes the plural `destinations` list.

## Test plan

- `uv run pytest packages/interloper-core/tests/cli` — 49 pass (added coverage: ref reuse/sharing, multi-destination fan-out, ref-in-config, unknown-ref, duplicate-alias, resources/destinations kind checks, and the four auto-use paths).
- ruff + ty clean; pre-commit full suite passed on commit.
- Migrated `examples/manifest.yaml`; verified end-to-end against real manifests (a source with zero explicit wiring authenticates via the auto connection and writes to the auto destination).