### PR TITLE
feat: enable oauth sign-in for tiktok ads connection

### DIFF
--- a/packages/interloper-assets/src/interloper_assets/tiktok_ads/connection.py
+++ b/packages/interloper-assets/src/interloper_assets/tiktok_ads/connection.py
@@ -10,9 +10,15 @@ from interloper_assets.tiktok_ads.constants import BASE_URL
     name="TikTok Ads",
     icon="logos:tiktok-icon",
     tags=["Advertising"],
+    oauth=il.OAuthConfig("tiktok", fields={"access_token": "access_token"}),
 )
 class TiktokAdsConnection(il.Connection):
-    """TikTok Ads (Business API) connection authenticated with a long-lived access token."""
+    """TikTok Ads (Business API) connection authenticated with a long-lived access token.
+
+    TikTok's token exchange returns a single long-lived ``access_token`` (no
+    refresh token), so this stays a plain ``Connection`` with a custom
+    ``OAuthConfig.fields`` mapping rather than subclassing ``OAuthConnection``.
+    """
 
     model_config = SettingsConfigDict(env_prefix="tiktok_ads_")
 


### PR DESCRIPTION
## What

Wire `OAuthConfig` onto `TiktokAdsConnection` so the connection advertises OAuth sign-in. With this, `definition()` injects an `x-oauth` extension into the connection's JSON Schema and the frontend renders a **"Sign in with TikTok"** button (resolving auth_url, label, and icon from the already-registered `tiktok` provider).

```python
@il.connection(
    name="TikTok Ads",
    icon="logos:tiktok-icon",
    tags=["Advertising"],
    oauth=il.OAuthConfig("tiktok", fields={"access_token": "access_token"}),
)
class TiktokAdsConnection(il.Connection):
    ...
    access_token: str = il.SecretField(...)
```

## Why a plain `Connection` + `OAuthConfig`, not an `OAuthConnection` subclass

`OAuthConnection` declares the standard credential trio (`client_id` / `client_secret` / `refresh_token`) used by Snapchat, Pinterest, etc. TikTok's Business API token exchange returns a **single long-lived `access_token` with no refresh token**, and the connection authenticates via the `Access-Token` header — not Bearer. Subclassing `OAuthConnection` would force three unused required fields onto the connect form.

This is exactly the "non-standard token response shape" case the `OAuthConnection` docstring calls out, and it mirrors the existing `FacebookAdsConnection` pattern (plain `Connection` + custom `fields=` mapping). The `tiktok` provider was already registered in `oauth/builtin.py` with the correct token-exchange params (`code`→`auth_code`, `client_id`→`app_id`, `client_secret`→`secret`, no `grant_type`/`redirect_uri`), so no provider changes were needed.

## Reviewer notes

- Verified: `ruff` + `ty` (scoped) + `pytest` pass; `validate_oauth_fields` passes (`access_token` is a declared field); the `x-oauth` extension serializes into the connection definition with the resolved provider metadata.
- The pre-commit `ty` hook reports pre-existing `facebook_business` import errors (optional SDK extra not installed in this worktree's venv) — unrelated to this change, present on `main`.
- **Out of scope / heads-up:** TikTok wraps its token under a `data` envelope (`{"code":0,"data":{"access_token":...}}`), whereas the generic exchange in `routes/oauth.py` reads top-level keys. End-to-end sign-in may need that route to unwrap `data` before the mapped `access_token` is populated. Happy to follow up in a separate PR.