### PR TITLE
feat: detect and surface catalog-key drift for sources and assets

### DIFF
--- a/packages/interloper-api/src/interloper_api/app.py
+++ b/packages/interloper-api/src/interloper_api/app.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from fastapi import APIRouter, FastAPI
+from fastapi import APIRouter, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from interloper.catalog.base import Catalog
+from interloper.errors import ComponentDriftError
 from interloper_db import Store
 
 from interloper_api.dependencies import set_auth_config, set_catalog, set_smtp_config, set_store
@@ -54,6 +56,15 @@ def create_app(
         The configured FastAPI application.
     """
     app = FastAPI(title="Interloper API", lifespan=ws.realtime_lifespan, **kwargs)
+
+    @app.exception_handler(ComponentDriftError)
+    async def _component_drift_handler(_request: Request, exc: ComponentDriftError) -> JSONResponse:
+        """A stored component whose catalog key has drifted is a conflict, not a 500.
+
+        Hydrating or running a drifted source/asset can't succeed until the
+        user resolves the drift, so surface it as a clean 409 the UI can act on.
+        """
+        return JSONResponse(status_code=409, content={"detail": str(exc)})
 
     if cors_origins:
         app.add_middleware(

--- a/packages/interloper-api/src/interloper_api/routes/assets.py
+++ b/packages/interloper-api/src/interloper_api/routes/assets.py
@@ -7,7 +7,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
 from interloper.errors import DataNotFoundError, NotFoundError
-from interloper_db import Profile, Store
+from interloper_db import ComponentStatus, Profile, Store
 from interloper_db.models import Asset, AssetResource, Destination, DestinationResource
 from pydantic import BaseModel
 from sqlmodel import Session, select
@@ -64,6 +64,7 @@ class AssetResponse(BaseModel):
     org_id: UUID
     key: str
     materializable: bool
+    status: ComponentStatus
     config: dict[str, Any] | None = None
     resources: dict[str, str] = {}
     destinations: list[DestinationResponse] = []
@@ -147,14 +148,21 @@ def _load_authorized_asset(asset_id: UUID, user: Profile, store: Store, *, minim
     return asset
 
 
-def _asset_to_response(asset: Asset) -> AssetResponse:
-    """Convert a DB Asset to an AssetResponse."""
+def _asset_to_response(asset: Asset, store: Store) -> AssetResponse:
+    """Convert a DB Asset to an AssetResponse.
+
+    Carries the asset's catalog-resolution ``status`` (derived from the same
+    resolver hydration uses) so the UI can flag drifted assets. Source-owned
+    assets resolve through their parent, so ``asset.source`` must be loaded.
+    """
+    source_key = asset.source.key if asset.source else None
     return AssetResponse(
         id=asset.id,
         source_id=asset.source_id,
         org_id=asset.org_id,
         key=asset.key,
         materializable=asset.materializable,
+        status=store.asset_status(asset.key, source_key=source_key),
         config=asset.config,
         resources=_resource_map(AssetResource, "asset_id", asset.id),
         destinations=[_dest_to_response(d) for d in asset.destinations],
@@ -173,7 +181,7 @@ def list_assets(
 ) -> list[AssetResponse]:
     """List all assets for the current organisation."""
     assets = store.list_assets(org_id)
-    return [_asset_to_response(a) for a in assets]
+    return [_asset_to_response(a, store) for a in assets]
 
 
 @router.post("/", status_code=201)
@@ -191,7 +199,7 @@ def create_asset(
         resources=body.resources,
         destination_ids=body.destination_ids,
     )
-    return _asset_to_response(asset)
+    return _asset_to_response(asset, store)
 
 
 @router.get("/dependencies")
@@ -219,7 +227,7 @@ def get_asset(
 ) -> AssetResponse:
     """Get a single asset by ID. Authorized by membership in the asset's org."""
     asset = _load_authorized_asset(asset_id, user, store)
-    return _asset_to_response(asset)
+    return _asset_to_response(asset, store)
 
 
 @router.put("/{asset_id}")
@@ -241,7 +249,7 @@ def update_asset(
         )
     except NotFoundError:
         raise HTTPException(status_code=404, detail=f"Asset {asset_id} not found")
-    return _asset_to_response(asset)
+    return _asset_to_response(asset, store)
 
 
 @router.delete("/{asset_id}")

--- a/packages/interloper-api/src/interloper_api/routes/sources.py
+++ b/packages/interloper-api/src/interloper_api/routes/sources.py
@@ -7,7 +7,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
 from interloper.errors import NotFoundError
-from interloper_db import Profile, Store
+from interloper_db import ComponentStatus, Profile, Store
 from interloper_db.models import Destination, DestinationResource, Source, SourceResource
 from pydantic import BaseModel
 from sqlalchemy.orm import selectinload
@@ -43,6 +43,7 @@ class AssetResponse(BaseModel):
     id: UUID
     key: str
     materializable: bool
+    status: ComponentStatus
 
 
 class DestinationResponse(BaseModel):
@@ -64,6 +65,7 @@ class SourceResponse(BaseModel):
     key: str
     name: str
     config: dict[str, Any] | None = None
+    status: ComponentStatus
     resources: dict[str, str] = {}
     destinations: list[DestinationResponse] = []
     assets: list[AssetResponse] = []
@@ -77,14 +79,20 @@ def _resource_map(session: Session, junction_cls: type, fk_column: str, fk_value
     return {r.key: str(r.resource_id) for r in rows}  # ty: ignore[unresolved-attribute]
 
 
-def _build_source_response(session: Session, source: Source) -> SourceResponse:
-    """Convert a DB Source to a SourceResponse within a session."""
+def _build_source_response(session: Session, source: Source, store: Store) -> SourceResponse:
+    """Convert a DB Source to a SourceResponse within a session.
+
+    Each source and asset carries its catalog-resolution ``status`` so the
+    UI can flag drift. Status is derived from the same resolver hydration
+    uses — detection is just building the response, not a separate pass.
+    """
     return SourceResponse(
         id=source.id,
         org_id=source.org_id,
         key=source.key,
         name=source.name,
         config=source.config,
+        status=store.source_status(source.key),
         resources=_resource_map(session, SourceResource, "source_id", source.id),
         destinations=[
             DestinationResponse(
@@ -98,14 +106,19 @@ def _build_source_response(session: Session, source: Source) -> SourceResponse:
             for d in source.destinations
         ],
         assets=[
-            AssetResponse(id=a.id, key=a.key, materializable=a.materializable)
+            AssetResponse(
+                id=a.id,
+                key=a.key,
+                materializable=a.materializable,
+                status=store.asset_status(a.key, source_key=source.key),
+            )
             for a in source.assets
         ],
         created_at=str(source.created_at) if source.created_at else None,
     )
 
 
-def _load_source_for_response(source_id: UUID) -> SourceResponse:
+def _load_source_for_response(source_id: UUID, store: Store) -> SourceResponse:
     """Load a source with relations and build the response."""
     from interloper_db.engine import get_engine
 
@@ -121,7 +134,7 @@ def _load_source_for_response(source_id: UUID) -> SourceResponse:
         )
         if not source:
             raise NotFoundError(f"Source {source_id} not found")
-        return _build_source_response(session, source)
+        return _build_source_response(session, source, store)
 
 
 @router.get("/")
@@ -135,7 +148,7 @@ def list_sources(
 
     sources = store.list_sources(org_id)
     with Session(get_engine()) as session:
-        return [_build_source_response(session, s) for s in sources]
+        return [_build_source_response(session, s, store) for s in sources]
 
 
 @router.post("/")
@@ -156,7 +169,7 @@ def create_source(
         destination_ids=body.destination_ids,
         cross_deps=body.cross_deps,
     )
-    return _load_source_for_response(source.id)
+    return _load_source_for_response(source.id, store)
 
 
 def _authorize_source(source_id: UUID, user: Profile, store: Store, *, minimum: str = "viewer") -> None:
@@ -194,7 +207,7 @@ def update_source(
         )
     except NotFoundError:
         raise HTTPException(status_code=404, detail=f"Source {source_id} not found")
-    return _load_source_for_response(source_id)
+    return _load_source_for_response(source_id, store)
 
 
 @router.delete("/{source_id}")

--- a/packages/interloper-app/app/app/components/DriftBanner.vue
+++ b/packages/interloper-app/app/app/components/DriftBanner.vue
@@ -1,0 +1,77 @@
+<script setup lang="ts">
+/**
+ * Health banner for catalog drift, shared across the Sources and Catalog
+ * pages. Surfaces removable drift (sources/assets whose key is gone from the
+ * catalog) and offers a one-click, confirmed cleanup. Self-contained: it reads
+ * state via useDrift and performs the cleanup itself.
+ */
+const sourcesStore = useSourcesStore()
+const toast = useToast()
+const { confirm } = useConfirm()
+const { hasDrift, missingSources, partialSources, missingAssetCount } = useDrift()
+
+const cleaningUp = ref(false)
+
+/** One-line summary of removable drift. */
+const driftSummary = computed(() => {
+    const parts: string[] = []
+    const sources = missingSources.value.length
+    const assets = missingAssetCount.value
+    if (sources) parts.push(`${sources} source${sources > 1 ? 's' : ''}`)
+    if (assets) parts.push(`${assets} asset${assets > 1 ? 's' : ''}`)
+    return parts.join(' and ')
+})
+
+async function handleCleanup() {
+    const confirmed = await confirm({
+        title: 'Clean up catalog drift',
+        description: `This permanently removes ${driftSummary.value} that no longer exist in the catalog. This cannot be undone.`,
+        confirmLabel: 'Remove',
+        confirmColor: 'error',
+        icon: 'i-lucide-triangle-alert',
+    })
+    if (!confirmed) return
+
+    cleaningUp.value = true
+    try {
+        // Prune drifted assets from still-valid sources, keeping the live ones.
+        for (const source of partialSources.value) {
+            const keep = source.assets.filter(a => a.status !== 'missing').map(a => a.key)
+            await sourcesStore.update(source.id, { key: source.key, name: source.name, asset_keys: keep })
+        }
+        // Delete sources whose own key is gone from the catalog (assets cascade).
+        const missingIds = missingSources.value.map(s => s.id)
+        if (missingIds.length) await sourcesStore.remove(missingIds)
+
+        await sourcesStore.fetch()
+        toast.add({ title: 'Catalog drift cleaned up', color: 'success' })
+    }
+    catch {
+        toast.add({ title: 'Failed to clean up drift', color: 'error' })
+    }
+    finally {
+        cleaningUp.value = false
+    }
+}
+</script>
+
+<template>
+    <div v-if="hasDrift"
+         class="px-4 pt-4">
+        <UAlert color="error"
+                variant="subtle"
+                icon="i-lucide-unplug"
+                title="Catalog drift detected"
+                :description="`${driftSummary} no longer exist in the catalog`">
+            <template #actions>
+                <UButton color="error"
+                         variant="solid"
+                         size="xs"
+                         icon="i-lucide-trash-2"
+                         label="Clean up"
+                         :loading="cleaningUp"
+                         @click="handleCleanup" />
+            </template>
+        </UAlert>
+    </div>
+</template>

--- a/packages/interloper-app/app/app/components/catalog/Table.vue
+++ b/packages/interloper-app/app/app/components/catalog/Table.vue
@@ -17,6 +17,7 @@ const { destinations } = storeToRefs(destinationsStore)
 const { jobs } = storeToRefs(jobsStore)
 const { runs } = storeToRefs(runsStore)
 const { getWarnings, filterByCategory } = useAssetWarnings()
+const { statusBadge } = useDrift()
 const { data, sourceInfoById, assetCount } = useCatalogRows({
     sources,
     assets,
@@ -26,6 +27,11 @@ const { data, sourceInfoById, assetCount } = useCatalogRows({
     runs,
     getWarnings,
 })
+
+/** Drift badge meta for a source's rollup status, or null when healthy. */
+function sourceDriftBadge(sourceId: string) {
+    return statusBadge(sourceInfoById.value.get(sourceId)?.drift ?? 'ok')
+}
 
 const statusColor: Record<string, 'error' | 'primary' | 'secondary' | 'success' | 'info' | 'warning' | 'neutral'> = {
     success: 'success',
@@ -268,6 +274,12 @@ function onRowClick(row: any) {
                             variant="subtle">
                         {{ sourceInfoById.get(row.original.sourceId)?.assetCount ?? 0 }}
                     </UBadge>
+                    <UBadge v-if="sourceDriftBadge(row.original.sourceId)"
+                            :color="sourceDriftBadge(row.original.sourceId)!.color"
+                            :icon="sourceDriftBadge(row.original.sourceId)!.icon"
+                            variant="subtle">
+                        {{ sourceDriftBadge(row.original.sourceId)!.label }}
+                    </UBadge>
                 </div>
                 <!-- Asset group header (depth 1) -->
                 <div v-else-if="row.getIsGrouped() && row.depth === 1"
@@ -280,6 +292,12 @@ function onRowClick(row: any) {
                     <UIcon :name="row.original.icon"
                            class="size-4.5 shrink-0 text-dimmed" />
                     <span>{{ row.original.name }}</span>
+                    <UBadge v-if="statusBadge(row.original.assetStatus)"
+                            :color="statusBadge(row.original.assetStatus)!.color"
+                            :icon="statusBadge(row.original.assetStatus)!.icon"
+                            variant="subtle">
+                        {{ statusBadge(row.original.assetStatus)!.label }}
+                    </UBadge>
                 </div>
                 <!-- Destination leaf row -->
                 <div v-else

--- a/packages/interloper-app/app/app/components/graph/AssetNode.vue
+++ b/packages/interloper-app/app/app/components/graph/AssetNode.vue
@@ -20,7 +20,11 @@ const emit = defineEmits<{
 const assetsStore = useAssetsStore()
 const { getWarnings } = useAssetWarnings()
 const { getBadgeForAssetId } = useDestinationBadge()
+const { statusBadge } = useDrift()
 const { confirm } = useConfirm()
+
+const isMissing = computed(() => props.asset.status === 'missing')
+const driftBadge = computed(() => statusBadge(props.asset.status))
 const nodeId = useNodeId()
 const { connectionStartHandle } = useVueFlow()
 
@@ -94,6 +98,7 @@ const showSourceHandle = computed(() => hasDownstream.value || isValidSource.val
 
 const ringClass = computed(() => {
     if (props.selected) return 'ring-2 ring-primary'
+    if (isMissing.value) return 'ring-1 ring-[var(--ui-error)]/60'
     if (props.viewMode === 'status' && props.status) return statusRingClass(props.status.state)
     return ''
 })
@@ -162,8 +167,22 @@ const contextMenuItems = computed<ContextMenuItem[][]>(() => {
                 </UTooltip>
             </div>
 
+            <!-- Drift badge — the asset key no longer resolves against the catalog. -->
+            <UTooltip v-if="isMissing"
+                      :delay-duration="0"
+                      :content="{ side: 'top', sideOffset: 6 }"
+                      class="absolute -right-3 -top-3 z-10">
+                <div class="flex size-7 items-center justify-center rounded-full border border-error/80 bg-error/20">
+                    <UIcon :name="driftBadge?.icon ?? 'i-lucide-unplug'"
+                           class="size-4 shrink-0 text-error" />
+                </div>
+                <template #content>
+                    <div class="text-xs">{{ driftBadge?.label }}</div>
+                </template>
+            </UTooltip>
+
             <!-- Warning badge -->
-            <UTooltip v-if="warnings.length > 0"
+            <UTooltip v-if="warnings.length > 0 && !isMissing"
                       :delay-duration="0"
                       :content="{ side: 'top', sideOffset: 6 }"
                       :ui="{ content: 'bg-transparent ring-0 shadow-none p-0 rounded-none' }"
@@ -230,6 +249,10 @@ const contextMenuItems = computed<ContextMenuItem[][]>(() => {
                 <div v-if="description"
                      class="line-clamp-2 border-t border-[var(--ui-border-accented)] bg-default px-3.5 py-2.5 text-xs leading-snug text-muted">
                     {{ description }}
+                </div>
+                <div v-else-if="isMissing"
+                     class="border-t border-[var(--ui-border-accented)] bg-default px-3.5 py-2.5 text-xs italic leading-snug text-dimmed">
+                    No catalog definition
                 </div>
             </div>
 

--- a/packages/interloper-app/app/app/components/graph/AssetPanel.vue
+++ b/packages/interloper-app/app/app/components/graph/AssetPanel.vue
@@ -15,7 +15,10 @@ const emit = defineEmits<{
 
 const catalogStore = useCatalogStore()
 const { apiFetch } = useApi()
+const { statusBadge } = useDrift()
 const sourceDefn = computed(() => catalogStore.getSourceDefinition(props.source.key))
+
+const driftBadge = computed(() => statusBadge(props.asset.status))
 
 const icon = computed(() => props.assetDefn ? componentIcon(props.assetDefn.key) : 'i-lucide-box')
 const sourceIcon = computed(() => componentIcon(props.source.key))
@@ -237,6 +240,17 @@ const dependencyRows = computed(() => {
         </div>
 
         <div class="flex-1 min-h-0 border-l border-t border-default overflow-auto">
+            <!-- Drift notice — this asset no longer resolves against the catalog. -->
+            <UAlert v-if="driftBadge"
+                    :color="driftBadge.color"
+                    :icon="driftBadge.icon"
+                    variant="subtle"
+                    class="m-5 mb-0"
+                    :title="driftBadge.label"
+                    :description="asset.status === 'missing'
+                        ? 'Its catalog key was renamed or removed in code. It can\'t materialize — remove the source (or edit it to drop this asset), or restore the catalog entry.'
+                        : 'This component is not enabled in the current deployment.'" />
+
             <!-- Materialization -->
             <UCollapsible default-open
                           class="border-b border-default">

--- a/packages/interloper-app/app/app/components/graph/SourceNode.vue
+++ b/packages/interloper-app/app/app/components/graph/SourceNode.vue
@@ -93,6 +93,11 @@ const { confirm } = useConfirm()
 const { getWarnings } = useAssetWarnings()
 const { getBadgeForSource } = useDestinationBadge()
 const { getSourceSchedule } = useSchedule()
+const { sourceDrift, statusBadge } = useDrift()
+
+const driftStatus = computed(() => sourceDrift(props.source))
+const driftBadge = computed(() => statusBadge(driftStatus.value))
+const isDrift = computed(() => driftStatus.value === 'missing' || driftStatus.value === 'partial')
 
 const sourceWarnings = computed(() => {
     const all = props.source.assets.flatMap(a => getWarnings(a.id, a.key))
@@ -188,8 +193,25 @@ const ringClass = computed(() => {
                 </UTooltip>
             </div>
 
+            <!-- Drift badge (collapsed) — takes precedence over warnings: the source
+                 or one of its assets no longer resolves against the catalog. -->
+            <UTooltip v-if="isDrift && collapsed"
+                      :delay-duration="0"
+                      :content="{ side: 'top', sideOffset: 6 }"
+                      class="absolute -right-2.5 -top-2.5 z-10">
+                <div class="flex size-7 items-center justify-center rounded-full border"
+                     :class="driftStatus === 'missing' ? 'border-error/40 bg-error/25' : 'border-warning/40 bg-warning/25'">
+                    <UIcon :name="driftBadge?.icon ?? 'i-lucide-unplug'"
+                           class="size-4 shrink-0"
+                           :class="driftStatus === 'missing' ? 'text-error' : 'text-warning'" />
+                </div>
+                <template #content>
+                    <div class="text-xs">{{ driftBadge?.label }}</div>
+                </template>
+            </UTooltip>
+
             <!-- Warning badge (collapsed only) -->
-            <UTooltip v-if="hasWarning && collapsed"
+            <UTooltip v-if="hasWarning && !isDrift && collapsed"
                       :delay-duration="0"
                       :content="{ side: 'top', sideOffset: 6 }"
                       :ui="{ content: 'bg-transparent ring-0 shadow-none p-0 rounded-none' }"
@@ -280,6 +302,16 @@ const ringClass = computed(() => {
                                    class="size-4 text-muted" />
                         </div>
                         <span class="min-w-0 flex-1 truncate text-sm font-semibold text-highlighted">{{ source.name }}</span>
+                        <UTooltip v-if="isDrift"
+                                  :delay-duration="0"
+                                  :content="{ side: 'top', sideOffset: 6 }">
+                            <UIcon :name="driftBadge?.icon ?? 'i-lucide-unplug'"
+                                   class="size-4 shrink-0"
+                                   :class="driftStatus === 'missing' ? 'text-error' : 'text-warning'" />
+                            <template #content>
+                                <div class="text-xs">{{ driftBadge?.label }}</div>
+                            </template>
+                        </UTooltip>
                         <span class="shrink-0 text-[11px] text-dimmed">{{ assetCount }} assets</span>
                         <UIcon name="i-lucide-chevron-down"
                                class="size-4 shrink-0 text-dimmed" />

--- a/packages/interloper-app/app/app/composables/catalog.ts
+++ b/packages/interloper-app/app/app/composables/catalog.ts
@@ -3,7 +3,9 @@ import type { Asset, AssetDependency } from '~/types/asset'
 import type { Job } from '~/types/job'
 import type { Run } from '~/types/run'
 import type { AssetDefinition, SourceDefinition } from '~/types/catalog'
+import type { ComponentStatus } from '~/types/component'
 import type { AssetWarning } from '~/composables/warnings'
+import type { SourceDriftStatus } from '~/composables/drift'
 
 // ─── Types ───────────────────────────────────────────────────────────
 
@@ -14,6 +16,7 @@ export interface CatalogRow {
     name: string
     icon: string
     sourceKey: string
+    assetStatus: ComponentStatus
     tags: string[]
     dependencies: Array<{ name: string; icon: string }>
     warnings: AssetWarning[]
@@ -43,6 +46,7 @@ interface UseCatalogRowsOptions {
 
 export function useCatalogRows(options: UseCatalogRowsOptions) {
     const catalogStore = useCatalogStore()
+    const { sourceDrift } = useDrift()
 
     /** Asset id → Asset record (for created_at etc.) */
     const assetById = computed(() => {
@@ -178,6 +182,7 @@ export function useCatalogRows(options: UseCatalogRowsOptions) {
                     name: assetDefn?.name ?? asset.key,
                     icon: componentIcon(asset.key),
                     sourceKey: source.key,
+                    assetStatus: asset.status,
                     tags: assetDefn?.tags ?? [],
                     dependencies: dependenciesByAssetId.value.get(asset.id) ?? [],
                     warnings: options.getWarnings(asset.id, asset.key),
@@ -222,6 +227,7 @@ export function useCatalogRows(options: UseCatalogRowsOptions) {
                     name: '(no assets)',
                     icon: 'i-lucide-box',
                     sourceKey: source.key,
+                    assetStatus: 'ok',
                     tags: [],
                     dependencies: [],
                     warnings: [],
@@ -247,6 +253,7 @@ export function useCatalogRows(options: UseCatalogRowsOptions) {
             icon: string
             assetCount: number
             warnings: AssetWarning[]
+            drift: SourceDriftStatus
         }>()
         for (const source of options.sources.value) {
             const sourceDefn = catalogStore.getSourceDefinition(source.key)
@@ -265,6 +272,7 @@ export function useCatalogRows(options: UseCatalogRowsOptions) {
                 icon: componentIcon(source.key, 'i-lucide-database'),
                 assetCount: source.assets.length,
                 warnings,
+                drift: sourceDrift(source),
             })
         }
         return map

--- a/packages/interloper-app/app/app/composables/drift.ts
+++ b/packages/interloper-app/app/app/composables/drift.ts
@@ -1,0 +1,83 @@
+import type { Source } from '~/types/source'
+import type { ComponentStatus } from '~/types/component'
+
+// ─── Types ───────────────────────────────────────────────────────────
+
+/**
+ * A source's rollup drift state: its own status, or `partial` when the
+ * source is live but one or more of its assets have drifted out of it.
+ */
+export type SourceDriftStatus = ComponentStatus | 'partial'
+
+export interface DriftBadge {
+    label: string
+    color: 'error' | 'warning' | 'neutral'
+    icon: string
+}
+
+// ─── Composable ──────────────────────────────────────────────────────
+
+/**
+ * Catalog-drift presentation, derived from the `status` each source/asset
+ * carries from the API (the same resolver hydration uses). Centralises the
+ * status→badge mapping and the source rollup so the table, graph nodes, and
+ * health banner stay consistent.
+ *
+ * Only `missing` is true drift (removable); `disabled` is intentional
+ * (the component may return when the deployment re-enables it) and is shown
+ * quietly, never flagged for cleanup.
+ */
+export function useDrift() {
+    const sourcesStore = useSourcesStore()
+
+    /** Badge metadata for a status, or `null` when nothing should be shown. */
+    function statusBadge(status: SourceDriftStatus): DriftBadge | null {
+        switch (status) {
+            case 'missing':
+                return { label: 'Unavailable in catalog', color: 'error', icon: 'i-lucide-unplug' }
+            case 'partial':
+                return { label: 'Some assets unavailable', color: 'warning', icon: 'i-lucide-triangle-alert' }
+            case 'disabled':
+                return { label: 'Disabled', color: 'neutral', icon: 'i-lucide-circle-slash' }
+            default:
+                return null
+        }
+    }
+
+    /** Rollup drift state for a source (see {@link SourceDriftStatus}). */
+    function sourceDrift(source: Source): SourceDriftStatus {
+        if (source.status !== 'ok') return source.status
+        if (source.assets.some(a => a.status === 'missing')) return 'partial'
+        return 'ok'
+    }
+
+    /** Sources whose own key has drifted out of the catalog. */
+    const missingSources = computed(() =>
+        sourcesStore.sources.filter(s => s.status === 'missing'),
+    )
+
+    /** Live sources that have at least one drifted asset. */
+    const partialSources = computed(() =>
+        sourcesStore.sources.filter(s => s.status === 'ok' && s.assets.some(a => a.status === 'missing')),
+    )
+
+    /** Total count of individual assets whose key has drifted. */
+    const missingAssetCount = computed(() =>
+        sourcesStore.sources.reduce(
+            (n, s) => n + s.assets.filter(a => a.status === 'missing').length,
+            0,
+        ),
+    )
+
+    /** Whether any removable drift (missing source or asset) exists. */
+    const hasDrift = computed(() => missingSources.value.length > 0 || missingAssetCount.value > 0)
+
+    return {
+        statusBadge,
+        sourceDrift,
+        missingSources,
+        partialSources,
+        missingAssetCount,
+        hasDrift,
+    }
+}

--- a/packages/interloper-app/app/app/pages/catalog.vue
+++ b/packages/interloper-app/app/app/pages/catalog.vue
@@ -83,6 +83,7 @@ function onCreateSource() {
 
 <template>
     <div class="flex flex-col min-h-0 flex-1">
+        <DriftBanner />
         <SplitterGroup direction="horizontal"
                        auto-save-id="catalog-panels"
                        class="flex-1 min-h-0">

--- a/packages/interloper-app/app/app/pages/sources.vue
+++ b/packages/interloper-app/app/app/pages/sources.vue
@@ -11,6 +11,7 @@ const UBadge = resolveComponent('UBadge')
 const catalogStore = useCatalogStore()
 const sourcesStore = useSourcesStore()
 const destinationsStore = useDestinationsStore()
+const { statusBadge, sourceDrift } = useDrift()
 
 function typeIcon(key: string): string {
     return componentIcon(key)
@@ -42,10 +43,25 @@ const columns: TableColumn<Source>[] = [
     {
         accessorKey: 'name',
         header: 'Source',
-        cell: ({ row }) => h('span', { class: 'flex items-center gap-2' }, [
-            h(UIcon, { name: typeIcon(row.original.key), class: 'size-4 shrink-0' }),
-            row.original.name,
-        ]),
+        cell: ({ row }) => {
+            const children: any[] = [
+                h(UIcon, { name: typeIcon(row.original.key), class: 'size-4 shrink-0' }),
+                row.original.name,
+            ]
+            const badge = statusBadge(sourceDrift(row.original))
+            if (badge) {
+                children.push(h(UBadge, {
+                    color: badge.color,
+                    variant: 'subtle',
+                    size: 'sm',
+                    class: 'ml-1',
+                }, () => h('span', { class: 'flex items-center gap-1' }, [
+                    h(UIcon, { name: badge.icon, class: 'size-3 shrink-0' }),
+                    badge.label,
+                ])))
+            }
+            return h('span', { class: 'flex items-center gap-2' }, children)
+        },
     },
     {
         accessorKey: 'type',
@@ -111,6 +127,8 @@ async function handleDelete(ids: string[]) {
 
 <template>
     <div>
+        <DriftBanner />
+
         <div class="flex flex-col h-full">
             <DataTable :columns="columns"
                        :data="sourcesStore.sources"

--- a/packages/interloper-app/app/app/types/asset.ts
+++ b/packages/interloper-app/app/app/types/asset.ts
@@ -1,3 +1,4 @@
+import type { ComponentStatus } from './component'
 import type { Destination } from './destination'
 
 export interface Asset {
@@ -6,6 +7,7 @@ export interface Asset {
     org_id: string
     key: string
     materializable: boolean
+    status: ComponentStatus
     config: Record<string, any> | null
     resources: Record<string, string>
     destinations: Destination[]

--- a/packages/interloper-app/app/app/types/component.ts
+++ b/packages/interloper-app/app/app/types/component.ts
@@ -1,0 +1,10 @@
+/**
+ * Catalog-resolution state of a persisted component (source or asset).
+ *
+ * Mirrors `interloper_db.drift.ComponentStatus` on the backend, derived from
+ * the same resolver hydration uses:
+ *   - `ok`       — key resolves in the enabled catalog; live and runnable
+ *   - `disabled` — key exists in code but is not exposed by this deployment
+ *   - `missing`  — key is gone from the code entirely; this is drift
+ */
+export type ComponentStatus = 'ok' | 'disabled' | 'missing'

--- a/packages/interloper-app/app/app/types/source.ts
+++ b/packages/interloper-app/app/app/types/source.ts
@@ -1,9 +1,11 @@
+import type { ComponentStatus } from './component'
 import type { Destination } from './destination'
 
 export interface SourceAsset {
     id: string
     key: string
     materializable: boolean
+    status: ComponentStatus
 }
 
 export interface Source {
@@ -12,6 +14,7 @@ export interface Source {
     key: string
     name: string
     config: Record<string, any> | null
+    status: ComponentStatus
     resources: Record<string, string>
     destinations: Destination[]
     assets: SourceAsset[]

--- a/packages/interloper-core/src/interloper/errors.py
+++ b/packages/interloper-core/src/interloper/errors.py
@@ -194,6 +194,19 @@ class CatalogKeyError(ConfigError):
     """
 
 
+class ComponentDriftError(InterloperError):
+    """A persisted component references a catalog key that no longer resolves.
+
+    Raised when hydrating a stored source or asset whose catalog key has
+    *drifted* — the underlying class was renamed or removed from the code
+    (``missing``), or is not exposed by this deployment's catalog
+    (``disabled``). Distinct from :class:`HydrationError` (which signals a
+    reconstruction failure for a key that *does* resolve) so callers and
+    the API layer can treat drift as a recoverable, user-resolvable state
+    rather than a hard failure.
+    """
+
+
 # ---------------------------------------------------------------------------
 # Scheduling
 # ---------------------------------------------------------------------------

--- a/packages/interloper-db/src/interloper_db/__init__.py
+++ b/packages/interloper-db/src/interloper_db/__init__.py
@@ -1,3 +1,4 @@
+from interloper_db.drift import ComponentStatus
 from interloper_db.engine import get_engine, init_engine
 from interloper_db.models import (
     Asset,
@@ -31,6 +32,7 @@ __all__ = [
     "AssetDestination",
     "AssetResource",
     "Backfill",
+    "ComponentStatus",
     "Destination",
     "DestinationResource",
     "Event",

--- a/packages/interloper-db/src/interloper_db/drift.py
+++ b/packages/interloper-db/src/interloper_db/drift.py
@@ -1,0 +1,164 @@
+"""Catalog drift: the single resolution primitive for stored component keys.
+
+Catalog keys (``Source.key`` / ``Asset.key``, derived from class names) are
+the only join between *code* (the catalog of Python classes) and *data* (the
+``sources`` / ``assets`` rows that reference those keys as bare strings, with
+no foreign key back to the catalog). When a class is renamed or removed, the
+stored key *drifts* — it no longer resolves against the catalog.
+
+Rather than discover drift with a separate scanner, drift is computed as the
+outcome of the resolution step every load already performs, surfaced as a
+:class:`ComponentStatus` value instead of an exception. Hydration and
+detection therefore consume the *same* resolver and can never disagree.
+
+Resolution is against two catalogs the system already has:
+
+- the **enabled** catalog (``AppSettings.catalog`` — what this deployment
+  exposes), passed in by the caller (the :class:`~interloper_db.store.Store`
+  holds it as ``_catalog``); and
+- the **discovered** universe (:meth:`Catalog.discover` — every component any
+  installed package declares), used to tell a key that is *gone from the code*
+  apart from one merely *not enabled here*.
+
+This yields a tri-state:
+
+================  ================================================  ==========
+``ComponentStatus``  meaning                                        drift?
+================  ================================================  ==========
+``ok``            key is in the enabled catalog — live, runnable     no
+``disabled``      key is in code (discovered) but not enabled here   no
+``missing``       key is gone from the code entirely                 **yes**
+================  ================================================  ==========
+
+Only ``missing`` is drift (removable). ``disabled`` is intentional — the
+component may return when the deployment re-enables it — so it must never be
+flagged for cleanup.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from functools import cache
+
+import interloper as il
+from interloper.catalog.base import Catalog
+from interloper.utils.imports import import_from_path
+
+
+class ComponentStatus(str, Enum):
+    """Resolution state of a persisted component against the catalog."""
+
+    OK = "ok"
+    """Key resolves in the enabled catalog — the component is live."""
+
+    DISABLED = "disabled"
+    """Key exists in code but is not exposed by this deployment's catalog."""
+
+    MISSING = "missing"
+    """Key no longer exists in code at all — this is drift."""
+
+
+@cache
+def _discovered_catalog() -> Catalog:
+    """The full installed component universe, memoised for the process.
+
+    Discovery imports every component declared via entry points, so the
+    result is stable for the life of the process (entry points don't change
+    at runtime) — matching the ``@cache`` on the underlying path scan.
+    """
+    return Catalog.discover()
+
+
+def resolve_source_cls(catalog: Catalog, key: str) -> type[il.Source] | None:
+    """Return the source class for *key*, or ``None`` if it does not resolve.
+
+    Value-based counterpart to the raise-on-miss lookup used by writes. The
+    catalog only holds keys whose classes imported cleanly at build time, but
+    the import is still guarded so a stale definition degrades to ``None``
+    rather than raising.
+    """
+    definition = catalog.get(key)
+    if definition is None:
+        return None
+    try:
+        obj = import_from_path(definition.path)
+    except (ImportError, AttributeError):
+        return None
+    return obj if isinstance(obj, type) and issubclass(obj, il.Source) else None
+
+
+def source_status(
+    catalog: Catalog,
+    key: str,
+    *,
+    discovered: Catalog | None = None,
+) -> ComponentStatus:
+    """Resolve a source key to its :class:`ComponentStatus`.
+
+    Args:
+        catalog: The enabled catalog (what this deployment exposes).
+        key: The stored source key.
+        discovered: The discovered universe; defaults to the cached
+            :func:`_discovered_catalog`. Injectable for testing.
+    """
+    if key in catalog.components:
+        return ComponentStatus.OK
+    discovered = discovered if discovered is not None else _discovered_catalog()
+    if key in discovered.components:
+        return ComponentStatus.DISABLED
+    return ComponentStatus.MISSING
+
+
+def asset_status(
+    catalog: Catalog,
+    key: str,
+    *,
+    source_key: str | None = None,
+    discovered: Catalog | None = None,
+) -> ComponentStatus:
+    """Resolve an asset key to its :class:`ComponentStatus`.
+
+    A standalone asset (``source_key is None``) is itself a catalog component
+    and resolves like a source. A source-owned asset resolves *through* its
+    parent: a missing/disabled parent cascades to the asset, and under a live
+    parent the asset is ``ok`` only if its key is still one of the source's
+    ``asset_types`` — otherwise the asset key has drifted out of the source.
+
+    Args:
+        catalog: The enabled catalog.
+        key: The stored asset key.
+        source_key: The owning source's key, or ``None`` for a standalone asset.
+        discovered: The discovered universe; defaults to the cached one.
+    """
+    if source_key is None:
+        return source_status(catalog, key, discovered=discovered)
+
+    parent = source_status(catalog, source_key, discovered=discovered)
+    if parent is not ComponentStatus.OK:
+        # A gone/not-exposed source drags its assets to the same state.
+        return parent
+
+    source_cls = resolve_source_cls(catalog, source_key)
+    if source_cls is None:  # defensive: enabled said ok but the import failed
+        return ComponentStatus.MISSING
+    valid_keys = {asset_type.key for asset_type in source_cls.asset_types}
+    return ComponentStatus.OK if key in valid_keys else ComponentStatus.MISSING
+
+
+class DriftMixin:
+    """Store methods that surface catalog drift for persisted components.
+
+    Thin delegation to the pure resolver functions, passing the Store's
+    enabled ``_catalog`` so callers (API routes, hydration) never reach into
+    catalog internals.
+    """
+
+    _catalog: Catalog
+
+    def source_status(self, key: str) -> ComponentStatus:
+        """Resolution state of a stored source key against the catalog."""
+        return source_status(self._catalog, key)
+
+    def asset_status(self, key: str, *, source_key: str | None = None) -> ComponentStatus:
+        """Resolution state of a stored asset key against the catalog."""
+        return asset_status(self._catalog, key, source_key=source_key)

--- a/packages/interloper-db/src/interloper_db/store/__init__.py
+++ b/packages/interloper-db/src/interloper_db/store/__init__.py
@@ -34,6 +34,7 @@ from typing import Any
 
 from interloper.catalog.base import Catalog
 
+from interloper_db.drift import DriftMixin
 from interloper_db.hydration import Hydrator
 from interloper_db.store.assets import AssetMixin
 from interloper_db.store.auth import AuthMixin
@@ -46,7 +47,7 @@ from interloper_db.store.sources import SourceMixin
 logger = logging.getLogger(__name__)
 
 
-class Store(AuthMixin, ResourceMixin, SourceMixin, AssetMixin, JobMixin, RunMixin, DestinationMixin):
+class Store(AuthMixin, ResourceMixin, SourceMixin, AssetMixin, JobMixin, RunMixin, DestinationMixin, DriftMixin):
     """Framework-level persistence layer.
 
     Bridges catalog definitions and database rows to hydrate and persist

--- a/packages/interloper-db/src/interloper_db/store/assets.py
+++ b/packages/interloper-db/src/interloper_db/store/assets.py
@@ -6,10 +6,11 @@ from typing import TYPE_CHECKING, Any, cast
 from uuid import UUID
 
 import interloper as il
-from interloper.errors import HydrationError, NotFoundError
+from interloper.errors import ComponentDriftError, HydrationError, NotFoundError
 from sqlalchemy.orm import selectinload
 from sqlmodel import Session, select
 
+from interloper_db.drift import ComponentStatus, asset_status
 from interloper_db.engine import get_engine
 from interloper_db.hydration import Hydrator
 from interloper_db.models import (
@@ -27,6 +28,7 @@ def _load_asset_with_relations(session: Session, asset_id: UUID) -> Asset:
         select(Asset)
         .where(Asset.id == asset_id)
         .options(
+            selectinload(Asset.source),  # ty: ignore[invalid-argument-type]
             selectinload(Asset.resources),  # ty: ignore[invalid-argument-type]
             selectinload(Asset.destinations).selectinload(Destination.resources),  # ty: ignore[invalid-argument-type]
         )
@@ -63,6 +65,7 @@ class AssetMixin:
     """Store methods for asset management."""
 
     _hydrator: Hydrator
+    _catalog: il.Catalog
 
     if TYPE_CHECKING:
         # Provided by SourceMixin on the composed Store.
@@ -200,6 +203,7 @@ class AssetMixin:
                 select(Asset)
                 .where(Asset.org_id == org_id)
                 .options(
+                    selectinload(Asset.source),  # ty: ignore[invalid-argument-type]
                     selectinload(Asset.resources),  # ty: ignore[invalid-argument-type]
                     selectinload(Asset.destinations).selectinload(Destination.resources),  # ty: ignore[invalid-argument-type]
                 )
@@ -231,14 +235,26 @@ class AssetMixin:
             db_asset = _load_asset_with_relations(session, asset_id)
 
             if db_asset.source_id is not None:
-                # Source-owned: hydrate via parent source and extract
+                # Source-owned: hydrate via parent source and extract. A drifted
+                # parent raises ComponentDriftError from load_source; if the
+                # parent is live but no longer declares this key, the asset key
+                # itself has drifted out of the source.
                 source = self.load_source(db_asset.source_id)
                 for asset in source.assets:
                     if type(asset).key == db_asset.key:
                         return asset
-                raise HydrationError(f"Asset '{db_asset.key}' not found in hydrated source")
+                raise ComponentDriftError(
+                    f"Asset '{db_asset.key}' ({db_asset.id}) is no longer declared "
+                    f"by source '{type(source).key}'; its catalog key has drifted."
+                )
 
-            # Standalone: build spec and reconstruct
+            # Standalone: drift-check then build spec and reconstruct.
+            status = asset_status(self._catalog, db_asset.key)
+            if status is not ComponentStatus.OK:
+                raise ComponentDriftError(
+                    f"Asset '{db_asset.key}' ({db_asset.id}) cannot be hydrated: "
+                    f"its catalog key is {status.value}."
+                )
             spec = self._hydrator.build_asset_spec(session, db_asset)
 
         try:

--- a/packages/interloper-db/src/interloper_db/store/sources.py
+++ b/packages/interloper-db/src/interloper_db/store/sources.py
@@ -6,10 +6,11 @@ from typing import Any, cast
 from uuid import UUID
 
 import interloper as il
-from interloper.errors import CatalogKeyError, HydrationError, SourceNotFoundError
+from interloper.errors import CatalogKeyError, ComponentDriftError, HydrationError, SourceNotFoundError
 from sqlalchemy.orm import selectinload
 from sqlmodel import Session, col, select
 
+from interloper_db.drift import ComponentStatus, resolve_source_cls, source_status
 from interloper_db.engine import get_engine
 from interloper_db.hydration import Hydrator
 from interloper_db.models import (
@@ -320,6 +321,13 @@ class SourceMixin:
             if not db_source:
                 raise SourceNotFoundError(f"Source {source_id} not found")
 
+            status = source_status(self._catalog, db_source.key)
+            if status is not ComponentStatus.OK:
+                raise ComponentDriftError(
+                    f"Source '{db_source.key}' ({db_source.id}) cannot be hydrated: "
+                    f"its catalog key is {status.value}."
+                )
+
             spec = self._hydrator.build_source_spec(session, db_source)
 
         try:
@@ -364,11 +372,12 @@ class SourceMixin:
             )
 
     def _resolve_source_cls(self, key: str) -> type[il.Source]:
-        """Import the source class from the catalog."""
-        from interloper.utils.imports import import_from_path
+        """Import the source class from the catalog (raise-on-miss).
 
-        catalog = self._catalog
-        definition = catalog.get(key)
-        if not definition:
+        Shares the value-based resolver used for drift detection so the write
+        path and the read/status path can never disagree on what resolves.
+        """
+        source_cls = resolve_source_cls(self._catalog, key)
+        if source_cls is None:
             raise CatalogKeyError(f"Unknown source key: {key}")
-        return import_from_path(definition.path)
+        return source_cls

--- a/packages/interloper-db/tests/test_drift.py
+++ b/packages/interloper-db/tests/test_drift.py
@@ -1,0 +1,107 @@
+"""Tests for the catalog-drift resolution primitive (``interloper_db.drift``).
+
+These exercise the pure resolver functions against constructed catalogs — the
+single source of truth that hydration and detection both consume — plus the
+thin ``DriftMixin`` delegation. The ``DemoSource`` fixture is a real catalog
+component, so resolution goes through the actual import path it would in prod.
+"""
+
+from __future__ import annotations
+
+import interloper as il
+import pytest
+from interloper_assets.demo.source import DemoSource
+
+from interloper_db.drift import (
+    ComponentStatus,
+    DriftMixin,
+    asset_status,
+    resolve_source_cls,
+    source_status,
+)
+
+_SOURCE_KEY = DemoSource.key
+_ASSET_KEY = DemoSource.asset_types[0].key
+
+# Enabled = what this deployment exposes; discovered = the full code universe.
+_ENABLED = il.Catalog.from_assets([DemoSource])
+_EMPTY = il.Catalog(components={})
+
+
+# -- source_status ------------------------------------------------------------
+
+
+def test_source_status_ok_when_in_enabled_catalog() -> None:
+    assert source_status(_ENABLED, _SOURCE_KEY, discovered=_EMPTY) is ComponentStatus.OK
+
+
+def test_source_status_disabled_when_in_discovered_but_not_enabled() -> None:
+    # Key exists in code (discovered) but the deployment didn't enable it.
+    assert source_status(_EMPTY, _SOURCE_KEY, discovered=_ENABLED) is ComponentStatus.DISABLED
+
+
+def test_source_status_missing_when_in_neither() -> None:
+    assert source_status(_EMPTY, "gone_from_code", discovered=_EMPTY) is ComponentStatus.MISSING
+
+
+# -- asset_status: standalone -------------------------------------------------
+
+
+def test_standalone_asset_status_resolves_like_a_source() -> None:
+    assert asset_status(_ENABLED, _SOURCE_KEY, discovered=_EMPTY) is ComponentStatus.OK
+    assert asset_status(_EMPTY, "gone", discovered=_EMPTY) is ComponentStatus.MISSING
+
+
+# -- asset_status: source-owned -----------------------------------------------
+
+
+def test_owned_asset_status_ok_when_key_in_source_asset_types() -> None:
+    status = asset_status(_ENABLED, _ASSET_KEY, source_key=_SOURCE_KEY, discovered=_EMPTY)
+    assert status is ComponentStatus.OK
+
+
+def test_owned_asset_status_missing_when_key_drifted_out_of_source() -> None:
+    # Source is live, but the asset key is no longer one of its asset_types.
+    status = asset_status(_ENABLED, "renamed_away", source_key=_SOURCE_KEY, discovered=_EMPTY)
+    assert status is ComponentStatus.MISSING
+
+
+def test_owned_asset_status_cascades_missing_parent() -> None:
+    status = asset_status(_EMPTY, _ASSET_KEY, source_key="gone", discovered=_EMPTY)
+    assert status is ComponentStatus.MISSING
+
+
+def test_owned_asset_status_cascades_disabled_parent() -> None:
+    status = asset_status(_EMPTY, _ASSET_KEY, source_key=_SOURCE_KEY, discovered=_ENABLED)
+    assert status is ComponentStatus.DISABLED
+
+
+# -- resolve_source_cls -------------------------------------------------------
+
+
+def test_resolve_source_cls_returns_class_when_present() -> None:
+    assert resolve_source_cls(_ENABLED, _SOURCE_KEY) is DemoSource
+
+
+def test_resolve_source_cls_returns_none_when_absent() -> None:
+    assert resolve_source_cls(_EMPTY, _SOURCE_KEY) is None
+
+
+# -- DriftMixin delegation ----------------------------------------------------
+
+
+class _Store(DriftMixin):
+    def __init__(self, catalog: il.Catalog) -> None:
+        self._catalog = catalog
+
+
+def test_drift_mixin_delegates_to_resolver() -> None:
+    store = _Store(_ENABLED)
+    assert store.source_status(_SOURCE_KEY) is ComponentStatus.OK
+    assert store.asset_status(_ASSET_KEY, source_key=_SOURCE_KEY) is ComponentStatus.OK
+
+
+@pytest.mark.parametrize("key", ["definitely_not_a_real_component_key"])
+def test_drift_mixin_reports_missing_against_real_universe(key: str) -> None:
+    # No discovered override: resolves against the real installed universe.
+    assert _Store(_EMPTY).source_status(key) is ComponentStatus.MISSING


### PR DESCRIPTION
## Problem

Catalog keys (snake_cased class names) are the only join between **code** (the catalog of Python classes) and **data** (`sources.key` / `assets.key`, stored as bare strings with no FK back). Renaming or removing a class — or a convention refactor like `ads_report` → `ads_stats` — **drifts** those rows: they reference a key the catalog no longer has.

Today drift is silent until something touches a drifted row, and then it's a hard failure: `load_source`/`load_asset` raise an uncaught `CatalogKeyError`/`HydrationError` → **HTTP 500** on a page load or a failed run on every cron tick.

## Approach

Drift is surfaced as a **first-class status on the persisted component**, computed as the *outcome of the resolution step every load already performs* — not a separate scanner. Hydration and detection consume **one resolver**, so they can never disagree (no "detector says healthy but hydration 500s").

Key design points:
- **Tri-state `ComponentStatus`**: `ok` (in enabled catalog) · `disabled` (in `Catalog.discover()` universe but not enabled here — *not* drift) · `missing` (gone from code — this is drift). Resolving against the discovered universe (not just the enabled subset) means a deployment-disabled source is never falsely flagged.
- **Lazy detection**: status falls out of building the API response — no endpoint, no background job, no startup scan. It's a pure function of code + rows, and both only change at request time.
- **Detect, never auto-purge** (per product decision): drift is only surfaced; cleanup stays user-driven via the existing delete (the FK cascade already cleans up). Empty jobs are left alone — a job that hydrates zero assets is a harmless no-op.

## What changed

**Backend**
- `interloper-db/drift.py` (new): `ComponentStatus` + value-based resolver (`source_status` / `asset_status` / `resolve_source_cls`) and a `DriftMixin` on `Store`.
- `ComponentDriftError` (core); `load_source`/`load_asset` pre-check via the resolver and raise it; `_resolve_source_cls` now delegates to the same resolver.
- API: source/asset responses carry `status`; `ComponentDriftError` maps to **409** instead of 500.

**Frontend**
- `ComponentStatus` type + `status` on `Source`/`SourceAsset`/`Asset`; `useDrift()` composable centralising the status→badge mapping and the source rollup (`partial` = live source with ≥1 drifted asset).
- Sources page: red health banner when drift exists + inline drift badge in the name cell. Graph: drift corner badges on source/asset nodes (take precedence over warning badges) + missing-asset card tint + asset-panel alert. Removal reuses the existing delete endpoints.

## Testing

- `interloper-db/tests/test_drift.py` (new, 12 cases) — tri-state resolution, rollup, cascade.
- Backend: `ruff` / `ty` clean, `pytest` green (33 db + 485 api/core).
- Frontend: `pnpm run lint` 0 errors, `nuxt typecheck` exit 0.

## Reviewer notes

- **Cleaning up an asset that drifted out of a *live* source**: there is no single source-owned-asset delete endpoint by design, so the path is re-saving the source via the stepper (sends explicit `asset_keys` → `_ensure_assets` prunes) or deleting the source. The panel alert says as much.
- **Bulk "remove all drift"** is intentionally deferred — per-item removal is in place.