### PR TITLE
refactor: move source-side reshaping into custom normalizers

### DIFF
--- a/packages/interloper-assets/src/interloper_assets/amazon_ads/source.py
+++ b/packages/interloper-assets/src/interloper_assets/amazon_ads/source.py
@@ -2,10 +2,10 @@ import datetime as dt
 import gzip
 import json
 from functools import partial
+from typing import Any
 
 import httpx
 import interloper as il
-import pandas as pd
 import tenacity as tc
 from interloper_pandas import DataFrameNormalizer
 
@@ -189,11 +189,11 @@ class AmazonAds(il.Source):
     )
 
     @il.asset(schema=schemas.Profiles, tags=["Entity"])
-    def profiles(self, connection: AmazonAdsConnection) -> pd.DataFrame:
+    def profiles(self, connection: AmazonAdsConnection) -> list[dict[str, Any]]:
         """Advertising profiles associated with the account."""
         response = connection.client.get("/v2/profiles")
         response.raise_for_status()
-        return pd.DataFrame(response.json())
+        return response.json()
 
     # --- Sponsored Products ---
 
@@ -204,7 +204,7 @@ class AmazonAds(il.Source):
     )
     def products_advertised_products(
         self, context: il.ExecutionContext, connection: AmazonAdsConnection
-    ) -> pd.DataFrame:
+    ) -> list[dict[str, Any]]:
         """Performance of advertised products."""
         data = request_and_download_report(
             connection,
@@ -217,7 +217,7 @@ class AmazonAds(il.Source):
             start_date=context.partition_date,
             end_date=context.partition_date,
         )
-        return pd.DataFrame(data)
+        return data
 
     @il.asset(
         schema=schemas.ProductsCampaigns,
@@ -228,7 +228,7 @@ class AmazonAds(il.Source):
         self,
         context: il.ExecutionContext,
         connection: AmazonAdsConnection,
-    ) -> pd.DataFrame:
+    ) -> list[dict[str, Any]]:
         """Campaign performance for sponsored products."""
         data = request_and_download_report(
             connection,
@@ -241,7 +241,7 @@ class AmazonAds(il.Source):
             start_date=context.partition_date,
             end_date=context.partition_date,
         )
-        return pd.DataFrame(data)
+        return data
 
     @il.asset(
         schema=schemas.ProductsSearchTerms,
@@ -252,7 +252,7 @@ class AmazonAds(il.Source):
         self,
         context: il.ExecutionContext,
         connection: AmazonAdsConnection,
-    ) -> pd.DataFrame:
+    ) -> list[dict[str, Any]]:
         """Performance of search terms in sponsored products campaigns."""
         data = request_and_download_report(
             connection,
@@ -265,7 +265,7 @@ class AmazonAds(il.Source):
             start_date=context.partition_date,
             end_date=context.partition_date,
         )
-        return pd.DataFrame(data)
+        return data
 
     @il.asset(
         schema=schemas.ProductsTargeting,
@@ -276,7 +276,7 @@ class AmazonAds(il.Source):
         self,
         context: il.ExecutionContext,
         connection: AmazonAdsConnection,
-    ) -> pd.DataFrame:
+    ) -> list[dict[str, Any]]:
         """Performance based on targeting criteria in sponsored products campaigns."""
         data = request_and_download_report(
             connection,
@@ -289,7 +289,7 @@ class AmazonAds(il.Source):
             start_date=context.partition_date,
             end_date=context.partition_date,
         )
-        return pd.DataFrame(data)
+        return data
 
     @il.asset(
         schema=schemas.ProductsPurchasedProducts,
@@ -300,7 +300,7 @@ class AmazonAds(il.Source):
         self,
         context: il.ExecutionContext,
         connection: AmazonAdsConnection,
-    ) -> pd.DataFrame:
+    ) -> list[dict[str, Any]]:
         """Products purchased through sponsored products campaigns."""
         data = request_and_download_report(
             connection,
@@ -313,7 +313,7 @@ class AmazonAds(il.Source):
             start_date=context.partition_date,
             end_date=context.partition_date,
         )
-        return pd.DataFrame(data)
+        return data
 
     @il.asset(
         schema=schemas.ProductsGrossAndInvalidTraffic,
@@ -324,7 +324,7 @@ class AmazonAds(il.Source):
         self,
         context: il.ExecutionContext,
         connection: AmazonAdsConnection,
-    ) -> pd.DataFrame:
+    ) -> list[dict[str, Any]]:
         """Gross and invalid traffic metrics for sponsored products campaigns."""
         data = request_and_download_report(
             connection,
@@ -337,7 +337,7 @@ class AmazonAds(il.Source):
             start_date=context.partition_date,
             end_date=context.partition_date,
         )
-        return pd.DataFrame(data)
+        return data
 
     # --- Sponsored Display ---
 
@@ -350,7 +350,7 @@ class AmazonAds(il.Source):
         self,
         context: il.ExecutionContext,
         connection: AmazonAdsConnection,
-    ) -> pd.DataFrame:
+    ) -> list[dict[str, Any]]:
         """Display advertising campaign performance."""
         data = request_and_download_report(
             connection,
@@ -363,7 +363,7 @@ class AmazonAds(il.Source):
             start_date=context.partition_date,
             end_date=context.partition_date,
         )
-        return pd.DataFrame(data)
+        return data
 
     @il.asset(
         schema=schemas.DisplayAdvertisedProducts,
@@ -374,7 +374,7 @@ class AmazonAds(il.Source):
         self,
         context: il.ExecutionContext,
         connection: AmazonAdsConnection,
-    ) -> pd.DataFrame:
+    ) -> list[dict[str, Any]]:
         """Performance of advertised products within display campaigns."""
         data = request_and_download_report(
             connection,
@@ -387,7 +387,7 @@ class AmazonAds(il.Source):
             start_date=context.partition_date,
             end_date=context.partition_date,
         )
-        return pd.DataFrame(data)
+        return data
 
     @il.asset(
         schema=schemas.DisplayPurchasedProducts,
@@ -398,7 +398,7 @@ class AmazonAds(il.Source):
         self,
         context: il.ExecutionContext,
         connection: AmazonAdsConnection,
-    ) -> pd.DataFrame:
+    ) -> list[dict[str, Any]]:
         """Products purchased through display campaigns."""
         data = request_and_download_report(
             connection,
@@ -411,7 +411,7 @@ class AmazonAds(il.Source):
             start_date=context.partition_date,
             end_date=context.partition_date,
         )
-        return pd.DataFrame(data)
+        return data
 
     @il.asset(
         schema=schemas.DisplayTargeting,
@@ -422,7 +422,7 @@ class AmazonAds(il.Source):
         self,
         context: il.ExecutionContext,
         connection: AmazonAdsConnection,
-    ) -> pd.DataFrame:
+    ) -> list[dict[str, Any]]:
         """Display campaign performance based on targeting criteria."""
         data = request_and_download_report(
             connection,
@@ -435,7 +435,7 @@ class AmazonAds(il.Source):
             start_date=context.partition_date,
             end_date=context.partition_date,
         )
-        return pd.DataFrame(data)
+        return data
 
     @il.asset(
         schema=schemas.DisplayGrossAndInvalidTraffic,
@@ -446,7 +446,7 @@ class AmazonAds(il.Source):
         self,
         context: il.ExecutionContext,
         connection: AmazonAdsConnection,
-    ) -> pd.DataFrame:
+    ) -> list[dict[str, Any]]:
         """Traffic quality metrics for display campaigns."""
         data = request_and_download_report(
             connection,
@@ -459,7 +459,7 @@ class AmazonAds(il.Source):
             start_date=context.partition_date,
             end_date=context.partition_date,
         )
-        return pd.DataFrame(data)
+        return data
 
     @il.asset(
         schema=schemas.DisplayAdGroups,
@@ -470,7 +470,7 @@ class AmazonAds(il.Source):
         self,
         context: il.ExecutionContext,
         connection: AmazonAdsConnection,
-    ) -> pd.DataFrame:
+    ) -> list[dict[str, Any]]:
         """Ad group performance within display campaigns."""
         data = request_and_download_report(
             connection,
@@ -483,7 +483,7 @@ class AmazonAds(il.Source):
             start_date=context.partition_date,
             end_date=context.partition_date,
         )
-        return pd.DataFrame(data)
+        return data
 
     # --- Sponsored Brands ---
 
@@ -496,7 +496,7 @@ class AmazonAds(il.Source):
         self,
         context: il.ExecutionContext,
         connection: AmazonAdsConnection,
-    ) -> pd.DataFrame:
+    ) -> list[dict[str, Any]]:
         """Brand promotion campaign performance."""
         data = request_and_download_report(
             connection,
@@ -509,7 +509,7 @@ class AmazonAds(il.Source):
             start_date=context.partition_date,
             end_date=context.partition_date,
         )
-        return pd.DataFrame(data)
+        return data
 
     @il.asset(
         schema=schemas.BrandsAds,
@@ -520,7 +520,7 @@ class AmazonAds(il.Source):
         self,
         context: il.ExecutionContext,
         connection: AmazonAdsConnection,
-    ) -> pd.DataFrame:
+    ) -> list[dict[str, Any]]:
         """Individual ad performance within brand campaigns."""
         data = request_and_download_report(
             connection,
@@ -533,7 +533,7 @@ class AmazonAds(il.Source):
             start_date=context.partition_date,
             end_date=context.partition_date,
         )
-        return pd.DataFrame(data)
+        return data
 
     @il.asset(
         schema=schemas.BrandsSearchTerms,
@@ -544,7 +544,7 @@ class AmazonAds(il.Source):
         self,
         context: il.ExecutionContext,
         connection: AmazonAdsConnection,
-    ) -> pd.DataFrame:
+    ) -> list[dict[str, Any]]:
         """Search term performance in brand campaigns."""
         data = request_and_download_report(
             connection,
@@ -557,7 +557,7 @@ class AmazonAds(il.Source):
             start_date=context.partition_date,
             end_date=context.partition_date,
         )
-        return pd.DataFrame(data)
+        return data
 
     @il.asset(
         schema=schemas.BrandsTargeting,
@@ -568,7 +568,7 @@ class AmazonAds(il.Source):
         self,
         context: il.ExecutionContext,
         connection: AmazonAdsConnection,
-    ) -> pd.DataFrame:
+    ) -> list[dict[str, Any]]:
         """Brand campaign performance based on targeting criteria."""
         data = request_and_download_report(
             connection,
@@ -581,7 +581,7 @@ class AmazonAds(il.Source):
             start_date=context.partition_date,
             end_date=context.partition_date,
         )
-        return pd.DataFrame(data)
+        return data
 
     @il.asset(
         schema=schemas.BrandsPurchasedProducts,
@@ -592,7 +592,7 @@ class AmazonAds(il.Source):
         self,
         context: il.ExecutionContext,
         connection: AmazonAdsConnection,
-    ) -> pd.DataFrame:
+    ) -> list[dict[str, Any]]:
         """Products purchased through brand campaigns."""
         data = request_and_download_report(
             connection,
@@ -605,7 +605,7 @@ class AmazonAds(il.Source):
             start_date=context.partition_date,
             end_date=context.partition_date,
         )
-        return pd.DataFrame(data)
+        return data
 
     @il.asset(
         schema=schemas.BrandsGrossAndInvalidTraffic,
@@ -616,7 +616,7 @@ class AmazonAds(il.Source):
         self,
         context: il.ExecutionContext,
         connection: AmazonAdsConnection,
-    ) -> pd.DataFrame:
+    ) -> list[dict[str, Any]]:
         """Traffic quality metrics for brand campaigns."""
         data = request_and_download_report(
             connection,
@@ -629,7 +629,7 @@ class AmazonAds(il.Source):
             start_date=context.partition_date,
             end_date=context.partition_date,
         )
-        return pd.DataFrame(data)
+        return data
 
     @il.asset(
         schema=schemas.BrandsPlacements,
@@ -640,7 +640,7 @@ class AmazonAds(il.Source):
         self,
         context: il.ExecutionContext,
         connection: AmazonAdsConnection,
-    ) -> pd.DataFrame:
+    ) -> list[dict[str, Any]]:
         """Campaign performance by ad placement."""
         data = request_and_download_report(
             connection,
@@ -653,7 +653,7 @@ class AmazonAds(il.Source):
             start_date=context.partition_date,
             end_date=context.partition_date,
         )
-        return pd.DataFrame(data)
+        return data
 
     @il.asset(
         schema=schemas.BrandsAdGroups,
@@ -664,7 +664,7 @@ class AmazonAds(il.Source):
         self,
         context: il.ExecutionContext,
         connection: AmazonAdsConnection,
-    ) -> pd.DataFrame:
+    ) -> list[dict[str, Any]]:
         """Ad group performance within brand campaigns."""
         data = request_and_download_report(
             connection,
@@ -677,7 +677,7 @@ class AmazonAds(il.Source):
             start_date=context.partition_date,
             end_date=context.partition_date,
         )
-        return pd.DataFrame(data)
+        return data
 
     # --- Sponsored Television ---
 
@@ -689,7 +689,7 @@ class AmazonAds(il.Source):
         self,
         context: il.ExecutionContext,
         connection: AmazonAdsConnection,
-    ) -> pd.DataFrame:
+    ) -> list[dict[str, Any]]:
         """Television campaign performance."""
         data = request_and_download_report(
             connection,
@@ -702,7 +702,7 @@ class AmazonAds(il.Source):
             start_date=context.partition_date,
             end_date=context.partition_date,
         )
-        return pd.DataFrame(data)
+        return data
 
     @il.asset(
         partitioning=il.TimePartitionConfig(column="date"),
@@ -712,7 +712,7 @@ class AmazonAds(il.Source):
         self,
         context: il.ExecutionContext,
         connection: AmazonAdsConnection,
-    ) -> pd.DataFrame:
+    ) -> list[dict[str, Any]]:
         """Television campaign performance by targeting."""
         data = request_and_download_report(
             connection,
@@ -725,4 +725,4 @@ class AmazonAds(il.Source):
             start_date=context.partition_date,
             end_date=context.partition_date,
         )
-        return pd.DataFrame(data)
+        return data

--- a/packages/interloper-assets/src/interloper_assets/criteo/source.py
+++ b/packages/interloper-assets/src/interloper_assets/criteo/source.py
@@ -1,8 +1,8 @@
 import datetime as dt
 import logging
+from typing import Any
 
 import interloper as il
-import pandas as pd
 from interloper_pandas import DataFrameNormalizer
 
 from interloper_assets.criteo import constants
@@ -66,7 +66,7 @@ class Criteo(il.Source):
         partitioning=il.TimePartitionConfig(column="day"),
         tags=["Report"],
     )
-    def ads(self, context: il.ExecutionContext, connection: CriteoConnection) -> pd.DataFrame:
+    def ads(self, context: il.ExecutionContext, connection: CriteoConnection) -> list[dict[str, Any]]:
         """Ad-level performance statistics with daily breakdowns."""
         rows = _statistics_report(
             connection,
@@ -75,14 +75,14 @@ class Criteo(il.Source):
             end_date=context.partition_date,
             dimensions=["Day", "AdId", "AdsetId", "CampaignId"],
         )
-        return pd.DataFrame(rows)
+        return rows
 
     @il.asset(
         schema=Campaigns,
         partitioning=il.TimePartitionConfig(column="day"),
         tags=["Report"],
     )
-    def campaigns(self, context: il.ExecutionContext, connection: CriteoConnection) -> pd.DataFrame:
+    def campaigns(self, context: il.ExecutionContext, connection: CriteoConnection) -> list[dict[str, Any]]:
         """Campaign-level performance statistics with daily breakdowns."""
         rows = _statistics_report(
             connection,
@@ -91,4 +91,4 @@ class Criteo(il.Source):
             end_date=context.partition_date,
             dimensions=["Day", "CampaignId"],
         )
-        return pd.DataFrame(rows)
+        return rows

--- a/packages/interloper-assets/src/interloper_assets/facebook_ads/source.py
+++ b/packages/interloper-assets/src/interloper_assets/facebook_ads/source.py
@@ -82,27 +82,36 @@ def _pivot_cell(column: str, cell: Any) -> dict[str, float]:
     return out
 
 
-def _flatten(rows: list[dict]) -> pd.DataFrame:
-    """Pivot the action-list columns and sanitize all column names."""
-    df = pd.DataFrame(rows)
-    if df.empty:
-        return df
+class FacebookActionsNormalizer(DataFrameNormalizer):
+    """Pivot Facebook insight action-lists into per-action-type columns.
 
-    for column in PIVOT_COLUMNS:
-        if column not in df.columns:
-            continue
-        pivoted = pd.DataFrame(list(df[column].map(lambda cell: _pivot_cell(column, cell))), index=df.index)
-        df = pd.concat([df.drop(columns=[column]), pivoted], axis=1)
+    Each ``actions``/``action_values``/… cell is a list of ``{action_type,
+    value}``; pivot it into one ``<column>_<action_type>`` column (summed across
+    the action-device breakdown), sanitize the names, coerce custom-conversion
+    columns to float, then defer to the base ``DataFrameNormalizer`` to flatten
+    nested entity dicts (``creative``) and snake-case the rest.
+    """
 
-    df.columns = [_sanitize(c) for c in df.columns]
+    def normalize(self, data: Any) -> pd.DataFrame:
+        df = data if isinstance(data, pd.DataFrame) else pd.DataFrame(data)
+        if df.empty:
+            return df
 
-    # Custom-conversion columns are not in the schema; coerce to float so mixed
-    # int/NaN values don't surface as objects.
-    for column in df.columns:
-        if re.match(r".*_custom(_.+)?$", column):
-            df[column] = pd.to_numeric(df[column], errors="coerce").astype(float)
+        for column in PIVOT_COLUMNS:
+            if column not in df.columns:
+                continue
+            pivoted = pd.DataFrame(list(df[column].map(lambda cell: _pivot_cell(column, cell))), index=df.index)
+            df = pd.concat([df.drop(columns=[column]), pivoted], axis=1)
 
-    return df
+        df.columns = [_sanitize(c) for c in df.columns]
+
+        # Custom-conversion columns are not in the schema; coerce to float so
+        # mixed int/NaN values don't surface as objects.
+        for column in df.columns:
+            if re.match(r".*_custom(_.+)?$", column):
+                df[column] = pd.to_numeric(df[column], errors="coerce").astype(float)
+
+        return super().normalize(df)
 
 
 # ------------------------------------------------------------------
@@ -273,9 +282,9 @@ def _time_range(date: dt.date) -> dict[str, str]:
     resources={"connection": FacebookAdsConnection},
     tags=["Advertising"],
     icon="logos:facebook",
-    # Action lists are pivoted in the source; the normalizer flattens nested
-    # entity dicts (e.g. ``creative``) and snake-cases the remaining columns.
-    normalizer=DataFrameNormalizer(flatten_max_level=1),
+    # Pivots action-lists, flattens nested entity dicts (e.g. ``creative``),
+    # and snake-cases the columns.
+    normalizer=FacebookActionsNormalizer(flatten_max_level=1),
 )
 class FacebookAds(il.Source):
     """Facebook Ads (Meta Marketing) advertising platform integration."""
@@ -293,7 +302,7 @@ class FacebookAds(il.Source):
         partitioning=il.TimePartitionConfig(column="date_start"),
         tags=["Report"],
     )
-    def campaigns(self, context: il.ExecutionContext, connection: FacebookAdsConnection) -> pd.DataFrame:
+    def campaigns(self, context: il.ExecutionContext, connection: FacebookAdsConnection) -> list[dict[str, Any]]:
         """Campaign-level performance insights with metrics, engagement, and cost breakdowns."""
         rows = _get_ads_insights(
             connection,
@@ -306,14 +315,14 @@ class FacebookAds(il.Source):
                 "action_breakdown": _ACTION_BREAKDOWNS,
             },
         )
-        return _flatten(rows)
+        return rows
 
     @il.asset(
         schema=schemas.Ads,
         partitioning=il.TimePartitionConfig(column="date_start"),
         tags=["Report"],
     )
-    def ads(self, context: il.ExecutionContext, connection: FacebookAdsConnection) -> pd.DataFrame:
+    def ads(self, context: il.ExecutionContext, connection: FacebookAdsConnection) -> list[dict[str, Any]]:
         """Ad-level performance insights with platform, device, and action breakdowns."""
         rows = _get_ads_insights(
             connection,
@@ -326,14 +335,16 @@ class FacebookAds(il.Source):
                 "action_breakdown": _ACTION_BREAKDOWNS,
             },
         )
-        return _flatten(rows)
+        return rows
 
     @il.asset(
         schema=schemas.AdsByAgeGender,
         partitioning=il.TimePartitionConfig(column="date_start"),
         tags=["Report"],
     )
-    def ads_by_age_gender(self, context: il.ExecutionContext, connection: FacebookAdsConnection) -> pd.DataFrame:
+    def ads_by_age_gender(
+        self, context: il.ExecutionContext, connection: FacebookAdsConnection
+    ) -> list[dict[str, Any]]:
         """Ad-level performance insights broken down by age and gender demographics."""
         rows = _get_ads_insights(
             connection,
@@ -346,14 +357,14 @@ class FacebookAds(il.Source):
                 "action_breakdown": _ACTION_BREAKDOWNS,
             },
         )
-        return _flatten(rows)
+        return rows
 
     @il.asset(
         schema=schemas.AdsByCountry,
         partitioning=il.TimePartitionConfig(column="date_start"),
         tags=["Report"],
     )
-    def ads_by_country(self, context: il.ExecutionContext, connection: FacebookAdsConnection) -> pd.DataFrame:
+    def ads_by_country(self, context: il.ExecutionContext, connection: FacebookAdsConnection) -> list[dict[str, Any]]:
         """Ad-level performance insights broken down by country and region."""
         rows = _get_ads_insights(
             connection,
@@ -366,14 +377,14 @@ class FacebookAds(il.Source):
                 "action_breakdown": _ACTION_BREAKDOWNS,
             },
         )
-        return _flatten(rows)
+        return rows
 
     @il.asset(
         schema=schemas.Videos,
         partitioning=il.TimePartitionConfig(column="date_start"),
         tags=["Report"],
     )
-    def videos(self, context: il.ExecutionContext, connection: FacebookAdsConnection) -> pd.DataFrame:
+    def videos(self, context: il.ExecutionContext, connection: FacebookAdsConnection) -> list[dict[str, Any]]:
         """Video ad performance with view retention, engagement, and conversion metrics."""
         rows = _get_ads_insights(
             connection,
@@ -386,13 +397,13 @@ class FacebookAds(il.Source):
                 "action_breakdown": _ACTION_BREAKDOWNS,
             },
         )
-        return _flatten(rows)
+        return rows
 
     @il.asset(
         schema=schemas.CustomAudiences,
         tags=["Entity"],
     )
-    def custom_audiences(self, connection: FacebookAdsConnection) -> pd.DataFrame:
+    def custom_audiences(self, connection: FacebookAdsConnection) -> list[dict[str, Any]]:
         """Custom audiences with approximate size bounds for the account."""
         rows = _get_custom_audiences(
             connection,
@@ -400,20 +411,20 @@ class FacebookAds(il.Source):
             fields=constants.CUSTOM_AUDIENCES_FIELDS,
             params={},
         )
-        return _flatten(rows)
+        return rows
 
     @il.asset(
         schema=schemas.AdsMetadata,
         tags=["Entity"],
     )
-    def ads_metadata(self, connection: FacebookAdsConnection) -> pd.DataFrame:
+    def ads_metadata(self, connection: FacebookAdsConnection) -> list[dict[str, Any]]:
         """Ad metadata including creative, status, and configuration."""
-        return _flatten(_get_ads(connection, self.account_id))
+        return _get_ads(connection, self.account_id)
 
     @il.asset(
         schema=schemas.CampaignsMetadata,
         tags=["Entity"],
     )
-    def campaigns_metadata(self, connection: FacebookAdsConnection) -> pd.DataFrame:
+    def campaigns_metadata(self, connection: FacebookAdsConnection) -> list[dict[str, Any]]:
         """Campaign metadata including objective, budget, and status configuration."""
-        return _flatten(_get_campaigns(connection, self.account_id))
+        return _get_campaigns(connection, self.account_id)

--- a/packages/interloper-assets/tests/test_facebook_ads.py
+++ b/packages/interloper-assets/tests/test_facebook_ads.py
@@ -1,10 +1,11 @@
 """Regression tests for the FacebookAds source.
 
-Facebook insights return nested ``actions``/``action_values`` lists that the
-source pivots into one column per action type (``actions`` ->
-``actions_link_click``), and entity reports return nested dicts (``creative``)
-that the normalizer flattens. These tests pin the pivot/sanitize logic and
-that the resulting frames reconcile against the ported schemas (missing
+Facebook insights nest ``actions``/``action_values`` lists that
+``FacebookActionsNormalizer`` pivots into one column per action type
+(``actions`` -> ``actions_link_click``); entity reports nest dicts
+(``creative``) that the base normalizer flattens. These tests pin the
+pivot/sanitize logic, that the custom normalizer survives the host→child spec
+round-trip, and that frames reconcile against the ported schemas (missing
 nullable columns are filled, so partial action sets are fine).
 """
 
@@ -19,7 +20,7 @@ from interloper.representation import representation_for
 from interloper_pandas import DataFrameNormalizer
 
 from interloper_assets.facebook_ads import schemas
-from interloper_assets.facebook_ads.source import FacebookAds, _flatten
+from interloper_assets.facebook_ads.source import FacebookActionsNormalizer, FacebookAds
 
 
 def _source() -> Any:
@@ -27,9 +28,9 @@ def _source() -> Any:
 
 
 class TestSourceNormalizer:
-    def test_all_assets_inherit_the_normalizer(self):
+    def test_all_assets_use_the_actions_normalizer(self):
         for asset in _source().assets:
-            assert isinstance(asset.normalizer, DataFrameNormalizer), type(asset).key
+            assert isinstance(asset.normalizer, FacebookActionsNormalizer), type(asset).key
 
     def test_all_eight_assets_present(self):
         keys = {type(a).key for a in _source().assets}
@@ -45,18 +46,15 @@ class TestSourceNormalizer:
         }
 
 
-class TestFlatten:
+class TestActionsNormalizer:
     """The action-list pivot is the crux of the Facebook port."""
 
     def test_pivots_actions_into_per_action_type_columns(self):
         rows = [
             {
                 "date_start": "2026-06-10",
-                "date_stop": "2026-06-10",
                 "account_id": "123",
                 "ad_id": "456",
-                "publisher_platform": "facebook",
-                "impression_device": "mobile_feed",
                 # link_click appears twice (action-device breakdown) -> summed.
                 "actions": [
                     {"action_type": "link_click", "action_device": "mobile", "value": "5"},
@@ -66,28 +64,20 @@ class TestFlatten:
                 "action_values": [
                     {"action_type": "offsite_conversion.fb_pixel_purchase", "value": "12.5"},
                 ],
-                "cost_per_action_type": [
-                    {"action_type": "link_click", "value": "0.5"},
-                ],
             }
         ]
-        df = _flatten(rows)
-
+        df = FacebookActionsNormalizer().normalize(rows)
         assert df.loc[0, "actions_link_click"] == 7.0  # summed across devices
         assert df.loc[0, "actions_video_view"] == 3.0
         # the "." in the action type is sanitized to "_"
         assert df.loc[0, "action_values_offsite_conversion_fb_pixel_purchase"] == 12.5
-        assert df.loc[0, "cost_per_action_type_link_click"] == 0.5
-        # original list columns are dropped
-        assert "actions" not in df.columns
+        assert "actions" not in df.columns  # original list column dropped
 
     def test_empty_rows_yield_empty_frame(self):
-        assert _flatten([]).empty
+        assert FacebookActionsNormalizer().normalize([]).empty
 
 
 class TestSpecRoundtripAndReconcile:
-    """Normalizer survives the host→child spec round-trip and frames reconcile."""
-
     def _child(self, key: str) -> Any:
         src = _source()
         asset = next(a for a in src.assets if type(a).key == key)
@@ -95,23 +85,20 @@ class TestSpecRoundtripAndReconcile:
         child_dag = DAGSpec(**spec_json).reconstruct()
         return next(a for a in child_dag.assets if type(a).key == key)
 
+    def test_custom_normalizer_survives_roundtrip(self):
+        norm = self._child("ads").normalizer
+        assert isinstance(norm, FacebookActionsNormalizer)  # not degraded to the base
+        assert norm.flatten_max_level == 1
+
     def test_insights_row_reconciles_against_ads_schema(self):
         child = self._child("ads")
-        assert isinstance(child.normalizer, DataFrameNormalizer)
-
         rows = [
-            {
-                "date_start": "2026-06-10",
-                "account_id": "123",
-                "ad_id": "456",
-                "actions": [{"action_type": "link_click", "value": "7"}],
-            }
+            {"date_start": "2026-06-10", "account_id": "123", "actions": [{"action_type": "link_click", "value": "7"}]}
         ]
-        normalized = child.normalizer.normalize(_flatten(rows))
-        # Pivoted column maps onto a real schema field and survives reconcile.
+        normalized = child.normalizer.normalize(rows)
         assert "actions_link_click" in normalized.columns
-        reconciled = representation_for(normalized).conformer.reconcile(normalized, schemas.Ads)
-        assert int(reconciled.loc[0, "actions_link_click"]) == 7
+        out = representation_for(normalized).conformer.reconcile(normalized, schemas.Ads)
+        assert int(out.loc[0, "actions_link_click"]) == 7
 
     def test_sparse_row_passes_validation(self):
         """Insights are sparse: a frame with only a few of the 75 fields must
@@ -122,14 +109,12 @@ class TestSpecRoundtripAndReconcile:
 
     def test_metadata_row_flattens_creative_and_reconciles(self):
         child = self._child("ads_metadata")
-        rows = [
-            {
-                "id": "456",
-                "name": "My Ad",
-                "creative": {"id": "789", "name": "Creative A"},
-            }
-        ]
-        normalized = child.normalizer.normalize(_flatten(rows))
+        rows = [{"id": "456", "name": "My Ad", "creative": {"id": "789", "name": "Creative A"}}]
+        normalized = child.normalizer.normalize(rows)
         assert "creative_id" in normalized.columns  # nested dict flattened by the normalizer
-        # must not raise
-        representation_for(normalized).conformer.reconcile(normalized, schemas.AdsMetadata)
+        representation_for(normalized).conformer.reconcile(normalized, schemas.AdsMetadata)  # must not raise
+
+
+def test_isinstance_of_dataframe_normalizer():
+    # The custom normalizer is a DataFrameNormalizer, so it inherits its config.
+    assert isinstance(FacebookActionsNormalizer(), DataFrameNormalizer)


### PR DESCRIPTION
## Summary

Follow-up to the SnapchatAds normalizer refactor: reviewed every real (non-`fake_data`) source for reshaping logic living in the source that belongs in the normalizer layer (the framework's home for "coercion, flattening, column naming"), and moved it.

### Reviewed
| source | source-side reshaping? | action |
|---|---|---|
| **facebook_ads** | **yes** — `_flatten` pivots `actions`/`action_values`/… list columns into per-action-type columns + sanitize + custom-conversion coercion | **moved → `FacebookActionsNormalizer`** |
| amazon_ads | no — returns records, uses `DataFrameNormalizer(snake_case_digits, column_overrides)` | none |
| criteo | no — returns records, `DataFrameNormalizer(snake_case_digits, column_overrides)` | none |
| bing_ads | only strips a `%` suffix from rate **values** during CSV parse (value cleaning, not structural reshaping) | left as-is |
| adservice / adup / awin | no — return `pd.DataFrame(data)` directly | none |

### Change
`FacebookActionsNormalizer(DataFrameNormalizer)` now owns the action-list pivot + sanitize + custom-conversion coercion, then defers to the base normalizer for nested-dict flattening (`creative`) and snake-casing. Each Facebook asset method shrinks to fetch → return raw rows; the source sets `normalizer=FacebookActionsNormalizer(flatten_max_level=1)`. Mirrors the SnapchatStatsNormalizer pattern.

## Test plan

- `uv run pytest packages/interloper-assets` — 27 pass. Updated `test_facebook_ads.py` to drive the normalizer (not the removed `_flatten`) and added a check that the custom subclass **survives the host→child spec round-trip** (reconstructs by import path, not degraded to the base — the AmazonAds failure mode).
- ruff + ty clean; pre-commit full suite passed on commit.

## Notes
- SnapchatAds already got its `SnapchatStatsNormalizer` in #54; this PR covers the rest.
- The reshape lives in the normalizer, but the API-envelope unwrap and the `date` stamp (needs `context`) necessarily stay in the source for snapchat/impact — the normalizer is context-free.