### PR TITLE
fix(api): install agent extra in api image so /agent routes mount

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -128,6 +128,7 @@ jobs:
           build-args: |
             CORE_EXTRAS=google-cloud
             ASSETS_EXTRAS=bing,facebook,google
+            API_EXTRAS=agent
             SCHEDULER_EXTRAS=${{ matrix.scheduler_extras }}
           cache-from: type=gha,scope=docker-${{ matrix.image }}
           cache-to: type=gha,scope=docker-${{ matrix.image }},mode=max

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ REGISTRY      := europe-docker.pkg.dev/dc-int-connectors-prd/docker
 VERSION       := $(shell python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
 CORE_EXTRAS   ?= google-cloud
 ASSETS_EXTRAS ?= bing,facebook,google
+API_EXTRAS    ?= agent
 
 # Image catalog. Each component is its own repository: "interloper-<role>".
 # NOTE: the `docker` job matrix in .github/workflows/release.yaml mirrors this
@@ -81,6 +82,7 @@ docker-build-linux-%:
 	docker build --target $(call role_of,$*) --platform linux/amd64 \
 		--build-arg CORE_EXTRAS=$(CORE_EXTRAS) \
 		--build-arg ASSETS_EXTRAS=$(ASSETS_EXTRAS) \
+		--build-arg API_EXTRAS=$(API_EXTRAS) \
 		--build-arg SCHEDULER_EXTRAS=$(call launcher_of,$*) \
 		-t $(call image_of,$*):$(VERSION) \
 		-t $(call image_of,$*):latest \
@@ -91,6 +93,7 @@ docker-build-%:
 	docker build --target $(call role_of,$*) \
 		--build-arg CORE_EXTRAS=$(CORE_EXTRAS) \
 		--build-arg ASSETS_EXTRAS=$(ASSETS_EXTRAS) \
+		--build-arg API_EXTRAS=$(API_EXTRAS) \
 		--build-arg SCHEDULER_EXTRAS=$(call launcher_of,$*) \
 		-t $(call image_of,$*):$(VERSION) \
 		-t $(call image_of,$*):latest \

--- a/docker/uv-sync.sh
+++ b/docker/uv-sync.sh
@@ -6,6 +6,7 @@
 #   CORE_EXTRAS       → --package interloper-{name} flags
 #   ASSETS_EXTRAS     → --extra {name} flags (scoped to interloper-assets)
 #   SCHEDULER_EXTRAS  → --extra {name} flags (scoped to interloper-scheduler)
+#   API_EXTRAS        → --extra {name} flags (scoped to interloper-api)
 set -e
 
 # NOTE: the install pass intentionally omits --locked. semantic-release bumps
@@ -60,6 +61,17 @@ if $INSTALL; then
     done
     if $HAS_SCHEDULER && [ -n "${SCHEDULER_EXTRAS:-}" ]; then
         for e in $(echo "$SCHEDULER_EXTRAS" | tr ',' ' '); do
+            EXTRA_FLAGS="$EXTRA_FLAGS --extra $e"
+        done
+    fi
+
+    # API_EXTRAS → --extra flags (only when interloper-api is included)
+    HAS_API=false
+    for p in "$@"; do
+        [ "$p" = "interloper-api" ] && HAS_API=true
+    done
+    if $HAS_API && [ -n "${API_EXTRAS:-}" ]; then
+        for e in $(echo "$API_EXTRAS" | tr ',' ' '); do
             EXTRA_FLAGS="$EXTRA_FLAGS --extra $e"
         done
     fi

--- a/dockerfile
+++ b/dockerfile
@@ -111,6 +111,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # (bing/google/facebook) are skipped.
 FROM base AS build-api
 ARG CORE_EXTRAS
+ARG API_EXTRAS
 ENV ASSETS_EXTRAS=""
 
 RUN --mount=type=cache,target=/root/.cache/uv \

--- a/packages/interloper-api/src/interloper_api/app.py
+++ b/packages/interloper-api/src/interloper_api/app.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from fastapi import APIRouter, FastAPI
@@ -26,6 +27,8 @@ from interloper_api.routes import (
     ws,
 )
 from interloper_api.routes import catalog as catalog_routes
+
+logger = logging.getLogger(__name__)
 
 
 def create_app(
@@ -91,7 +94,10 @@ def create_app(
 
         api.include_router(agent_routes.router, prefix="/agent", tags=["agent"])
     except ImportError:
-        pass
+        logger.warning(
+            "Agent routes not mounted: the 'agent' extra is not installed "
+            "(install interloper-api[agent]); /agent endpoints will return 404."
+        )
 
     @api.get("/health")
     def health() -> dict[str, str]:


### PR DESCRIPTION
## Problem

The agent feature is broken in production — every `/api/agent/*` request 404s:

```
GET  https://interloper.digitlcloud.dev/api/agent/sessions  404
POST https://interloper.digitlcloud.dev/api/agent/sessions  404
```

## Root cause

The agent router is mounted **conditionally** and depends on an **optional** dependency that the prod `api` image never installs:

1. `interloper-agent` (which pulls `google-adk`) is an optional extra of `interloper-api` — `agent = ["interloper-agent"]` under `[project.optional-dependencies]`, not a hard dependency.
2. `create_app()` mounts the agent router inside a `try/except ImportError: pass`. If the extra isn't installed, the import raises, the exception is swallowed, and the `/agent` router is never registered — so the routes 404.
3. The `api` image is built without the extra: the dockerfile installs `interloper-api` with no extras, and `docker/uv-sync.sh` only knew how to expand `ASSETS_EXTRAS` / `SCHEDULER_EXTRAS`. There was no `API_EXTRAS` plumbing, so `google-adk` was never installed and the router never mounted.

The routes work in dev (the workspace installs everything) but not in the slimmer prod image.

## Fix

Add an `API_EXTRAS` build arg, mirroring the existing `*_EXTRAS` pattern, and set it to `agent` in the release build:

- **`docker/uv-sync.sh`** — expand `API_EXTRAS` into `--extra` flags scoped to `interloper-api` (with a `HAS_API` guard, matching the assets/scheduler blocks).
- **`dockerfile`** — declare `ARG API_EXTRAS` in the `build-api` stage so it reaches the install pass.
- **`Makefile`** — add `API_EXTRAS ?= agent` and pass `--build-arg API_EXTRAS` in both build rules (local builds include the agent by default).
- **`.github/workflows/publish.yaml`** — add `API_EXTRAS=agent` to the build args. **This is the change that fixes prod**, since released images are built by this workflow.
- **`app.py`** — replace the silent `except ImportError: pass` with a `logger.warning`, so a missing extra is diagnosable from API logs instead of surfacing only as a runtime 404.

## Reviewer notes

- The `agent` extra pulls in `google-adk`, so the api image grows. The build-time toggle preserves the ability to ship a slim api (`API_EXTRAS=`) if ever needed.
- Takes effect on the **next released image** — the publish workflow runs on release tags.
- Worth confirming the agent runner's runtime config (model/env it expects at startup in `routes/agent.py`) is present in the prod api deployment once the image rebuilds.

## Checks

`ruff`, `ty`, and `pytest` all pass (pre-commit green).