### PR TITLE
feat(app): add type column with logo to sources and destinations tables

### DIFF
--- a/packages/interloper-app/app/app/pages/destinations.vue
+++ b/packages/interloper-app/app/app/pages/destinations.vue
@@ -48,7 +48,10 @@ const columns: TableColumn<Destination>[] = [
         cell: ({ row }) => h(UBadge, {
             color: 'neutral',
             variant: 'subtle',
-        }, () => typeName(row.original.key)),
+        }, () => h('span', { class: 'flex items-center gap-1.5' }, [
+            h(UIcon, { name: typeIcon(row.original.key), class: 'size-4 shrink-0' }),
+            typeName(row.original.key),
+        ])),
     },
     {
         accessorKey: 'resources',

--- a/packages/interloper-app/app/app/pages/sources.vue
+++ b/packages/interloper-app/app/app/pages/sources.vue
@@ -16,6 +16,10 @@ function typeIcon(key: string): string {
     return componentIcon(key)
 }
 
+function typeName(key: string): string {
+    return catalogStore.catalog[key]?.name ?? key
+}
+
 const drawerOpen = ref(false)
 const editingSource = ref<Source | null>(null)
 const stepperRef = ref<any>(null)
@@ -42,6 +46,17 @@ const columns: TableColumn<Source>[] = [
             h(UIcon, { name: typeIcon(row.original.key), class: 'size-4 shrink-0' }),
             row.original.name,
         ]),
+    },
+    {
+        accessorKey: 'type',
+        header: 'Type',
+        cell: ({ row }) => h(UBadge, {
+            color: 'neutral',
+            variant: 'subtle',
+        }, () => h('span', { class: 'flex items-center gap-1.5' }, [
+            h(UIcon, { name: typeIcon(row.original.key), class: 'size-4 shrink-0' }),
+            typeName(row.original.key),
+        ])),
     },
     {
         accessorKey: 'assets',


### PR DESCRIPTION
## What

Adds a **Type** column to the **Sources** and **Destinations** page tables, rendering the provider logo alongside the type name — consistent with the **Connections** (resources) table.

- **Sources** ([sources.vue](packages/interloper-app/app/app/pages/sources.vue)): new Type column (between *Source* and *Assets*) showing logo + type name in a subtle badge. Added a `typeName()` helper.
- **Destinations** ([destinations.vue](packages/interloper-app/app/app/pages/destinations.vue)): the existing Type column previously showed only the name — it now includes the provider logo too.

## Why

Brings the sources/destinations tables in line with the connections table, where the type is shown as a badge with its logo, for a consistent visual language across the listing pages.

## Implementation notes

Both columns reuse the same pattern as the connections page: a `UBadge` wrapping a `UIcon` (resolved via `componentIcon()` / the catalog) plus the type name. Icon is resolved from `row.original.key` against `catalogStore.catalog`.

## Verification

- `pnpm run lint` — 0 errors (only pre-existing warnings in unrelated files).
- `pnpm exec nuxt typecheck` — exit 0, no type errors.