### PR TITLE
feat: add impact/programs external API route

### DIFF
--- a/packages/interloper-api/src/interloper_api/routes/external/__init__.py
+++ b/packages/interloper-api/src/interloper_api/routes/external/__init__.py
@@ -39,6 +39,7 @@ from interloper_api.routes.external.amazon_ads import sub_router as amazon_ads_r
 from interloper_api.routes.external.facebook_ads import sub_router as facebook_ads_router  # noqa: E402
 from interloper_api.routes.external.google_ads import sub_router as google_ads_router  # noqa: E402
 from interloper_api.routes.external.google_cloud import sub_router as google_cloud_router  # noqa: E402
+from interloper_api.routes.external.impact import sub_router as impact_router  # noqa: E402
 from interloper_api.routes.external.pinterest_ads import sub_router as pinterest_ads_router  # noqa: E402
 from interloper_api.routes.external.snapchat_ads import sub_router as snapchat_ads_router  # noqa: E402
 
@@ -46,5 +47,6 @@ router.include_router(amazon_ads_router)
 router.include_router(facebook_ads_router)
 router.include_router(google_ads_router)
 router.include_router(google_cloud_router)
+router.include_router(impact_router)
 router.include_router(pinterest_ads_router)
 router.include_router(snapchat_ads_router)

--- a/packages/interloper-api/src/interloper_api/routes/external/impact.py
+++ b/packages/interloper-api/src/interloper_api/routes/external/impact.py
@@ -1,0 +1,54 @@
+"""Impact external API routes."""
+
+from __future__ import annotations
+
+import httpx
+from fastapi import APIRouter, Depends
+from interloper_db import Profile
+from pydantic import BaseModel
+
+from interloper_api.dependencies import require_viewer
+from interloper_api.routes.external import handle_error
+
+sub_router = APIRouter()
+
+_BASE_URL = "https://api.impact.com"
+
+
+class ImpactConnectionRequest(BaseModel):
+    """Impact connection credentials (matches ImpactConnection fields)."""
+
+    account_sid: str
+    auth_token: str
+
+
+@sub_router.post("/impact/programs")
+async def impact_programs(
+    body: ImpactConnectionRequest,
+    _user: Profile = Depends(require_viewer),
+) -> list[dict[str, str]]:
+    """Fetch Impact programs (campaigns) accessible by the connection."""
+    try:
+        programs: list[dict[str, str]] = []
+        async with httpx.AsyncClient(
+            timeout=30,
+            auth=httpx.BasicAuth(body.account_sid, body.auth_token),
+            headers={"Accept": "application/json"},
+        ) as client:
+            page, num_pages = 1, 1
+            while page <= num_pages:
+                resp = await client.get(
+                    f"{_BASE_URL}/Advertisers/{body.account_sid}/Campaigns",
+                    params={"Page": page},
+                )
+                resp.raise_for_status()
+                data = resp.json()
+                num_pages = int(data["@numpages"])
+                for campaign in data.get("Campaigns", []):
+                    programs.append({"Id": campaign["Id"], "Name": campaign.get("Name", campaign["Id"])})
+                page += 1
+
+        return programs
+    except Exception as exc:
+        handle_error(exc, "fetching Impact programs")
+        return []


### PR DESCRIPTION
## Summary

Adds the external API route backing the Impact source's `program_id` FetchField (`endpoint="impact/programs"`), so the program (campaign) picker resolves in the UI — mirroring the existing facebook/pinterest/amazon fetch routes.

- `POST /impact/programs` takes the connection's `account_sid` + `auth_token` (HTTP Basic auth).
- Pages the Impact `/Advertisers/{sid}/Campaigns` endpoint (`@numpages`).
- Returns `[{Id, Name}]`, matching the FetchField's `value_key="Id"` / `label_key="Name"`.
- Registered in `routes/external/__init__.py`.

## Test plan

- **Live** (real Impact creds): handler returns the account's programs —
  `[{'Id': '13549', 'Name': 'SWAROVSKI'}, {'Id': '42563', 'Name': 'Swarovski Crystal Online - Creator'}]`.
- ruff + ty clean; pre-commit full suite passed on commit.
- No unit test added, matching the sibling external fetch routes (facebook/pinterest/amazon), which hit live APIs and aren't unit-tested.

## Related
Pairs with the Impact source PR (#52), where the `program_id` FetchField is declared. Independent change (this route doesn't import the source).