### PR TITLE
fix(ci): build frontend SPA on native arch to stop multi-arch publish hang

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -130,7 +130,13 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 
 # ── frontend (Nuxt SPA, built static) ────────────────────────
-FROM node:22-alpine AS build-spa
+# Pin this stage to the *build* platform (the runner's native arch) rather
+# than the target. The SPA output is static, architecture-independent assets,
+# so there is no reason to run the heavy Vite/Rollup/Tailwind build under
+# QEMU for the linux/arm64 target — emulating that bundler is what made the
+# multi-arch frontend build hang. Only the final nginx runtime stage below
+# is built per-target-arch (a trivial COPY).
+FROM --platform=$BUILDPLATFORM node:22-alpine AS build-spa
 
 WORKDIR /app
 RUN corepack enable


### PR DESCRIPTION
## What

Pin the `build-spa` stage in [dockerfile](dockerfile) to `--platform=$BUILDPLATFORM` so the Nuxt SPA is built once on the runner's native architecture instead of once per target arch.

## Why

The `publish` workflow builds `interloper-frontend` for `linux/amd64,linux/arm64` on an amd64 runner, so the **arm64 image is produced under QEMU emulation**. Unlike the Python images (which install prebuilt wheels and barely compile anything under emulation), the frontend's `build-spa` stage runs the full **Nuxt/Vite/Rollup/Tailwind** build — a CPU-bound JS + native-binary workload that is the worst case for QEMU.

Confirmed from the v0.18.0 publish run ([job 82724897128](https://github.com/digitl-cloud/interloper/actions/runs/27956127059/job/82724897128)):

```
#30 [linux/arm64 build-spa 8/8] RUN pnpm exec nuxt prepare && NUXT_PRESET=static pnpm build  →  DONE 454.2s
```

That single emulated step is **~7.5 min of the 11 min** frontend job (the amd64 build of the same step is near-instant). When the emulated bundler tips from "very slow" into a deadlock (rollup/oxc/lightningcss under QEMU), that is the recurring **hang** on the frontend job specifically.

## How

The SPA output is **static, architecture-independent assets**, so there's no reason to rebuild it per target arch. Pinning `build-spa` to `$BUILDPLATFORM` makes it run once natively (amd64 on the runner); only the trivial final `nginx` runtime stage — a `COPY` of those static files — is still built per-target-arch. Both `linux/amd64` and `linux/arm64` frontend images are still produced.

`$BUILDPLATFORM` is a BuildKit-predefined arg, so no `ARG` declaration is needed.

## Notes for reviewer

- No change to the other (Python) image targets — they were never the bottleneck.
- The GHA cache scope (`docker-frontend`) effectively warms from the native build after this lands.
- A follow-up option (not in this PR): add `timeout-minutes` to the `docker` job as a guardrail so any future emulation stall fails fast instead of running to the 6h ceiling.