### PR TITLE
refactor!: publish one image per role, flavors as tag suffixes

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -93,15 +93,19 @@ jobs:
         run: pnpm exec nuxt typecheck
 
   docker:
-    name: Docker smoke (${{ matrix.target }})
+    name: Docker smoke (${{ matrix.name }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        # Light smoke set: `core` exercises the Python build path;
-        # `frontend` exercises the Node/Nuxt build path. Full matrix
-        # (worker/scheduler/api + launcher variants) runs on release.
-        target: [core, frontend]
+        # Light smoke set: `core` exercises the Python build path; `frontend`
+        # the Node/Nuxt build path; `api-agent` the optional agent extra (the
+        # only release flavor whose dep resolution isn't otherwise built in CI).
+        # Full matrix + launcher tag variants run on release (publish.yaml).
+        include:
+          - { name: core,      target: core,     api_extras: "" }
+          - { name: frontend,  target: frontend, api_extras: "" }
+          - { name: api-agent, target: api,      api_extras: agent }
     permissions:
       contents: read
     steps:
@@ -111,7 +115,7 @@ jobs:
       - name: Setup Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build (${{ matrix.target }})
+      - name: Build (${{ matrix.name }})
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -120,8 +124,11 @@ jobs:
           platforms: linux/amd64
           push: false
           load: false
-          cache-from: type=gha,scope=docker-${{ matrix.target }}
-          cache-to: type=gha,scope=docker-${{ matrix.target }},mode=max
+          build-args: |
+            CORE_EXTRAS=google-cloud
+            API_EXTRAS=${{ matrix.api_extras }}
+          cache-from: type=gha,scope=docker-${{ matrix.name }}
+          cache-to: type=gha,scope=docker-${{ matrix.name }},mode=max
 
   helm:
     name: Helm lint

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -60,12 +60,13 @@ jobs:
   # ────────────────────────────────────────────────────────────────────
   # Docker images → GitHub Container Registry (ghcr.io)
   #
-  # One image per component, tagged with the released version (plus `latest`
-  # on stable releases only). The matrix mirrors the image catalog in the
-  # Makefile (ROLES + ROLES_LAUNCHER_AWARE) — keep the two in sync.
+  # One image per role, tagged with the released version (plus `latest` on
+  # stable releases only). Flavors (extra-bearing variants) ride the tag as a
+  # "-<flavor>" suffix rather than a separate image. The matrix mirrors the
+  # image catalog in the Makefile (ROLES + FLAVORS_*) — keep the two in sync.
   # ────────────────────────────────────────────────────────────────────
   docker:
-    name: Docker (${{ matrix.image }})
+    name: Docker (${{ matrix.role }}${{ matrix.flavor && format('-{0}', matrix.flavor) || '' }})
     needs: resolve
     runs-on: ubuntu-latest
 
@@ -76,13 +77,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # role  → dockerfile target + image name (interloper-<role>)
+        # flavor → tag suffix; api_extras/scheduler_extras feed the build args
         include:
-          - { target: api,       image: interloper-api,              scheduler_extras: "" }
-          - { target: frontend,  image: interloper-frontend,         scheduler_extras: "" }
-          - { target: worker,    image: interloper-worker,           scheduler_extras: "" }
-          - { target: scheduler, image: interloper-scheduler,        scheduler_extras: "" }
-          - { target: scheduler, image: interloper-scheduler-k8s,    scheduler_extras: "k8s" }
-          - { target: scheduler, image: interloper-scheduler-docker, scheduler_extras: "docker" }
+          - { role: api,       flavor: "",       api_extras: "",      scheduler_extras: "" }
+          - { role: api,       flavor: agent,    api_extras: "agent", scheduler_extras: "" }
+          - { role: frontend,  flavor: "",       api_extras: "",      scheduler_extras: "" }
+          - { role: worker,    flavor: "",       api_extras: "",      scheduler_extras: "" }
+          - { role: scheduler, flavor: "",       api_extras: "",      scheduler_extras: "" }
+          - { role: scheduler, flavor: k8s,      api_extras: "",      scheduler_extras: "k8s" }
+          - { role: scheduler, flavor: docker,   api_extras: "",      scheduler_extras: "docker" }
 
     steps:
       - name: Checkout (released tag)
@@ -109,29 +113,31 @@ jobs:
         id: tags
         run: |
           owner="$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
-          repo="ghcr.io/${owner}/${{ matrix.image }}"
-          tags="${repo}:${{ needs.resolve.outputs.version }}"
+          repo="ghcr.io/${owner}/interloper-${{ matrix.role }}"
+          suffix=""
+          [ -n "${{ matrix.flavor }}" ] && suffix="-${{ matrix.flavor }}"
+          tags="${repo}:${{ needs.resolve.outputs.version }}${suffix}"
           if [ "${{ needs.resolve.outputs.stable }}" = "true" ]; then
-            tags="${tags},${repo}:latest"
+            tags="${tags},${repo}:latest${suffix}"
           fi
           echo "tags=${tags}" >> "$GITHUB_OUTPUT"
 
-      - name: Build & Push (${{ matrix.target }})
+      - name: Build & Push (${{ matrix.role }}${{ matrix.flavor && format('-{0}', matrix.flavor) || '' }})
         uses: docker/build-push-action@v6
         with:
           context: .
           file: dockerfile
-          target: ${{ matrix.target }}
+          target: ${{ matrix.role }}
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.tags.outputs.tags }}
           build-args: |
             CORE_EXTRAS=google-cloud
             ASSETS_EXTRAS=bing,facebook,google
-            API_EXTRAS=agent
+            API_EXTRAS=${{ matrix.api_extras }}
             SCHEDULER_EXTRAS=${{ matrix.scheduler_extras }}
-          cache-from: type=gha,scope=docker-${{ matrix.image }}
-          cache-to: type=gha,scope=docker-${{ matrix.image }},mode=max
+          cache-from: type=gha,scope=docker-${{ matrix.role }}-${{ matrix.flavor }}
+          cache-to: type=gha,scope=docker-${{ matrix.role }}-${{ matrix.flavor }},mode=max
 
   # ────────────────────────────────────────────────────────────────────
   # Helm chart → GitHub Pages (chart-releaser)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,15 +65,15 @@ Both run against [dev/interloper.yaml](dev/interloper.yaml), which carries **onl
 
 ## Docker images
 
-Built from a single multi-target [dockerfile](dockerfile). The image catalog is defined in the [Makefile](Makefile):
+Built from a single multi-target [dockerfile](dockerfile). The image catalog is defined in the [Makefile](Makefile): one image per role (`interloper-<role>`), with **flavors** (extra-bearing variants) riding the **tag** as a `-<flavor>` suffix — not a separate image name.
 
-- `ROLES` (`api`, `frontend`, `worker`) → image `interloper-<role>:<version>`.
-- `ROLES_LAUNCHER_AWARE` (`scheduler`) builds one image per launcher: `interloper-scheduler`, `interloper-scheduler-k8s`, `interloper-scheduler-docker`. The launcher lives in the **image name**, not the tag; the Helm chart picks the suffix from `config.launcher.type`.
-- Build one target: `make docker-build-<role>` or `make docker-build-<role>-<launcher>`.
+- `ROLES` (`api`, `frontend`, `worker`, `scheduler`) → image `interloper-<role>:<version>` (base, no flavor extras).
+- `FLAVORS_<role>` defines the per-role flavors and `EXTRAS_ARG_<role>` the build arg that carries them: `scheduler` → `k8s`, `docker` (via `SCHEDULER_EXTRAS`); `api` → `agent` (via `API_EXTRAS`). These build `interloper-scheduler:<version>-k8s`, `interloper-api:<version>-agent`, etc. (plus matching `latest-<flavor>` tags). The Helm chart picks the scheduler tag suffix from `config.launcher.type` and the api `-agent` tag from `api.agent.enabled`.
+- Build one target: `make docker-build-<role>` (base) or `make docker-build-<role>-<flavor>` (e.g. `docker-build-scheduler-k8s`, `docker-build-api-agent`).
 - Build everything: `make docker-build` (host arch) or `make docker-build-linux` (linux/amd64 for the registry).
 - Push: `make docker-push`, or `make docker-build-push` to build linux + push in one step.
 
-Override extras at `make` time: `CORE_EXTRAS`, `ASSETS_EXTRAS`, `SCHEDULER_EXTRAS`.
+Override extras at `make` time: `CORE_EXTRAS`, `ASSETS_EXTRAS` (flavor extras come from the target stem, not these).
 
 ## Conventions
 

--- a/Makefile
+++ b/Makefile
@@ -47,34 +47,47 @@ REGISTRY      := europe-docker.pkg.dev/dc-int-connectors-prd/docker
 VERSION       := $(shell python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
 CORE_EXTRAS   ?= google-cloud
 ASSETS_EXTRAS ?= bing,facebook,google
-API_EXTRAS    ?= agent
 
-# Image catalog. Each component is its own repository: "interloper-<role>".
-# NOTE: the `docker` job matrix in .github/workflows/release.yaml mirrors this
-# catalog — update both together when adding or removing a role.
-#   ROLES                  → image "interloper-<role>",         tag = "<version>"
-#   ROLES_LAUNCHER_AWARE   → one image per (role, launcher) pair, all tagged
-#                            "<version>", with the launcher in the image name:
-#                              interloper-<role>             (no launcher extras)
-#                              interloper-<role>-k8s
-#                              interloper-<role>-docker
-# The chart picks the suffix from config.launcher.type — no manual mapping.
-ROLES                := api frontend worker
-ROLES_LAUNCHER_AWARE := scheduler
-LAUNCHERS            := k8s docker
+# Image catalog. Each role is its own repository "interloper-<role>"; flavors
+# (extra-bearing variants) ride the TAG, not the image name:
+#   interloper-<role>:<version>            base image (no flavor extras)
+#   interloper-<role>:<version>-<flavor>   flavored variant
+# plus the matching "latest" / "latest-<flavor>" tags on stable releases.
+# NOTE: the `docker` job matrix in .github/workflows/publish.yaml mirrors this
+# catalog — update both together when adding or removing a role or flavor.
+ROLES := api frontend worker scheduler
 
-# Concrete target stems built by `docker-build`.
-TARGETS := $(ROLES) $(ROLES_LAUNCHER_AWARE) \
-           $(foreach r,$(ROLES_LAUNCHER_AWARE), \
-             $(foreach l,$(LAUNCHERS),$(r)-$(l)))
+# Flavors per role, and the build-arg that carries a flavor's extra. A role
+# with no FLAVORS_<role> builds only its base image.
+FLAVORS_api          := agent
+FLAVORS_scheduler    := k8s docker
+EXTRAS_ARG_api       := API_EXTRAS
+EXTRAS_ARG_scheduler := SCHEDULER_EXTRAS
 
-# Parse a target stem (e.g. "scheduler-k8s") into role + launcher.
-# Launcher is empty for base targets ("scheduler", "api", …).
-launcher_of = $(if $(filter %-k8s %-docker,$(1)),$(lastword $(subst -, ,$(1))))
-role_of     = $(if $(call launcher_of,$(1)),$(patsubst %-$(call launcher_of,$(1)),%,$(1)),$(1))
-# Image name derived from a stem. Tag carries the version only;
-# launcher variants live in the image name.
-image_of    = interloper-$(call role_of,$(1))$(if $(call launcher_of,$(1)),-$(call launcher_of,$(1)))
+# All flavor tokens, used to split a "<role>-<flavor>" stem back apart.
+ALL_FLAVORS := $(sort $(foreach r,$(ROLES),$(FLAVORS_$(r))))
+
+# Concrete target stems built by `docker-build`: every role plus each
+# "<role>-<flavor>" pair → api api-agent frontend worker scheduler
+# scheduler-k8s scheduler-docker.
+TARGETS := $(ROLES) \
+           $(foreach r,$(ROLES),$(foreach f,$(FLAVORS_$(r)),$(r)-$(f)))
+
+# Parse a stem (e.g. "scheduler-k8s") into flavor + role. Flavor is empty for
+# base stems ("scheduler", "api", …).
+flavor_of = $(lastword $(filter $(ALL_FLAVORS),$(subst -, ,$(1))))
+role_of   = $(if $(call flavor_of,$(1)),$(patsubst %-$(call flavor_of,$(1)),%,$(1)),$(1))
+
+# One image name per role; the flavor (when any) rides the tag.
+image_of  = interloper-$(call role_of,$(1))
+tag_of    = $(VERSION)$(if $(call flavor_of,$(1)),-$(call flavor_of,$(1)))
+latest_of = latest$(if $(call flavor_of,$(1)),-$(call flavor_of,$(1)))
+
+# Build-arg injecting the flavor's extra, scoped to the role that defines it
+# (e.g. "--build-arg API_EXTRAS=agent"). Roles with an extras arg always get
+# it set — empty for the base stem — so the dockerfile default can't leak in
+# (SCHEDULER_EXTRAS defaults to "docker" there).
+extras_arg = $(if $(EXTRAS_ARG_$(call role_of,$(1))),--build-arg $(EXTRAS_ARG_$(call role_of,$(1)))=$(call flavor_of,$(1)))
 
 # Pattern rules. Order matters on macOS' GNU make 3.81 (no shortest-stem):
 # the more specific docker-build-linux-% must come first.
@@ -82,27 +95,25 @@ docker-build-linux-%:
 	docker build --target $(call role_of,$*) --platform linux/amd64 \
 		--build-arg CORE_EXTRAS=$(CORE_EXTRAS) \
 		--build-arg ASSETS_EXTRAS=$(ASSETS_EXTRAS) \
-		--build-arg API_EXTRAS=$(API_EXTRAS) \
-		--build-arg SCHEDULER_EXTRAS=$(call launcher_of,$*) \
-		-t $(call image_of,$*):$(VERSION) \
-		-t $(call image_of,$*):latest \
-		-t $(REGISTRY)/$(call image_of,$*):$(VERSION) \
-		-t $(REGISTRY)/$(call image_of,$*):latest .
+		$(call extras_arg,$*) \
+		-t $(call image_of,$*):$(call tag_of,$*) \
+		-t $(call image_of,$*):$(call latest_of,$*) \
+		-t $(REGISTRY)/$(call image_of,$*):$(call tag_of,$*) \
+		-t $(REGISTRY)/$(call image_of,$*):$(call latest_of,$*) .
 
 docker-build-%:
 	docker build --target $(call role_of,$*) \
 		--build-arg CORE_EXTRAS=$(CORE_EXTRAS) \
 		--build-arg ASSETS_EXTRAS=$(ASSETS_EXTRAS) \
-		--build-arg API_EXTRAS=$(API_EXTRAS) \
-		--build-arg SCHEDULER_EXTRAS=$(call launcher_of,$*) \
-		-t $(call image_of,$*):$(VERSION) \
-		-t $(call image_of,$*):latest \
-		-t $(REGISTRY)/$(call image_of,$*):$(VERSION) \
-		-t $(REGISTRY)/$(call image_of,$*):latest .
+		$(call extras_arg,$*) \
+		-t $(call image_of,$*):$(call tag_of,$*) \
+		-t $(call image_of,$*):$(call latest_of,$*) \
+		-t $(REGISTRY)/$(call image_of,$*):$(call tag_of,$*) \
+		-t $(REGISTRY)/$(call image_of,$*):$(call latest_of,$*) .
 
 docker-push-%:
-	docker push $(REGISTRY)/$(call image_of,$*):$(VERSION)
-	docker push $(REGISTRY)/$(call image_of,$*):latest
+	docker push $(REGISTRY)/$(call image_of,$*):$(call tag_of,$*)
+	docker push $(REGISTRY)/$(call image_of,$*):$(call latest_of,$*)
 
 docker-build:       $(addprefix docker-build-,$(TARGETS))
 docker-build-linux: $(addprefix docker-build-linux-,$(TARGETS))

--- a/README.md
+++ b/README.md
@@ -70,19 +70,19 @@ pip install interloper-core
 
 ### Docker images (GHCR)
 
-Container images are published to the [GitHub Container Registry](https://github.com/orgs/digitl-cloud/packages?repo_name=interloper), tagged with the release version and `latest`.
+Container images are published to the [GitHub Container Registry](https://github.com/orgs/digitl-cloud/packages?repo_name=interloper), tagged with the release version and `latest`. There's one image per role; flavored variants ride the tag as a `-<flavor>` suffix (e.g. `:<version>-k8s`).
 
-| Image                                                                                                            | Role                              |
-| ---------------------------------------------------------------------------------------------------------------- | --------------------------------- |
-| [`ghcr.io/digitl-cloud/interloper-api`](https://github.com/digitl-cloud/interloper/pkgs/container/interloper-api)                             | FastAPI HTTP backend              |
-| [`ghcr.io/digitl-cloud/interloper-frontend`](https://github.com/digitl-cloud/interloper/pkgs/container/interloper-frontend)                   | Web UI (nginx-served SPA)         |
-| [`ghcr.io/digitl-cloud/interloper-worker`](https://github.com/digitl-cloud/interloper/pkgs/container/interloper-worker)                       | Queue worker                      |
-| [`ghcr.io/digitl-cloud/interloper-scheduler`](https://github.com/digitl-cloud/interloper/pkgs/container/interloper-scheduler)                 | Scheduler (local launcher)        |
-| [`ghcr.io/digitl-cloud/interloper-scheduler-k8s`](https://github.com/digitl-cloud/interloper/pkgs/container/interloper-scheduler-k8s)         | Scheduler (Kubernetes launcher)   |
-| [`ghcr.io/digitl-cloud/interloper-scheduler-docker`](https://github.com/digitl-cloud/interloper/pkgs/container/interloper-scheduler-docker)   | Scheduler (Docker launcher)       |
+| Image                                                                                                            | Role                              | Flavor tags (`:<version>-<flavor>`)            |
+| ---------------------------------------------------------------------------------------------------------------- | --------------------------------- | ---------------------------------------------- |
+| [`ghcr.io/digitl-cloud/interloper-api`](https://github.com/digitl-cloud/interloper/pkgs/container/interloper-api)                             | FastAPI HTTP backend              | `-agent` (bundles the ADK agent / `/agent` routes) |
+| [`ghcr.io/digitl-cloud/interloper-frontend`](https://github.com/digitl-cloud/interloper/pkgs/container/interloper-frontend)                   | Web UI (nginx-served SPA)         | —                                              |
+| [`ghcr.io/digitl-cloud/interloper-worker`](https://github.com/digitl-cloud/interloper/pkgs/container/interloper-worker)                       | Queue worker                      | —                                              |
+| [`ghcr.io/digitl-cloud/interloper-scheduler`](https://github.com/digitl-cloud/interloper/pkgs/container/interloper-scheduler)                 | Scheduler (cron + worker + reaper) | `-k8s` (Kubernetes launcher), `-docker` (Docker launcher) |
 
 ```bash
 docker pull ghcr.io/digitl-cloud/interloper-api:latest
+docker pull ghcr.io/digitl-cloud/interloper-api:latest-agent
+docker pull ghcr.io/digitl-cloud/interloper-scheduler:latest-k8s
 ```
 
 ### Helm chart

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -96,21 +96,25 @@ All workspace packages are published:
 
 ## Docker images (GitHub Container Registry)
 
-The `docker` job builds one image per component and pushes it to GHCR. The
-matrix mirrors the image catalog in the [`Makefile`](Makefile) — keep the two in
-sync if a role is added or removed.
+The `docker` job builds one image per role and pushes it to GHCR. Flavored
+variants (extra-bearing builds) ride the **tag** as a `-<flavor>` suffix on the
+same image rather than a separate image name. The matrix mirrors the image
+catalog in the [`Makefile`](Makefile) (`ROLES` + `FLAVORS_*`) — keep the two in
+sync if a role or flavor is added or removed.
 
-| Image | Dockerfile target | Notes |
+| Image:tag | Dockerfile target | Build arg |
 | --- | --- | --- |
-| `ghcr.io/<owner>/interloper-api` | `api` | |
-| `ghcr.io/<owner>/interloper-frontend` | `frontend` | nginx serving the built SPA |
-| `ghcr.io/<owner>/interloper-worker` | `worker` | |
-| `ghcr.io/<owner>/interloper-scheduler` | `scheduler` | no launcher extras |
-| `ghcr.io/<owner>/interloper-scheduler-k8s` | `scheduler` | `SCHEDULER_EXTRAS=k8s` |
-| `ghcr.io/<owner>/interloper-scheduler-docker` | `scheduler` | `SCHEDULER_EXTRAS=docker` |
+| `ghcr.io/<owner>/interloper-api:<version>` | `api` | — |
+| `ghcr.io/<owner>/interloper-api:<version>-agent` | `api` | `API_EXTRAS=agent` |
+| `ghcr.io/<owner>/interloper-frontend:<version>` | `frontend` | nginx serving the built SPA |
+| `ghcr.io/<owner>/interloper-worker:<version>` | `worker` | — |
+| `ghcr.io/<owner>/interloper-scheduler:<version>` | `scheduler` | no launcher extras |
+| `ghcr.io/<owner>/interloper-scheduler:<version>-k8s` | `scheduler` | `SCHEDULER_EXTRAS=k8s` |
+| `ghcr.io/<owner>/interloper-scheduler:<version>-docker` | `scheduler` | `SCHEDULER_EXTRAS=docker` |
 
-Each image is tagged with the released version. On **stable** releases the
-`latest` tag is also moved; release candidates push the version tag only.
+Each image is tagged with the released version (and `-<flavor>` variants). On
+**stable** releases the `latest` / `latest-<flavor>` tags are also moved;
+release candidates push the version tags only.
 
 One-time setup: the first push creates each package as **private** and not yet
 linked to the repository. After the first release, for each package go to the

--- a/chart/interloper/README.md
+++ b/chart/interloper/README.md
@@ -15,22 +15,25 @@ disabled via `<component>.enabled: false`.
 
 ## Images
 
-Each component is its own image, named `interloper-<component>`. Images are
-published to GitHub Container Registry, which is the chart's default
-`image.registry` (`ghcr.io/digitl-cloud`):
+Each component is its own image, named `interloper-<component>`. Flavored
+variants ride the **tag** as a `-<flavor>` suffix on the same image (not a
+separate image name). Images are published to GitHub Container Registry, which
+is the chart's default `image.registry` (`ghcr.io/digitl-cloud`):
 
 ```
 ghcr.io/digitl-cloud/interloper-scheduler:<version>          # in-process launcher
-ghcr.io/digitl-cloud/interloper-scheduler-k8s:<version>      # kubernetes launcher
-ghcr.io/digitl-cloud/interloper-scheduler-docker:<version>   # docker launcher
-ghcr.io/digitl-cloud/interloper-api:<version>
+ghcr.io/digitl-cloud/interloper-scheduler:<version>-k8s      # kubernetes launcher
+ghcr.io/digitl-cloud/interloper-scheduler:<version>-docker   # docker launcher
+ghcr.io/digitl-cloud/interloper-api:<version>                # base (no /agent routes)
+ghcr.io/digitl-cloud/interloper-api:<version>-agent          # bundles the ADK agent
 ghcr.io/digitl-cloud/interloper-frontend:<version>
 ghcr.io/digitl-cloud/interloper-worker:<version>             # kubernetes runner per-asset Job target
 ```
 
-The chart picks the scheduler image suffix from `config.launcher.type`
-automatically — no manual mapping. Override `image.registry` (and
-`image.pullSecrets` for a private registry) to pull from elsewhere.
+The chart picks the scheduler tag suffix from `config.launcher.type`
+automatically, and the api `-agent` tag when `api.agent.enabled=true` — no
+manual mapping. Override `image.registry` (and `image.pullSecrets` for a
+private registry) to pull from elsewhere.
 
 ## Quick start (dev)
 

--- a/chart/interloper/templates/_helpers.tpl
+++ b/chart/interloper/templates/_helpers.tpl
@@ -58,37 +58,46 @@ Secret name — either user-provided existingSecret or chart-generated.
 {{- end -}}
 
 {{/*
-Launcher suffix appended to the scheduler image NAME. Maps the runtime
-launcher choice (config.launcher.type) onto the build-time SCHEDULER_EXTRAS
-that produced each image variant.
+Flavor token for the scheduler image, derived from the runtime launcher
+choice (config.launcher.type). Flavors are tag suffixes on the single
+interloper-scheduler image, matching the build-time SCHEDULER_EXTRAS that
+produced each variant.
 
   in_process → ""        (base image, no launcher extras)
-  kubernetes → "-k8s"
-  docker     → "-docker"
+  kubernetes → "k8s"
+  docker     → "docker"
 */}}
-{{- define "interloper.launcherSuffix" -}}
+{{- define "interloper.schedulerFlavor" -}}
 {{- $type := .Values.config.launcher.type | default "in_process" -}}
-{{- if eq $type "kubernetes" -}}-k8s
-{{- else if eq $type "docker" -}}-docker
+{{- if eq $type "kubernetes" -}}k8s
+{{- else if eq $type "docker" -}}docker
 {{- end -}}
 {{- end -}}
 
 {{/*
-Image reference for a component.
-Falls back to "<registry>/interloper-<component>[<launcher-suffix>]:<tag>"
-if repository is not set. Launcher suffix only applies to the scheduler.
-Usage: {{ include "interloper.image" (dict "root" . "component" "scheduler" "image" .Values.scheduler.image) }}
+Flavor token for the api image. The "agent" flavor
+(interloper-api:<tag>-agent) bundles interloper-agent so the /agent routes
+mount; the base image omits it (those routes 404).
+*/}}
+{{- define "interloper.apiFlavor" -}}
+{{- if .Values.api.agent.enabled -}}agent{{- end -}}
+{{- end -}}
+
+{{/*
+Image reference for a component. Falls back to
+"<registry>/interloper-<component>:<tag>[-<flavor>]" if repository is not set.
+The optional "flavor" rides the tag (e.g. scheduler "-k8s", api "-agent").
+Usage: {{ include "interloper.image" (dict "root" . "component" "scheduler" "image" .Values.scheduler.image "flavor" (include "interloper.schedulerFlavor" .)) }}
 */}}
 {{- define "interloper.image" -}}
 {{- $tag := default .root.Values.image.tag .image.tag | default .root.Chart.AppVersion -}}
-{{- if .image.repository -}}
-{{ .image.repository }}:{{ $tag }}
-{{- else -}}
+{{- $flavor := .flavor | default "" -}}
 {{- $suffix := "" -}}
-{{- if eq .component "scheduler" -}}
-{{- $suffix = include "interloper.launcherSuffix" .root -}}
-{{- end -}}
-{{ .root.Values.image.registry }}/interloper-{{ .component }}{{ $suffix }}:{{ $tag }}
+{{- if $flavor -}}{{- $suffix = printf "-%s" $flavor -}}{{- end -}}
+{{- if .image.repository -}}
+{{ .image.repository }}:{{ $tag }}{{ $suffix }}
+{{- else -}}
+{{ .root.Values.image.registry }}/interloper-{{ .component }}:{{ $tag }}{{ $suffix }}
 {{- end -}}
 {{- end -}}
 
@@ -96,7 +105,7 @@ Usage: {{ include "interloper.image" (dict "root" . "component" "scheduler" "ima
 Scheduler image reference (used as default for the K8s launcher).
 */}}
 {{- define "interloper.schedulerImage" -}}
-{{ include "interloper.image" (dict "root" . "component" "scheduler" "image" .Values.scheduler.image) }}
+{{ include "interloper.image" (dict "root" . "component" "scheduler" "image" .Values.scheduler.image "flavor" (include "interloper.schedulerFlavor" .)) }}
 {{- end -}}
 
 {{/*

--- a/chart/interloper/templates/api-deployment.yaml
+++ b/chart/interloper/templates/api-deployment.yaml
@@ -28,7 +28,7 @@ spec:
       {{- end }}
       containers:
         - name: api
-          image: {{ include "interloper.image" (dict "root" . "component" "api" "image" .Values.api.image) }}
+          image: {{ include "interloper.image" (dict "root" . "component" "api" "image" .Values.api.image "flavor" (include "interloper.apiFlavor" .)) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["interloper"]
           args:

--- a/chart/interloper/templates/scheduler-deployment.yaml
+++ b/chart/interloper/templates/scheduler-deployment.yaml
@@ -31,7 +31,7 @@ spec:
       {{- end }}
       containers:
         - name: scheduler
-          image: {{ include "interloper.image" (dict "root" . "component" "scheduler" "image" .Values.scheduler.image) }}
+          image: {{ include "interloper.image" (dict "root" . "component" "scheduler" "image" .Values.scheduler.image "flavor" (include "interloper.schedulerFlavor" .)) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["interloper"]
           # Singleton: cron reconciler + queue worker + reaper run together.

--- a/chart/interloper/values.yaml
+++ b/chart/interloper/values.yaml
@@ -6,9 +6,9 @@
 #
 # Images are published to GitHub Container Registry and follow the
 # convention "<registry>/interloper-<component>:<tag>" — e.g.
-# ghcr.io/digitl-cloud/interloper-api:0.3.1. For launcher-aware images
-# (scheduler) the image name gets a "-k8s" or "-docker" suffix derived from
-# config.launcher.type (the tag is just the version).
+# ghcr.io/digitl-cloud/interloper-api:0.3.1. Flavored variants ride the TAG as
+# a "-<flavor>" suffix on the same image: the scheduler gets "-k8s"/"-docker"
+# from config.launcher.type, and the api gets "-agent" when api.agent.enabled.
 image:
   registry: ghcr.io/digitl-cloud
   tag: ""  # defaults to Chart.appVersion
@@ -54,6 +54,13 @@ worker:
 api:
   enabled: true
   replicaCount: 1
+  # Agent (ADK chat) support. When true, the chart deploys the
+  # `interloper-api:<tag>-agent` image, which bundles interloper-agent so the
+  # /agent routes mount (the base image omits them → those routes 404). The
+  # agent also needs Google/Gemini credentials at runtime — supply them via
+  # api.extraEnv (e.g. GOOGLE_API_KEY / GEMINI_API_KEY).
+  agent:
+    enabled: false
   image:
     repository: ""  # defaults to {image.registry}/interloper-api
     tag: ""

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -54,10 +54,14 @@ x-interloper-env: &interloper-env
 # The api image (core + db + assets + api) is enough to run both the API and the
 # seed script. Reused by the `seed` and `api` services so it builds once.
 # Build context is the repo root (the dockerfile and packages live there).
+# API_EXTRAS=agent bundles interloper-agent so the /agent routes mount in dev
+# (chat needs GEMINI_API_KEY, loaded from the repo-root .env below).
 x-api-build: &api-build
   context: ..
   dockerfile: dockerfile
   target: api
+  args:
+    API_EXTRAS: agent
 
 # Mount the dev catalog so seed/api/scheduler all load the same sources.
 x-interloper-config: &interloper-config

--- a/dockerfile
+++ b/dockerfile
@@ -10,8 +10,12 @@
 #   api        core + db + api (assets installed; SDK extras skipped)
 #   frontend   pre-built Nuxt SPA served by nginx
 #
-# Tagging convention:
-#   docker build --target scheduler -t interloper-scheduler:0.2.0 .
+# Tagging convention: one image per role, flavors ride the tag.
+#   docker build --target scheduler -t interloper-scheduler:0.2.0 .        # base
+#   docker build --target scheduler --build-arg SCHEDULER_EXTRAS=k8s \
+#       -t interloper-scheduler:0.2.0-k8s .                                # flavored
+#   docker build --target api --build-arg API_EXTRAS=agent \
+#       -t interloper-api:0.2.0-agent .
 #
 # Build args:
 #   CORE_EXTRAS       comma-separated interloper-core extras (default: google-cloud)
@@ -21,7 +25,11 @@
 #                     Pass "" to disable.
 #   SCHEDULER_EXTRAS  comma-separated interloper-scheduler extras (default: docker)
 #                     Supported: docker, k8s.  Each extra pulls in the
-#                     corresponding launcher/runner package.
+#                     corresponding launcher/runner package. Pass "" for the
+#                     base scheduler (in-process launcher, no extras).
+#   API_EXTRAS        comma-separated interloper-api extras (default: none).
+#                     Supported: agent (bundles interloper-agent so the
+#                     /agent routes mount). Each maps to --extra {name}.
 #
 # ================================================================
 

--- a/interloper.yaml
+++ b/interloper.yaml
@@ -20,12 +20,12 @@ launcher:
 
   # type: docker
   # config:
-  #   image: interloper-scheduler-docker:latest
+  #   image: interloper-scheduler:latest-docker
   #   postgres_host: host.docker.internal
 
   # type: kubernetes
   # config:
-  #   image: interloper-scheduler-k8s:latest
+  #   image: interloper-scheduler:latest-k8s
   #   namespace: interloper
   #   image_pull_policy: Never
 
@@ -34,13 +34,13 @@ runner:
 
   # type: docker
   # config:
-  #   image: interloper-scheduler-docker:latest
+  #   image: interloper-scheduler:latest-docker
   #   auto_remove: false
   #   image_pull_policy: Never
 
   # type: kubernetes
   # config:
-  #   image: interloper-scheduler-k8s:latest
+  #   image: interloper-scheduler:latest-k8s
   #   namespace: interloper
 
 catalog:


### PR DESCRIPTION
## What

Restructures the Docker image scheme so there is **one image per role**, with flavors (extra-bearing variants) riding the **tag** as a `-<flavor>` suffix instead of being separate images.

Before → after:

| Before (image-per-flavor) | After (flavor-as-tag) |
| --- | --- |
| `interloper-scheduler` | `interloper-scheduler:<v>` |
| `interloper-scheduler-k8s` | `interloper-scheduler:<v>-k8s` |
| `interloper-scheduler-docker` | `interloper-scheduler:<v>-docker` |
| `interloper-api` (agent baked in) | `interloper-api:<v>` (base, no agent) + `interloper-api:<v>-agent` |

The base `:<v>` tag carries no flavor extras. The agent is now an **opt-in api flavor** rather than baked into every api image (it was made always-on in the just-merged #59 — this supersedes that).

## Changes

- **[Makefile](Makefile)** — generic `FLAVORS_<role>` / `EXTRAS_ARG_<role>` catalog. `image_of` drops the flavor; new `tag_of` / `latest_of` add the `-<flavor>` suffix; `extras_arg` injects the per-role build arg. Targets: `make docker-build-scheduler-k8s`, `make docker-build-api-agent`, etc.
- **[publish.yaml](.github/workflows/publish.yaml)** — matrix keyed on `(role, flavor)`; tags computed as `interloper-<role>:<version>[-<flavor>]` (+ `latest[-flavor]` on stable). Builds both `interloper-api` and `interloper-api:…-agent`, and the three scheduler tags.
- **[checks.yaml](.github/workflows/checks.yaml)** — smoke matrix adds `api-agent`, so the agent extra's dependency resolution is exercised in CI (it never was before — that's the class of bug #59 fixed).
- **[chart](chart/interloper)** — scheduler tag suffix from `config.launcher.type`; api `-agent` tag from the new `api.agent.enabled` (default **false**). The `interloper.image` helper appends the flavor to the tag. db-init stays on the lean base api image.
- **[dev/docker-compose.yml](dev/docker-compose.yml)** — dev api image builds with `API_EXTRAS=agent` (it already plumbs `GEMINI_API_KEY`).
- Docs ([README](README.md), [RELEASING](RELEASING.md), [AGENTS.md](AGENTS.md), [chart README](chart/interloper/README.md)) + [interloper.yaml](interloper.yaml) examples updated.

## Verification

- `make -n docker-build` produces exactly the 14 expected `image:tag` combinations.
- `helm template` renders the right tag for every case: in_process→bare, kubernetes→`-k8s`, docker→`-docker`, `api.agent.enabled`→`-agent`, and custom `repository` overrides keep the suffix. `helm lint` clean.
- Built `interloper-api:<v>-agent` locally → `import google.adk` + `interloper_api.routes.agent` succeed. Built base `interloper-api:<v>` → `google.adk` absent (routes 404 by design) while the app still imports and mounts everything else.
- Workflow YAML + `docker compose config` parse clean.

## ⚠️ Breaking / operational

- **`interloper-scheduler-k8s` and `interloper-scheduler-docker` images are no longer published.** Anything pulling those by name (deployment manifests, the `int-dwh-kubernetes` repo) must switch to `interloper-scheduler:<version>-k8s` / `-docker` **tags**. The Helm chart in this repo is already updated.
- **The base `interloper-api` no longer bundles the agent.** To restore the `/agent` routes (the #59 fix), deploy `interloper-api:<version>-agent` — set `api.agent.enabled=true` in the chart. Chat additionally needs `GOOGLE_API_KEY`/`GEMINI_API_KEY` via `api.extraEnv`.
- `major_on_zero=false`, so this releases as a **minor** (0.18.0), not 1.0.0.