### PR TITLE
fix: encrypt resources by default and fail closed without an encryption key

### DIFF
--- a/packages/interloper-core/src/interloper/settings.py
+++ b/packages/interloper-core/src/interloper/settings.py
@@ -52,10 +52,11 @@ class AuthSettings(BaseSettings):
 class SecretsSettings(BaseSettings):
     """Secrets used to protect sensitive data at rest.
 
-    ``encryption_key`` enables symmetric encryption of resource ``data`` blobs
-    marked ``encrypted=True``. It is read from ``INTERLOPER_ENCRYPTION_KEY``;
-    the Helm chart and runner launchers forward that exact variable into
-    spawned containers.
+    ``encryption_key`` enables symmetric encryption of resource ``data`` blobs.
+    Encryption is the default, so a key is required to persist resources: with
+    none set, writes fail closed (rejected) rather than storing plaintext. It is
+    read from ``INTERLOPER_ENCRYPTION_KEY``; the Helm chart and runner launchers
+    forward that exact variable into spawned containers.
     """
 
     model_config = SettingsConfigDict(env_prefix=PREFIX)

--- a/packages/interloper-db/src/interloper_db/store/__init__.py
+++ b/packages/interloper-db/src/interloper_db/store/__init__.py
@@ -29,6 +29,7 @@ Implementation is split across domain-specific mixins:
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from interloper.catalog.base import Catalog
@@ -41,6 +42,8 @@ from interloper_db.store.jobs import JobMixin
 from interloper_db.store.resources import ResourceMixin
 from interloper_db.store.runs import RunMixin
 from interloper_db.store.sources import SourceMixin
+
+logger = logging.getLogger(__name__)
 
 
 class Store(AuthMixin, ResourceMixin, SourceMixin, AssetMixin, JobMixin, RunMixin, DestinationMixin):
@@ -76,9 +79,9 @@ class Store(AuthMixin, ResourceMixin, SourceMixin, AssetMixin, JobMixin, RunMixi
         """Build a Store with encryption wired from runtime settings.
 
         Reads ``INTERLOPER_ENCRYPTION_KEY`` via :class:`AppSettings`. When set, the
-        derived cipher is attached so resources marked ``encrypted=True`` are
-        encrypted at rest; when unset, the store falls back to plaintext and
-        rejects any attempt to persist an encrypted resource.
+        derived cipher is attached so resources are encrypted at rest; when
+        unset, the store has no cipher and resource persistence fails closed
+        (raising rather than writing secrets in plaintext).
 
         This is the canonical constructor for every long-lived process (API,
         scheduler, runner, agent) — prefer it over ``Store(catalog)`` so the
@@ -94,6 +97,11 @@ class Store(AuthMixin, ResourceMixin, SourceMixin, AssetMixin, JobMixin, RunMixi
 
         key = AppSettings.get().secrets.encryption_key
         if not key:
+            logger.warning(
+                "INTERLOPER_ENCRYPTION_KEY is not configured; resource persistence will "
+                "fail closed (writes are rejected rather than stored in plaintext). Set it "
+                "to enable encrypted resources at rest."
+            )
             return cls(catalog=catalog)
 
         from interloper_db.crypto import make_cipher

--- a/packages/interloper-db/src/interloper_db/store/resources.py
+++ b/packages/interloper-db/src/interloper_db/store/resources.py
@@ -27,24 +27,26 @@ class ResourceMixin:
 
         Args:
             data: Resource configuration dict.
-            encrypted: ``True`` to require encryption, ``False`` to force
-                plaintext, or ``None`` (default) to encrypt only when an
-                encryption key is configured.
+            encrypted: ``True`` or ``None`` (default) to encrypt — both require
+                a configured key; ``False`` to opt out and store plaintext.
 
         Returns:
             A ``(blob, encrypted)`` tuple: the bytes to persist and whether
             they are encrypted.
 
         Raises:
-            ConfigError: If encryption is explicitly requested but no
-                encryption key is configured.
+            ConfigError: If encryption is required (the default, or an explicit
+                ``True``) but no encryption key is configured. Fails closed so
+                secrets are never silently written in plaintext.
         """
-        should_encrypt = self._encrypt is not None if encrypted is None else encrypted
+        should_encrypt = True if encrypted is None else encrypted
         raw = json.dumps(data).encode()
         if should_encrypt:
             if not self._encrypt:
                 raise ConfigError(
-                    "Cannot store an encrypted resource: INTERLOPER_ENCRYPTION_KEY is not configured"
+                    "Refusing to store a resource without encryption at rest: "
+                    "INTERLOPER_ENCRYPTION_KEY is not configured. Set it, or pass "
+                    "encrypted=false to store this resource in plaintext."
                 )
             raw = self._encrypt(raw)
         return raw, should_encrypt
@@ -67,9 +69,8 @@ class ResourceMixin:
             key: Catalog key identifying the resource class.
             name: User-facing label.
             data: Resource configuration dict.
-            encrypted: ``True`` to require encryption, ``False`` to force
-                plaintext, or ``None`` (default) to encrypt when an
-                encryption key is configured.
+            encrypted: ``True`` or ``None`` (default) to encrypt (requires a
+                configured key); ``False`` to opt out and store plaintext.
 
         Returns:
             The saved Resource row.
@@ -108,9 +109,8 @@ class ResourceMixin:
             key: Catalog key.
             name: User-facing label.
             data: Resource configuration dict.
-            encrypted: ``True`` to require encryption, ``False`` to force
-                plaintext, or ``None`` (default) to encrypt when an
-                encryption key is configured.
+            encrypted: ``True`` or ``None`` (default) to encrypt (requires a
+                configured key); ``False`` to opt out and store plaintext.
 
         Returns:
             The updated Resource row.

--- a/packages/interloper-db/tests/test_resource_encoding.py
+++ b/packages/interloper-db/tests/test_resource_encoding.py
@@ -32,10 +32,10 @@ def test_default_encrypts_when_key_is_configured() -> None:
     assert raw == b"ENC:" + json.dumps({"a": 1}).encode()
 
 
-def test_default_is_plaintext_when_no_key() -> None:
-    raw, encrypted = _Encoder(encrypt=None)._encode_data({"a": 1}, None)
-    assert encrypted is False
-    assert raw == json.dumps({"a": 1}).encode()
+def test_default_without_key_raises() -> None:
+    # Fail closed: the default must never silently store a resource in plaintext.
+    with pytest.raises(ConfigError):
+        _Encoder(encrypt=None)._encode_data({"a": 1}, None)
 
 
 def test_explicit_true_without_key_raises() -> None:
@@ -45,5 +45,12 @@ def test_explicit_true_without_key_raises() -> None:
 
 def test_explicit_false_stays_plaintext_even_with_key() -> None:
     raw, encrypted = _Encoder(encrypt=_fake_encrypt)._encode_data({"a": 1}, False)
+    assert encrypted is False
+    assert raw == json.dumps({"a": 1}).encode()
+
+
+def test_explicit_false_without_key_stays_plaintext() -> None:
+    # Opting out explicitly still works without a key (for non-secret resources).
+    raw, encrypted = _Encoder(encrypt=None)._encode_data({"a": 1}, False)
     assert encrypted is False
     assert raw == json.dumps({"a": 1}).encode()


### PR DESCRIPTION
## What

Resource writes encrypted **only when an encryption key happened to be configured**, and the API always sends `encrypted=None`. So a deployment that forgot `INTERLOPER_ENCRYPTION_KEY` **silently stored connection credentials** (client secrets, refresh tokens, API keys) in plaintext — no error, no warning. (Finding #4 from the security review.)

## Fix

Encryption is now the **default**, and writes **fail closed**:

- `encrypted=None` (what the API sends) now means *encrypt*, which **requires a key** — a missing key raises `ConfigError` instead of writing plaintext. The whole change is one line in `_encode_data`:
  ```diff
  - should_encrypt = self._encrypt is not None if encrypted is None else encrypted
  + should_encrypt = True if encrypted is None else encrypted
  ```
- Storing a resource in plaintext is now an **explicit opt-in** via `encrypted=false` (for genuinely non-secret resources).
- `Store.from_settings` logs a **startup warning** when no key is configured, so the misconfiguration is visible before a user hits it.

## Blast radius

Correctly-configured deployments are unaffected — dev (`make`), `docker-compose`, and the Helm chart all set `INTERLOPER_ENCRYPTION_KEY`. The only behavior change is that a **keyless** deploy now rejects resource writes (the intended fail-closed) instead of silently storing plaintext. The sole runtime callers are the API create/update routes.

Existing plaintext rows remain readable via their per-row `encrypted` flag; **re-encrypting historical plaintext rows is a separate follow-up**.

## Verification

`make check` green locally: ruff, ty (all extras), **675 pytest passed**.

Tests updated: the default-without-key case now asserts it raises; added a case that explicit `encrypted=false` still stores plaintext without a key (non-secret opt-out).