### PR TITLE
feat: redesign the asset graph view (reusable canvas, expand modes, panel, filters)

### DIFF
--- a/packages/interloper-app/app/app/components/graph/AssetGraph.vue
+++ b/packages/interloper-app/app/app/components/graph/AssetGraph.vue
@@ -10,9 +10,13 @@ import { qualifiedKey } from '~/types/catalog'
 const props = withDefaults(defineProps<{
     sourceIds?: string[]
     readonly?: boolean
+    expandMode?: ExpandMode
+    viewMode?: ViewMode
 }>(), {
     sourceIds: undefined,
     readonly: false,
+    expandMode: 'nodes',
+    viewMode: 'topology',
 })
 
 const emit = defineEmits<{
@@ -72,6 +76,8 @@ function onConnect(connection: Connection) {
     <GraphCanvas :model="model"
                  :editable="!readonly"
                  :loading="loading"
+                 :expand-mode="expandMode"
+                 :view-mode="viewMode"
                  :is-valid-connection="isValidConnection"
                  @add-source="emit('add-source')"
                  @edit-source="emit('edit-source', $event)"

--- a/packages/interloper-app/app/app/components/graph/AssetGraph.vue
+++ b/packages/interloper-app/app/app/components/graph/AssetGraph.vue
@@ -12,11 +12,15 @@ const props = withDefaults(defineProps<{
     readonly?: boolean
     expandMode?: ExpandMode
     viewMode?: ViewMode
+    statusFilter?: StatusFilter
+    showNewSourceButton?: boolean
 }>(), {
     sourceIds: undefined,
     readonly: false,
     expandMode: 'nodes',
     viewMode: 'topology',
+    statusFilter: 'all',
+    showNewSourceButton: true,
 })
 
 const emit = defineEmits<{
@@ -58,6 +62,31 @@ function getAssetDefinition(qk: string): AssetDefinition | undefined {
     return catalogStore.getAssetDefinition(qk)
 }
 
+// Filtered model for display (the status filter narrows which sources render).
+const displayModel = computed<GraphModel>(() => {
+    const m = model.value
+    if (props.statusFilter === 'all') return m
+
+    const keep = new Set(
+        m.sources
+            .filter((s) => {
+                const state = s.status?.state ?? 'idle'
+                if (props.statusFilter === 'healthy') return state === 'idle'
+                if (props.statusFilter === 'attention') return state === 'attention'
+                if (props.statusFilter === 'paused') return state === 'paused'
+                return true
+            })
+            .map(s => s.source.id),
+    )
+
+    return {
+        sources: m.sources.filter(s => keep.has(s.source.id)),
+        // Keep standalone assets (no source) regardless of the source filter.
+        assets: m.assets.filter(a => a.source === null || keep.has(a.source.id)),
+        dependencies: m.dependencies,
+    }
+})
+
 const { resolveConnectionPairs, isValidConnection } = useGraphConnectionRules({
     sources,
     assetDependencies,
@@ -73,11 +102,12 @@ function onConnect(connection: Connection) {
 </script>
 
 <template>
-    <GraphCanvas :model="model"
+    <GraphCanvas :model="displayModel"
                  :editable="!readonly"
                  :loading="loading"
                  :expand-mode="expandMode"
                  :view-mode="viewMode"
+                 :show-new-source-button="showNewSourceButton"
                  :is-valid-connection="isValidConnection"
                  @add-source="emit('add-source')"
                  @edit-source="emit('edit-source', $event)"

--- a/packages/interloper-app/app/app/components/graph/AssetGraph.vue
+++ b/packages/interloper-app/app/app/components/graph/AssetGraph.vue
@@ -1,32 +1,18 @@
 <script setup lang="ts">
-import type { ContextMenuItem } from '@nuxt/ui'
-import { VueFlow, useVueFlow, Panel, MarkerType } from '@vue-flow/core'
-import type { Node, Edge, Connection } from '@vue-flow/core'
-import { Background } from '@vue-flow/background'
-import { Controls } from '@vue-flow/controls'
+import type { Connection } from '@vue-flow/core'
+import { qualifiedKey } from '~/types/catalog'
 
+/**
+ * Catalog adapter: binds the store-backed catalog model + dependency-editing
+ * rules to the presentational <GraphCanvas>. Keeps the original props/emits
+ * so the graph page is unaffected.
+ */
 const props = withDefaults(defineProps<{
     sourceIds?: string[]
     readonly?: boolean
 }>(), {
     sourceIds: undefined,
     readonly: false,
-})
-
-const flowId = `asset-graph-${useId()}`
-const vueFlow = useVueFlow(flowId)
-const sourcesStore = useSourcesStore()
-const assetsStore = useAssetsStore()
-const catalogStore = useCatalogStore()
-const { sources: allSources, loading } = storeToRefs(sourcesStore)
-const { dependencies: assetDependencies } = storeToRefs(assetsStore)
-const { layoutDag } = useGraphLayout()
-
-// Filter sources when sourceIds prop is provided
-const sources = computed(() => {
-    if (!props.sourceIds) return allSources.value
-    const ids = new Set(props.sourceIds)
-    return allSources.value.filter(s => ids.has(s.id))
 })
 
 const emit = defineEmits<{
@@ -39,318 +25,34 @@ const emit = defineEmits<{
     'delete-dependency': [payload: { upstreamAssetId: string; downstreamAssetId: string }]
 }>()
 
-// Track which sources are expanded
-const expandedSources = ref(new Set<string>())
+const assetsStore = useAssetsStore()
+const catalogStore = useCatalogStore()
+const sourcesStore = useSourcesStore()
+const { loading } = storeToRefs(sourcesStore)
+const { dependencies: assetDependencies } = storeToRefs(assetsStore)
 
-function toggleSource(sourceId: string) {
-    const next = new Set(expandedSources.value)
-    if (next.has(sourceId)) next.delete(sourceId)
-    else next.add(sourceId)
-    expandedSources.value = next
-}
+const { model } = useCatalogGraph({ sourceIds: () => props.sourceIds })
 
-// Layout constants
-const ASSET_W = 220
-const ASSET_H = 160
-const SRC_PADDING = 26
-const SRC_HEADER_H = 50
-const COLLAPSED_W = 232
-const COLLAPSED_H = 76
+// ── Maps for connection validation/creation (catalog editing only) ──
+const sources = computed(() => model.value.sources.map(e => e.source))
 
-// Actual measured heights from VueFlow's ResizeObserver
-const measuredHeights = ref(new Map<string, number>())
-
-// Clear measured heights for a source's assets when it collapses
-watch(expandedSources, (next, prev) => {
-    for (const sourceId of prev) {
-        if (!next.has(sourceId)) {
-            const source = sources.value.find(s => s.id === sourceId)
-            if (source) {
-                const updated = new Map(measuredHeights.value)
-                for (const asset of source.assets) {
-                    updated.delete(asset.id)
-                }
-                measuredHeights.value = updated
-            }
-        }
-    }
-})
-
-// Standalone assets from the assets store
-const standaloneAssets = computed(() => assetsStore.standalone)
-
-// Asset ID -> Source ID lookup (null for standalone assets)
 const assetToSource = computed(() => {
     const map = new Map<string, string | null>()
-    for (const source of sources.value) {
-        for (const asset of source.assets) {
-            map.set(asset.id, source.id)
-        }
-    }
-    for (const asset of standaloneAssets.value) {
-        map.set(asset.id, null)
-    }
+    for (const e of model.value.assets) map.set(e.asset.id, e.source?.id ?? null)
     return map
 })
 
-// Asset ID -> qualified key ("source_key.asset_key" or bare "key") lookup
 const qualifiedKeyById = computed(() => {
     const map = new Map<string, string>()
-    for (const source of sources.value) {
-        for (const asset of source.assets) {
-            map.set(asset.id, `${source.key}.${asset.key}`)
-        }
-    }
-    for (const asset of standaloneAssets.value) {
-        map.set(asset.id, asset.key)
+    for (const e of model.value.assets) {
+        map.set(e.asset.id, e.source ? qualifiedKey(e.source.key, e.asset.key) : e.asset.key)
     }
     return map
 })
 
-/** Look up an AssetDefinition by qualified key or bare key. */
 function getAssetDefinition(qk: string): AssetDefinition | undefined {
     return catalogStore.getAssetDefinition(qk)
 }
-
-/** Run inner DAG layout for a source's assets. */
-function getInnerLayout(source: Source) {
-    const assetIds = new Set(source.assets.map(a => a.id))
-    const intraEdges = assetDependencies.value
-        .filter(d => assetIds.has(d.asset_id) && assetIds.has(d.upstream_asset_id))
-        .map(d => ({ source: d.upstream_asset_id, target: d.asset_id }))
-
-    const layoutNodes = source.assets.map(a => ({
-        id: a.id,
-        width: ASSET_W,
-        height: measuredHeights.value.get(a.id) ?? ASSET_H,
-    }))
-
-    return layoutDag(layoutNodes, intraEdges)
-}
-
-/** Compute each source node's dimensions. */
-function getSourceDimensions(source: Source): { width: number; height: number } {
-    if (!expandedSources.value.has(source.id)) {
-        return { width: COLLAPSED_W, height: COLLAPSED_H }
-    }
-
-    if (source.assets.length === 0) {
-        return { width: COLLAPSED_W, height: COLLAPSED_H }
-    }
-
-    const dag = getInnerLayout(source)
-
-    return {
-        width: dag.width + SRC_PADDING * 2,
-        height: dag.height + SRC_HEADER_H + SRC_PADDING * 2,
-    }
-}
-
-/** Cross-group edges at the top level (between sources and standalone assets). */
-const topLevelEdges = computed(() => {
-    const seen = new Set<string>()
-    const result: Array<{ source: string; target: string }> = []
-
-    for (const dep of assetDependencies.value) {
-        const downstreamSourceId = assetToSource.value.get(dep.asset_id)
-        const upstreamSourceId = assetToSource.value.get(dep.upstream_asset_id)
-        if (downstreamSourceId === undefined || upstreamSourceId === undefined) continue
-
-        // For top-level layout: use source ID if source-owned, asset ID if standalone
-        const upstreamNode = upstreamSourceId ?? dep.upstream_asset_id
-        const downstreamNode = downstreamSourceId ?? dep.asset_id
-        if (upstreamNode === downstreamNode) continue
-
-        const key = `${upstreamNode}->${downstreamNode}`
-        if (seen.has(key)) continue
-        seen.add(key)
-        result.push({ source: upstreamNode, target: downstreamNode })
-    }
-
-    return result
-})
-
-/** Layout top-level nodes (sources + standalone assets) using DAG layout. */
-const sourceLayout = computed(() => {
-    const layoutNodes = [
-        ...sources.value.map((source) => {
-            const dims = getSourceDimensions(source)
-            return { id: source.id, width: dims.width, height: dims.height }
-        }),
-        ...standaloneAssets.value.map(asset => ({
-            id: asset.id,
-            width: ASSET_W,
-            height: measuredHeights.value.get(asset.id) ?? ASSET_H,
-        })),
-    ]
-
-    return layoutDag(layoutNodes, topLevelEdges.value, { gapX: 60, gapY: 60 })
-})
-
-/** Flat node array: source nodes + asset child nodes + standalone asset nodes. */
-const nodes = computed<Node[]>(() => {
-    const result: Node[] = []
-
-    // Source nodes with their child assets
-    for (const source of sources.value) {
-        const sourceDefn = catalogStore.getSourceDefinition(source.key)
-        const pos = sourceLayout.value.positions.get(source.id) ?? { x: 0, y: 0 }
-        const isExpanded = expandedSources.value.has(source.id)
-        const dims = getSourceDimensions(source)
-
-        result.push({
-            id: source.id,
-            type: 'source',
-            position: { x: pos.x, y: pos.y },
-            width: dims.width,
-            height: dims.height,
-            connectable: !isExpanded,
-            data: {
-                source,
-                sourceDefn,
-                expanded: isExpanded,
-            },
-        })
-
-        if (isExpanded && source.assets.length > 0) {
-            const innerLayout = getInnerLayout(source)
-            for (const asset of source.assets) {
-                const assetDefn = getAssetDefinition(`${source.key}.${asset.key}`)
-                const assetPos = innerLayout.positions.get(asset.id) ?? { x: 0, y: 0 }
-                result.push({
-                    id: asset.id,
-                    type: 'asset',
-                    parentNode: source.id,
-                    extent: 'parent',
-                    position: {
-                        x: assetPos.x + SRC_PADDING,
-                        y: assetPos.y + SRC_HEADER_H + SRC_PADDING,
-                    },
-                    data: { asset, assetDefn, source },
-                    draggable: true,
-                    expandParent: true,
-                    connectable: true,
-                    zIndex: 1,
-                })
-            }
-        }
-    }
-
-    // Standalone asset nodes (top-level, no parent)
-    for (const asset of standaloneAssets.value) {
-        const assetDefn = getAssetDefinition(asset.key)
-        const pos = sourceLayout.value.positions.get(asset.id) ?? { x: 0, y: 0 }
-        result.push({
-            id: asset.id,
-            type: 'asset',
-            position: { x: pos.x, y: pos.y },
-            data: { asset, assetDefn, source: null },
-            draggable: true,
-            connectable: true,
-        })
-    }
-
-    return result
-})
-
-/** Unified edge list from all asset dependencies. */
-const edges = computed<Edge[]>(() => {
-    const result: Edge[] = []
-    const seen = new Set<string>()
-
-    for (const dep of assetDependencies.value) {
-        const upstreamSourceId = assetToSource.value.get(dep.upstream_asset_id)
-        const downstreamSourceId = assetToSource.value.get(dep.asset_id)
-        // Skip if either asset is unknown
-        if (upstreamSourceId === undefined || downstreamSourceId === undefined) continue
-
-        // Standalone assets (null source) are always "expanded" — they're top-level nodes
-        const upstreamIsStandalone = upstreamSourceId === null
-        const downstreamIsStandalone = downstreamSourceId === null
-        const upstreamExpanded = upstreamIsStandalone || expandedSources.value.has(upstreamSourceId!)
-        const downstreamExpanded = downstreamIsStandalone || expandedSources.value.has(downstreamSourceId!)
-        const isSameSource = upstreamSourceId !== null
-            && downstreamSourceId !== null
-            && upstreamSourceId === downstreamSourceId
-
-        if (isSameSource) {
-            if (upstreamExpanded) {
-                result.push({
-                    id: `asset:${dep.upstream_asset_id}->${dep.asset_id}`,
-                    type: 'dependency',
-                    source: dep.upstream_asset_id,
-                    target: dep.asset_id,
-                    animated: true,
-                    markerEnd: MarkerType.ArrowClosed,
-                    zIndex: 1002,
-                })
-            }
-        }
-        else {
-            const edgeSource = upstreamExpanded ? dep.upstream_asset_id : upstreamSourceId!
-            const edgeTarget = downstreamExpanded ? dep.asset_id : downstreamSourceId!
-            const sourceHandle = upstreamExpanded ? undefined : 'source-source'
-            const targetHandle = downstreamExpanded ? undefined : 'source-target'
-
-            const key = `${edgeSource}->${edgeTarget}`
-            if (seen.has(key)) continue
-            seen.add(key)
-
-            result.push({
-                id: key,
-                type: 'dependency',
-                source: edgeSource,
-                target: edgeTarget,
-                sourceHandle,
-                targetHandle,
-                animated: true,
-                markerEnd: MarkerType.ArrowClosed,
-                zIndex: 1002,
-            })
-        }
-    }
-
-    return result
-})
-
-function onNodeClick({ node }: { node: Node }) {
-    if (node.type === 'source') {
-        toggleSource(node.id)
-    }
-    else if (node.type === 'asset') {
-        emit('asset-click', node.data.asset, node.data.assetDefn, node.data.source)
-    }
-}
-
-async function onDeleteSource(sourceId: string) {
-    if (props.readonly) return
-    emit('delete-source', sourceId)
-    const next = new Set(expandedSources.value)
-    next.delete(sourceId)
-    expandedSources.value = next
-}
-
-vueFlow.onNodesInitialized(() => {
-    const heights = new Map(measuredHeights.value)
-    let changed = false
-    for (const graphNode of vueFlow.getNodes.value) {
-        if (graphNode.type === 'asset' && graphNode.dimensions.height > 0) {
-            const prev = heights.get(graphNode.id)
-            if (prev !== graphNode.dimensions.height) {
-                heights.set(graphNode.id, graphNode.dimensions.height)
-                changed = true
-            }
-        }
-    }
-    if (changed) {
-        measuredHeights.value = heights
-    }
-
-    vueFlow.fitView({ padding: 0.25 })
-    vueFlow.zoomTo(1)
-})
-
-// ── Connection validation & creation ──
 
 const { resolveConnectionPairs, isValidConnection } = useGraphConnectionRules({
     sources,
@@ -362,186 +64,20 @@ const { resolveConnectionPairs, isValidConnection } = useGraphConnectionRules({
 
 function onConnect(connection: Connection) {
     if (props.readonly) return
-    const pairs = resolveConnectionPairs(connection)
-    emit('create-dependencies', pairs)
-}
-
-provide('isValidConnection', isValidConnection)
-provide('graphReadonly', toRef(() => props.readonly))
-
-// Provide empty materializing set for now (can be wired up later)
-const materializingAssetIds = computed(() => new Set<string>())
-provide('materializingAssetIds', materializingAssetIds)
-
-// ── Edge context menu ──
-const edgeMenuOpen = ref(false)
-const edgeMenuVirtual = ref({ getBoundingClientRect: () => new DOMRect() })
-const edgeMenuEdge = ref<{ source: string; target: string } | null>(null)
-
-const { confirm } = useConfirm()
-
-const edgeMenuItems = computed<ContextMenuItem[][]>(() => {
-    const edge = edgeMenuEdge.value
-    if (!edge) return []
-    return [
-        [
-            {
-                label: 'Delete dependency',
-                icon: 'i-lucide-trash',
-                color: 'error' as const,
-                onSelect: async () => {
-                    const confirmed = await confirm({
-                        title: 'Delete dependency',
-                        description: 'This will remove the dependency between these assets. This action cannot be undone.',
-                    })
-                    if (confirmed) {
-                        emit('delete-dependency', {
-                            downstreamAssetId: edge.target,
-                            upstreamAssetId: edge.source,
-                        })
-                    }
-                },
-            },
-        ],
-    ]
-})
-
-// ── Pane context menu ──
-const paneMenuOpen = ref(false)
-const paneMenuVirtual = ref({ getBoundingClientRect: () => new DOMRect() })
-
-const paneMenuItems = computed<ContextMenuItem[][]>(() => [
-    [
-        {
-            label: 'Expand all',
-            icon: 'i-lucide-maximize-2',
-            onSelect: () => {
-                expandedSources.value = new Set(sources.value.map(s => s.id))
-            },
-        },
-        {
-            label: 'Collapse all',
-            icon: 'i-lucide-minimize-2',
-            onSelect: () => {
-                expandedSources.value = new Set()
-            },
-        },
-        {
-            label: 'Fit view',
-            icon: 'i-lucide-scan',
-            onSelect: () => {
-                vueFlow.fitView({ padding: 0.25 })
-            },
-        },
-    ],
-])
-
-function onPaneContextMenu(event: MouseEvent) {
-    event.preventDefault()
-
-    const { clientX: x, clientY: y } = event
-    paneMenuVirtual.value = {
-        getBoundingClientRect: () => new DOMRect(x, y, 0, 0),
-    }
-    paneMenuOpen.value = true
-}
-
-function onEdgeContextMenu({ edge, event }: { edge: Edge; event: MouseEvent | TouchEvent }) {
-    event.preventDefault()
-    event.stopPropagation()
-
-    if (props.readonly) return
-    if (!('clientX' in event)) return
-
-    // Only allow delete on asset-to-asset edges (not source-level collapsed edges)
-    const isSourceAsset = assetToSource.value.has(edge.source) || standaloneAssets.value.some(a => a.id === edge.source)
-    const isTargetAsset = assetToSource.value.has(edge.target) || standaloneAssets.value.some(a => a.id === edge.target)
-    if (!isSourceAsset || !isTargetAsset) return
-
-    edgeMenuEdge.value = { source: edge.source, target: edge.target }
-
-    const { clientX: x, clientY: y } = event
-    edgeMenuVirtual.value = {
-        getBoundingClientRect: () => new DOMRect(x, y, 0, 0),
-    }
-    edgeMenuOpen.value = true
+    emit('create-dependencies', resolveConnectionPairs(connection))
 }
 </script>
 
 <template>
-    <div class="relative flex-1 min-h-0 w-full">
-        <VueFlow :id="flowId"
-                 :nodes="nodes"
-                 :edges="edges"
-                 fit-view
-                 class="!absolute inset-0"
-                 :max-zoom="1"
-                 :min-zoom="0.6"
-                 snap-to-grid
-                 :nodes-draggable="true"
-                 :select-nodes-on-drag="false"
-                 :connection-radius="80"
-                 :auto-connect="false"
-                 @node-click="onNodeClick"
+    <GraphCanvas :model="model"
+                 :editable="!readonly"
+                 :loading="loading"
+                 :is-valid-connection="isValidConnection"
+                 @add-source="emit('add-source')"
+                 @edit-source="emit('edit-source', $event)"
+                 @asset-click="(a, d, s) => emit('asset-click', a, d, s)"
+                 @delete-source="emit('delete-source', $event)"
                  @connect="onConnect"
-                 @edge-context-menu="onEdgeContextMenu"
-                 @pane-click="emit('pane-click')"
-                 @pane-context-menu="onPaneContextMenu">
-            <template #node-source="{ data }">
-                <GraphSourceNode :source="data.source"
-                                 :source-defn="data.sourceDefn"
-                                 :expanded="data.expanded"
-                                 @edit="emit('edit-source', $event)"
-                                 @delete="onDeleteSource" />
-            </template>
-            <template #node-asset="{ data }">
-                <GraphAssetNode :asset="data.asset"
-                                :asset-defn="data.assetDefn"
-                                @view="emit('asset-click', data.asset, data.assetDefn, data.source)" />
-            </template>
-            <template #edge-dependency="edgeProps">
-                <GraphDependencyEdge v-bind="edgeProps" />
-            </template>
-            <Background :size=".8" />
-            <Controls position="bottom-left"
-                      :show-interactive="false" />
-
-            <Panel v-if="!props.readonly && sources.length === 0"
-                   position="top-left"
-                   class="!inset-0 !m-0 flex items-center justify-center pointer-events-none">
-                <UButton icon="i-lucide-plus"
-                         label="Add your first source"
-                         size="lg"
-                         class="pointer-events-auto"
-                         @click="emit('add-source')" />
-            </Panel>
-            <Panel v-else-if="!props.readonly"
-                   position="top-center"
-                   class="!m-4">
-                <UButton icon="i-lucide-plus"
-                         label="New Source"
-                         @click="emit('add-source')" />
-            </Panel>
-        </VueFlow>
-
-        <div v-if="loading"
-             class="absolute inset-0 z-50 flex items-center justify-center bg-default/50">
-            <UIcon name="i-lucide-loader-circle"
-                   class="size-8 text-muted animate-spin" />
-        </div>
-
-        <UDropdownMenu v-model:open="edgeMenuOpen"
-                       :items="edgeMenuItems"
-                       :modal="false"
-                       :content="{ reference: edgeMenuVirtual, side: 'bottom', align: 'start', sideOffset: 4 }">
-            <div class="hidden" />
-        </UDropdownMenu>
-
-        <UDropdownMenu v-model:open="paneMenuOpen"
-                       :items="paneMenuItems"
-                       :modal="false"
-                       :content="{ reference: paneMenuVirtual, side: 'bottom', align: 'start', sideOffset: 4 }">
-            <div class="hidden" />
-        </UDropdownMenu>
-    </div>
+                 @delete-dependency="emit('delete-dependency', $event)"
+                 @pane-click="emit('pane-click')" />
 </template>

--- a/packages/interloper-app/app/app/components/graph/AssetNode.vue
+++ b/packages/interloper-app/app/app/components/graph/AssetNode.vue
@@ -6,6 +6,9 @@ import type { Connection } from '@vue-flow/core'
 const props = defineProps<{
     asset: SourceAsset
     assetDefn: AssetDefinition | undefined
+    /** Derived node status (used by the Status view mode; see Phase 3). */
+    status?: NodeStatus
+    viewMode?: ViewMode
 }>()
 
 const emit = defineEmits<{

--- a/packages/interloper-app/app/app/components/graph/AssetNode.vue
+++ b/packages/interloper-app/app/app/components/graph/AssetNode.vue
@@ -210,35 +210,27 @@ const contextMenuItems = computed<ContextMenuItem[][]>(() => {
                 </UTooltip>
             </div>
 
-            <UCard variant="outline"
-                   class="rounded-xl !bg-muted"
-                   :class="statusRing"
-                   :ui="{ header: '!px-4 !py-3 !bg-elevated', body: '!px-4 !py-4 border-0', footer: '!px-4 !py-0 !pb-3' }">
-                <template #header>
-                    <div class="flex items-center gap-2">
+            <div class="overflow-hidden rounded-xl border border-[var(--ui-border-accented)] bg-muted shadow-[0_10px_30px_-10px_rgba(0,0,0,0.55)]"
+                 :class="statusRing">
+                <div class="flex items-center gap-2.5 px-3.5 py-3">
+                    <div class="flex size-9 shrink-0 items-center justify-center rounded-lg bg-elevated">
                         <UIcon :name="icon"
-                               class="size-6 shrink-0" />
-                        <span class="truncate text-sm font-semibold">{{ label }}</span>
+                               class="size-5 text-muted" />
                     </div>
-                </template>
-
-                <p v-if="description"
-                   class="line-clamp-2 text-xs leading-snug text-muted">
+                    <div class="min-w-0 flex-1">
+                        <div class="truncate text-sm font-semibold text-highlighted">{{ label }}</div>
+                        <div v-if="tags.length"
+                             class="truncate text-xs text-muted">{{ tags.join(' · ') }}</div>
+                    </div>
+                    <span v-if="status"
+                          class="size-2 shrink-0 rounded-full"
+                          :class="statusDotClass(status.state)" />
+                </div>
+                <div v-if="description"
+                     class="line-clamp-2 border-t border-[var(--ui-border-accented)] bg-default px-3.5 py-2.5 text-xs leading-snug text-muted">
                     {{ description }}
-                </p>
-
-                <template v-if="tags.length"
-                          #footer>
-                    <div class="flex flex-wrap gap-1">
-                        <UBadge v-for="tag in tags"
-                                :key="tag"
-                                variant="subtle"
-                                size="sm">
-                            {{ tag }}
-                        </UBadge>
-                    </div>
-                </template>
-            </UCard>
+                </div>
+            </div>
 
             <Handle v-if="showSourceHandle"
                     type="source"

--- a/packages/interloper-app/app/app/components/graph/AssetNode.vue
+++ b/packages/interloper-app/app/app/components/graph/AssetNode.vue
@@ -6,9 +6,11 @@ import type { Connection } from '@vue-flow/core'
 const props = defineProps<{
     asset: SourceAsset
     assetDefn: AssetDefinition | undefined
-    /** Derived node status (used by the Status view mode; see Phase 3). */
+    /** Derived node status (used by the Status view mode). */
     status?: NodeStatus
     viewMode?: ViewMode
+    /** VueFlow selection state — drives the blue selection ring. */
+    selected?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -90,9 +92,11 @@ const isRunnable = computed(() => {
 const showTargetHandle = computed(() => hasUpstream.value || !isRunnable.value || isValidTarget.value)
 const showSourceHandle = computed(() => hasDownstream.value || isValidSource.value)
 
-const statusRing = computed(() =>
-    props.viewMode === 'status' && props.status ? statusRingClass(props.status.state) : '',
-)
+const ringClass = computed(() => {
+    if (props.selected) return 'ring-2 ring-primary'
+    if (props.viewMode === 'status' && props.status) return statusRingClass(props.status.state)
+    return ''
+})
 
 const contextMenuItems = computed<ContextMenuItem[][]>(() => {
     const items: ContextMenuItem[][] = [
@@ -211,7 +215,7 @@ const contextMenuItems = computed<ContextMenuItem[][]>(() => {
             </div>
 
             <div class="overflow-hidden rounded-xl border border-[var(--ui-border-accented)] bg-muted shadow-[0_10px_30px_-10px_rgba(0,0,0,0.55)]"
-                 :class="statusRing">
+                 :class="ringClass">
                 <div class="flex items-center gap-2.5 px-3.5 py-3">
                     <div class="flex size-9 shrink-0 items-center justify-center rounded-lg bg-elevated">
                         <UIcon :name="icon"
@@ -222,9 +226,6 @@ const contextMenuItems = computed<ContextMenuItem[][]>(() => {
                         <div v-if="tags.length"
                              class="truncate text-xs text-muted">{{ tags.join(' · ') }}</div>
                     </div>
-                    <span v-if="status"
-                          class="size-2 shrink-0 rounded-full"
-                          :class="statusDotClass(status.state)" />
                 </div>
                 <div v-if="description"
                      class="line-clamp-2 border-t border-[var(--ui-border-accented)] bg-default px-3.5 py-2.5 text-xs leading-snug text-muted">

--- a/packages/interloper-app/app/app/components/graph/AssetNode.vue
+++ b/packages/interloper-app/app/app/components/graph/AssetNode.vue
@@ -90,6 +90,10 @@ const isRunnable = computed(() => {
 const showTargetHandle = computed(() => hasUpstream.value || !isRunnable.value || isValidTarget.value)
 const showSourceHandle = computed(() => hasDownstream.value || isValidSource.value)
 
+const statusRing = computed(() =>
+    props.viewMode === 'status' && props.status ? statusRingClass(props.status.state) : '',
+)
+
 const contextMenuItems = computed<ContextMenuItem[][]>(() => {
     const items: ContextMenuItem[][] = [
         [
@@ -208,6 +212,7 @@ const contextMenuItems = computed<ContextMenuItem[][]>(() => {
 
             <UCard variant="outline"
                    class="rounded-xl !bg-muted"
+                   :class="statusRing"
                    :ui="{ header: '!px-4 !py-3 !bg-elevated', body: '!px-4 !py-4 border-0', footer: '!px-4 !py-0 !pb-3' }">
                 <template #header>
                     <div class="flex items-center gap-2">

--- a/packages/interloper-app/app/app/components/graph/AssetPanel.vue
+++ b/packages/interloper-app/app/app/components/graph/AssetPanel.vue
@@ -135,24 +135,28 @@ function formatType(type?: string, format?: string): string {
 // ── Latest materialization + schedule ───────────────────────────
 const { jobsForSource } = useSchedule()
 
-// Latest run of the job that materialises this asset (per-job — the closest
-// real signal). Fetched directly to avoid clobbering the runs store.
-const latestRun = ref<Run | undefined>()
+// Recent runs of the job that materialises this asset (newest first, max 7).
+// Fetched directly to avoid clobbering the runs store.
+const recentRuns = ref<Run[]>([])
 
-async function fetchLatestRun() {
+async function fetchRecentRuns() {
     const job = jobsForSource(props.source)[0]
     if (!job) {
-        latestRun.value = undefined
+        recentRuns.value = []
         return
     }
     try {
-        latestRun.value = (await apiFetch<Run[]>(`/runs?job_id=${job.id}&limit=1`))[0]
+        recentRuns.value = await apiFetch<Run[]>(`/runs?job_id=${job.id}&limit=7`)
     }
     catch {
-        latestRun.value = undefined
+        recentRuns.value = []
     }
 }
-watch(() => props.asset.id, fetchLatestRun, { immediate: true })
+watch(() => props.asset.id, fetchRecentRuns, { immediate: true })
+
+const latestRun = computed(() => recentRuns.value[0])
+/** Oldest → newest, for the materialization history heatmap. */
+const history = computed(() => [...recentRuns.value].reverse())
 
 const lastRunText = computed(() => {
     const at = latestRun.value?.completed_at ?? latestRun.value?.started_at
@@ -178,6 +182,17 @@ const materializationMeta = computed(() => {
     const head = lastRunText.value ? `Last run ${lastRunText.value}` : 'Not yet materialized'
     return jobName.value ? `${head} · ${jobName.value}` : head
 })
+
+/** Heatmap cell colour for a run status. */
+function heatColor(status: string): string {
+    const color = statusColor(status)
+    return color === 'neutral' ? 'var(--ui-text-dimmed)' : `var(--ui-${color})`
+}
+
+function historyTooltip(run: Run): string {
+    const elapsed = formatElapsed(run.started_at, run.completed_at)
+    return `${statusLabel(run.status)}${elapsed ? ` · ${elapsed}` : ''} · ${formatDate(run.started_at)}`
+}
 
 /** Upstream dependencies as display rows (param → resolved upstream asset). */
 const dependencyRows = computed(() => {
@@ -222,22 +237,45 @@ const dependencyRows = computed(() => {
         </div>
 
         <div class="flex-1 min-h-0 border-l border-t border-default overflow-auto">
-            <!-- Latest materialization -->
-            <div class="border-b border-default px-5 py-4">
-                <div class="mb-2 text-xs font-semibold uppercase tracking-wide text-muted">Latest materialization</div>
-                <UCard :ui="{ body: 'flex items-center gap-4 !p-4' }">
-                    <UIcon :name="materialization.icon"
-                           class="size-10 shrink-0"
-                           :class="[materialization.color, materialization.spin && 'animate-spin']" />
-                    <div class="min-w-0 flex-1">
-                        <div class="text-sm font-medium"
-                             :class="materialization.color">
-                            {{ materialization.label }}
-                        </div>
-                        <div class="truncate text-xs text-muted">{{ materializationMeta }}</div>
+            <!-- Materialization -->
+            <UCollapsible default-open
+                          class="border-b border-default">
+                <button class="flex items-center gap-2 w-full px-5 py-4.5 group cursor-pointer">
+                    <UIcon name="i-lucide-chevron-right"
+                           class="size-3.5 shrink-0 text-dimmed group-data-[state=open]:rotate-90 transition-transform duration-200" />
+                    <span class="text-xs font-semibold text-muted uppercase tracking-wide">Materialization</span>
+                </button>
+
+                <template #content>
+                    <div class="px-5 pb-4 flex flex-col gap-2">
+                        <!-- Latest materialization -->
+                        <UCard :ui="{ body: 'flex items-center gap-4 !p-4' }">
+                            <UIcon :name="materialization.icon"
+                                   class="size-10 shrink-0"
+                                   :class="[materialization.color, materialization.spin && 'animate-spin']" />
+                            <div class="min-w-0 flex-1">
+                                <div class="text-sm font-medium text-highlighted">
+                                    Latest materialization: <span :class="materialization.color">{{ materialization.label }}</span>
+                                </div>
+                                <div class="truncate text-xs text-muted">{{ materializationMeta }}</div>
+                            </div>
+                        </UCard>
+
+                        <!-- History heatmap (max last 7 runs) -->
+                        <UCard v-if="history.length"
+                               :ui="{ body: '!p-4' }">
+                            <div class="mb-2.5 text-xs font-medium text-muted">Materialization history</div>
+                            <div class="flex gap-1.5">
+                                <div v-for="run in history"
+                                     :key="run.id"
+                                     class="size-7 rounded-md"
+                                     :style="{ backgroundColor: heatColor(run.status) }"
+                                     :title="historyTooltip(run)" />
+                            </div>
+                        </UCard>
                     </div>
-                </UCard>
-            </div>
+                </template>
+            </UCollapsible>
 
             <!-- Description -->
             <UCollapsible default-open

--- a/packages/interloper-app/app/app/components/graph/AssetPanel.vue
+++ b/packages/interloper-app/app/app/components/graph/AssetPanel.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 import type { JsonSchemaProperty } from '~/types/catalog'
+import { parseQualifiedKey } from '~/types/catalog'
+import type { Run } from '~/types/run'
 
 const props = defineProps<{
     asset: SourceAsset
@@ -129,6 +131,107 @@ function formatType(type?: string, format?: string): string {
     if (format === 'uri') return 'uri'
     return type
 }
+
+// ── Status hero, metric tiles & recent runs ─────────────────────
+const { getSourceSchedule, jobsForSource } = useSchedule()
+const { getWarnings } = useAssetWarnings()
+
+const schedule = computed(() => getSourceSchedule(props.source))
+const assetWarnings = computed(() => getWarnings(props.asset.id, props.asset.key))
+const hasRequires = computed(() => Object.keys(props.assetDefn?.requires ?? {}).length > 0)
+
+/** Cadence shown in the Refresh tile — adapted to the data we actually have. */
+const refreshLabel = computed(() => {
+    if (schedule.value?.paused) return 'Paused'
+    if (schedule.value) return schedule.value.label
+    if (hasRequires.value) return 'On dependencies'
+    return 'Manual'
+})
+
+// Recent runs of the job that materialises this asset (per-job, not per-asset —
+// the closest real signal). Fetched directly to avoid clobbering the runs store.
+const recentRuns = ref<Run[]>([])
+
+async function fetchRecentRuns() {
+    const job = jobsForSource(props.source)[0]
+    if (!job) {
+        recentRuns.value = []
+        return
+    }
+    try {
+        recentRuns.value = await apiFetch<Run[]>(`/runs?job_id=${job.id}&limit=14`)
+    }
+    catch {
+        recentRuns.value = []
+    }
+}
+watch(() => props.asset.id, fetchRecentRuns, { immediate: true })
+
+/** API returns newest first. */
+const latestRun = computed(() => recentRuns.value[0])
+/** Oldest → newest for the sparkline. */
+const sparklineRuns = computed(() => [...recentRuns.value].reverse())
+
+const lastRunText = computed(() => {
+    const at = latestRun.value?.completed_at ?? latestRun.value?.started_at
+    return at ? `${timeSince(new Date(at))} ago` : null
+})
+
+const statusChip = computed<{ label: string; color: 'success' | 'error' | 'info' | 'warning' | 'neutral' }>(() => {
+    if (latestRun.value) return { label: statusLabel(latestRun.value.status), color: statusColor(latestRun.value.status) }
+    if (assetWarnings.value.length > 0) return { label: 'Attention', color: 'warning' }
+    return { label: 'No runs yet', color: 'neutral' }
+})
+
+const compactNumber = new Intl.NumberFormat('en', { notation: 'compact', maximumFractionDigits: 1 })
+
+/** Rows = sum of partition row counts when available, else null (we have no total-row endpoint). */
+const rowsLabel = computed(() => {
+    if (!partitionData.value.length) return null
+    return compactNumber.format(partitionData.value.reduce((s, p) => s + p.rowCount, 0))
+})
+const columnsLabel = computed(() => schemaFields.value.length || null)
+
+/** Upstream dependencies as display rows (param → resolved upstream asset). */
+const dependencyRows = computed(() => {
+    const reqs = props.assetDefn?.requires ?? {}
+    return Object.entries(reqs).map(([param, qk]) => {
+        const { sourceKey } = parseQualifiedKey(qk)
+        return {
+            param,
+            qk,
+            name: catalogStore.getAssetDefinition(qk)?.name ?? qk,
+            icon: componentIcon(sourceKey || qk),
+            sourceKey,
+        }
+    })
+})
+
+function barColor(status: string): string {
+    return `var(--ui-${statusColor(status)})`
+}
+
+const maxDurationMs = computed(() => {
+    let max = 0
+    for (const r of recentRuns.value) {
+        if (r.started_at && r.completed_at) {
+            max = Math.max(max, new Date(r.completed_at).getTime() - new Date(r.started_at).getTime())
+        }
+    }
+    return max
+})
+
+/** Bar height encodes run duration (min 30%); flat for in-flight/unknown. */
+function barHeight(run: Run): string {
+    if (!run.started_at || !run.completed_at || maxDurationMs.value === 0) return '100%'
+    const d = new Date(run.completed_at).getTime() - new Date(run.started_at).getTime()
+    return `${Math.round(30 + 70 * (d / maxDurationMs.value))}%`
+}
+
+function barTooltip(run: Run): string {
+    const elapsed = formatElapsed(run.started_at, run.completed_at)
+    return `${statusLabel(run.status)}${elapsed ? ` · ${elapsed}` : ''} · ${formatDate(run.started_at)}`
+}
 </script>
 
 <template>
@@ -158,6 +261,48 @@ function formatType(type?: string, format?: string): string {
         </div>
 
         <div class="flex-1 min-h-0 border-l border-t border-default overflow-auto">
+            <!-- Status hero + metric tiles + recent runs -->
+            <div class="space-y-4 border-b border-default px-5 py-4">
+                <div class="flex items-center gap-2">
+                    <UBadge :color="statusChip.color"
+                            variant="subtle"
+                            class="capitalize">
+                        {{ statusChip.label }}
+                    </UBadge>
+                    <span v-if="lastRunText"
+                          class="text-xs text-muted">Last run {{ lastRunText }}</span>
+                </div>
+
+                <div class="grid grid-cols-3 gap-2">
+                    <div class="rounded-lg bg-muted px-3 py-2">
+                        <div class="text-[10px] uppercase tracking-wide text-dimmed">Rows</div>
+                        <div class="text-sm font-semibold">{{ rowsLabel ?? '—' }}</div>
+                    </div>
+                    <div class="rounded-lg bg-muted px-3 py-2">
+                        <div class="text-[10px] uppercase tracking-wide text-dimmed">Columns</div>
+                        <div class="text-sm font-semibold">{{ columnsLabel ?? '—' }}</div>
+                    </div>
+                    <div class="min-w-0 rounded-lg bg-muted px-3 py-2">
+                        <div class="text-[10px] uppercase tracking-wide text-dimmed">Refresh</div>
+                        <div class="truncate text-sm font-semibold"
+                             :title="refreshLabel">
+                            {{ refreshLabel }}
+                        </div>
+                    </div>
+                </div>
+
+                <div v-if="sparklineRuns.length">
+                    <div class="mb-1.5 text-[10px] uppercase tracking-wide text-dimmed">Recent runs</div>
+                    <div class="flex h-10 items-end gap-1">
+                        <div v-for="run in sparklineRuns"
+                             :key="run.id"
+                             class="min-w-[3px] flex-1 rounded-sm"
+                             :style="{ height: barHeight(run), backgroundColor: barColor(run.status) }"
+                             :title="barTooltip(run)" />
+                    </div>
+                </div>
+            </div>
+
             <!-- Description -->
             <UCollapsible default-open
                           class="border-b border-default">
@@ -220,39 +365,37 @@ function formatType(type?: string, format?: string): string {
             </UCollapsible>
 
             <!-- Dependencies -->
-            <UCollapsible v-if="assetDefn?.requires && Object.keys(assetDefn.requires).length > 0"
+            <UCollapsible v-if="dependencyRows.length"
                           default-open
                           class="border-b border-default">
                 <button class="flex items-center gap-2 w-full px-5 py-4.5 group cursor-pointer">
                     <UIcon name="i-lucide-chevron-right"
                            class="size-3.5 shrink-0 text-dimmed group-data-[state=open]:rotate-90 transition-transform duration-200" />
-                    <span class="text-xs font-semibold text-muted uppercase tracking-wide">Dependencies</span>
+                    <span class="text-xs font-semibold text-muted uppercase tracking-wide">Upstream dependencies</span>
                     <UBadge color="neutral"
                             variant="subtle"
                             class="ml-auto">
-                        {{ Object.keys(assetDefn.requires).length }}
+                        {{ dependencyRows.length }}
                     </UBadge>
                 </button>
 
                 <template #content>
-                    <div class="px-5 pb-4">
-                        <div class="bg-muted rounded-md p-2">
-                            <table class="w-full text-sm">
-                                <thead>
-                                    <tr class="border-b border-default text-left text-xs text-muted">
-                                        <th class="p-1.5 font-medium">Parameter</th>
-                                        <th class="p-1.5 font-medium">Asset</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    <tr v-for="(assetKey, param) in assetDefn.requires"
-                                        :key="param"
-                                        class="border-b border-default last:border-0">
-                                        <td class="p-1.5 font-mono text-xs">{{ param }}</td>
-                                        <td class="p-1.5 text-xs">{{ assetKey }}</td>
-                                    </tr>
-                                </tbody>
-                            </table>
+                    <div class="px-5 pb-4 flex flex-col gap-1.5">
+                        <div v-for="dep in dependencyRows"
+                             :key="dep.param"
+                             class="flex items-center gap-2.5 rounded-md bg-muted px-3 py-2">
+                            <UIcon :name="dep.icon"
+                                   class="size-4 shrink-0 text-muted" />
+                            <div class="min-w-0 flex-1">
+                                <div class="truncate text-sm">{{ dep.name }}</div>
+                                <div class="truncate font-mono text-xs text-dimmed">{{ dep.qk }}</div>
+                            </div>
+                            <UBadge color="neutral"
+                                    variant="subtle"
+                                    size="sm"
+                                    class="shrink-0 font-mono">
+                                {{ dep.param }}
+                            </UBadge>
                         </div>
                     </div>
                 </template>

--- a/packages/interloper-app/app/app/components/graph/AssetPanel.vue
+++ b/packages/interloper-app/app/app/components/graph/AssetPanel.vue
@@ -300,40 +300,48 @@ const dependencyRows = computed(() => {
                 </template>
             </UCollapsible>
 
-            <!-- Destinations -->
-            <UCollapsible default-open
+            <!-- Schema -->
+            <UCollapsible v-if="schemaFields.length"
+                          default-open
                           class="border-b border-default">
                 <button class="flex items-center gap-2 w-full px-5 py-4.5 group cursor-pointer">
                     <UIcon name="i-lucide-chevron-right"
                            class="size-3.5 shrink-0 text-dimmed group-data-[state=open]:rotate-90 transition-transform duration-200" />
-                    <span class="text-xs font-semibold text-muted uppercase tracking-wide">Destinations</span>
-                    <UBadge v-if="destinations.length"
-                            color="neutral"
+                    <span class="text-xs font-semibold text-muted uppercase tracking-wide">Schema</span>
+                    <UBadge color="neutral"
                             variant="subtle"
                             class="ml-auto">
-                        {{ destinations.length }}
+                        {{ schemaFields.length }}
                     </UBadge>
                 </button>
 
                 <template #content>
                     <div class="px-5 pb-4">
-                        <div v-if="destinations.length"
-                             class="flex flex-col gap-2">
-                            <UCard v-for="dest in destinations"
-                                   :key="dest.id"
-                                   :ui="{ body: 'flex items-center gap-4 !p-4' }">
-                                <UIcon :name="dest.icon"
-                                       class="size-10 shrink-0" />
-                                <div class="min-w-0 flex-1">
-                                    <div class="text-sm font-medium">{{ dest.label }}</div>
-                                    <div class="text-xs text-muted">{{ dest.key }}</div>
-                                </div>
-                            </UCard>
+                        <div class="bg-muted rounded-md p-2 overflow-x-auto">
+                            <table class="w-full text-sm">
+                                <thead>
+                                    <tr class="border-b border-default text-left text-xs text-muted">
+                                        <th class="p-1.5 font-medium whitespace-nowrap">Name</th>
+                                        <th class="p-1.5 font-medium whitespace-nowrap">Type</th>
+                                        <th class="p-1.5 font-medium whitespace-nowrap">Description</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr v-for="field in schemaFields"
+                                        :key="field.name"
+                                        class="border-b border-default last:border-0">
+                                        <td class="p-1.5 font-mono text-xs whitespace-nowrap">{{ field.name }}</td>
+                                        <td class="p-1.5 whitespace-nowrap">
+                                            <UBadge color="neutral"
+                                                    variant="subtle">
+                                                {{ field.type }}
+                                            </UBadge>
+                                        </td>
+                                        <td class="p-1.5 text-muted whitespace-nowrap">{{ field.description }}</td>
+                                    </tr>
+                                </tbody>
+                            </table>
                         </div>
-                        <p v-else
-                           class="text-sm text-dimmed italic">
-                            No destinations configured
-                        </p>
                     </div>
                 </template>
             </UCollapsible>
@@ -371,6 +379,44 @@ const dependencyRows = computed(() => {
                                 {{ dep.param }}
                             </UBadge>
                         </div>
+                    </div>
+                </template>
+            </UCollapsible>
+
+            <!-- Destinations -->
+            <UCollapsible default-open
+                          class="border-b border-default">
+                <button class="flex items-center gap-2 w-full px-5 py-4.5 group cursor-pointer">
+                    <UIcon name="i-lucide-chevron-right"
+                           class="size-3.5 shrink-0 text-dimmed group-data-[state=open]:rotate-90 transition-transform duration-200" />
+                    <span class="text-xs font-semibold text-muted uppercase tracking-wide">Destinations</span>
+                    <UBadge v-if="destinations.length"
+                            color="neutral"
+                            variant="subtle"
+                            class="ml-auto">
+                        {{ destinations.length }}
+                    </UBadge>
+                </button>
+
+                <template #content>
+                    <div class="px-5 pb-4">
+                        <div v-if="destinations.length"
+                             class="flex flex-col gap-2">
+                            <UCard v-for="dest in destinations"
+                                   :key="dest.id"
+                                   :ui="{ body: 'flex items-center gap-4 !p-4' }">
+                                <UIcon :name="dest.icon"
+                                       class="size-10 shrink-0" />
+                                <div class="min-w-0 flex-1">
+                                    <div class="text-sm font-medium">{{ dest.label }}</div>
+                                    <div class="text-xs text-muted">{{ dest.key }}</div>
+                                </div>
+                            </UCard>
+                        </div>
+                        <p v-else
+                           class="text-sm text-dimmed italic">
+                            No destinations configured
+                        </p>
                     </div>
                 </template>
             </UCollapsible>
@@ -423,52 +469,6 @@ const dependencyRows = computed(() => {
                            class="text-sm text-dimmed italic">
                             No partition data available.
                         </p>
-                    </div>
-                </template>
-            </UCollapsible>
-
-            <!-- Schema -->
-            <UCollapsible v-if="schemaFields.length"
-                          default-open
-                          class="border-b border-default">
-                <button class="flex items-center gap-2 w-full px-5 py-4.5 group cursor-pointer">
-                    <UIcon name="i-lucide-chevron-right"
-                           class="size-3.5 shrink-0 text-dimmed group-data-[state=open]:rotate-90 transition-transform duration-200" />
-                    <span class="text-xs font-semibold text-muted uppercase tracking-wide">Schema</span>
-                    <UBadge color="neutral"
-                            variant="subtle"
-                            class="ml-auto">
-                        {{ schemaFields.length }}
-                    </UBadge>
-                </button>
-
-                <template #content>
-                    <div class="px-5 pb-4">
-                        <div class="bg-muted rounded-md p-2 overflow-x-auto">
-                            <table class="w-full text-sm">
-                                <thead>
-                                    <tr class="border-b border-default text-left text-xs text-muted">
-                                        <th class="p-1.5 font-medium whitespace-nowrap">Name</th>
-                                        <th class="p-1.5 font-medium whitespace-nowrap">Type</th>
-                                        <th class="p-1.5 font-medium whitespace-nowrap">Description</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    <tr v-for="field in schemaFields"
-                                        :key="field.name"
-                                        class="border-b border-default last:border-0">
-                                        <td class="p-1.5 font-mono text-xs whitespace-nowrap">{{ field.name }}</td>
-                                        <td class="p-1.5 whitespace-nowrap">
-                                            <UBadge color="neutral"
-                                                    variant="subtle">
-                                                {{ field.type }}
-                                            </UBadge>
-                                        </td>
-                                        <td class="p-1.5 text-muted whitespace-nowrap">{{ field.description }}</td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
                     </div>
                 </template>
             </UCollapsible>

--- a/packages/interloper-app/app/app/components/graph/AssetPanel.vue
+++ b/packages/interloper-app/app/app/components/graph/AssetPanel.vue
@@ -233,18 +233,18 @@ const dependencyRows = computed(() => {
             <!-- Latest materialization -->
             <div class="border-b border-default px-5 py-4">
                 <div class="mb-2 text-xs font-semibold uppercase tracking-wide text-muted">Latest materialization</div>
-                <div class="flex items-center gap-3 rounded-xl border border-[var(--ui-border-accented)] bg-elevated px-4 py-3">
+                <UCard :ui="{ body: 'flex items-center gap-4 !p-4' }">
                     <UIcon :name="materialization.icon"
-                           class="size-5 shrink-0"
+                           class="size-10 shrink-0"
                            :class="[materialization.color, materialization.spin && 'animate-spin']" />
-                    <div class="min-w-0">
-                        <div class="text-sm font-semibold"
+                    <div class="min-w-0 flex-1">
+                        <div class="text-sm font-medium"
                              :class="materialization.color">
                             {{ materialization.label }}
                         </div>
                         <div class="truncate text-xs text-muted">{{ materializationMeta }}</div>
                     </div>
-                </div>
+                </UCard>
             </div>
 
             <!-- Description -->

--- a/packages/interloper-app/app/app/components/graph/AssetPanel.vue
+++ b/packages/interloper-app/app/app/components/graph/AssetPanel.vue
@@ -133,18 +133,7 @@ function formatType(type?: string, format?: string): string {
 }
 
 // ── Latest materialization + schedule ───────────────────────────
-const { getSourceSchedule, jobsForSource } = useSchedule()
-
-const schedule = computed(() => getSourceSchedule(props.source))
-const hasRequires = computed(() => Object.keys(props.assetDefn?.requires ?? {}).length > 0)
-
-/** What triggers a materialization — shown beside the last-run time. */
-const triggerLabel = computed(() => {
-    if (hasRequires.value) return 'After upstreams'
-    if (schedule.value?.paused) return 'Paused'
-    if (schedule.value) return schedule.value.label
-    return 'Manual'
-})
+const { jobsForSource } = useSchedule()
 
 // Latest run of the job that materialises this asset (per-job — the closest
 // real signal). Fetched directly to avoid clobbering the runs store.
@@ -182,9 +171,12 @@ const materialization = computed(() => {
     }
 })
 
+/** Job that materialises this asset (from the latest run, else the source's first job). */
+const jobName = computed(() => latestRun.value?.job?.name ?? jobsForSource(props.source)[0]?.name ?? null)
+
 const materializationMeta = computed(() => {
     const head = lastRunText.value ? `Last run ${lastRunText.value}` : 'Not yet materialized'
-    return `${head} · ${triggerLabel.value}`
+    return jobName.value ? `${head} · ${jobName.value}` : head
 })
 
 /** Upstream dependencies as display rows (param → resolved upstream asset). */

--- a/packages/interloper-app/app/app/components/graph/AssetPanel.vue
+++ b/packages/interloper-app/app/app/components/graph/AssetPanel.vue
@@ -132,65 +132,60 @@ function formatType(type?: string, format?: string): string {
     return type
 }
 
-// ── Status hero, metric tiles & recent runs ─────────────────────
+// ── Latest materialization + schedule ───────────────────────────
 const { getSourceSchedule, jobsForSource } = useSchedule()
-const { getWarnings } = useAssetWarnings()
 
 const schedule = computed(() => getSourceSchedule(props.source))
-const assetWarnings = computed(() => getWarnings(props.asset.id, props.asset.key))
 const hasRequires = computed(() => Object.keys(props.assetDefn?.requires ?? {}).length > 0)
 
-/** Cadence shown in the Refresh tile — adapted to the data we actually have. */
-const refreshLabel = computed(() => {
+/** What triggers a materialization — shown beside the last-run time. */
+const triggerLabel = computed(() => {
+    if (hasRequires.value) return 'After upstreams'
     if (schedule.value?.paused) return 'Paused'
     if (schedule.value) return schedule.value.label
-    if (hasRequires.value) return 'On dependencies'
     return 'Manual'
 })
 
-// Recent runs of the job that materialises this asset (per-job, not per-asset —
-// the closest real signal). Fetched directly to avoid clobbering the runs store.
-const recentRuns = ref<Run[]>([])
+// Latest run of the job that materialises this asset (per-job — the closest
+// real signal). Fetched directly to avoid clobbering the runs store.
+const latestRun = ref<Run | undefined>()
 
-async function fetchRecentRuns() {
+async function fetchLatestRun() {
     const job = jobsForSource(props.source)[0]
     if (!job) {
-        recentRuns.value = []
+        latestRun.value = undefined
         return
     }
     try {
-        recentRuns.value = await apiFetch<Run[]>(`/runs?job_id=${job.id}&limit=14`)
+        latestRun.value = (await apiFetch<Run[]>(`/runs?job_id=${job.id}&limit=1`))[0]
     }
     catch {
-        recentRuns.value = []
+        latestRun.value = undefined
     }
 }
-watch(() => props.asset.id, fetchRecentRuns, { immediate: true })
-
-/** API returns newest first. */
-const latestRun = computed(() => recentRuns.value[0])
-/** Oldest → newest for the sparkline. */
-const sparklineRuns = computed(() => [...recentRuns.value].reverse())
+watch(() => props.asset.id, fetchLatestRun, { immediate: true })
 
 const lastRunText = computed(() => {
     const at = latestRun.value?.completed_at ?? latestRun.value?.started_at
     return at ? `${timeSince(new Date(at))} ago` : null
 })
 
-const statusChip = computed<{ label: string; color: 'success' | 'error' | 'info' | 'warning' | 'neutral' }>(() => {
-    if (latestRun.value) return { label: statusLabel(latestRun.value.status), color: statusColor(latestRun.value.status) }
-    if (assetWarnings.value.length > 0) return { label: 'Attention', color: 'warning' }
-    return { label: 'No runs yet', color: 'neutral' }
+/** Latest-materialization presentation: icon, label, colour. */
+const materialization = computed(() => {
+    switch (latestRun.value?.status) {
+        case 'success': return { label: 'Healthy', icon: 'i-lucide-circle-check', color: 'text-[var(--ui-success)]', spin: false }
+        case 'failed': return { label: 'Failed', icon: 'i-lucide-circle-x', color: 'text-[var(--ui-error)]', spin: false }
+        case 'running': return { label: 'Running', icon: 'i-lucide-loader-circle', color: 'text-[var(--ui-info)]', spin: true }
+        case 'canceled': return { label: 'Canceled', icon: 'i-lucide-circle-slash', color: 'text-[var(--ui-warning)]', spin: false }
+        case undefined: return { label: 'Not materialized', icon: 'i-lucide-circle-dashed', color: 'text-dimmed', spin: false }
+        default: return { label: statusLabel(latestRun.value!.status), icon: 'i-lucide-circle-dot', color: 'text-muted', spin: false }
+    }
 })
 
-const compactNumber = new Intl.NumberFormat('en', { notation: 'compact', maximumFractionDigits: 1 })
-
-/** Rows = sum of partition row counts when available, else null (we have no total-row endpoint). */
-const rowsLabel = computed(() => {
-    if (!partitionData.value.length) return null
-    return compactNumber.format(partitionData.value.reduce((s, p) => s + p.rowCount, 0))
+const materializationMeta = computed(() => {
+    const head = lastRunText.value ? `Last run ${lastRunText.value}` : 'Not yet materialized'
+    return `${head} · ${triggerLabel.value}`
 })
-const columnsLabel = computed(() => schemaFields.value.length || null)
 
 /** Upstream dependencies as display rows (param → resolved upstream asset). */
 const dependencyRows = computed(() => {
@@ -206,32 +201,6 @@ const dependencyRows = computed(() => {
         }
     })
 })
-
-function barColor(status: string): string {
-    return `var(--ui-${statusColor(status)})`
-}
-
-const maxDurationMs = computed(() => {
-    let max = 0
-    for (const r of recentRuns.value) {
-        if (r.started_at && r.completed_at) {
-            max = Math.max(max, new Date(r.completed_at).getTime() - new Date(r.started_at).getTime())
-        }
-    }
-    return max
-})
-
-/** Bar height encodes run duration (min 30%); flat for in-flight/unknown. */
-function barHeight(run: Run): string {
-    if (!run.started_at || !run.completed_at || maxDurationMs.value === 0) return '100%'
-    const d = new Date(run.completed_at).getTime() - new Date(run.started_at).getTime()
-    return `${Math.round(30 + 70 * (d / maxDurationMs.value))}%`
-}
-
-function barTooltip(run: Run): string {
-    const elapsed = formatElapsed(run.started_at, run.completed_at)
-    return `${statusLabel(run.status)}${elapsed ? ` · ${elapsed}` : ''} · ${formatDate(run.started_at)}`
-}
 </script>
 
 <template>
@@ -261,44 +230,19 @@ function barTooltip(run: Run): string {
         </div>
 
         <div class="flex-1 min-h-0 border-l border-t border-default overflow-auto">
-            <!-- Status hero + metric tiles + recent runs -->
-            <div class="space-y-4 border-b border-default px-5 py-4">
-                <div class="flex items-center gap-2">
-                    <UBadge :color="statusChip.color"
-                            variant="subtle"
-                            class="capitalize">
-                        {{ statusChip.label }}
-                    </UBadge>
-                    <span v-if="lastRunText"
-                          class="text-xs text-muted">Last run {{ lastRunText }}</span>
-                </div>
-
-                <div class="grid grid-cols-3 gap-2">
-                    <div class="rounded-lg bg-muted px-3 py-2">
-                        <div class="text-[10px] uppercase tracking-wide text-dimmed">Rows</div>
-                        <div class="text-sm font-semibold">{{ rowsLabel ?? '—' }}</div>
-                    </div>
-                    <div class="rounded-lg bg-muted px-3 py-2">
-                        <div class="text-[10px] uppercase tracking-wide text-dimmed">Columns</div>
-                        <div class="text-sm font-semibold">{{ columnsLabel ?? '—' }}</div>
-                    </div>
-                    <div class="min-w-0 rounded-lg bg-muted px-3 py-2">
-                        <div class="text-[10px] uppercase tracking-wide text-dimmed">Refresh</div>
-                        <div class="truncate text-sm font-semibold"
-                             :title="refreshLabel">
-                            {{ refreshLabel }}
+            <!-- Latest materialization -->
+            <div class="border-b border-default px-5 py-4">
+                <div class="mb-2 text-xs font-semibold uppercase tracking-wide text-muted">Latest materialization</div>
+                <div class="flex items-center gap-3 rounded-xl border border-[var(--ui-border-accented)] bg-elevated px-4 py-3">
+                    <UIcon :name="materialization.icon"
+                           class="size-5 shrink-0"
+                           :class="[materialization.color, materialization.spin && 'animate-spin']" />
+                    <div class="min-w-0">
+                        <div class="text-sm font-semibold"
+                             :class="materialization.color">
+                            {{ materialization.label }}
                         </div>
-                    </div>
-                </div>
-
-                <div v-if="sparklineRuns.length">
-                    <div class="mb-1.5 text-[10px] uppercase tracking-wide text-dimmed">Recent runs</div>
-                    <div class="flex h-10 items-end gap-1">
-                        <div v-for="run in sparklineRuns"
-                             :key="run.id"
-                             class="min-w-[3px] flex-1 rounded-sm"
-                             :style="{ height: barHeight(run), backgroundColor: barColor(run.status) }"
-                             :title="barTooltip(run)" />
+                        <div class="truncate text-xs text-muted">{{ materializationMeta }}</div>
                     </div>
                 </div>
             </div>

--- a/packages/interloper-app/app/app/components/graph/GraphCanvas.vue
+++ b/packages/interloper-app/app/app/components/graph/GraphCanvas.vue
@@ -1,0 +1,528 @@
+<script setup lang="ts">
+import type { ContextMenuItem } from '@nuxt/ui'
+import { VueFlow, useVueFlow, Panel, MarkerType } from '@vue-flow/core'
+import type { Node, Edge, Connection } from '@vue-flow/core'
+import { Background } from '@vue-flow/background'
+import { Controls } from '@vue-flow/controls'
+
+/**
+ * Presentational graph renderer. Consumes a normalised {@link GraphModel}
+ * and knows nothing about stores — every surface (catalog/job/run) feeds it
+ * the same shape. Interactions are emitted; the host wires them.
+ */
+const props = withDefaults(defineProps<{
+    model: GraphModel
+    /** Allow dependency editing (drag-connect, edge delete) + source CRUD affordances. */
+    editable?: boolean
+    expandMode?: ExpandMode
+    viewMode?: ViewMode
+    loading?: boolean
+    /** Connection validator, supplied by an editable host. */
+    isValidConnection?: (connection: Connection) => boolean
+    /** Asset ids currently materialising (spinner overlay). */
+    materializingAssetIds?: Set<string>
+    /** Show the in-canvas "New Source" button (off once a toolbar owns it). */
+    showNewSourceButton?: boolean
+}>(), {
+    editable: false,
+    expandMode: 'nodes',
+    viewMode: 'topology',
+    loading: false,
+    isValidConnection: undefined,
+    materializingAssetIds: undefined,
+    showNewSourceButton: true,
+})
+
+const emit = defineEmits<{
+    'add-source': []
+    'edit-source': [sourceId: string]
+    'asset-click': [asset: SourceAsset | Asset, assetDefn: AssetDefinition | undefined, source: Source | null]
+    'pane-click': []
+    'delete-source': [sourceId: string]
+    'connect': [connection: Connection]
+    'delete-dependency': [payload: { upstreamAssetId: string; downstreamAssetId: string }]
+}>()
+
+const flowId = `asset-graph-${useId()}`
+const vueFlow = useVueFlow(flowId)
+const { layoutDag } = useGraphLayout()
+
+const sourceEntries = computed(() => props.model.sources)
+const assetEntries = computed(() => props.model.assets)
+const dependencies = computed(() => props.model.dependencies)
+
+// Track which sources are expanded
+const expandedSources = ref(new Set<string>())
+
+function toggleSource(sourceId: string) {
+    const next = new Set(expandedSources.value)
+    if (next.has(sourceId)) next.delete(sourceId)
+    else next.add(sourceId)
+    expandedSources.value = next
+}
+
+// Layout constants
+const ASSET_W = 220
+const ASSET_H = 160
+const SRC_PADDING = 26
+const SRC_HEADER_H = 50
+const COLLAPSED_W = 232
+const COLLAPSED_H = 76
+
+// Actual measured heights from VueFlow's ResizeObserver
+const measuredHeights = ref(new Map<string, number>())
+
+// ── Lookups derived from the model ──
+const assetEntryById = computed(() => {
+    const map = new Map<string, GraphAssetEntry>()
+    for (const entry of assetEntries.value) map.set(entry.asset.id, entry)
+    return map
+})
+
+const assetToSource = computed(() => {
+    const map = new Map<string, string | null>()
+    for (const entry of assetEntries.value) map.set(entry.asset.id, entry.source?.id ?? null)
+    return map
+})
+
+function childEntries(sourceId: string): GraphAssetEntry[] {
+    return assetEntries.value.filter(e => e.source?.id === sourceId)
+}
+
+const standaloneEntries = computed(() => assetEntries.value.filter(e => e.source === null))
+
+// Clear measured heights for a source's assets when it collapses
+watch(expandedSources, (next, prev) => {
+    for (const sourceId of prev) {
+        if (!next.has(sourceId)) {
+            const updated = new Map(measuredHeights.value)
+            for (const entry of childEntries(sourceId)) updated.delete(entry.asset.id)
+            measuredHeights.value = updated
+        }
+    }
+})
+
+/** Run inner DAG layout for a source's assets. */
+function getInnerLayout(sourceId: string) {
+    const children = childEntries(sourceId)
+    const assetIds = new Set(children.map(c => c.asset.id))
+    const intraEdges = dependencies.value
+        .filter(d => assetIds.has(d.downstreamAssetId) && assetIds.has(d.upstreamAssetId))
+        .map(d => ({ source: d.upstreamAssetId, target: d.downstreamAssetId }))
+
+    const layoutNodes = children.map(c => ({
+        id: c.asset.id,
+        width: ASSET_W,
+        height: measuredHeights.value.get(c.asset.id) ?? ASSET_H,
+    }))
+
+    return layoutDag(layoutNodes, intraEdges)
+}
+
+/** Whether a source is rendered as expanded child nodes on the canvas. */
+function isNodesExpanded(sourceId: string): boolean {
+    return props.expandMode === 'nodes' && expandedSources.value.has(sourceId)
+}
+
+/** Compute each source node's dimensions. */
+function getSourceDimensions(sourceId: string): { width: number; height: number } {
+    const children = childEntries(sourceId)
+    if (!isNodesExpanded(sourceId) || children.length === 0) {
+        return { width: COLLAPSED_W, height: COLLAPSED_H }
+    }
+    const dag = getInnerLayout(sourceId)
+    return {
+        width: dag.width + SRC_PADDING * 2,
+        height: dag.height + SRC_HEADER_H + SRC_PADDING * 2,
+    }
+}
+
+/** Cross-group edges at the top level (between sources and standalone assets). */
+const topLevelEdges = computed(() => {
+    const seen = new Set<string>()
+    const result: Array<{ source: string; target: string }> = []
+
+    for (const dep of dependencies.value) {
+        const downstreamSourceId = assetToSource.value.get(dep.downstreamAssetId)
+        const upstreamSourceId = assetToSource.value.get(dep.upstreamAssetId)
+        if (downstreamSourceId === undefined || upstreamSourceId === undefined) continue
+
+        const upstreamNode = upstreamSourceId ?? dep.upstreamAssetId
+        const downstreamNode = downstreamSourceId ?? dep.downstreamAssetId
+        if (upstreamNode === downstreamNode) continue
+
+        const key = `${upstreamNode}->${downstreamNode}`
+        if (seen.has(key)) continue
+        seen.add(key)
+        result.push({ source: upstreamNode, target: downstreamNode })
+    }
+
+    return result
+})
+
+/** Layout top-level nodes (sources + standalone assets) using DAG layout. */
+const sourceLayout = computed(() => {
+    const layoutNodes = [
+        ...sourceEntries.value.map((entry) => {
+            const dims = getSourceDimensions(entry.source.id)
+            return { id: entry.source.id, width: dims.width, height: dims.height }
+        }),
+        ...standaloneEntries.value.map(entry => ({
+            id: entry.asset.id,
+            width: ASSET_W,
+            height: measuredHeights.value.get(entry.asset.id) ?? ASSET_H,
+        })),
+    ]
+
+    return layoutDag(layoutNodes, topLevelEdges.value, { gapX: 60, gapY: 60 })
+})
+
+/** Flat node array: source nodes + asset child nodes + standalone asset nodes. */
+const nodes = computed<Node[]>(() => {
+    const result: Node[] = []
+
+    for (const entry of sourceEntries.value) {
+        const source = entry.source
+        const pos = sourceLayout.value.positions.get(source.id) ?? { x: 0, y: 0 }
+        const expanded = isNodesExpanded(source.id)
+        const dims = getSourceDimensions(source.id)
+
+        result.push({
+            id: source.id,
+            type: 'source',
+            position: { x: pos.x, y: pos.y },
+            width: dims.width,
+            height: dims.height,
+            connectable: !expanded,
+            data: {
+                source,
+                sourceDefn: entry.sourceDefn,
+                status: entry.status,
+                expanded,
+            },
+        })
+
+        if (expanded) {
+            const children = childEntries(source.id)
+            if (children.length > 0) {
+                const innerLayout = getInnerLayout(source.id)
+                for (const child of children) {
+                    const assetPos = innerLayout.positions.get(child.asset.id) ?? { x: 0, y: 0 }
+                    result.push({
+                        id: child.asset.id,
+                        type: 'asset',
+                        parentNode: source.id,
+                        extent: 'parent',
+                        position: {
+                            x: assetPos.x + SRC_PADDING,
+                            y: assetPos.y + SRC_HEADER_H + SRC_PADDING,
+                        },
+                        data: { asset: child.asset, assetDefn: child.assetDefn, source, status: child.status },
+                        draggable: true,
+                        expandParent: true,
+                        connectable: true,
+                        zIndex: 1,
+                    })
+                }
+            }
+        }
+    }
+
+    for (const entry of standaloneEntries.value) {
+        const pos = sourceLayout.value.positions.get(entry.asset.id) ?? { x: 0, y: 0 }
+        result.push({
+            id: entry.asset.id,
+            type: 'asset',
+            position: { x: pos.x, y: pos.y },
+            data: { asset: entry.asset, assetDefn: entry.assetDefn, source: null, status: entry.status },
+            draggable: true,
+            connectable: true,
+        })
+    }
+
+    return result
+})
+
+/** Unified edge list from all asset dependencies. */
+const edges = computed<Edge[]>(() => {
+    const result: Edge[] = []
+    const seen = new Set<string>()
+
+    for (const dep of dependencies.value) {
+        const upstreamSourceId = assetToSource.value.get(dep.upstreamAssetId)
+        const downstreamSourceId = assetToSource.value.get(dep.downstreamAssetId)
+        if (upstreamSourceId === undefined || downstreamSourceId === undefined) continue
+
+        const upstreamIsStandalone = upstreamSourceId === null
+        const downstreamIsStandalone = downstreamSourceId === null
+        const upstreamExpanded = upstreamIsStandalone || isNodesExpanded(upstreamSourceId!)
+        const downstreamExpanded = downstreamIsStandalone || isNodesExpanded(downstreamSourceId!)
+        const isSameSource = upstreamSourceId !== null
+            && downstreamSourceId !== null
+            && upstreamSourceId === downstreamSourceId
+
+        if (isSameSource) {
+            if (upstreamExpanded) {
+                result.push({
+                    id: `asset:${dep.upstreamAssetId}->${dep.downstreamAssetId}`,
+                    type: 'dependency',
+                    source: dep.upstreamAssetId,
+                    target: dep.downstreamAssetId,
+                    animated: true,
+                    markerEnd: MarkerType.ArrowClosed,
+                    zIndex: 1002,
+                })
+            }
+        }
+        else {
+            const edgeSource = upstreamExpanded ? dep.upstreamAssetId : upstreamSourceId!
+            const edgeTarget = downstreamExpanded ? dep.downstreamAssetId : downstreamSourceId!
+            const sourceHandle = upstreamExpanded ? undefined : 'source-source'
+            const targetHandle = downstreamExpanded ? undefined : 'source-target'
+
+            const key = `${edgeSource}->${edgeTarget}`
+            if (seen.has(key)) continue
+            seen.add(key)
+
+            result.push({
+                id: key,
+                type: 'dependency',
+                source: edgeSource,
+                target: edgeTarget,
+                sourceHandle,
+                targetHandle,
+                animated: true,
+                markerEnd: MarkerType.ArrowClosed,
+                zIndex: 1002,
+            })
+        }
+    }
+
+    return result
+})
+
+function onNodeClick({ node }: { node: Node }) {
+    if (node.type === 'source') {
+        toggleSource(node.id)
+    }
+    else if (node.type === 'asset') {
+        emit('asset-click', node.data.asset, node.data.assetDefn, node.data.source)
+    }
+}
+
+function onDeleteSource(sourceId: string) {
+    if (!props.editable) return
+    emit('delete-source', sourceId)
+    const next = new Set(expandedSources.value)
+    next.delete(sourceId)
+    expandedSources.value = next
+}
+
+vueFlow.onNodesInitialized(() => {
+    const heights = new Map(measuredHeights.value)
+    let changed = false
+    for (const graphNode of vueFlow.getNodes.value) {
+        if (graphNode.type === 'asset' && graphNode.dimensions.height > 0) {
+            const prev = heights.get(graphNode.id)
+            if (prev !== graphNode.dimensions.height) {
+                heights.set(graphNode.id, graphNode.dimensions.height)
+                changed = true
+            }
+        }
+    }
+    if (changed) {
+        measuredHeights.value = heights
+    }
+
+    vueFlow.fitView({ padding: 0.25 })
+    vueFlow.zoomTo(1)
+})
+
+// ── Connection plumbing provided to child node components ──
+const validateConnection = (connection: Connection) => props.isValidConnection?.(connection) ?? false
+provide('isValidConnection', validateConnection)
+provide('graphReadonly', toRef(() => !props.editable))
+
+const materializing = computed(() => props.materializingAssetIds ?? new Set<string>())
+provide('materializingAssetIds', materializing)
+
+function onConnect(connection: Connection) {
+    if (!props.editable) return
+    emit('connect', connection)
+}
+
+// ── Edge context menu ──
+const edgeMenuOpen = ref(false)
+const edgeMenuVirtual = ref({ getBoundingClientRect: () => new DOMRect() })
+const edgeMenuEdge = ref<{ source: string; target: string } | null>(null)
+
+const { confirm } = useConfirm()
+
+const edgeMenuItems = computed<ContextMenuItem[][]>(() => {
+    const edge = edgeMenuEdge.value
+    if (!edge) return []
+    return [
+        [
+            {
+                label: 'Delete dependency',
+                icon: 'i-lucide-trash',
+                color: 'error' as const,
+                onSelect: async () => {
+                    const confirmed = await confirm({
+                        title: 'Delete dependency',
+                        description: 'This will remove the dependency between these assets. This action cannot be undone.',
+                    })
+                    if (confirmed) {
+                        emit('delete-dependency', {
+                            downstreamAssetId: edge.target,
+                            upstreamAssetId: edge.source,
+                        })
+                    }
+                },
+            },
+        ],
+    ]
+})
+
+// ── Pane context menu ──
+const paneMenuOpen = ref(false)
+const paneMenuVirtual = ref({ getBoundingClientRect: () => new DOMRect() })
+
+const paneMenuItems = computed<ContextMenuItem[][]>(() => [
+    [
+        {
+            label: 'Expand all',
+            icon: 'i-lucide-maximize-2',
+            onSelect: () => {
+                expandedSources.value = new Set(sourceEntries.value.map(e => e.source.id))
+            },
+        },
+        {
+            label: 'Collapse all',
+            icon: 'i-lucide-minimize-2',
+            onSelect: () => {
+                expandedSources.value = new Set()
+            },
+        },
+        {
+            label: 'Fit view',
+            icon: 'i-lucide-scan',
+            onSelect: () => {
+                vueFlow.fitView({ padding: 0.25 })
+            },
+        },
+    ],
+])
+
+function onPaneContextMenu(event: MouseEvent) {
+    event.preventDefault()
+    const { clientX: x, clientY: y } = event
+    paneMenuVirtual.value = {
+        getBoundingClientRect: () => new DOMRect(x, y, 0, 0),
+    }
+    paneMenuOpen.value = true
+}
+
+function onEdgeContextMenu({ edge, event }: { edge: Edge; event: MouseEvent | TouchEvent }) {
+    event.preventDefault()
+    event.stopPropagation()
+
+    if (!props.editable) return
+    if (!('clientX' in event)) return
+
+    // Only allow delete on asset-to-asset edges (not source-level collapsed edges)
+    const isSourceAsset = assetToSource.value.has(edge.source)
+    const isTargetAsset = assetToSource.value.has(edge.target)
+    if (!isSourceAsset || !isTargetAsset) return
+
+    edgeMenuEdge.value = { source: edge.source, target: edge.target }
+
+    const { clientX: x, clientY: y } = event
+    edgeMenuVirtual.value = {
+        getBoundingClientRect: () => new DOMRect(x, y, 0, 0),
+    }
+    edgeMenuOpen.value = true
+}
+</script>
+
+<template>
+    <div class="relative flex-1 min-h-0 w-full">
+        <VueFlow :id="flowId"
+                 :nodes="nodes"
+                 :edges="edges"
+                 fit-view
+                 class="!absolute inset-0"
+                 :max-zoom="1"
+                 :min-zoom="0.6"
+                 snap-to-grid
+                 :nodes-draggable="true"
+                 :select-nodes-on-drag="false"
+                 :connection-radius="80"
+                 :auto-connect="false"
+                 @node-click="onNodeClick"
+                 @connect="onConnect"
+                 @edge-context-menu="onEdgeContextMenu"
+                 @pane-click="emit('pane-click')"
+                 @pane-context-menu="onPaneContextMenu">
+            <template #node-source="{ data }">
+                <GraphSourceNode :source="data.source"
+                                 :source-defn="data.sourceDefn"
+                                 :status="data.status"
+                                 :view-mode="viewMode"
+                                 :expanded="data.expanded"
+                                 @edit="emit('edit-source', $event)"
+                                 @delete="onDeleteSource" />
+            </template>
+            <template #node-asset="{ data }">
+                <GraphAssetNode :asset="data.asset"
+                                :asset-defn="data.assetDefn"
+                                :status="data.status"
+                                :view-mode="viewMode"
+                                @view="emit('asset-click', data.asset, data.assetDefn, data.source)" />
+            </template>
+            <template #edge-dependency="edgeProps">
+                <GraphDependencyEdge v-bind="edgeProps" />
+            </template>
+            <Background :size=".8" />
+            <Controls position="bottom-left"
+                      :show-interactive="false" />
+
+            <Panel v-if="editable && sourceEntries.length === 0"
+                   position="top-left"
+                   class="!inset-0 !m-0 flex items-center justify-center pointer-events-none">
+                <UButton icon="i-lucide-plus"
+                         label="Add your first source"
+                         size="lg"
+                         class="pointer-events-auto"
+                         @click="emit('add-source')" />
+            </Panel>
+            <Panel v-else-if="editable && showNewSourceButton"
+                   position="top-center"
+                   class="!m-4">
+                <UButton icon="i-lucide-plus"
+                         label="New Source"
+                         @click="emit('add-source')" />
+            </Panel>
+        </VueFlow>
+
+        <div v-if="loading"
+             class="absolute inset-0 z-50 flex items-center justify-center bg-default/50">
+            <UIcon name="i-lucide-loader-circle"
+                   class="size-8 text-muted animate-spin" />
+        </div>
+
+        <UDropdownMenu v-model:open="edgeMenuOpen"
+                       :items="edgeMenuItems"
+                       :modal="false"
+                       :content="{ reference: edgeMenuVirtual, side: 'bottom', align: 'start', sideOffset: 4 }">
+            <div class="hidden" />
+        </UDropdownMenu>
+
+        <UDropdownMenu v-model:open="paneMenuOpen"
+                       :items="paneMenuItems"
+                       :modal="false"
+                       :content="{ reference: paneMenuVirtual, side: 'bottom', align: 'start', sideOffset: 4 }">
+            <div class="hidden" />
+        </UDropdownMenu>
+    </div>
+</template>

--- a/packages/interloper-app/app/app/components/graph/GraphCanvas.vue
+++ b/packages/interloper-app/app/app/components/graph/GraphCanvas.vue
@@ -69,6 +69,16 @@ const SRC_HEADER_H = 50
 const COLLAPSED_W = 232
 const COLLAPSED_H = 76
 
+// In-card expand modes (list / graph)
+const MINI_W = 108
+const MINI_H = 30
+const MINI_GAP_X = 22
+const MINI_GAP_Y = 22
+const MINI_PAD = 16
+const LIST_W = 256
+const LIST_ROW_H = 34
+const LIST_PAD_Y = 8
+
 // Actual measured heights from VueFlow's ResizeObserver
 const measuredHeights = ref(new Map<string, number>())
 
@@ -124,16 +134,52 @@ function isNodesExpanded(sourceId: string): boolean {
     return props.expandMode === 'nodes' && expandedSources.value.has(sourceId)
 }
 
-/** Compute each source node's dimensions. */
-function getSourceDimensions(sourceId: string): { width: number; height: number } {
+/** Mini DAG layout for the in-card "graph" expand mode. */
+function getMiniGraph(sourceId: string) {
     const children = childEntries(sourceId)
-    if (!isNodesExpanded(sourceId) || children.length === 0) {
+    const ids = new Set(children.map(c => c.asset.id))
+    const intra = dependencies.value.filter(d => ids.has(d.upstreamAssetId) && ids.has(d.downstreamAssetId))
+    const layout = layoutDag(
+        children.map(c => ({ id: c.asset.id, width: MINI_W, height: MINI_H })),
+        intra.map(d => ({ source: d.upstreamAssetId, target: d.downstreamAssetId })),
+        { gapX: MINI_GAP_X, gapY: MINI_GAP_Y },
+    )
+    return {
+        width: layout.width,
+        height: layout.height,
+        nodes: children.map(c => ({ entry: c, pos: layout.positions.get(c.asset.id) ?? { x: 0, y: 0 } })),
+        edges: intra.map(d => ({ from: d.upstreamAssetId, to: d.downstreamAssetId })),
+    }
+}
+
+/** Compute each source node's dimensions for the active expand mode. */
+function getSourceDimensions(sourceId: string): { width: number; height: number } {
+    const open = expandedSources.value.has(sourceId)
+    const children = childEntries(sourceId)
+    if (!open || children.length === 0) {
         return { width: COLLAPSED_W, height: COLLAPSED_H }
     }
-    const dag = getInnerLayout(sourceId)
+
+    if (props.expandMode === 'nodes') {
+        const dag = getInnerLayout(sourceId)
+        return {
+            width: dag.width + SRC_PADDING * 2,
+            height: dag.height + SRC_HEADER_H + SRC_PADDING * 2,
+        }
+    }
+
+    if (props.expandMode === 'list') {
+        return {
+            width: LIST_W,
+            height: SRC_HEADER_H + children.length * LIST_ROW_H + LIST_PAD_Y * 2,
+        }
+    }
+
+    // graph
+    const mini = getMiniGraph(sourceId)
     return {
-        width: dag.width + SRC_PADDING * 2,
-        height: dag.height + SRC_HEADER_H + SRC_PADDING * 2,
+        width: Math.max(COLLAPSED_W, mini.width + MINI_PAD * 2),
+        height: SRC_HEADER_H + mini.height + MINI_PAD * 2,
     }
 }
 
@@ -184,7 +230,9 @@ const nodes = computed<Node[]>(() => {
     for (const entry of sourceEntries.value) {
         const source = entry.source
         const pos = sourceLayout.value.positions.get(source.id) ?? { x: 0, y: 0 }
-        const expanded = isNodesExpanded(source.id)
+        const open = expandedSources.value.has(source.id)
+        const container = isNodesExpanded(source.id)
+        const inCard = open && props.expandMode !== 'nodes'
         const dims = getSourceDimensions(source.id)
 
         result.push({
@@ -193,16 +241,19 @@ const nodes = computed<Node[]>(() => {
             position: { x: pos.x, y: pos.y },
             width: dims.width,
             height: dims.height,
-            connectable: !expanded,
+            connectable: !container,
             data: {
                 source,
                 sourceDefn: entry.sourceDefn,
                 status: entry.status,
-                expanded,
+                open,
+                mode: props.expandMode,
+                children: inCard ? childEntries(source.id) : [],
+                miniGraph: (open && props.expandMode === 'graph') ? getMiniGraph(source.id) : undefined,
             },
         })
 
-        if (expanded) {
+        if (container) {
             const children = childEntries(source.id)
             if (children.length > 0) {
                 const innerLayout = getInnerLayout(source.id)
@@ -469,9 +520,13 @@ function onEdgeContextMenu({ edge, event }: { edge: Edge; event: MouseEvent | To
                                  :source-defn="data.sourceDefn"
                                  :status="data.status"
                                  :view-mode="viewMode"
-                                 :expanded="data.expanded"
+                                 :open="data.open"
+                                 :mode="data.mode"
+                                 :children="data.children"
+                                 :mini-graph="data.miniGraph"
                                  @edit="emit('edit-source', $event)"
-                                 @delete="onDeleteSource" />
+                                 @delete="onDeleteSource"
+                                 @asset-click="(a, d, s) => emit('asset-click', a, d, s)" />
             </template>
             <template #node-asset="{ data }">
                 <GraphAssetNode :asset="data.asset"

--- a/packages/interloper-app/app/app/components/graph/GraphCanvas.vue
+++ b/packages/interloper-app/app/app/components/graph/GraphCanvas.vue
@@ -66,8 +66,8 @@ const ASSET_W = 220
 const ASSET_H = 160
 const SRC_PADDING = 26
 const SRC_HEADER_H = 50
-const COLLAPSED_W = 232
-const COLLAPSED_H = 76
+const COLLAPSED_W = 244
+const COLLAPSED_H = 112
 
 // In-card expand modes (list / graph)
 const MINI_W = 108

--- a/packages/interloper-app/app/app/components/graph/GraphCanvas.vue
+++ b/packages/interloper-app/app/app/components/graph/GraphCanvas.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { ContextMenuItem } from '@nuxt/ui'
-import { VueFlow, useVueFlow, Panel, MarkerType } from '@vue-flow/core'
+import { VueFlow, useVueFlow, Panel } from '@vue-flow/core'
 import type { Node, Edge, Connection } from '@vue-flow/core'
 import { Background } from '@vue-flow/background'
 import { Controls } from '@vue-flow/controls'
@@ -223,6 +223,87 @@ const sourceLayout = computed(() => {
     return layoutDag(layoutNodes, topLevelEdges.value, { gapX: 60, gapY: 60 })
 })
 
+/** Structural edges (id/source/target/handles); styling + focus applied in `edges`. */
+const baseEdges = computed(() => {
+    const result: Array<{ id: string; source: string; target: string; sourceHandle?: string; targetHandle?: string }> = []
+    const seen = new Set<string>()
+
+    for (const dep of dependencies.value) {
+        const upstreamSourceId = assetToSource.value.get(dep.upstreamAssetId)
+        const downstreamSourceId = assetToSource.value.get(dep.downstreamAssetId)
+        if (upstreamSourceId === undefined || downstreamSourceId === undefined) continue
+
+        const upstreamExpanded = upstreamSourceId === null || isNodesExpanded(upstreamSourceId)
+        const downstreamExpanded = downstreamSourceId === null || isNodesExpanded(downstreamSourceId)
+        const isSameSource = upstreamSourceId !== null
+            && downstreamSourceId !== null
+            && upstreamSourceId === downstreamSourceId
+
+        if (isSameSource) {
+            if (upstreamExpanded) {
+                result.push({
+                    id: `asset:${dep.upstreamAssetId}->${dep.downstreamAssetId}`,
+                    source: dep.upstreamAssetId,
+                    target: dep.downstreamAssetId,
+                })
+            }
+        }
+        else {
+            const edgeSource = upstreamExpanded ? dep.upstreamAssetId : upstreamSourceId!
+            const edgeTarget = downstreamExpanded ? dep.downstreamAssetId : downstreamSourceId!
+            const key = `${edgeSource}->${edgeTarget}`
+            if (seen.has(key)) continue
+            seen.add(key)
+            result.push({
+                id: key,
+                source: edgeSource,
+                target: edgeTarget,
+                sourceHandle: upstreamExpanded ? undefined : 'source-source',
+                targetHandle: downstreamExpanded ? undefined : 'source-target',
+            })
+        }
+    }
+    return result
+})
+
+// ── Selection focus ──
+// Default edges are faint; selecting a node turns its incident edges blue and
+// fades every node that isn't the selection or one of its direct neighbours.
+const selectedIds = computed(() => new Set(vueFlow.getSelectedNodes.value.map(n => n.id)))
+
+/** Selected ids, plus the child assets of any selected (expanded) source. */
+const selectionGroup = computed(() => {
+    if (!selectedIds.value.size) return null
+    const group = new Set(selectedIds.value)
+    for (const id of selectedIds.value) {
+        if (sourceEntries.value.some(e => e.source.id === id)) {
+            for (const c of childEntries(id)) group.add(c.asset.id)
+        }
+    }
+    return group
+})
+
+const focus = computed(() => {
+    const group = selectionGroup.value
+    if (!group) return null
+    const edgeKeys = new Set<string>()
+    const nodeIds = new Set<string>(group)
+    for (const e of baseEdges.value) {
+        if (group.has(e.source) || group.has(e.target)) {
+            edgeKeys.add(e.id)
+            nodeIds.add(e.source)
+            nodeIds.add(e.target)
+        }
+    }
+    // A source container must stay un-faded when it holds a focused asset —
+    // CSS opacity cascades to children, which would otherwise dim the asset too.
+    for (const id of [...nodeIds]) {
+        const parent = assetEntryById.value.get(id)?.source
+        if (parent) nodeIds.add(parent.id)
+    }
+    return { edgeKeys, nodeIds }
+})
+
 /** Flat node array: source nodes + asset child nodes + standalone asset nodes. */
 const nodes = computed<Node[]>(() => {
     const result: Node[] = []
@@ -291,65 +372,42 @@ const nodes = computed<Node[]>(() => {
         })
     }
 
-    return result
-})
-
-/** Unified edge list from all asset dependencies. */
-const edges = computed<Edge[]>(() => {
-    const result: Edge[] = []
-    const seen = new Set<string>()
-
-    for (const dep of dependencies.value) {
-        const upstreamSourceId = assetToSource.value.get(dep.upstreamAssetId)
-        const downstreamSourceId = assetToSource.value.get(dep.downstreamAssetId)
-        if (upstreamSourceId === undefined || downstreamSourceId === undefined) continue
-
-        const upstreamIsStandalone = upstreamSourceId === null
-        const downstreamIsStandalone = downstreamSourceId === null
-        const upstreamExpanded = upstreamIsStandalone || isNodesExpanded(upstreamSourceId!)
-        const downstreamExpanded = downstreamIsStandalone || isNodesExpanded(downstreamSourceId!)
-        const isSameSource = upstreamSourceId !== null
-            && downstreamSourceId !== null
-            && upstreamSourceId === downstreamSourceId
-
-        if (isSameSource) {
-            if (upstreamExpanded) {
-                result.push({
-                    id: `asset:${dep.upstreamAssetId}->${dep.downstreamAssetId}`,
-                    type: 'dependency',
-                    source: dep.upstreamAssetId,
-                    target: dep.downstreamAssetId,
-                    animated: true,
-                    markerEnd: MarkerType.ArrowClosed,
-                    zIndex: 1002,
-                })
+    // Selection focus. Set opacity explicitly on EVERY node each pass — only
+    // setting it on faded nodes leaves a stale 0.28 that VueFlow never clears,
+    // so nodes would stay dimmed after the selection moves. Likewise always set
+    // the child-ring flag (true/false) rather than only when true.
+    const f = focus.value
+    for (const node of result) {
+        const faded = f ? !f.nodeIds.has(node.id) : false
+        node.style = { opacity: faded ? '0.28' : '1', transition: 'opacity 0.2s ease' }
+        if (node.type === 'asset' && node.parentNode) {
+            node.data = {
+                ...node.data,
+                parentSelected: !!f && selectedIds.value.has(node.parentNode),
             }
-        }
-        else {
-            const edgeSource = upstreamExpanded ? dep.upstreamAssetId : upstreamSourceId!
-            const edgeTarget = downstreamExpanded ? dep.downstreamAssetId : downstreamSourceId!
-            const sourceHandle = upstreamExpanded ? undefined : 'source-source'
-            const targetHandle = downstreamExpanded ? undefined : 'source-target'
-
-            const key = `${edgeSource}->${edgeTarget}`
-            if (seen.has(key)) continue
-            seen.add(key)
-
-            result.push({
-                id: key,
-                type: 'dependency',
-                source: edgeSource,
-                target: edgeTarget,
-                sourceHandle,
-                targetHandle,
-                animated: true,
-                markerEnd: MarkerType.ArrowClosed,
-                zIndex: 1002,
-            })
         }
     }
 
     return result
+})
+
+/** Styled edges: faint gray by default; the selection's incident edges go blue, the rest dim. */
+const edges = computed<Edge[]>(() => {
+    const f = focus.value
+    return baseEdges.value.map((e) => {
+        const active = f?.edgeKeys.has(e.id) ?? false
+        const style = !f
+            ? { stroke: 'var(--ui-border-accented)', strokeWidth: 1.5 }
+            : active
+                ? { stroke: 'var(--ui-primary)', strokeWidth: 2.5 }
+                : { stroke: 'var(--ui-border-accented)', strokeWidth: 1.5, opacity: '0.15' }
+        return {
+            ...e,
+            type: 'dependency',
+            zIndex: active ? 1003 : 1001,
+            style,
+        }
+    })
 })
 
 function onNodeClick({ node }: { node: Node }) {
@@ -515,7 +573,7 @@ function onEdgeContextMenu({ edge, event }: { edge: Edge; event: MouseEvent | To
                  @edge-context-menu="onEdgeContextMenu"
                  @pane-click="emit('pane-click')"
                  @pane-context-menu="onPaneContextMenu">
-            <template #node-source="{ data }">
+            <template #node-source="{ data, selected }">
                 <GraphSourceNode :source="data.source"
                                  :source-defn="data.sourceDefn"
                                  :status="data.status"
@@ -524,15 +582,17 @@ function onEdgeContextMenu({ edge, event }: { edge: Edge; event: MouseEvent | To
                                  :mode="data.mode"
                                  :children="data.children"
                                  :mini-graph="data.miniGraph"
+                                 :selected="selected"
                                  @edit="emit('edit-source', $event)"
                                  @delete="onDeleteSource"
                                  @asset-click="(a, d, s) => emit('asset-click', a, d, s)" />
             </template>
-            <template #node-asset="{ data }">
+            <template #node-asset="{ data, selected }">
                 <GraphAssetNode :asset="data.asset"
                                 :asset-defn="data.assetDefn"
                                 :status="data.status"
                                 :view-mode="viewMode"
+                                :selected="selected || data.parentSelected"
                                 @view="emit('asset-click', data.asset, data.assetDefn, data.source)" />
             </template>
             <template #edge-dependency="edgeProps">

--- a/packages/interloper-app/app/app/components/graph/SourceAssetList.vue
+++ b/packages/interloper-app/app/app/components/graph/SourceAssetList.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+/** In-card asset list for a source's "List" expand mode. */
+defineProps<{
+    assets: GraphAssetEntry[]
+}>()
+
+const emit = defineEmits<{
+    select: [entry: GraphAssetEntry]
+}>()
+
+function labelFor(e: GraphAssetEntry): string {
+    return e.assetDefn?.name ?? e.asset.key
+}
+
+function iconFor(e: GraphAssetEntry): string {
+    return e.assetDefn ? componentIcon(e.assetDefn.key) : 'i-lucide-box'
+}
+</script>
+
+<template>
+    <div class="nowheel py-1">
+        <button v-for="e in assets"
+                :key="e.asset.id"
+                type="button"
+                class="nodrag flex w-full items-center gap-2.5 px-4 py-2 text-left transition-colors hover:bg-elevated/60"
+                @click.stop="emit('select', e)">
+            <span class="size-1.5 shrink-0 rounded-full"
+                  :class="statusDotClass(e.status?.state ?? 'idle')" />
+            <UIcon :name="iconFor(e)"
+                   class="size-4 shrink-0 text-muted" />
+            <span class="min-w-0 flex-1 truncate text-xs">{{ labelFor(e) }}</span>
+        </button>
+    </div>
+</template>

--- a/packages/interloper-app/app/app/components/graph/SourceMiniGraph.vue
+++ b/packages/interloper-app/app/app/components/graph/SourceMiniGraph.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+interface MiniGraph {
+    width: number
+    height: number
+    nodes: Array<{ entry: GraphAssetEntry; pos: { x: number; y: number } }>
+    edges: Array<{ from: string; to: string }>
+}
+
+/** In-card mini dependency graph for a source's "Graph" expand mode. */
+const props = defineProps<{
+    miniGraph: MiniGraph
+}>()
+
+const emit = defineEmits<{
+    select: [entry: GraphAssetEntry]
+}>()
+
+const NODE_W = 108
+const NODE_H = 30
+
+const posById = computed(() => {
+    const map = new Map<string, { x: number; y: number }>()
+    for (const n of props.miniGraph.nodes) map.set(n.entry.asset.id, n.pos)
+    return map
+})
+
+function center(id: string): { x: number; y: number } {
+    const p = posById.value.get(id) ?? { x: 0, y: 0 }
+    return { x: p.x + NODE_W / 2, y: p.y + NODE_H / 2 }
+}
+
+function labelFor(e: GraphAssetEntry): string {
+    return e.assetDefn?.name ?? e.asset.key
+}
+</script>
+
+<template>
+    <div class="nodrag nowheel relative"
+         :style="{ width: `${miniGraph.width}px`, height: `${miniGraph.height}px` }">
+        <svg class="pointer-events-none absolute inset-0 overflow-visible"
+             :width="miniGraph.width"
+             :height="miniGraph.height">
+            <line v-for="(ed, i) in miniGraph.edges"
+                  :key="i"
+                  :x1="center(ed.from).x"
+                  :y1="center(ed.from).y"
+                  :x2="center(ed.to).x"
+                  :y2="center(ed.to).y"
+                  stroke="var(--ui-border-accented)"
+                  stroke-width="1.5" />
+        </svg>
+        <button v-for="n in miniGraph.nodes"
+                :key="n.entry.asset.id"
+                type="button"
+                class="absolute flex items-center gap-1.5 rounded-md border border-default bg-elevated px-2 transition-colors hover:border-primary"
+                :style="{ left: `${n.pos.x}px`, top: `${n.pos.y}px`, width: `${NODE_W}px`, height: `${NODE_H}px` }"
+                @click.stop="emit('select', n.entry)">
+            <span class="size-1.5 shrink-0 rounded-full"
+                  :class="statusDotClass(n.entry.status?.state ?? 'idle')" />
+            <span class="min-w-0 flex-1 truncate text-left text-[11px]">{{ labelFor(n.entry) }}</span>
+        </button>
+    </div>
+</template>

--- a/packages/interloper-app/app/app/components/graph/SourceNode.vue
+++ b/packages/interloper-app/app/app/components/graph/SourceNode.vue
@@ -7,8 +7,13 @@ const props = withDefaults(defineProps<{
     source: Source
     sourceDefn: SourceDefinition | undefined
     expanded?: boolean
+    /** Derived node status (used by the Status view mode; see Phase 3). */
+    status?: NodeStatus
+    viewMode?: ViewMode
 }>(), {
     expanded: false,
+    status: undefined,
+    viewMode: 'topology',
 })
 
 const emit = defineEmits<{

--- a/packages/interloper-app/app/app/components/graph/SourceNode.vue
+++ b/packages/interloper-app/app/app/components/graph/SourceNode.vue
@@ -24,6 +24,8 @@ const props = withDefaults(defineProps<{
     /** Derived node status (used by the Status view mode; see Phase 3). */
     status?: NodeStatus
     viewMode?: ViewMode
+    /** VueFlow selection state — drives the blue selection ring. */
+    selected?: boolean
 }>(), {
     open: false,
     mode: 'nodes',
@@ -31,6 +33,7 @@ const props = withDefaults(defineProps<{
     miniGraph: undefined,
     status: undefined,
     viewMode: 'topology',
+    selected: false,
 })
 
 const emit = defineEmits<{
@@ -147,9 +150,11 @@ function onAssetSelect(entry: GraphAssetEntry) {
     emit('asset-click', entry.asset, entry.assetDefn, entry.source)
 }
 
-const statusRing = computed(() =>
-    props.viewMode === 'status' && props.status ? statusRingClass(props.status.state) : '',
-)
+const ringClass = computed(() => {
+    if (props.selected) return 'ring-2 ring-primary'
+    if (props.viewMode === 'status' && props.status) return statusRingClass(props.status.state)
+    return ''
+})
 </script>
 
 <template>
@@ -237,7 +242,7 @@ const statusRing = computed(() =>
 
             <!-- Main card -->
             <div class="relative flex h-full w-full flex-col overflow-hidden rounded-xl border border-[var(--ui-border-accented)] shadow-[0_10px_30px_-10px_rgba(0,0,0,0.55)]"
-                 :class="[collapsed ? 'bg-muted' : 'bg-default', statusRing]">
+                 :class="[collapsed ? 'bg-muted' : 'bg-default', ringClass]">
                 <!-- Collapsed: header + divided meta row -->
                 <template v-if="collapsed">
                     <div class="flex flex-1 items-center gap-3 px-4">

--- a/packages/interloper-app/app/app/components/graph/SourceNode.vue
+++ b/packages/interloper-app/app/app/components/graph/SourceNode.vue
@@ -236,40 +236,45 @@ const statusRing = computed(() =>
             </div>
 
             <!-- Main card -->
-            <div class="relative flex h-full w-full flex-col overflow-hidden rounded-xl border border-default bg-muted"
-                 :class="statusRing">
-                <!-- Collapsed: full card with meta line -->
-                <div v-if="collapsed"
-                     class="flex h-full items-center gap-3 p-4">
-                    <UIcon :name="icon"
-                           class="size-8 shrink-0" />
-                    <div class="min-w-0 flex-1">
-                        <div class="truncate text-sm font-semibold">{{ source.name }}</div>
-                        <div v-if="sourceDefn"
-                             class="truncate text-xs text-muted">
-                            {{ sourceDefn.name }}
+            <div class="relative flex h-full w-full flex-col overflow-hidden rounded-xl border border-[var(--ui-border-accented)] shadow-[0_10px_30px_-10px_rgba(0,0,0,0.55)]"
+                 :class="[collapsed ? 'bg-muted' : 'bg-default', statusRing]">
+                <!-- Collapsed: header + divided meta row -->
+                <template v-if="collapsed">
+                    <div class="flex flex-1 items-center gap-3 px-4">
+                        <div class="flex size-11 shrink-0 items-center justify-center rounded-xl bg-elevated">
+                            <UIcon :name="icon"
+                                   class="size-6 text-muted" />
                         </div>
-                        <div class="mt-1 flex items-center gap-1.5 overflow-hidden whitespace-nowrap text-xs text-dimmed">
-                            <UIcon name="i-lucide-box"
-                                   class="size-3 shrink-0" />
-                            <span>{{ assetCount }} {{ assetCount === 1 ? 'asset' : 'assets' }}</span>
-                            <template v-if="metaSuffix">
-                                <span>·</span>
-                                <span :class="schedule?.paused ? 'text-warning' : ''"
-                                      class="truncate">{{ metaSuffix }}</span>
-                            </template>
+                        <div class="min-w-0 flex-1">
+                            <div class="truncate text-sm font-semibold text-highlighted">{{ source.name }}</div>
+                            <div v-if="sourceDefn"
+                                 class="truncate text-xs text-muted">
+                                {{ sourceDefn.name }}
+                            </div>
                         </div>
+                        <UIcon name="i-lucide-chevron-right"
+                               class="size-4 shrink-0 text-dimmed" />
                     </div>
-                    <UIcon name="i-lucide-chevron-right"
-                           class="size-4 shrink-0 text-dimmed" />
-                </div>
+                    <div class="flex shrink-0 items-center gap-1.5 overflow-hidden whitespace-nowrap border-t border-[var(--ui-border-accented)] bg-default px-4 py-2.5 text-xs text-muted">
+                        <UIcon name="i-lucide-box"
+                               class="size-3.5 shrink-0 text-dimmed" />
+                        <span>{{ assetCount }} {{ assetCount === 1 ? 'asset' : 'assets' }}</span>
+                        <template v-if="metaSuffix">
+                            <span class="text-dimmed">·</span>
+                            <span :class="schedule?.paused ? 'text-warning' : ''"
+                                  class="truncate">{{ metaSuffix }}</span>
+                        </template>
+                    </div>
+                </template>
 
                 <!-- Expanded: compact header + optional in-card body -->
                 <template v-else>
-                    <div class="flex h-12 shrink-0 items-center gap-2 border-b border-default px-4">
-                        <UIcon :name="icon"
-                               class="size-5 shrink-0" />
-                        <span class="min-w-0 flex-1 truncate text-xs font-semibold">{{ source.name }}</span>
+                    <div class="flex h-12 shrink-0 items-center gap-2.5 border-b border-[var(--ui-border-accented)] px-4">
+                        <div class="flex size-7 shrink-0 items-center justify-center rounded-lg bg-elevated">
+                            <UIcon :name="icon"
+                                   class="size-4 text-muted" />
+                        </div>
+                        <span class="min-w-0 flex-1 truncate text-sm font-semibold text-highlighted">{{ source.name }}</span>
                         <span class="shrink-0 text-[11px] text-dimmed">{{ assetCount }} assets</span>
                         <UIcon name="i-lucide-chevron-down"
                                class="size-4 shrink-0 text-dimmed" />

--- a/packages/interloper-app/app/app/components/graph/SourceNode.vue
+++ b/packages/interloper-app/app/app/components/graph/SourceNode.vue
@@ -146,6 +146,10 @@ const metaSuffix = computed(() => {
 function onAssetSelect(entry: GraphAssetEntry) {
     emit('asset-click', entry.asset, entry.assetDefn, entry.source)
 }
+
+const statusRing = computed(() =>
+    props.viewMode === 'status' && props.status ? statusRingClass(props.status.state) : '',
+)
 </script>
 
 <template>
@@ -232,7 +236,8 @@ function onAssetSelect(entry: GraphAssetEntry) {
             </div>
 
             <!-- Main card -->
-            <div class="relative flex h-full w-full flex-col overflow-hidden rounded-xl border border-default bg-muted">
+            <div class="relative flex h-full w-full flex-col overflow-hidden rounded-xl border border-default bg-muted"
+                 :class="statusRing">
                 <!-- Collapsed: full card with meta line -->
                 <div v-if="collapsed"
                      class="flex h-full items-center gap-3 p-4">

--- a/packages/interloper-app/app/app/components/graph/SourceNode.vue
+++ b/packages/interloper-app/app/app/components/graph/SourceNode.vue
@@ -3,15 +3,32 @@ import type { ContextMenuItem } from '@nuxt/ui'
 import type { Connection } from '@vue-flow/core'
 import { Handle, Position, useNodeConnections, useVueFlow, useNodeId } from '@vue-flow/core'
 
+interface MiniGraph {
+    width: number
+    height: number
+    nodes: Array<{ entry: GraphAssetEntry; pos: { x: number; y: number } }>
+    edges: Array<{ from: string; to: string }>
+}
+
 const props = withDefaults(defineProps<{
     source: Source
     sourceDefn: SourceDefinition | undefined
-    expanded?: boolean
+    /** Source is expanded (showing its assets), in any expand mode. */
+    open?: boolean
+    /** Active expand mode. */
+    mode?: ExpandMode
+    /** Child asset entries — for the in-card list/graph modes. */
+    children?: GraphAssetEntry[]
+    /** Pre-laid-out mini graph — for the in-card graph mode. */
+    miniGraph?: MiniGraph
     /** Derived node status (used by the Status view mode; see Phase 3). */
     status?: NodeStatus
     viewMode?: ViewMode
 }>(), {
-    expanded: false,
+    open: false,
+    mode: 'nodes',
+    children: () => [],
+    miniGraph: undefined,
     status: undefined,
     viewMode: 'topology',
 })
@@ -19,7 +36,15 @@ const props = withDefaults(defineProps<{
 const emit = defineEmits<{
     edit: [sourceId: string]
     delete: [sourceId: string]
+    'asset-click': [asset: SourceAsset | Asset, assetDefn: AssetDefinition | undefined, source: Source | null]
 }>()
+
+// container = expanded onto the canvas as child nodes (header-only card);
+// inCard   = expanded inside the card (list / graph);
+// collapsed = not open.
+const container = computed(() => props.open && props.mode === 'nodes')
+const inCard = computed(() => props.open && props.mode !== 'nodes')
+const collapsed = computed(() => !props.open)
 
 const isValidConnection = inject<(connection: Connection) => boolean>('isValidConnection')
 const graphReadonly = inject<Ref<boolean>>('graphReadonly', ref(false))
@@ -32,11 +57,10 @@ const targetConnections = useNodeConnections({ handleType: 'target' })
 const hasDownstream = computed(() => sourceConnections.value.length > 0)
 const hasUpstream = computed(() => targetConnections.value.length > 0)
 
-// Connection drag awareness (collapsed only)
 const isDragging = computed(() => connectionStartHandle.value !== null)
 
 const isValidTarget = computed(() => {
-    if (props.expanded) return false
+    if (container.value) return false
     const start = connectionStartHandle.value
     if (!start || start.type !== 'source' || !nodeId) return false
     return isValidConnection?.({
@@ -48,7 +72,7 @@ const isValidTarget = computed(() => {
 })
 
 const isValidSource = computed(() => {
-    if (props.expanded) return false
+    if (container.value) return false
     const start = connectionStartHandle.value
     if (!start || start.type !== 'target' || !nodeId) return false
     return isValidConnection?.({
@@ -60,11 +84,12 @@ const isValidSource = computed(() => {
 })
 
 const isCompatible = computed(() => isValidTarget.value || isValidSource.value)
-const shouldFade = computed(() => !props.expanded && isDragging.value && !isCompatible.value)
+const shouldFade = computed(() => !container.value && isDragging.value && !isCompatible.value)
 
 const { confirm } = useConfirm()
 const { getWarnings } = useAssetWarnings()
 const { getBadgeForSource } = useDestinationBadge()
+const { getSourceSchedule } = useSchedule()
 
 const sourceWarnings = computed(() => {
     const all = props.source.assets.flatMap(a => getWarnings(a.id, a.key))
@@ -103,14 +128,24 @@ const contextMenuItems = computed<ContextMenuItem[][]>(() => [
 
 const icon = computed(() => componentIcon(props.source.key))
 
-const COLLAPSED_W = 232
-const COLLAPSED_H = 76
-
 const assetCount = computed(() => props.source.assets?.length ?? 0)
 const destinationBadge = computed(() => getBadgeForSource(props.source))
 const isMaterializing = computed(() =>
     props.source.assets?.some(a => materializingAssetIds?.value?.has(a.id)) ?? false,
 )
+
+const schedule = computed(() => getSourceSchedule(props.source))
+
+/** Collapsed meta suffix: "Paused" when scheduled-but-disabled, else the schedule label. */
+const metaSuffix = computed(() => {
+    const s = schedule.value
+    if (!s) return null
+    return s.paused ? 'Paused' : s.label
+})
+
+function onAssetSelect(entry: GraphAssetEntry) {
+    emit('asset-click', entry.asset, entry.assetDefn, entry.source)
+}
 </script>
 
 <template>
@@ -129,8 +164,8 @@ const isMaterializing = computed(() =>
                         isValidTarget && '!size-3 !bg-transparent !border-2 !border-warning animate-pulse-grow',
                     ]" />
 
-            <!-- Materializing spinner -->
-            <div v-if="isMaterializing && !props.expanded"
+            <!-- Materializing spinner (collapsed only) -->
+            <div v-if="isMaterializing && collapsed"
                  class="absolute -left-2.5 -top-2.5 z-10">
                 <UTooltip :delay-duration="0"
                           :content="{ side: 'top', sideOffset: 6 }">
@@ -144,8 +179,8 @@ const isMaterializing = computed(() =>
                 </UTooltip>
             </div>
 
-            <!-- Warning badge — visible when collapsed and some assets have warnings -->
-            <UTooltip v-if="hasWarning && !props.expanded"
+            <!-- Warning badge (collapsed only) -->
+            <UTooltip v-if="hasWarning && collapsed"
                       :delay-duration="0"
                       :content="{ side: 'top', sideOffset: 6 }"
                       :ui="{ content: 'bg-transparent ring-0 shadow-none p-0 rounded-none' }"
@@ -175,8 +210,8 @@ const isMaterializing = computed(() =>
                 </template>
             </UTooltip>
 
-            <!-- Destination badge — bottom-right corner, visible when collapsed -->
-            <div v-if="destinationBadge && !props.expanded"
+            <!-- Destination badge (collapsed only) -->
+            <div v-if="destinationBadge && collapsed"
                  class="absolute -bottom-3 -right-3 z-10">
                 <UTooltip :delay-duration="0"
                           :content="{ side: 'bottom', sideOffset: 6 }">
@@ -196,45 +231,63 @@ const isMaterializing = computed(() =>
                 </UTooltip>
             </div>
 
-            <!-- Stack layers behind (visible when collapsed) -->
-            <div class="absolute rounded-xl border border-default bg-muted transition-all duration-300 ease-out"
-                 :class="props.expanded ? 'opacity-0' : 'opacity-100'"
-                 :style="{ width: `${COLLAPSED_W - 16}px`, height: `${COLLAPSED_H}px`, left: '8px', top: '16px' }" />
-            <div class="absolute rounded-xl border border-default bg-muted transition-all duration-300 ease-out"
-                 :class="props.expanded ? 'opacity-0' : 'opacity-100'"
-                 :style="{ width: `${COLLAPSED_W - 8}px`, height: `${COLLAPSED_H}px`, left: '4px', top: '8px' }" />
-
             <!-- Main card -->
-            <div class="relative h-full w-full rounded-xl border border-default bg-muted">
-                <div class="flex items-center transition-[gap,padding] duration-300"
-                     :class="props.expanded ? 'h-12 gap-2 border-b border-default px-4' : 'gap-3 p-5'">
+            <div class="relative flex h-full w-full flex-col overflow-hidden rounded-xl border border-default bg-muted">
+                <!-- Collapsed: full card with meta line -->
+                <div v-if="collapsed"
+                     class="flex h-full items-center gap-3 p-4">
                     <UIcon :name="icon"
-                           class="shrink-0 transition-all duration-300"
-                           :class="props.expanded ? 'size-5' : 'size-8'" />
+                           class="size-8 shrink-0" />
                     <div class="min-w-0 flex-1">
-                        <div class="truncate font-semibold"
-                             :class="props.expanded ? 'text-xs' : 'text-sm'">
-                            {{ props.source.name }}
-                        </div>
-                        <div v-if="!props.expanded && sourceDefn"
+                        <div class="truncate text-sm font-semibold">{{ source.name }}</div>
+                        <div v-if="sourceDefn"
                              class="truncate text-xs text-muted">
                             {{ sourceDefn.name }}
                         </div>
+                        <div class="mt-1 flex items-center gap-1.5 overflow-hidden whitespace-nowrap text-xs text-dimmed">
+                            <UIcon name="i-lucide-box"
+                                   class="size-3 shrink-0" />
+                            <span>{{ assetCount }} {{ assetCount === 1 ? 'asset' : 'assets' }}</span>
+                            <template v-if="metaSuffix">
+                                <span>·</span>
+                                <span :class="schedule?.paused ? 'text-warning' : ''"
+                                      class="truncate">{{ metaSuffix }}</span>
+                            </template>
+                        </div>
                     </div>
-                    <UBadge v-if="!props.expanded && assetCount > 0"
-                            color="neutral"
-                            variant="subtle"
-                            size="sm">
-                        {{ assetCount }}
-                    </UBadge>
+                    <UIcon name="i-lucide-chevron-right"
+                           class="size-4 shrink-0 text-dimmed" />
                 </div>
+
+                <!-- Expanded: compact header + optional in-card body -->
+                <template v-else>
+                    <div class="flex h-12 shrink-0 items-center gap-2 border-b border-default px-4">
+                        <UIcon :name="icon"
+                               class="size-5 shrink-0" />
+                        <span class="min-w-0 flex-1 truncate text-xs font-semibold">{{ source.name }}</span>
+                        <span class="shrink-0 text-[11px] text-dimmed">{{ assetCount }} assets</span>
+                        <UIcon name="i-lucide-chevron-down"
+                               class="size-4 shrink-0 text-dimmed" />
+                    </div>
+
+                    <GraphSourceAssetList v-if="inCard && mode === 'list'"
+                                          class="flex-1 min-h-0 overflow-auto"
+                                          :assets="children"
+                                          @select="onAssetSelect" />
+
+                    <div v-else-if="inCard && mode === 'graph' && miniGraph"
+                         class="flex flex-1 min-h-0 items-center justify-center p-4">
+                        <GraphSourceMiniGraph :mini-graph="miniGraph"
+                                              @select="onAssetSelect" />
+                    </div>
+                </template>
             </div>
 
             <Handle id="source-source"
                     type="source"
                     :position="Position.Bottom"
-                    :connectable-start="!props.expanded && !graphReadonly"
-                    :connectable-end="!props.expanded && !graphReadonly"
+                    :connectable-start="!container && !graphReadonly"
+                    :connectable-end="!container && !graphReadonly"
                     :is-valid-connection="isValidConnection"
                     :class="[
                         'transition-all duration-150',

--- a/packages/interloper-app/app/app/components/graph/Toolbar.vue
+++ b/packages/interloper-app/app/app/components/graph/Toolbar.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 /**
- * Graph canvas toolbar: status filter pills (left), expand-mode + view-mode
- * controls and host actions (right). An `end` slot holds host actions such
- * as New Source.
+ * Graph canvas toolbar. Status filter, expand-mode and view-mode are all
+ * rendered as the same left-aligned segmented control; the `end` slot holds
+ * host actions (e.g. New Source), pushed to the right.
  */
 const expandMode = defineModel<ExpandMode>('expandMode', { default: 'nodes' })
 const viewMode = defineModel<ViewMode>('viewMode', { default: 'topology' })
@@ -36,16 +36,16 @@ const visibleFilters = computed(() => FILTERS.filter(f => f.value === 'all' || p
 </script>
 
 <template>
-    <div class="flex shrink-0 items-center justify-between gap-3 border-b border-default px-4 py-2">
-        <!-- Status filter pills -->
-        <div class="flex items-center gap-1">
+    <div class="flex shrink-0 items-center gap-2 border-b border-default px-4 py-2">
+        <!-- Status filter -->
+        <div class="flex items-center gap-0.5 rounded-lg bg-elevated p-0.5">
             <button v-for="f in visibleFilters"
                     :key="f.value"
                     type="button"
-                    class="flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium transition-colors"
+                    class="flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors"
                     :class="statusFilter === f.value
-                        ? 'border-default bg-elevated text-highlighted'
-                        : 'border-transparent text-muted hover:text-default'"
+                        ? 'bg-default text-highlighted shadow-sm'
+                        : 'text-muted hover:text-default'"
                     @click="statusFilter = f.value">
                 <span v-if="f.dot"
                       class="size-1.5 rounded-full"
@@ -55,41 +55,39 @@ const visibleFilters = computed(() => FILTERS.filter(f => f.value === 'all' || p
             </button>
         </div>
 
-        <!-- Controls -->
-        <div class="flex items-center gap-3">
-            <div class="hidden items-center gap-2 sm:flex">
-                <span class="text-xs text-muted">Expand as</span>
-                <div class="flex items-center gap-0.5 rounded-lg bg-elevated p-0.5">
-                    <button v-for="opt in EXPAND_OPTIONS"
-                            :key="opt.value"
-                            type="button"
-                            class="flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors"
-                            :class="expandMode === opt.value
-                                ? 'bg-default text-highlighted shadow-sm'
-                                : 'text-muted hover:text-default'"
-                            @click="expandMode = opt.value">
-                        <UIcon :name="opt.icon"
-                               class="size-3.5" />
-                        {{ opt.label }}
-                    </button>
-                </div>
-            </div>
+        <!-- Expand mode -->
+        <div class="flex items-center gap-0.5 rounded-lg bg-elevated p-0.5">
+            <button v-for="opt in EXPAND_OPTIONS"
+                    :key="opt.value"
+                    type="button"
+                    class="flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors"
+                    :class="expandMode === opt.value
+                        ? 'bg-default text-highlighted shadow-sm'
+                        : 'text-muted hover:text-default'"
+                    @click="expandMode = opt.value">
+                <UIcon :name="opt.icon"
+                       class="size-3.5" />
+                {{ opt.label }}
+            </button>
+        </div>
 
-            <div class="flex items-center gap-0.5 rounded-lg bg-elevated p-0.5">
-                <button v-for="opt in VIEW_OPTIONS"
-                        :key="opt.value"
-                        type="button"
-                        class="flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors"
-                        :class="viewMode === opt.value
-                            ? 'bg-default text-highlighted shadow-sm'
-                            : 'text-muted hover:text-default'"
-                        @click="viewMode = opt.value">
-                    <UIcon :name="opt.icon"
-                           class="size-3.5" />
-                    {{ opt.label }}
-                </button>
-            </div>
+        <!-- View mode -->
+        <div class="flex items-center gap-0.5 rounded-lg bg-elevated p-0.5">
+            <button v-for="opt in VIEW_OPTIONS"
+                    :key="opt.value"
+                    type="button"
+                    class="flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors"
+                    :class="viewMode === opt.value
+                        ? 'bg-default text-highlighted shadow-sm'
+                        : 'text-muted hover:text-default'"
+                    @click="viewMode = opt.value">
+                <UIcon :name="opt.icon"
+                       class="size-3.5" />
+                {{ opt.label }}
+            </button>
+        </div>
 
+        <div class="ml-auto">
             <slot name="end" />
         </div>
     </div>

--- a/packages/interloper-app/app/app/components/graph/Toolbar.vue
+++ b/packages/interloper-app/app/app/components/graph/Toolbar.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+/**
+ * Graph canvas toolbar. Owns the "Expand as" control today; filters and
+ * view modes are added in Phase 3. An `end` slot holds host actions
+ * (e.g. New Source).
+ */
+const expandMode = defineModel<ExpandMode>('expandMode', { default: 'nodes' })
+
+const EXPAND_OPTIONS: Array<{ value: ExpandMode; label: string; icon: string }> = [
+    { value: 'list', label: 'List', icon: 'i-lucide-list' },
+    { value: 'graph', label: 'Graph', icon: 'i-lucide-git-fork' },
+    { value: 'nodes', label: 'Nodes', icon: 'i-lucide-box' },
+]
+</script>
+
+<template>
+    <div class="flex shrink-0 items-center justify-between gap-3 border-b border-default px-4 py-2">
+        <div class="flex items-center gap-2">
+            <span class="text-xs text-muted">Expand as</span>
+            <div class="flex items-center gap-0.5 rounded-lg bg-elevated p-0.5">
+                <button v-for="opt in EXPAND_OPTIONS"
+                        :key="opt.value"
+                        type="button"
+                        class="flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors"
+                        :class="expandMode === opt.value
+                            ? 'bg-default text-highlighted shadow-sm'
+                            : 'text-muted hover:text-default'"
+                        @click="expandMode = opt.value">
+                    <UIcon :name="opt.icon"
+                           class="size-3.5" />
+                    {{ opt.label }}
+                </button>
+            </div>
+        </div>
+        <slot name="end" />
+    </div>
+</template>

--- a/packages/interloper-app/app/app/components/graph/Toolbar.vue
+++ b/packages/interloper-app/app/app/components/graph/Toolbar.vue
@@ -1,37 +1,96 @@
 <script setup lang="ts">
 /**
- * Graph canvas toolbar. Owns the "Expand as" control today; filters and
- * view modes are added in Phase 3. An `end` slot holds host actions
- * (e.g. New Source).
+ * Graph canvas toolbar: status filter pills (left), expand-mode + view-mode
+ * controls and host actions (right). An `end` slot holds host actions such
+ * as New Source.
  */
 const expandMode = defineModel<ExpandMode>('expandMode', { default: 'nodes' })
+const viewMode = defineModel<ViewMode>('viewMode', { default: 'topology' })
+const statusFilter = defineModel<StatusFilter>('statusFilter', { default: 'all' })
+
+const props = defineProps<{
+    /** Per-state source counts for the filter pills. */
+    counts: Record<StatusFilter, number>
+}>()
+
+const FILTERS: Array<{ value: StatusFilter; label: string; dot?: GraphNodeState }> = [
+    { value: 'all', label: 'All' },
+    { value: 'healthy', label: 'Healthy', dot: 'idle' },
+    { value: 'attention', label: 'Attention', dot: 'attention' },
+    { value: 'paused', label: 'Paused', dot: 'paused' },
+]
 
 const EXPAND_OPTIONS: Array<{ value: ExpandMode; label: string; icon: string }> = [
     { value: 'list', label: 'List', icon: 'i-lucide-list' },
     { value: 'graph', label: 'Graph', icon: 'i-lucide-git-fork' },
     { value: 'nodes', label: 'Nodes', icon: 'i-lucide-box' },
 ]
+
+const VIEW_OPTIONS: Array<{ value: ViewMode; label: string; icon: string }> = [
+    { value: 'topology', label: 'Topology', icon: 'i-lucide-workflow' },
+    { value: 'status', label: 'Status', icon: 'i-lucide-activity' },
+]
+
+// Hide a filter pill when it has no members (except All), to avoid dead options.
+const visibleFilters = computed(() => FILTERS.filter(f => f.value === 'all' || props.counts[f.value] > 0))
 </script>
 
 <template>
     <div class="flex shrink-0 items-center justify-between gap-3 border-b border-default px-4 py-2">
-        <div class="flex items-center gap-2">
-            <span class="text-xs text-muted">Expand as</span>
+        <!-- Status filter pills -->
+        <div class="flex items-center gap-1">
+            <button v-for="f in visibleFilters"
+                    :key="f.value"
+                    type="button"
+                    class="flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium transition-colors"
+                    :class="statusFilter === f.value
+                        ? 'border-default bg-elevated text-highlighted'
+                        : 'border-transparent text-muted hover:text-default'"
+                    @click="statusFilter = f.value">
+                <span v-if="f.dot"
+                      class="size-1.5 rounded-full"
+                      :class="statusDotClass(f.dot)" />
+                {{ f.label }}
+                <span class="text-dimmed">{{ counts[f.value] }}</span>
+            </button>
+        </div>
+
+        <!-- Controls -->
+        <div class="flex items-center gap-3">
+            <div class="hidden items-center gap-2 sm:flex">
+                <span class="text-xs text-muted">Expand as</span>
+                <div class="flex items-center gap-0.5 rounded-lg bg-elevated p-0.5">
+                    <button v-for="opt in EXPAND_OPTIONS"
+                            :key="opt.value"
+                            type="button"
+                            class="flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors"
+                            :class="expandMode === opt.value
+                                ? 'bg-default text-highlighted shadow-sm'
+                                : 'text-muted hover:text-default'"
+                            @click="expandMode = opt.value">
+                        <UIcon :name="opt.icon"
+                               class="size-3.5" />
+                        {{ opt.label }}
+                    </button>
+                </div>
+            </div>
+
             <div class="flex items-center gap-0.5 rounded-lg bg-elevated p-0.5">
-                <button v-for="opt in EXPAND_OPTIONS"
+                <button v-for="opt in VIEW_OPTIONS"
                         :key="opt.value"
                         type="button"
                         class="flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors"
-                        :class="expandMode === opt.value
+                        :class="viewMode === opt.value
                             ? 'bg-default text-highlighted shadow-sm'
                             : 'text-muted hover:text-default'"
-                        @click="expandMode = opt.value">
+                        @click="viewMode = opt.value">
                     <UIcon :name="opt.icon"
                            class="size-3.5" />
                     {{ opt.label }}
                 </button>
             </div>
+
+            <slot name="end" />
         </div>
-        <slot name="end" />
     </div>
 </template>

--- a/packages/interloper-app/app/app/composables/graphModel.ts
+++ b/packages/interloper-app/app/app/composables/graphModel.ts
@@ -1,0 +1,189 @@
+import type { MaybeRefOrGetter } from 'vue'
+import { qualifiedKey } from '~/types/catalog'
+import { stateFromExecution, toGraphDependency } from '~/types/graph'
+import type { GraphModel, GraphSourceEntry, GraphAssetEntry, NodeStatus } from '~/types/graph'
+import type { AssetDependency } from '~/types/asset'
+
+/**
+ * Graph model builders — one per surface. Each returns the same normalised
+ * {@link GraphModel} so a single <GraphCanvas> can render the catalog page,
+ * a job's subgraph, or a run's live subgraph.
+ *
+ * Only {@link useCatalogGraph} is mounted today; {@link useJobGraph} and
+ * {@link useRunGraph} are the seams for the (future) job and run pages.
+ */
+
+/** Assemble a model, keeping only dependencies whose endpoints are both present. */
+function assemble(
+    sources: GraphSourceEntry[],
+    assets: GraphAssetEntry[],
+    deps: AssetDependency[],
+): GraphModel {
+    const present = new Set(assets.map(e => e.asset.id))
+    const dependencies = deps
+        .filter(d => present.has(d.asset_id) && present.has(d.upstream_asset_id))
+        .map(toGraphDependency)
+    return { sources, assets, dependencies }
+}
+
+interface CatalogGraphOptions {
+    /** Restrict to these source ids (undefined = every source). */
+    sourceIds?: MaybeRefOrGetter<string[] | undefined>
+}
+
+/** Catalog-wide graph: every source, its assets, standalone assets, all deps. */
+export function useCatalogGraph(options: CatalogGraphOptions = {}) {
+    const sourcesStore = useSourcesStore()
+    const assetsStore = useAssetsStore()
+    const catalogStore = useCatalogStore()
+    const { assetStatus, sourceStatus } = useNodeStatus()
+
+    const sources = computed(() => {
+        const ids = toValue(options.sourceIds)
+        if (!ids) return sourcesStore.sources
+        const set = new Set(ids)
+        return sourcesStore.sources.filter(s => set.has(s.id))
+    })
+
+    const model = computed<GraphModel>(() => {
+        const sourceEntries: GraphSourceEntry[] = sources.value.map(source => ({
+            source,
+            sourceDefn: catalogStore.getSourceDefinition(source.key),
+            status: sourceStatus(source),
+        }))
+
+        const assetEntries: GraphAssetEntry[] = []
+        for (const source of sources.value) {
+            for (const asset of source.assets) {
+                assetEntries.push({
+                    asset,
+                    assetDefn: catalogStore.getAssetDefinition(qualifiedKey(source.key, asset.key)),
+                    source,
+                    status: assetStatus(asset.id, asset.key),
+                })
+            }
+        }
+        for (const asset of assetsStore.standalone) {
+            assetEntries.push({
+                asset,
+                assetDefn: catalogStore.getAssetDefinition(asset.key),
+                source: null,
+                status: assetStatus(asset.id, asset.key),
+            })
+        }
+
+        return assemble(sourceEntries, assetEntries, assetsStore.dependencies)
+    })
+
+    return { model }
+}
+
+/** A single job's subgraph: the sources/assets the job materialises. (Seam — page not yet wired.) */
+export function useJobGraph(jobId: MaybeRefOrGetter<string>) {
+    const jobsStore = useJobsStore()
+    const sourcesStore = useSourcesStore()
+    const assetsStore = useAssetsStore()
+    const catalogStore = useCatalogStore()
+    const { assetStatus, sourceStatus } = useNodeStatus()
+
+    const model = computed<GraphModel>(() => {
+        const job = jobsStore.jobs.find(j => j.id === toValue(jobId))
+        if (!job) return { sources: [], assets: [], dependencies: [] }
+
+        const sourceIds = new Set(job.source_ids)
+        const assetIds = new Set(job.asset_ids)
+        const sources = sourcesStore.sources.filter(s => sourceIds.has(s.id))
+
+        const sourceEntries: GraphSourceEntry[] = sources.map(source => ({
+            source,
+            sourceDefn: catalogStore.getSourceDefinition(source.key),
+            status: sourceStatus(source),
+        }))
+
+        const assetEntries: GraphAssetEntry[] = []
+        for (const source of sources) {
+            for (const asset of source.assets) {
+                if (!assetIds.has(asset.id)) continue
+                assetEntries.push({
+                    asset,
+                    assetDefn: catalogStore.getAssetDefinition(qualifiedKey(source.key, asset.key)),
+                    source,
+                    status: assetStatus(asset.id, asset.key),
+                })
+            }
+        }
+        for (const asset of assetsStore.standalone) {
+            if (!assetIds.has(asset.id)) continue
+            assetEntries.push({
+                asset,
+                assetDefn: catalogStore.getAssetDefinition(asset.key),
+                source: null,
+                status: assetStatus(asset.id, asset.key),
+            })
+        }
+
+        return assemble(sourceEntries, assetEntries, assetsStore.dependencies)
+    })
+
+    return { model }
+}
+
+/**
+ * A run's subgraph with *live* per-asset status from asset executions.
+ * The caller is responsible for `useAssetExecutionsStore().fetchForRun(runId)`;
+ * this model tracks that store (which is realtime-backed). (Seam — page not yet wired.)
+ */
+export function useRunGraph(runId: MaybeRefOrGetter<string>) {
+    const assetExecutionsStore = useAssetExecutionsStore()
+    const sourcesStore = useSourcesStore()
+    const assetsStore = useAssetsStore()
+    const catalogStore = useCatalogStore()
+
+    const statusByAssetId = computed(() => {
+        const map = new Map<string, NodeStatus>()
+        for (const exec of assetExecutionsStore.assetExecutions) {
+            if (exec.asset_id) map.set(exec.asset_id, { state: stateFromExecution(exec.status) })
+        }
+        return map
+    })
+
+    const model = computed<GraphModel>(() => {
+        // runId identifies which run the page loaded into the store; the model
+        // tracks the store contents reactively.
+        void toValue(runId)
+        const present = statusByAssetId.value
+        const sources = sourcesStore.sources.filter(s => s.assets.some(a => present.has(a.id)))
+
+        const sourceEntries: GraphSourceEntry[] = sources.map(source => ({
+            source,
+            sourceDefn: catalogStore.getSourceDefinition(source.key),
+            status: { state: 'running' as const },
+        }))
+
+        const assetEntries: GraphAssetEntry[] = []
+        for (const source of sources) {
+            for (const asset of source.assets) {
+                if (!present.has(asset.id)) continue
+                assetEntries.push({
+                    asset,
+                    assetDefn: catalogStore.getAssetDefinition(qualifiedKey(source.key, asset.key)),
+                    source,
+                    status: present.get(asset.id),
+                })
+            }
+        }
+        for (const asset of assetsStore.standalone) {
+            if (!present.has(asset.id)) continue
+            assetEntries.push({
+                asset,
+                assetDefn: catalogStore.getAssetDefinition(asset.key),
+                source: null,
+                status: present.get(asset.id),
+            })
+        }
+
+        return assemble(sourceEntries, assetEntries, assetsStore.dependencies)
+    })
+
+    return { model }
+}

--- a/packages/interloper-app/app/app/composables/nodeStatus.ts
+++ b/packages/interloper-app/app/app/composables/nodeStatus.ts
@@ -1,5 +1,23 @@
 import type { Source } from '~/types/source'
-import type { NodeStatus } from '~/types/graph'
+import type { NodeStatus, GraphNodeState } from '~/types/graph'
+
+/** Tailwind class for a status indicator dot, keyed by node state. */
+const STATUS_DOT: Record<GraphNodeState, string> = {
+    idle: 'bg-[var(--ui-success)]',
+    attention: 'bg-[var(--ui-warning)]',
+    paused: 'bg-[var(--ui-text-dimmed)]',
+    queued: 'bg-[var(--ui-text-dimmed)]',
+    pending: 'bg-[var(--ui-text-dimmed)]',
+    running: 'bg-[var(--ui-info)] animate-pulse',
+    success: 'bg-[var(--ui-success)]',
+    failed: 'bg-[var(--ui-error)]',
+    skipped: 'bg-[var(--ui-text-dimmed)]',
+    canceled: 'bg-[var(--ui-text-dimmed)]',
+}
+
+export function statusDotClass(state: GraphNodeState): string {
+    return STATUS_DOT[state]
+}
 
 /**
  * Derives {@link NodeStatus} for catalog graph nodes from data that

--- a/packages/interloper-app/app/app/composables/nodeStatus.ts
+++ b/packages/interloper-app/app/app/composables/nodeStatus.ts
@@ -1,0 +1,31 @@
+import type { Source } from '~/types/source'
+import type { NodeStatus } from '~/types/graph'
+
+/**
+ * Derives {@link NodeStatus} for catalog graph nodes from data that
+ * actually exists today: configuration warnings ({@link useAssetWarnings})
+ * and job enablement ({@link useSchedule}).
+ *
+ * The catalog page has no per-asset *run* status loaded, so live states
+ * (running/success/failed) are intentionally absent here — those are
+ * supplied by the run-page model from asset executions instead.
+ */
+export function useNodeStatus() {
+    const { getWarnings } = useAssetWarnings()
+    const { getSourceSchedule } = useSchedule()
+
+    function assetStatus(assetId: string, assetKey: string): NodeStatus {
+        return getWarnings(assetId, assetKey).length > 0
+            ? { state: 'attention' }
+            : { state: 'idle' }
+    }
+
+    function sourceStatus(source: Source): NodeStatus {
+        const schedule = getSourceSchedule(source)
+        if (schedule?.paused) return { state: 'paused' }
+        const hasWarning = source.assets.some(a => getWarnings(a.id, a.key).length > 0)
+        return hasWarning ? { state: 'attention' } : { state: 'idle' }
+    }
+
+    return { assetStatus, sourceStatus }
+}

--- a/packages/interloper-app/app/app/composables/nodeStatus.ts
+++ b/packages/interloper-app/app/app/composables/nodeStatus.ts
@@ -19,6 +19,24 @@ export function statusDotClass(state: GraphNodeState): string {
     return STATUS_DOT[state]
 }
 
+/** Ring/border tint applied to a node in the Status view mode. */
+const STATUS_RING: Record<GraphNodeState, string> = {
+    idle: 'ring-2 ring-[var(--ui-success)]/40',
+    attention: 'ring-2 ring-[var(--ui-warning)]/70',
+    paused: 'ring-2 ring-[var(--ui-text-dimmed)]/40',
+    queued: 'ring-2 ring-[var(--ui-text-dimmed)]/40',
+    pending: 'ring-2 ring-[var(--ui-text-dimmed)]/40',
+    running: 'ring-2 ring-[var(--ui-info)]/70',
+    success: 'ring-2 ring-[var(--ui-success)]/60',
+    failed: 'ring-2 ring-[var(--ui-error)]/70',
+    skipped: 'ring-2 ring-[var(--ui-text-dimmed)]/40',
+    canceled: 'ring-2 ring-[var(--ui-text-dimmed)]/40',
+}
+
+export function statusRingClass(state: GraphNodeState): string {
+    return STATUS_RING[state]
+}
+
 /**
  * Derives {@link NodeStatus} for catalog graph nodes from data that
  * actually exists today: configuration warnings ({@link useAssetWarnings})

--- a/packages/interloper-app/app/app/composables/schedule.ts
+++ b/packages/interloper-app/app/app/composables/schedule.ts
@@ -1,0 +1,55 @@
+import cronstrue from 'cronstrue'
+import type { Source } from '~/types/source'
+import type { Job } from '~/types/job'
+
+/** Human-readable cron, e.g. "Daily at 06:00". Falls back to the raw expression. */
+export function cronLabel(cron: string): string {
+    try {
+        return cronstrue.toString(cron, { use24HourTimeFormat: true })
+    }
+    catch {
+        return cron
+    }
+}
+
+export interface SourceSchedule {
+    /** Display label: a single cron description, or "Multiple schedules". */
+    label: string
+    /** All referencing jobs are disabled. */
+    paused: boolean
+    /** Number of jobs that schedule this source. */
+    jobCount: number
+    nextRunAt: string | null
+}
+
+/**
+ * Schedule helpers derived from jobs. A source carries no schedule of its
+ * own — schedules live on jobs, which may reference many sources — so we
+ * summarise the job(s) that reference a given source.
+ */
+export function useSchedule() {
+    const jobsStore = useJobsStore()
+
+    function jobsForSource(source: Source): Job[] {
+        return jobsStore.jobs.filter(j => j.source_ids.includes(source.id))
+    }
+
+    /** Schedule summary for a source, or null when no job references it. */
+    function getSourceSchedule(source: Source): SourceSchedule | null {
+        const jobs = jobsForSource(source)
+        if (jobs.length === 0) return null
+
+        const paused = jobs.every(j => !j.enabled)
+        const nextRunAt = jobs
+            .map(j => j.next_run_at)
+            .filter((d): d is string => !!d)
+            .sort()[0] ?? null
+
+        if (jobs.length === 1) {
+            return { label: cronLabel(jobs[0]!.cron), paused, jobCount: 1, nextRunAt }
+        }
+        return { label: 'Multiple schedules', paused, jobCount: jobs.length, nextRunAt }
+    }
+
+    return { cronLabel, jobsForSource, getSourceSchedule }
+}

--- a/packages/interloper-app/app/app/composables/schedule.ts
+++ b/packages/interloper-app/app/app/composables/schedule.ts
@@ -12,6 +12,39 @@ export function cronLabel(cron: string): string {
     }
 }
 
+const DOW = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+
+/**
+ * Compact cadence label for common crons, e.g. "Daily · 06:00", "Hourly",
+ * "Weekly · Mon 06:00". Falls back to {@link cronLabel} for anything exotic.
+ */
+export function scheduleSummary(cron: string): string {
+    const parts = cron.trim().split(/\s+/)
+    if (parts.length !== 5) return cronLabel(cron)
+
+    const [min, hour, dom, mon, dow] = parts as [string, string, string, string, string]
+    const num = (s: string) => (/^\d+$/.test(s) ? Number(s) : null)
+    const hh = num(hour)
+    const mm = num(min)
+    const time = hh !== null && mm !== null
+        ? `${String(hh).padStart(2, '0')}:${String(mm).padStart(2, '0')}`
+        : null
+
+    if (dom === '*' && mon === '*') {
+        if (dow === '*') {
+            if (hour === '*' && mm === 0) return 'Hourly'
+            if (time) return `Daily · ${time}`
+        }
+        else if (num(dow) !== null && time) {
+            return `Weekly · ${DOW[num(dow)!] ?? dow} ${time}`
+        }
+    }
+    if (num(dom) !== null && mon === '*' && dow === '*' && time) {
+        return `Monthly · ${dom} ${time}`
+    }
+    return cronLabel(cron)
+}
+
 export interface SourceSchedule {
     /** Display label: a single cron description, or "Multiple schedules". */
     label: string
@@ -46,7 +79,7 @@ export function useSchedule() {
             .sort()[0] ?? null
 
         if (jobs.length === 1) {
-            return { label: cronLabel(jobs[0]!.cron), paused, jobCount: 1, nextRunAt }
+            return { label: scheduleSummary(jobs[0]!.cron), paused, jobCount: 1, nextRunAt }
         }
         return { label: 'Multiple schedules', paused, jobCount: jobs.length, nextRunAt }
     }

--- a/packages/interloper-app/app/app/pages/graph.vue
+++ b/packages/interloper-app/app/app/pages/graph.vue
@@ -13,6 +13,10 @@ const jobsStore = useJobsStore()
 const catalogStore = useCatalogStore()
 const toast = useToast()
 
+// Canvas view controls (toolbar-owned)
+const expandMode = ref<ExpandMode>('nodes')
+const viewMode = ref<ViewMode>('topology')
+
 onMounted(() => {
     if (!sourcesStore.loading) sourcesStore.fetch()
     if (!assetsStore.loading) assetsStore.fetch()
@@ -96,14 +100,17 @@ async function onDeleteDependency(payload: { upstreamAssetId: string; downstream
 </script>
 
 <template>
-    <div>
+    <div class="flex flex-col flex-1 min-h-0">
+        <GraphToolbar v-model:expand-mode="expandMode" />
         <SplitterGroup direction="horizontal"
                        auto-save-id="graph-panels"
                        class="flex-1 min-h-0">
             <SplitterPanel :default-size="panelVisible ? 70 : 100"
                            :min-size="30"
                            class="flex">
-                <GraphAssetGraph @add-source="onCreateSource"
+                <GraphAssetGraph :expand-mode="expandMode"
+                                 :view-mode="viewMode"
+                                 @add-source="onCreateSource"
                                  @edit-source="onEditSource"
                                  @asset-click="onAssetClick"
                                  @delete-source="onDeleteSource"

--- a/packages/interloper-app/app/app/pages/graph.vue
+++ b/packages/interloper-app/app/app/pages/graph.vue
@@ -16,6 +16,20 @@ const toast = useToast()
 // Canvas view controls (toolbar-owned)
 const expandMode = ref<ExpandMode>('nodes')
 const viewMode = ref<ViewMode>('topology')
+const statusFilter = ref<StatusFilter>('all')
+
+const { sourceStatus } = useNodeStatus()
+const statusCounts = computed<Record<StatusFilter, number>>(() => {
+    const c: Record<StatusFilter, number> = { all: 0, healthy: 0, attention: 0, paused: 0 }
+    for (const s of sourcesStore.sources) {
+        c.all++
+        const state = sourceStatus(s).state
+        if (state === 'paused') c.paused++
+        else if (state === 'attention') c.attention++
+        else c.healthy++
+    }
+    return c
+})
 
 onMounted(() => {
     if (!sourcesStore.loading) sourcesStore.fetch()
@@ -101,7 +115,17 @@ async function onDeleteDependency(payload: { upstreamAssetId: string; downstream
 
 <template>
     <div class="flex flex-col flex-1 min-h-0">
-        <GraphToolbar v-model:expand-mode="expandMode" />
+        <GraphToolbar v-model:expand-mode="expandMode"
+                      v-model:view-mode="viewMode"
+                      v-model:status-filter="statusFilter"
+                      :counts="statusCounts">
+            <template #end>
+                <UButton icon="i-lucide-plus"
+                         label="New Source"
+                         size="sm"
+                         @click="onCreateSource" />
+            </template>
+        </GraphToolbar>
         <SplitterGroup direction="horizontal"
                        auto-save-id="graph-panels"
                        class="flex-1 min-h-0">
@@ -110,6 +134,8 @@ async function onDeleteDependency(payload: { upstreamAssetId: string; downstream
                            class="flex">
                 <GraphAssetGraph :expand-mode="expandMode"
                                  :view-mode="viewMode"
+                                 :status-filter="statusFilter"
+                                 :show-new-source-button="false"
                                  @add-source="onCreateSource"
                                  @edit-source="onEditSource"
                                  @asset-click="onAssetClick"

--- a/packages/interloper-app/app/app/types/graph.ts
+++ b/packages/interloper-app/app/app/types/graph.ts
@@ -1,0 +1,78 @@
+import type { Asset, AssetDependency } from './asset'
+import type { Source, SourceAsset } from './source'
+import type { AssetDefinition, SourceDefinition } from './catalog'
+import type { ExecutionStatus } from './asset_execution'
+
+/**
+ * Canonical node status states shared across every graph surface
+ * (catalog graph page, job page, run page). Decoration (colour, dot)
+ * is derived from this single union so all surfaces agree.
+ *
+ * `idle | attention | paused` are catalog-level states; the remainder
+ * mirror {@link ExecutionStatus} for the live run-page graph.
+ */
+export type GraphNodeState =
+    | 'idle'
+    | 'attention'
+    | 'paused'
+    | 'queued'
+    | 'pending'
+    | 'running'
+    | 'success'
+    | 'failed'
+    | 'skipped'
+    | 'canceled'
+
+export interface NodeStatus {
+    state: GraphNodeState
+    /** Optional human label, e.g. "Last run 38m ago". */
+    label?: string
+}
+
+/** Map a backend execution status onto a graph node state. */
+export function stateFromExecution(status: ExecutionStatus): GraphNodeState {
+    return status
+}
+
+/** How a source reveals its assets on the canvas. */
+export type ExpandMode = 'list' | 'graph' | 'nodes'
+
+/** Which dimension the canvas decorates nodes by. */
+export type ViewMode = 'topology' | 'status'
+
+/** A directed asset→asset dependency, normalised away from the store shape. */
+export interface GraphDependency {
+    upstreamAssetId: string
+    downstreamAssetId: string
+}
+
+export interface GraphSourceEntry {
+    source: Source
+    sourceDefn: SourceDefinition | undefined
+    status?: NodeStatus
+}
+
+export interface GraphAssetEntry {
+    asset: SourceAsset | Asset
+    assetDefn: AssetDefinition | undefined
+    /** Owning source, or null for standalone assets. */
+    source: Source | null
+    status?: NodeStatus
+}
+
+/**
+ * Normalised, store-independent graph model consumed by <GraphCanvas>.
+ * Each surface (catalog / job / run) produces this same shape from its
+ * own data, which is what lets one renderer serve all three.
+ */
+export interface GraphModel {
+    sources: GraphSourceEntry[]
+    /** All assets — source-owned and standalone — for child + node lookup by id. */
+    assets: GraphAssetEntry[]
+    dependencies: GraphDependency[]
+}
+
+/** Convert a raw store dependency into the normalised graph shape. */
+export function toGraphDependency(dep: AssetDependency): GraphDependency {
+    return { upstreamAssetId: dep.upstream_asset_id, downstreamAssetId: dep.asset_id }
+}

--- a/packages/interloper-app/app/app/types/graph.ts
+++ b/packages/interloper-app/app/app/types/graph.ts
@@ -40,6 +40,9 @@ export type ExpandMode = 'list' | 'graph' | 'nodes'
 /** Which dimension the canvas decorates nodes by. */
 export type ViewMode = 'topology' | 'status'
 
+/** Source health filter for the catalog graph (derived states only). */
+export type StatusFilter = 'all' | 'healthy' | 'attention' | 'paused'
+
 /** A directed asset→asset dependency, normalised away from the store shape. */
 export interface GraphDependency {
     upstreamAssetId: string


### PR DESCRIPTION
## Summary

Redesigns the asset **Graph** view to be more compelling and, structurally, to make the same graph reusable on the **job** and **run** pages later (with live run status). Rendering is now separated from the data source: a presentational `GraphCanvas` consumes a normalised `GraphModel` that any surface can produce.

Built incrementally; each commit is a self-contained logical change.

## What changed

- **Reusable core** (`refactor`): extract `GraphCanvas` (store-independent renderer) + `types/graph.ts` (`GraphModel`/`NodeStatus`) + `composables/graphModel.ts` (`useCatalogGraph`, plus `useJobGraph`/`useRunGraph` seams) + `useNodeStatus` + `schedule` helpers. `AssetGraph` becomes a thin catalog adapter; the page's props/emits are unchanged.
- **Source cards + expand modes**: redesigned collapsed card (icon tile, schedule meta line, elevation) and an "Expand as" toggle with three modes — **Nodes** (on-canvas children, as before), **List** (in-card asset list), **Graph** (in-card mini dependency graph).
- **Detail panel enrichment**: status hero (latest run + last-run time), Rows/Columns/Refresh metric tiles, a recent-runs sparkline (bar height = duration, colour = status), and upstream dependencies as rows.
- **Toolbar + filters + view modes**: status filter pills (All / Healthy / Attention / Paused with counts), Topology/Status view modes, New Source moved to the toolbar.
- **Visual polish to match the design**: two-tone elevated node cards with a hairline border; plain graph styling where **edges are faint gray by default**, and **selecting a node turns its incident edges blue and fades everything outside the selection's neighbourhood** (selected node + a selected source's assets get a blue ring).

## Adapted to real data

Per a deliberate decision, the design was adapted to data that exists today and unbacked elements were dropped: schedule via `cronstrue`; status derived from config warnings + job enablement; Columns from the schema; Rows from partition counts (falls back to "—"). Model/destination canvas nodes, a fabricated "Healthy", and Running/Freshness/Volume view modes were intentionally left out for lack of backing data.

## Reusability (seams, not yet wired)

`useJobGraph`/`useRunGraph` return the same `GraphModel` shape; `useRunGraph` maps live `AssetExecution` status → node state. The job page and run-page live graph are a small follow-up that fills in those bodies and drops `<GraphCanvas>` onto the pages — **not** included here.

## Verification

- `pnpm exec nuxt typecheck` and `pnpm run lint` clean.
- Manually verified against the seeded demo instance: all three expand modes, panel enrichment, filter pills narrowing the graph, Status view tints, and the selection-focus behaviour (including clicking between assets — fixed a stale-opacity bug where nodes stayed dimmed).

## Notes for reviewer

- Frontend-only (`packages/interloper-app/app`).
- The detail panel's Partitions section surfaces a pre-existing backend `500` from `/assets/{id}/partition-row-counts` for unmaterialised demo assets — handled gracefully, not introduced here.
- The small status dots in the List/Graph in-card modes were kept (they matched the original design exploration); the always-on dot on canvas nodes was removed.
