### PR TITLE
refactor!: follower_stats + line_items_stats naming fixes

### DIFF
--- a/packages/interloper-assets/src/interloper_assets/double_click_bid_manager/schemas/__init__.py
+++ b/packages/interloper-assets/src/interloper_assets/double_click_bid_manager/schemas/__init__.py
@@ -1,7 +1,7 @@
-from .lineitems_stats import LineitemsStats
-from .lineitems_stats_by_country import LineitemsStatsByCountry
+from .line_items_stats import LineItemsStats
+from .line_items_stats_by_country import LineItemsStatsByCountry
 
 __all__ = [
-    "LineitemsStats",
-    "LineitemsStatsByCountry",
+    "LineItemsStats",
+    "LineItemsStatsByCountry",
 ]

--- a/packages/interloper-assets/src/interloper_assets/double_click_bid_manager/schemas/line_items_stats.py
+++ b/packages/interloper-assets/src/interloper_assets/double_click_bid_manager/schemas/line_items_stats.py
@@ -4,8 +4,8 @@ from interloper.schema import Schema
 from pydantic import Field
 
 
-class LineitemsStatsByCountry(Schema):
-    """DBM line items by country report with performance and cost metrics segmented by country."""
+class LineItemsStats(Schema):
+    """DBM line items report with performance metrics including impressions, clicks, costs, and fees."""
 
     advertiser_currency: str | None = Field(..., description="The advertiser currency")
     advertiser_name: str | None = Field(..., description="The advertiser name")
@@ -30,7 +30,6 @@ class LineitemsStatsByCountry(Schema):
     partner_currency: str | None = Field(..., description="The partner currency")
     partner_name: str | None = Field(..., description="The partner name")
     partner: str | None = Field(..., description="The partner ID")
-    country: str | None = Field(..., description="The country")
     active_view_average_viewable_time: float | None = Field(
         ..., description="Average viewable time for active view"
     )
@@ -72,4 +71,67 @@ class LineitemsStatsByCountry(Schema):
     )
     app_mediation_partner_fee_partner_currency: float | None = Field(
         ..., description="App mediation partner fee in partner currency"
+    )
+    adlingo_fee_advertiser_currency: float | None = Field(
+        ..., description="Adlingo fee in advertiser currency"
+    )
+    adlingo_fee_partner_currency: float | None = Field(
+        ..., description="Adlingo fee in partner currency"
+    )
+    billable_cost_advertiser: float | None = Field(..., description="Billable cost advertiser")
+    billable_cost_partner: float | None = Field(..., description="Billable cost partner")
+    fee10_advertiser: float | None = Field(..., description="Fee 10 advertiser")
+    fee10_partner: float | None = Field(..., description="Fee 10 partner")
+    fee11_advertiser: float | None = Field(..., description="Fee 11 advertiser")
+    fee11_partner: float | None = Field(..., description="Fee 11 partner")
+    fee12_advertiser: float | None = Field(..., description="Fee 12 advertiser")
+    fee12_partner: float | None = Field(..., description="Fee 12 partner")
+    fee13_advertiser: float | None = Field(..., description="Fee 13 advertiser")
+    fee13_partner: float | None = Field(..., description="Fee 13 partner")
+    fee14_advertiser: float | None = Field(..., description="Fee 14 advertiser")
+    fee14_partner: float | None = Field(..., description="Fee 14 partner")
+    fee15_advertiser: float | None = Field(..., description="Fee 15 advertiser")
+    fee15_partner: float | None = Field(..., description="Fee 15 partner")
+    fee16_advertiser: float | None = Field(..., description="Fee 16 advertiser")
+    fee16_partner: float | None = Field(..., description="Fee 16 partner")
+    fee17_advertiser: float | None = Field(..., description="Fee 17 advertiser")
+    fee17_partner: float | None = Field(..., description="Fee 17 partner")
+    fee18_advertiser: float | None = Field(..., description="Fee 18 advertiser")
+    fee18_partner: float | None = Field(..., description="Fee 18 partner")
+    fee2_advertiser: float | None = Field(..., description="Fee 2 advertiser")
+    fee2_partner: float | None = Field(..., description="Fee 2 partner")
+    fee20_advertiser: float | None = Field(..., description="Fee 20 advertiser")
+    fee20_partner: float | None = Field(..., description="Fee 20 partner")
+    fee21_advertiser: float | None = Field(..., description="Fee 21 advertiser")
+    fee21_partner: float | None = Field(..., description="Fee 21 partner")
+    fee22_advertiser: float | None = Field(..., description="Fee 22 advertiser")
+    fee22_partner: float | None = Field(..., description="Fee 22 partner")
+    fee31_advertiser: float | None = Field(..., description="Fee 31 advertiser")
+    fee31_partner: float | None = Field(..., description="Fee 31 partner")
+    fee4_advertiser: float | None = Field(..., description="Fee 4 advertiser")
+    fee4_partner: float | None = Field(..., description="Fee 4 partner")
+    fee5_advertiser: float | None = Field(..., description="Fee 5 advertiser")
+    fee5_partner: float | None = Field(..., description="Fee 5 partner")
+    fee6_advertiser: float | None = Field(..., description="Fee 6 advertiser")
+    fee6_partner: float | None = Field(..., description="Fee 6 partner")
+    fee7_advertiser: float | None = Field(..., description="Fee 7 advertiser")
+    fee7_partner: float | None = Field(..., description="Fee 7 partner")
+    fee8_advertiser: float | None = Field(..., description="Fee 8 advertiser")
+    fee8_partner: float | None = Field(..., description="Fee 8 partner")
+    fee9_advertiser: float | None = Field(..., description="Fee 9 advertiser")
+    fee9_partner: float | None = Field(..., description="Fee 9 partner")
+    platform_fee_advertiser: float | None = Field(..., description="Platform fee advertiser")
+    platform_fee_partner: float | None = Field(..., description="Platform fee partner")
+    platform_fee_rate: float | None = Field(..., description="Platform fee rate")
+    scibids_fee_advertiser_currency: float | None = Field(
+        ..., description="Scibids fee in advertiser currency"
+    )
+    scibids_fee_partner_currency: float | None = Field(
+        ..., description="Scibids fee in partner currency"
+    )
+    seller_id_blocklist_fee_advertiser_currency: float | None = Field(
+        ..., description="Seller ID blocklist fee in advertiser currency"
+    )
+    seller_id_blocklist_fee_partner_currency: float | None = Field(
+        ..., description="Seller ID blocklist fee in partner currency"
     )

--- a/packages/interloper-assets/src/interloper_assets/double_click_bid_manager/schemas/line_items_stats_by_country.py
+++ b/packages/interloper-assets/src/interloper_assets/double_click_bid_manager/schemas/line_items_stats_by_country.py
@@ -4,8 +4,8 @@ from interloper.schema import Schema
 from pydantic import Field
 
 
-class LineitemsStats(Schema):
-    """DBM line items report with performance metrics including impressions, clicks, costs, and fees."""
+class LineItemsStatsByCountry(Schema):
+    """DBM line items by country report with performance and cost metrics segmented by country."""
 
     advertiser_currency: str | None = Field(..., description="The advertiser currency")
     advertiser_name: str | None = Field(..., description="The advertiser name")
@@ -30,6 +30,7 @@ class LineitemsStats(Schema):
     partner_currency: str | None = Field(..., description="The partner currency")
     partner_name: str | None = Field(..., description="The partner name")
     partner: str | None = Field(..., description="The partner ID")
+    country: str | None = Field(..., description="The country")
     active_view_average_viewable_time: float | None = Field(
         ..., description="Average viewable time for active view"
     )
@@ -71,67 +72,4 @@ class LineitemsStats(Schema):
     )
     app_mediation_partner_fee_partner_currency: float | None = Field(
         ..., description="App mediation partner fee in partner currency"
-    )
-    adlingo_fee_advertiser_currency: float | None = Field(
-        ..., description="Adlingo fee in advertiser currency"
-    )
-    adlingo_fee_partner_currency: float | None = Field(
-        ..., description="Adlingo fee in partner currency"
-    )
-    billable_cost_advertiser: float | None = Field(..., description="Billable cost advertiser")
-    billable_cost_partner: float | None = Field(..., description="Billable cost partner")
-    fee10_advertiser: float | None = Field(..., description="Fee 10 advertiser")
-    fee10_partner: float | None = Field(..., description="Fee 10 partner")
-    fee11_advertiser: float | None = Field(..., description="Fee 11 advertiser")
-    fee11_partner: float | None = Field(..., description="Fee 11 partner")
-    fee12_advertiser: float | None = Field(..., description="Fee 12 advertiser")
-    fee12_partner: float | None = Field(..., description="Fee 12 partner")
-    fee13_advertiser: float | None = Field(..., description="Fee 13 advertiser")
-    fee13_partner: float | None = Field(..., description="Fee 13 partner")
-    fee14_advertiser: float | None = Field(..., description="Fee 14 advertiser")
-    fee14_partner: float | None = Field(..., description="Fee 14 partner")
-    fee15_advertiser: float | None = Field(..., description="Fee 15 advertiser")
-    fee15_partner: float | None = Field(..., description="Fee 15 partner")
-    fee16_advertiser: float | None = Field(..., description="Fee 16 advertiser")
-    fee16_partner: float | None = Field(..., description="Fee 16 partner")
-    fee17_advertiser: float | None = Field(..., description="Fee 17 advertiser")
-    fee17_partner: float | None = Field(..., description="Fee 17 partner")
-    fee18_advertiser: float | None = Field(..., description="Fee 18 advertiser")
-    fee18_partner: float | None = Field(..., description="Fee 18 partner")
-    fee2_advertiser: float | None = Field(..., description="Fee 2 advertiser")
-    fee2_partner: float | None = Field(..., description="Fee 2 partner")
-    fee20_advertiser: float | None = Field(..., description="Fee 20 advertiser")
-    fee20_partner: float | None = Field(..., description="Fee 20 partner")
-    fee21_advertiser: float | None = Field(..., description="Fee 21 advertiser")
-    fee21_partner: float | None = Field(..., description="Fee 21 partner")
-    fee22_advertiser: float | None = Field(..., description="Fee 22 advertiser")
-    fee22_partner: float | None = Field(..., description="Fee 22 partner")
-    fee31_advertiser: float | None = Field(..., description="Fee 31 advertiser")
-    fee31_partner: float | None = Field(..., description="Fee 31 partner")
-    fee4_advertiser: float | None = Field(..., description="Fee 4 advertiser")
-    fee4_partner: float | None = Field(..., description="Fee 4 partner")
-    fee5_advertiser: float | None = Field(..., description="Fee 5 advertiser")
-    fee5_partner: float | None = Field(..., description="Fee 5 partner")
-    fee6_advertiser: float | None = Field(..., description="Fee 6 advertiser")
-    fee6_partner: float | None = Field(..., description="Fee 6 partner")
-    fee7_advertiser: float | None = Field(..., description="Fee 7 advertiser")
-    fee7_partner: float | None = Field(..., description="Fee 7 partner")
-    fee8_advertiser: float | None = Field(..., description="Fee 8 advertiser")
-    fee8_partner: float | None = Field(..., description="Fee 8 partner")
-    fee9_advertiser: float | None = Field(..., description="Fee 9 advertiser")
-    fee9_partner: float | None = Field(..., description="Fee 9 partner")
-    platform_fee_advertiser: float | None = Field(..., description="Platform fee advertiser")
-    platform_fee_partner: float | None = Field(..., description="Platform fee partner")
-    platform_fee_rate: float | None = Field(..., description="Platform fee rate")
-    scibids_fee_advertiser_currency: float | None = Field(
-        ..., description="Scibids fee in advertiser currency"
-    )
-    scibids_fee_partner_currency: float | None = Field(
-        ..., description="Scibids fee in partner currency"
-    )
-    seller_id_blocklist_fee_advertiser_currency: float | None = Field(
-        ..., description="Seller ID blocklist fee in advertiser currency"
-    )
-    seller_id_blocklist_fee_partner_currency: float | None = Field(
-        ..., description="Seller ID blocklist fee in partner currency"
     )

--- a/packages/interloper-assets/src/interloper_assets/double_click_bid_manager/source.py
+++ b/packages/interloper-assets/src/interloper_assets/double_click_bid_manager/source.py
@@ -4,7 +4,7 @@ import interloper as il
 import pandas as pd
 
 from interloper_assets.double_click_bid_manager.connection import DoubleClickBidManagerConnection
-from interloper_assets.double_click_bid_manager.schemas import LineitemsStats, LineitemsStatsByCountry
+from interloper_assets.double_click_bid_manager.schemas import LineItemsStats, LineItemsStatsByCountry
 from interloper_assets.fake import fake_data
 
 logger = logging.getLogger(__name__)
@@ -24,27 +24,27 @@ class DoubleClickBidManager(il.Source):
     advertiser_id: str = il.InputField(description="DV360 advertiser ID for report filtering (optional)")
 
     @il.asset(
-        schema=LineitemsStats,
+        schema=LineItemsStats,
         partitioning=il.TimePartitionConfig(column="date"),
         tags=["Report"],
     )
-    def lineitems_stats(
+    def line_items_stats(
         self,
         context: il.ExecutionContext,
         connection: DoubleClickBidManagerConnection,
     ) -> pd.DataFrame:
         """Line item performance report with full metrics and fee breakdown."""
-        return fake_data(LineitemsStats, partition_column="date", partition_date=context.partition_date)
+        return fake_data(LineItemsStats, partition_column="date", partition_date=context.partition_date)
 
     @il.asset(
-        schema=LineitemsStatsByCountry,
+        schema=LineItemsStatsByCountry,
         partitioning=il.TimePartitionConfig(column="date"),
         tags=["Report"],
     )
-    def lineitems_stats_by_country(
+    def line_items_stats_by_country(
         self,
         context: il.ExecutionContext,
         connection: DoubleClickBidManagerConnection,
     ) -> pd.DataFrame:
         """Line item performance report segmented by country."""
-        return fake_data(LineitemsStatsByCountry, partition_column="date", partition_date=context.partition_date)
+        return fake_data(LineItemsStatsByCountry, partition_column="date", partition_date=context.partition_date)

--- a/packages/interloper-assets/src/interloper_assets/linkedin_organic/schemas/__init__.py
+++ b/packages/interloper-assets/src/interloper_assets/linkedin_organic/schemas/__init__.py
@@ -1,9 +1,9 @@
-from .follower_demographics import FollowerDemographics
+from .follower_stats import FollowerStats
 from .page_stats import PageStats
 from .share_stats import ShareStats
 
 __all__ = [
-    "FollowerDemographics",
+    "FollowerStats",
     "PageStats",
     "ShareStats",
 ]

--- a/packages/interloper-assets/src/interloper_assets/linkedin_organic/schemas/follower_stats.py
+++ b/packages/interloper-assets/src/interloper_assets/linkedin_organic/schemas/follower_stats.py
@@ -1,10 +1,17 @@
+import datetime as dt
+
 from interloper.schema import Schema
 from pydantic import Field
 
 
-class FollowerDemographics(Schema):
-    """LinkedIn organization follower counts by various dimensions (function, geo, industry, seniority)."""
+class FollowerStats(Schema):
+    """LinkedIn organization follower counts by various dimensions (function, geo, industry, seniority).
 
+    The LinkedIn API returns a single current snapshot (no time dimension); the ``date`` column is
+    stamped from the partition value so successive runs accumulate a daily history.
+    """
+
+    date: dt.date = Field(description="The date of the record (partition value)")
     follower_counts_by_association_type: str = Field(description="Counts of followers by association type")
     follower_counts_by_function: str = Field(description="Counts of followers by function")
     follower_counts_by_geo: str = Field(description="Counts of followers by geographic location")

--- a/packages/interloper-assets/src/interloper_assets/linkedin_organic/source.py
+++ b/packages/interloper-assets/src/interloper_assets/linkedin_organic/source.py
@@ -6,7 +6,7 @@ from interloper_pandas import DataFrameNormalizer
 from interloper_assets.fake import fake_data
 from interloper_assets.linkedin_organic.connection import LinkedinOrganicConnection
 from interloper_assets.linkedin_organic.schemas import (
-    FollowerDemographics,
+    FollowerStats,
     PageStats,
     ShareStats,
 )
@@ -51,7 +51,15 @@ class LinkedinOrganic(il.Source):
         """Daily organic share statistics including impressions, clicks, and engagement."""
         return fake_data(ShareStats, partition_column="date", partition_date=context.partition_date)
 
-    @il.asset(schema=FollowerDemographics, tags=["Entity"])
-    def follower_demographics(self, connection: LinkedinOrganicConnection) -> pd.DataFrame:
-        """Follower counts broken down by association type, function, geo, industry, and seniority."""
-        return fake_data(FollowerDemographics)
+    @il.asset(
+        schema=FollowerStats,
+        partitioning=il.TimePartitionConfig(column="date"),
+        tags=["Report"],
+    )
+    def follower_stats(self, context: il.ExecutionContext, connection: LinkedinOrganicConnection) -> pd.DataFrame:
+        """Follower counts broken down by association type, function, geo, industry, and seniority.
+
+        LinkedIn returns a current snapshot with no date; the ``date`` column is stamped from the
+        partition value so successive runs accumulate a daily history.
+        """
+        return fake_data(FollowerStats, partition_column="date", partition_date=context.partition_date)


### PR DESCRIPTION
Follow-up to #63 (the stats/entity/event rename), from a semantic re-audit of every asset against its actual schema columns.

## 1. `follower_demographics` → `follower_stats` (+ promoted to a partitioned Report)

The columns are `follower_counts_by_association_type / _function / _geo / _industry / _seniority / _staff_count_range` — a **mix of demographic and firmographic** segments (industry, company-size, employee-vs-not aren't demographics), so "demographics" misnamed it. `follower_stats` matches what the data is.

It was also a static `Entity` (no date). LinkedIn returns a single **current snapshot** with no time dimension, so it's now a **time-partitioned Report**: the `date` column is stamped from the partition value (`fake_data(..., partition_column="date", partition_date=context.partition_date)`), so successive daily runs accumulate a history rather than overwriting one snapshot.

## 2. `lineitems_stats` → `line_items_stats` (+ `_by_country`)

Token alignment: `display_video_360` already spells it `line_items`, and `ad_groups` is two words in every source (pinterest, search_ads_360, thetradedesk). `double_click_bid_manager` was the lone `lineitems`.

## Carried through
Schema classes/files renamed (`FollowerStats`, `LineItemsStats`, `LineItemsStatsByCountry`); `__init__` exports updated. A `date` field was added to the `FollowerStats` schema.

## ⚠️ Breaking change
These asset keys change → destination table names and run manifests referencing them must be updated.

## Verification
`uv run ruff check` ✅ · `uv run ty check` ✅ · `uv run pytest` ✅ (664 passed)

## Deferred (from the same audit, not in this PR)
- Stub schemas: `usercentrics.granular`/`interaction`, `brandwatch.channel_stats` (only `date`/`channel_id` columns) — schema-completeness work.
- Duplicate schemas: `display_video_360.audience_composition` mirrors `audiences`; `snapchat.ad_account` vs `ad_accounts` are identical.
- Untagged analysis assets in `campaign_performance_analysis` / `marketing_mix_modeling`.