### PR TITLE
feat(app): add interactive column sorting to client-side tables

### DIFF
--- a/packages/interloper-app/app/app/components/DataTable.vue
+++ b/packages/interloper-app/app/app/components/DataTable.vue
@@ -88,9 +88,10 @@ function buildRowActions(item: TData): DropdownMenuItem[][] {
 // ── Append actions column ──
 
 const columnsWithActions = computed<TableColumn<TData>[]>(() => {
-    if (props.noActions) return props.columns
+    const sortable = withSortableHeaders(props.columns)
+    if (props.noActions) return sortable
     return [
-        ...props.columns,
+        ...sortable,
         {
             id: 'actions',
             header: '',

--- a/packages/interloper-app/app/app/components/executions/BackfillsTable.vue
+++ b/packages/interloper-app/app/app/components/executions/BackfillsTable.vue
@@ -33,9 +33,10 @@ function jobName(backfill: Backfill): string {
 }
 
 const pagination = ref({ pageIndex: 0, pageSize: PAGE_SIZE })
+const sorting = ref([{ id: 'started_at', desc: true }])
 const totalPages = computed(() => Math.ceil(backfills.value.length / PAGE_SIZE))
 
-const columns: TableColumn<Backfill>[] = [
+const columns: TableColumn<Backfill>[] = withSortableHeaders([
     {
         accessorKey: 'id',
         header: 'ID',
@@ -83,16 +84,16 @@ const columns: TableColumn<Backfill>[] = [
             return h('span', { class: 'text-muted' }, formatElapsed(backfill.started_at, backfill.completed_at) || '—')
         },
     },
-]
+])
 </script>
 
 <template>
     <div class="flex flex-col flex-1 min-h-0">
         <UTable v-model:pagination="pagination"
+                v-model:sorting="sorting"
                 :data="backfills"
                 :columns="columns"
                 :loading="loading"
-                :sorting="[{ id: 'started_at', desc: true }]"
                 :pagination-options="{ getPaginationRowModel: getPaginationRowModel() }"
                 sticky
                 @select="(_e: Event, row: any) => navigateTo(`/executions/backfills/${row.original.id}`)" />

--- a/packages/interloper-app/app/app/pages/executions/backfills/[backfill].vue
+++ b/packages/interloper-app/app/app/pages/executions/backfills/[backfill].vue
@@ -20,6 +20,7 @@ const jobsStore = useJobsStore()
 const backfill = ref<Backfill | null>(null)
 const backfillRuns = ref<Run[]>([])
 const runsLoading = ref(false)
+const sorting = ref([{ id: 'partition_date', desc: false }])
 
 const backfillJobName = computed(() =>
     backfill.value?.job?.name ?? jobsStore.findById(backfill.value?.job_id ?? '')?.name ?? 'Deleted job',
@@ -46,7 +47,7 @@ onMounted(async () => {
     }
 })
 
-const columns: TableColumn<Run>[] = [
+const columns: TableColumn<Run>[] = withSortableHeaders([
     {
         accessorKey: 'id',
         header: 'ID',
@@ -83,7 +84,7 @@ const columns: TableColumn<Run>[] = [
             return h('span', { class: 'text-muted' }, formatElapsed(run.started_at, run.completed_at) || '—')
         },
     },
-]
+])
 </script>
 
 <template>
@@ -131,10 +132,10 @@ const columns: TableColumn<Run>[] = [
             </div>
         </div>
 
-        <UTable :data="backfillRuns"
+        <UTable v-model:sorting="sorting"
+                :data="backfillRuns"
                 :columns="columns"
                 :loading="runsLoading"
-                :sorting="[{ id: 'partition_date', desc: false }]"
                 sticky
                 class="flex-1"
                 @select="(_e: Event, row: any) => navigateTo(`/executions/runs/${row.original.id}`)" />

--- a/packages/interloper-app/app/app/utils/table.ts
+++ b/packages/interloper-app/app/app/utils/table.ts
@@ -1,0 +1,50 @@
+import { h } from 'vue'
+import { UButton } from '#components'
+import type { Column } from '@tanstack/vue-table'
+import type { TableColumn } from '@nuxt/ui'
+
+/**
+ * Builds a clickable column header that toggles sorting (none → asc → desc)
+ * and reflects the current state with an arrow icon. Use as a column's
+ * `header` to make it sortable.
+ */
+export function sortableHeader<T>(label: string) {
+    return ({ column }: { column: Column<T> }) => {
+        const sorted = column.getIsSorted()
+        const icon = sorted === 'asc'
+            ? 'i-lucide-arrow-up-narrow-wide'
+            : sorted === 'desc'
+                ? 'i-lucide-arrow-down-wide-narrow'
+                : 'i-lucide-arrow-up-down'
+        return h(UButton, {
+            color: 'neutral',
+            variant: 'ghost',
+            size: 'sm',
+            label,
+            icon,
+            trailing: true,
+            class: '-mx-2.5 data-[state=open]:bg-elevated',
+            'aria-label': `Sort by ${label}`,
+            onClick: () => column.toggleSorting(column.getIsSorted() === 'asc'),
+        })
+    }
+}
+
+/**
+ * Returns a copy of `columns` with sortable headers applied to every column
+ * that (a) has a real accessor to sort on, (b) has a plain string header, and
+ * (c) hasn't opted out via `enableSorting: false`. Display-only columns
+ * (selection checkbox, avatar, actions, custom-rendered headers) pass through
+ * untouched.
+ */
+export function withSortableHeaders<T>(columns: TableColumn<T>[]): TableColumn<T>[] {
+    return columns.map((column) => {
+        const hasAccessor = 'accessorKey' in column || 'accessorFn' in column
+        if (!hasAccessor) return column
+        if (typeof column.header !== 'string' || column.header === '') return column
+        if (column.enableSorting === false) return column
+        // Only the header is overridden; cast back since the spread widens the
+        // discriminated `TableColumn` union (its `id` becomes optional).
+        return { ...column, header: sortableHeader<T>(column.header) } as TableColumn<T>
+    })
+}


### PR DESCRIPTION
## What

Adds click-to-sort column headers to the data tables that hold all their rows client-side.

A shared helper (`app/utils/table.ts`) does the work:
- `sortableHeader(label)` — renders a header button that cycles **none → asc → desc** with an arrow indicator.
- `withSortableHeaders(columns)` — makes a column sortable only when it has a real accessor (`accessorKey`/`accessorFn`), a plain string header, and hasn't opted out via `enableSorting: false`. Selection/avatar/actions and custom-rendered headers pass through untouched.

Wired into:
- **`DataTable.vue`** (one line) — the generic wrapper behind **Sources, Destinations, Jobs, Resources, Admin organisations, and Members**, so all six gain sorting with no per-page changes.
- **`BackfillsTable.vue`** and the **backfill-detail runs list** — wrapped their columns and converted the static `:sorting="[…]"` literal (which locked the order) into a `v-model`-bound `ref`, so header clicks update the sort while keeping the original default.

## Why

Tables had no way to reorder rows by column. This is purely additive — TanStack/Nuxt UI handle the sorting in-browser since the data is already fully loaded.

## Intentionally excluded

- **Runs & Events** — server-paginated/infinite-scroll, so a header click would only reorder the current page (misleading). True sorting there needs `sort`/`order` params on the API + stores; deferred.
- **Catalog** — a grouped tree (source → asset → destination) with expand/collapse; column sorting fights the grouping model.

## Testing

- `pnpm exec nuxt typecheck` — passes (exit 0).
- `pnpm run lint` — clean for changed files (remaining warnings are pre-existing in unrelated files).
- Not yet visually verified in a running app.