### PR TITLE
fix: resolve in-house oauth app secret from env, never ship it to the browser

### DIFF
--- a/packages/interloper-api/src/interloper_api/routes/oauth.py
+++ b/packages/interloper-api/src/interloper_api/routes/oauth.py
@@ -24,9 +24,12 @@ import os
 from typing import Any
 
 import httpx
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from interloper.oauth import OAuthProvider, providers
+from interloper_db import Profile
 from pydantic import BaseModel
+
+from interloper_api.dependencies import get_current_user
 
 logger = logging.getLogger(__name__)
 
@@ -77,8 +80,10 @@ async def _exchange(
         code: The authorization code.
 
     Returns:
-        The token response, with ``client_id`` / ``client_secret`` injected
-        so they can be stored alongside the tokens.
+        The provider's raw token response (e.g. ``refresh_token``). The app
+        credentials are *not* injected: they are the in-house per-provider
+        values resolved from env at runtime, so the secret never leaves the
+        server.
     """
     logical_values = {
         "grant_type": "authorization_code",
@@ -103,10 +108,7 @@ async def _exchange(
         resp = await client.post(spec.token_url, json=params, headers=headers)
     resp.raise_for_status()
 
-    result = resp.json()
-    result["client_id"] = cfg.client_id
-    result["client_secret"] = cfg.client_secret
-    return result
+    return resp.json()
 
 
 # ---------------------------------------------------------------------------
@@ -155,11 +157,16 @@ def list_providers() -> list[ProviderInfo]:
 
 
 @router.post("/{provider}")
-async def exchange_token(provider: str, body: TokenExchangeRequest) -> dict[str, Any]:
-    """Exchange an authorization code for tokens.
+async def exchange_token(
+    provider: str,
+    body: TokenExchangeRequest,
+    _user: Profile = Depends(get_current_user),
+) -> dict[str, Any]:
+    """Exchange an authorization code for tokens. Requires authentication.
 
-    The response includes ``client_id`` and ``client_secret`` so they
-    can be stored alongside the tokens in the connection data.
+    Returns only the provider's token response (e.g. ``refresh_token``); the
+    in-house app credentials are never included — connections resolve them
+    from env at runtime.
     """
     spec = providers().get(provider)
     if spec is None:

--- a/packages/interloper-api/tests/test_oauth.py
+++ b/packages/interloper-api/tests/test_oauth.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 import asyncio
 import json
+from types import SimpleNamespace
+from uuid import uuid4
 
 import httpx
 import pytest
@@ -18,6 +20,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from interloper.oauth import provider, providers
 
+from interloper_api.dependencies import get_current_user, get_store
 from interloper_api.routes import oauth as oauth_module
 
 _SUFFIXES = ("CLIENT_ID", "CLIENT_SECRET", "REDIRECT_URI")
@@ -39,6 +42,8 @@ def _configure(monkeypatch: pytest.MonkeyPatch, provider: str, **vals: str) -> N
 def _client() -> TestClient:
     app = FastAPI()
     app.include_router(oauth_module.router)
+    # Stand in for an authenticated user; auth itself is covered separately.
+    app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(id=uuid4())
     return TestClient(app)
 
 
@@ -95,6 +100,17 @@ def test_exchange_unconfigured_provider_is_rejected() -> None:
     assert resp.status_code == 400
 
 
+def test_exchange_requires_authentication(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Fully configured provider, but no session: the token exchange must not
+    # be reachable anonymously (it spends the in-house app credentials).
+    _configure(monkeypatch, "amazon", client_id="id", client_secret="secret", redirect_uri="uri")
+    app = FastAPI()
+    app.include_router(oauth_module.router)
+    app.dependency_overrides[get_store] = lambda: SimpleNamespace()
+    resp = TestClient(app).post("/oauth/amazon", json={"code": "x"})
+    assert resp.status_code == 401
+
+
 # ---------------------------------------------------------------------------
 # Generic exchange request shaping
 # ---------------------------------------------------------------------------
@@ -133,8 +149,8 @@ def test_exchange_post_json(monkeypatch: pytest.MonkeyPatch) -> None:
         "client_id": "cid",
         "client_secret": "cs",
     }
-    # app credentials are injected into the token response for storage
-    assert result == {"refresh_token": "rt", "client_id": "cid", "client_secret": "cs"}
+    # The app secret is never returned: only the provider's token response.
+    assert result == {"refresh_token": "rt"}
 
 
 def test_exchange_post_form(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/packages/interloper-app/app/app/components/OAuthSignIn.vue
+++ b/packages/interloper-app/app/app/components/OAuthSignIn.vue
@@ -2,8 +2,10 @@
 /**
  * "Sign in with X" button that triggers the OAuth popup flow.
  *
- * When the flow completes, emits `success` with the token response
- * (includes client_id, client_secret, refresh_token, etc.).
+ * When the flow completes, emits `success` with the provider's token
+ * response (e.g. refresh_token). The in-house app credentials are never
+ * returned — connections resolve them from env at runtime — so a per-user
+ * override of client_id/client_secret stays blank unless filled manually.
  */
 
 const props = defineProps<{

--- a/packages/interloper-core/src/interloper/connection/base.py
+++ b/packages/interloper-core/src/interloper/connection/base.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import os
 from typing import Any, ClassVar
 
+from pydantic import model_validator
 from pydantic_settings import BaseSettings
 
 from interloper.oauth import OAuthConfig
@@ -84,8 +86,38 @@ class OAuthConnection(Connection):
     Connections with a non-standard token response shape (e.g. Facebook's
     app_id/app_secret/access_token) declare their own fields on a plain
     ``Connection`` and pass a custom ``fields=`` mapping to ``OAuthConfig``.
+
+    ``client_id`` / ``client_secret`` are the *app* credentials. They are
+    optional and default to the in-house per-provider credentials resolved
+    from the ``<PROVIDER>_CLIENT_ID`` / ``<PROVIDER>_CLIENT_SECRET``
+    environment (the same vars the API's token-exchange endpoint reads), so
+    the in-house secret is never sent to the browser or stored per
+    connection. Setting them explicitly overrides the in-house app — e.g. to
+    use your own OAuth client.
     """
 
-    client_id: str = InputField(description="OAuth2 client ID")
-    client_secret: str = SecretField(description="OAuth2 client secret")
+    client_id: str = InputField("", description="OAuth2 client ID (defaults to the in-house app)")
+    client_secret: str = SecretField("", description="OAuth2 client secret (defaults to the in-house app)")
     refresh_token: str = SecretField(description="OAuth2 refresh token")
+
+    @model_validator(mode="after")
+    def _resolve_app_credentials(self) -> OAuthConnection:
+        """Fall back to the in-house per-provider app credentials from env.
+
+        Only fills blanks: an explicitly set ``client_id`` / ``client_secret``
+        (a per-connection override) always wins. Keyed on the provider from
+        ``oauth`` — not the connection's settings ``env_prefix`` — so it reads
+        the same ``<PROVIDER>_CLIENT_ID`` / ``_CLIENT_SECRET`` vars the token
+        exchange uses.
+
+        Returns:
+            The connection instance (self), with app credentials filled in.
+        """
+        if self.oauth is None:
+            return self
+        prefix = self.oauth.provider.upper()
+        if not self.client_id:
+            self.client_id = os.environ.get(f"{prefix}_CLIENT_ID", "")
+        if not self.client_secret:
+            self.client_secret = os.environ.get(f"{prefix}_CLIENT_SECRET", "")
+        return self

--- a/packages/interloper-core/src/interloper/oauth/config.py
+++ b/packages/interloper-core/src/interloper/oauth/config.py
@@ -26,8 +26,9 @@ class OAuthConfig:
         provider: OAuth provider key (e.g. ``"amazon"``, ``"facebook"``).
         scope: OAuth scope string to request.
         fields: Mapping of ``{token_response_key: model_field_name}``.
-            Defaults to the standard trio: client_id, client_secret,
-            refresh_token (the fields ``OAuthConnection`` declares).
+            Defaults to ``{"refresh_token": "refresh_token"}`` — only the
+            per-user refresh token is filled from the exchange; the app
+            credentials come from env at runtime.
         auth_url: Authorization endpoint override.  Required when the
             provider is not in the registry.
         label: Display label override.
@@ -84,11 +85,11 @@ class OAuthConfig:
         self.scope = scope
         self.label = label or (spec.label if spec else "") or provider.title()
         self.icon = icon or (spec.icon if spec else "")
-        self.fields = fields or {
-            "client_id": "client_id",
-            "client_secret": "client_secret",
-            "refresh_token": "refresh_token",
-        }
+        # Only the per-user refresh token is auto-filled from the token
+        # exchange. The app credentials (client_id/client_secret) are the
+        # in-house per-provider values resolved from env at runtime, so they
+        # are never returned to the browser or stored per connection.
+        self.fields = fields or {"refresh_token": "refresh_token"}
 
     def to_schema_ext(self) -> dict[str, Any]:
         """Serialize to a JSON Schema ``x-oauth`` extension dict.

--- a/packages/interloper-core/tests/connection/test_base.py
+++ b/packages/interloper-core/tests/connection/test_base.py
@@ -3,6 +3,7 @@
 from typing import ClassVar
 
 import pytest
+from pydantic_settings import SettingsConfigDict
 
 from interloper.connection import Connection, OAuthConnection
 from interloper.oauth import OAuthConfig
@@ -58,3 +59,34 @@ class TestOAuthConnection:
         properties = definition.config_schema["properties"]
         assert {"client_id", "client_secret", "refresh_token", "account_id"} <= set(properties)
         assert properties["client_secret"]["x-widget"] == "password"
+
+    def test_default_mapping_auto_fills_only_refresh_token(self):
+        # The app credentials are not pulled from the token exchange; only the
+        # per-user refresh token is, so the in-house secret never round-trips.
+        assert OAuthConfig("amazon").fields == {"refresh_token": "refresh_token"}
+
+    def test_app_credentials_resolved_from_provider_env(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("AMAZON_CLIENT_ID", "in-house-id")
+        monkeypatch.setenv("AMAZON_CLIENT_SECRET", "in-house-secret")
+
+        class AmazonConn(OAuthConnection):
+            oauth: ClassVar[OAuthConfig] = OAuthConfig("amazon")
+            model_config = SettingsConfigDict(env_prefix="amazon_conn_test_")
+
+        conn = AmazonConn(refresh_token="rt")
+
+        assert (conn.client_id, conn.client_secret) == ("in-house-id", "in-house-secret")
+        assert conn.refresh_token == "rt"
+
+    def test_explicit_app_credentials_override_env(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("AMAZON_CLIENT_ID", "in-house-id")
+        monkeypatch.setenv("AMAZON_CLIENT_SECRET", "in-house-secret")
+
+        class AmazonConn(OAuthConnection):
+            oauth: ClassVar[OAuthConfig] = OAuthConfig("amazon")
+            model_config = SettingsConfigDict(env_prefix="amazon_conn_test2_")
+
+        conn = AmazonConn(refresh_token="rt", client_id="my-id", client_secret="my-secret")
+
+        # A per-connection override always wins over the in-house env app.
+        assert (conn.client_id, conn.client_secret) == ("my-id", "my-secret")

--- a/packages/interloper-core/tests/oauth/test_config.py
+++ b/packages/interloper-core/tests/oauth/test_config.py
@@ -32,14 +32,12 @@ class TestOAuthConfig:
         assert cfg.auth_url == "https://nope/auth"
         assert cfg.label == "Nope"
 
-    def test_default_fields_mapping_is_standard_trio(self):
+    def test_default_fields_mapping_auto_fills_only_refresh_token(self):
+        # The app credentials are resolved from env at runtime, never from the
+        # token exchange, so only the per-user refresh token is auto-filled.
         cfg = OAuthConfig("amazon")
 
-        assert cfg.fields == {
-            "client_id": "client_id",
-            "client_secret": "client_secret",
-            "refresh_token": "refresh_token",
-        }
+        assert cfg.fields == {"refresh_token": "refresh_token"}
 
     def test_to_schema_ext(self):
         cfg = OAuthConfig("facebook", scope="ads_read", fields={"access_token": "access_token"})


### PR DESCRIPTION
## What

The connector OAuth token exchange injected the in-house `client_secret` into its response, so the **shared app secret round-tripped through every connecting user's browser** and was stored in each connection row. The exchange endpoint was also **unauthenticated**. (Finding #3 from the security review.)

This keeps the in-house app secret **only in env** — never sent to the browser, never stored per connection — while preserving per-connection credential **override** as a first-class feature.

### Changes

- **`POST /oauth/{provider}` now requires auth** (`get_current_user`) and no longer injects `client_id`/`client_secret` into the response — it returns only the provider's token payload (the per-user `refresh_token`). — `routes/oauth.py`
- **OAuth button auto-fills only `refresh_token`** (`OAuthConfig` default `fields`). — `oauth/config.py`
- **`OAuthConnection.client_id` / `client_secret` are optional** and resolve from the in-house `<PROVIDER>_CLIENT_ID` / `<PROVIDER>_CLIENT_SECRET` env at runtime, keyed on the oauth provider. An explicitly set value always wins. — `connection/base.py`

### Behavior

- **Button flow** → stores only `refresh_token`; runtime falls back to the in-house env app creds.
- **Manual override** → user fills `client_id`/`client_secret` (e.g. their own OAuth client) → stored encrypted, wins at runtime.
- **Existing rows** that already carry the app creds keep working as explicit overrides — no migration, no re-connect.

## Deployment note

The worker/runner pods must now have `<PROVIDER>_CLIENT_ID` / `<PROVIDER>_CLIENT_SECRET` in their env, **not just the API pod**. Today these are injected via `api.extraEnv` only (the `interloper-oauth-providers` GSM + ESO wiring); the Helm values must extend that env to the worker. Connections created via the OAuth button after this change resolve the secret from env at execution time — without it, new-connection token refresh fails. Existing connections (with stored creds) are unaffected.

## Verification

`make check` green locally: ruff, ty (all extras), **674 pytest passed**, frontend lint (0 errors), nuxt typecheck.

New tests: exchange requires auth; exchange response carries no app secret; app creds resolve from provider env; explicit override wins.

## Follow-up

Facebook's custom `app_id`/`app_secret` connection has the same shape and could get the same env-resolution treatment — left out of scope here.