### PR TITLE
feat(api): add criteo/advertisers FetchField endpoint

### DIFF
--- a/packages/interloper-api/src/interloper_api/routes/external/__init__.py
+++ b/packages/interloper-api/src/interloper_api/routes/external/__init__.py
@@ -36,6 +36,7 @@ def handle_error(error: Exception, context: str) -> None:
 
 # Import and register sub-routers after helpers are defined.
 from interloper_api.routes.external.amazon_ads import sub_router as amazon_ads_router  # noqa: E402
+from interloper_api.routes.external.criteo import sub_router as criteo_router  # noqa: E402
 from interloper_api.routes.external.facebook_ads import sub_router as facebook_ads_router  # noqa: E402
 from interloper_api.routes.external.google_ads import sub_router as google_ads_router  # noqa: E402
 from interloper_api.routes.external.google_cloud import sub_router as google_cloud_router  # noqa: E402
@@ -45,6 +46,7 @@ from interloper_api.routes.external.snapchat_ads import sub_router as snapchat_a
 from interloper_api.routes.external.tiktok_ads import sub_router as tiktok_ads_router  # noqa: E402
 
 router.include_router(amazon_ads_router)
+router.include_router(criteo_router)
 router.include_router(facebook_ads_router)
 router.include_router(google_ads_router)
 router.include_router(google_cloud_router)

--- a/packages/interloper-api/src/interloper_api/routes/external/criteo.py
+++ b/packages/interloper-api/src/interloper_api/routes/external/criteo.py
@@ -1,0 +1,68 @@
+"""Criteo external API routes."""
+
+from __future__ import annotations
+
+import httpx
+from fastapi import APIRouter, Depends
+from interloper_db import Profile
+from pydantic import BaseModel
+
+from interloper_api.dependencies import require_viewer
+from interloper_api.routes.external import handle_error
+
+sub_router = APIRouter()
+
+_BASE_URL = "https://api.criteo.com"
+_TOKEN_URL = f"{_BASE_URL}/oauth2/token"
+_ADVERTISERS_URL = f"{_BASE_URL}/2025-04/advertisers/me"
+
+
+class CriteoConnectionRequest(BaseModel):
+    """Criteo connection credentials (matches CriteoConnection fields)."""
+
+    client_id: str
+    client_secret: str
+    refresh_token: str
+
+
+async def _get_access_token(client: httpx.AsyncClient, body: CriteoConnectionRequest) -> str:
+    """Exchange the refresh token for an access token."""
+    resp = await client.post(
+        _TOKEN_URL,
+        data={
+            "grant_type": "refresh_token",
+            "client_id": body.client_id,
+            "client_secret": body.client_secret,
+            "refresh_token": body.refresh_token,
+        },
+    )
+    resp.raise_for_status()
+    return resp.json()["access_token"]
+
+
+async def _list_advertisers(client: httpx.AsyncClient, body: CriteoConnectionRequest) -> list[dict[str, str]]:
+    """List the advertisers the connection can access, sorted by name."""
+    token = await _get_access_token(client, body)
+    resp = await client.get(_ADVERTISERS_URL, headers={"Authorization": f"Bearer {token}"})
+    resp.raise_for_status()
+
+    advertisers = resp.json().get("data", [])
+    results = [
+        {"id": a["id"], "name": a.get("attributes", {}).get("advertiserName") or a["id"]}
+        for a in advertisers
+    ]
+    return sorted(results, key=lambda a: a["name"].lower())
+
+
+@sub_router.post("/criteo/advertisers")
+async def criteo_advertisers(
+    body: CriteoConnectionRequest,
+    _user: Profile = Depends(require_viewer),
+) -> list[dict[str, str]]:
+    """Fetch the Criteo advertisers accessible by the connection."""
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            return await _list_advertisers(client, body)
+    except Exception as exc:
+        handle_error(exc, "fetching Criteo advertisers")
+        return []

--- a/packages/interloper-api/tests/test_external_criteo.py
+++ b/packages/interloper-api/tests/test_external_criteo.py
@@ -1,0 +1,88 @@
+"""Tests for ``interloper_api.routes.external.criteo`` (FetchField resolution)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from interloper_api.dependencies import require_viewer
+from interloper_api.routes import external as external_module
+from interloper_api.routes.external import criteo as criteo_module
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(external_module.router, prefix="/external")
+    app.dependency_overrides[require_viewer] = lambda: None
+    return TestClient(app)
+
+
+def _body() -> criteo_module.CriteoConnectionRequest:
+    return criteo_module.CriteoConnectionRequest(
+        client_id="cid",
+        client_secret="secret",
+        refresh_token="refresh",
+    )
+
+
+class TestListAdvertisers:
+    def _client(self, captured: list[httpx.Request]) -> httpx.AsyncClient:
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            if request.url.path == "/oauth2/token":
+                return httpx.Response(200, json={"access_token": "the-token"})
+            return httpx.Response(
+                200,
+                json={
+                    "data": [
+                        {"type": "advertiser", "id": "2", "attributes": {"advertiserName": "Bravo"}},
+                        {"type": "advertiser", "id": "1", "attributes": {"advertiserName": "alpha"}},
+                        {"type": "advertiser", "id": "3", "attributes": {}},  # missing name falls back to id
+                    ]
+                },
+            )
+
+        return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+    def test_maps_fields_and_sorts_by_name(self):
+        captured: list[httpx.Request] = []
+
+        async def run() -> list[dict[str, str]]:
+            async with self._client(captured) as client:
+                return await criteo_module._list_advertisers(client, _body())
+
+        results = asyncio.run(run())
+
+        assert results == [
+            {"id": "3", "name": "3"},
+            {"id": "1", "name": "alpha"},
+            {"id": "2", "name": "Bravo"},
+        ]
+        # The refresh token is exchanged before listing, and the access token is forwarded.
+        token_req, advertisers_req = captured
+        assert token_req.url.path == "/oauth2/token"
+        assert advertisers_req.headers["Authorization"] == "Bearer the-token"
+        assert advertisers_req.url.path == "/2025-04/advertisers/me"
+
+
+class TestRoute:
+    def test_auth_failure_surfaces_as_401(self, monkeypatch: pytest.MonkeyPatch):
+        async def fail(client: httpx.AsyncClient, *args: object) -> list[dict[str, str]]:
+            response = httpx.Response(
+                401,
+                request=httpx.Request("POST", criteo_module._TOKEN_URL),
+                json={"errors": [{"detail": "invalid_grant"}]},
+            )
+            raise httpx.HTTPStatusError("unauthorized", request=response.request, response=response)
+
+        monkeypatch.setattr(criteo_module, "_list_advertisers", fail)
+
+        resp = _client().post(
+            "/external/criteo/advertisers",
+            json={"client_id": "cid", "client_secret": "secret", "refresh_token": "bad"},
+        )
+        assert resp.status_code == 401

--- a/packages/interloper-assets/src/interloper_assets/criteo/connection.py
+++ b/packages/interloper-assets/src/interloper_assets/criteo/connection.py
@@ -17,8 +17,6 @@ class CriteoConnection(il.OAuthConnection):
 
     model_config = SettingsConfigDict(env_prefix="criteo_")
 
-    advertiser_id: str = il.InputField(description="Criteo advertiser ID")
-
     @cached_property
     def client(self) -> il.RESTClient:
         return il.RESTClient(

--- a/packages/interloper-assets/src/interloper_assets/criteo/source.py
+++ b/packages/interloper-assets/src/interloper_assets/criteo/source.py
@@ -61,6 +61,14 @@ def _statistics_report(
 class Criteo(il.Source):
     """Criteo advertising platform integration."""
 
+    advertiser_id: str = il.FetchField(
+        endpoint="criteo/advertisers",
+        depends_on="connection",
+        label_key="name",
+        value_key="id",
+        description="Criteo advertiser account",
+    )
+
     @il.asset(
         schema=Ads,
         partitioning=il.TimePartitionConfig(column="day"),
@@ -70,7 +78,7 @@ class Criteo(il.Source):
         """Ad-level performance statistics with daily breakdowns."""
         rows = _statistics_report(
             connection,
-            advertiser_id=connection.advertiser_id,
+            advertiser_id=self.advertiser_id,
             start_date=context.partition_date,
             end_date=context.partition_date,
             dimensions=["Day", "AdId", "AdsetId", "CampaignId"],
@@ -86,7 +94,7 @@ class Criteo(il.Source):
         """Campaign-level performance statistics with daily breakdowns."""
         rows = _statistics_report(
             connection,
-            advertiser_id=connection.advertiser_id,
+            advertiser_id=self.advertiser_id,
             start_date=context.partition_date,
             end_date=context.partition_date,
             dimensions=["Day", "CampaignId"],

--- a/packages/interloper-assets/tests/test_criteo.py
+++ b/packages/interloper-assets/tests/test_criteo.py
@@ -33,7 +33,7 @@ CAMPAIGNS_COLUMNS = ["Day", "CampaignId", "Campaign", "Currency", *constants.STA
 
 
 def _source() -> Any:
-    return Criteo(id="src-1")
+    return Criteo(id="src-1", advertiser_id="123")  # ty: ignore[unknown-argument]
 
 
 class TestSourceNormalizer:


### PR DESCRIPTION
## What

Move the Criteo `advertiser_id` off the **connection** and onto the **source** as a `FetchField`, backed by a new API endpoint that lists the advertisers a connection can access — so users pick an advertiser from a dropdown instead of typing an ID.

## Changes

- **New endpoint** `POST /api/external/criteo/advertisers` ([criteo.py](packages/interloper-api/src/interloper_api/routes/external/criteo.py)) — exchanges the connection's refresh token for an access token, then calls Criteo's `GET /2025-04/advertisers/me`, returning `[{id, name}]` sorted by name. Mirrors the existing OAuth refresh-token routes (pinterest/snapchat/google_ads). Registered in `external/__init__.py`.
- **Source** ([criteo/source.py](packages/interloper-assets/src/interloper_assets/criteo/source.py)) — `advertiser_id` is now `il.FetchField(endpoint="criteo/advertisers", label_key="name", value_key="id")`, removed from `CriteoConnection`.
- **Tests** ([test_external_criteo.py](packages/interloper-api/tests/test_external_criteo.py)) — field mapping + sort + id fallback, token-then-list ordering, 401 propagation; updated `test_criteo.py` for the now-required field.

## Testing

- ruff + ty clean; API suite (44) and criteo tests pass.
- **Live-tested against the real Criteo API** with prod creds: returned 42 real advertisers, correctly shaped (`id`/`name`) and sorted.