### PR TITLE
fix: coerce tiktok stat_time_day to a date for the destination

### DIFF
--- a/packages/interloper-assets/src/interloper_assets/tiktok_ads/source.py
+++ b/packages/interloper-assets/src/interloper_assets/tiktok_ads/source.py
@@ -31,7 +31,9 @@ class TiktokStatsNormalizer(DataFrameNormalizer):
 
     Each row nests its requested dimensions under ``dimensions`` and its metrics
     under ``metrics``; merge both into a single flat record (dropping the parent
-    prefix) before the base ``DataFrameNormalizer`` runs.
+    prefix) before the base ``DataFrameNormalizer`` runs. ``stat_time_day`` comes
+    back as a midnight datetime string (``2026-01-01 00:00:00``) — coerce it to a
+    plain date so it lands on the ``date``-typed schema column.
     """
 
     def normalize(self, data: Any) -> pd.DataFrame:
@@ -45,7 +47,11 @@ class TiktokStatsNormalizer(DataFrameNormalizer):
                 if key not in ("dimensions", "metrics"):
                     merged[key] = value
             flat.append(merged)
-        return super().normalize(flat)
+
+        df = super().normalize(flat)
+        if "stat_time_day" in df.columns:
+            df["stat_time_day"] = pd.to_datetime(df["stat_time_day"], errors="coerce").dt.date
+        return df
 
 
 class TiktokMetadataNormalizer(DataFrameNormalizer):


### PR DESCRIPTION
## Summary

Follow-up to #57 (TikTok Ads source), found while materializing the swarovski manifest to BigQuery.

TikTok's integrated reports return `stat_time_day` as a **midnight datetime string** (`2026-01-01 00:00:00`), not a bare date. Under the AUTO conform strategy the raw value reaches the BigQuery destination's Parquet load uncast, and pyarrow can't fit it to the column type:
- typed as `date` → `Failed to parse string '2026-01-01 00:00:00' as a scalar of type date32[day]`
- typed as `datetime` → `... as a scalar of type timestamp[us, tz=UTC]: expected a zone offset`

`stat_time_day` is semantically a day (the reference schema types it `DATE`), so the schema stays a `date` and `TiktokStatsNormalizer` now coerces the value (`pd.to_datetime(...).dt.date`) so it lands cleanly on the `date32` column.

## Test plan
- Materialized `tiktok_ads.ads` to BigQuery via the swarovski manifest — `ASSET_COMPLETED` (previously `ASSET_FAILED` on the cast).
- `uv run pytest packages/interloper-assets/tests/test_tiktok_ads.py` (7 pass), ruff + ty clean, pre-commit full suite passed on commit.