### PR TITLE
fix: JSON-encode nested values for str-typed schema fields in conformer

### DIFF
--- a/packages/interloper-assets/src/interloper_assets/facebook_ads/schemas/ads.py
+++ b/packages/interloper-assets/src/interloper_assets/facebook_ads/schemas/ads.py
@@ -3,7 +3,7 @@ from pydantic import Field
 
 
 class Ads(Schema):
-    """Facebook Ads metadata snapshot. One row per ad (not time-series). Captures ad configuration, status, and creative details. Join to the ads insights table on id=ad_id. Join to facebook_insights.posts on creative_effective_object_story_id=post_id to resolve paid vs organic split."""
+    """Facebook Ads entity snapshot. One row per ad (not time-series). Captures ad configuration, status, and creative details. Join to the ads insights table on id=ad_id. Join to facebook_insights.posts on creative_effective_object_story_id=post_id to resolve paid vs organic split."""
 
     id: str | None = Field(default=None, description="Unique ad identifier. Join key to ads insights table (ad_id).")
     account_id: str | None = Field(default=None, description="Ad account ID.")

--- a/packages/interloper-assets/src/interloper_assets/facebook_ads/schemas/campaigns.py
+++ b/packages/interloper-assets/src/interloper_assets/facebook_ads/schemas/campaigns.py
@@ -3,7 +3,7 @@ from pydantic import Field
 
 
 class Campaigns(Schema):
-    """Facebook Ads campaign metadata snapshot. One row per campaign (not time-series). Captures campaign-level configuration, objective, budget, and status. boosted_object_id is the join key to facebook_insights.posts for Boost Post campaigns."""
+    """Facebook Ads campaign entity snapshot. One row per campaign (not time-series). Captures campaign-level configuration, objective, budget, and status. boosted_object_id is the join key to facebook_insights.posts for Boost Post campaigns."""
 
     id: str | None = Field(default=None, description="Unique campaign identifier. Join key to campaign insights table (campaign_id).")
     account_id: str | None = Field(default=None, description="Ad account ID this campaign belongs to.")

--- a/packages/interloper-assets/src/interloper_assets/facebook_ads/source.py
+++ b/packages/interloper-assets/src/interloper_assets/facebook_ads/source.py
@@ -420,7 +420,7 @@ class FacebookAds(il.Source):
         tags=["Entity"],
     )
     def ads(self, connection: FacebookAdsConnection) -> list[dict[str, Any]]:
-        """Ad metadata including creative, status, and configuration."""
+        """Ad entities including creative, status, and configuration."""
         return _get_ads(connection, self.account_id)
 
     @il.asset(
@@ -428,5 +428,5 @@ class FacebookAds(il.Source):
         tags=["Entity"],
     )
     def campaigns(self, connection: FacebookAdsConnection) -> list[dict[str, Any]]:
-        """Campaign metadata including objective, budget, and status configuration."""
+        """Campaign entities including objective, budget, and status configuration."""
         return _get_campaigns(connection, self.account_id)

--- a/packages/interloper-assets/src/interloper_assets/pinterest_ads/source.py
+++ b/packages/interloper-assets/src/interloper_assets/pinterest_ads/source.py
@@ -24,4 +24,4 @@ class PinterestAds(il.Source):
         description="Pinterest Ads account",
     )
 
-    # --- Entity assets (metadata) ---
+    # --- Entity assets ---

--- a/packages/interloper-assets/src/interloper_assets/snapchat_ads/schemas/ad_account.py
+++ b/packages/interloper-assets/src/interloper_assets/snapchat_ads/schemas/ad_account.py
@@ -5,7 +5,7 @@ from pydantic import Field
 
 
 class AdAccount(Schema):
-    """The Ad Account Metadata report provides detailed information about each advertising account, including identifiers, timestamps, names, types, statuses, and various financial and organizational details."""
+    """The Ad Account entity provides detailed information about each advertising account, including identifiers, timestamps, names, types, statuses, and various financial and organizational details."""
 
     id: str | None = Field(default=None, description="Unique identifier for the ad account.")
     updated_at: dt.datetime | None = Field(default=None, description="Timestamp of when the ad account was last updated.")

--- a/packages/interloper-assets/src/interloper_assets/snapchat_ads/schemas/ad_accounts.py
+++ b/packages/interloper-assets/src/interloper_assets/snapchat_ads/schemas/ad_accounts.py
@@ -5,7 +5,7 @@ from pydantic import Field
 
 
 class AdAccounts(Schema):
-    """The Ad Accounts Metadata report provides detailed information about each advertising account, including identifiers, timestamps, names, types, statuses, and various financial and organizational details."""
+    """The Ad Accounts entity provides detailed information about each advertising account, including identifiers, timestamps, names, types, statuses, and various financial and organizational details."""
 
     id: str | None = Field(default=None, description="Unique identifier for the ad account.")
     updated_at: dt.datetime | None = Field(default=None, description="Timestamp of when the ad account was last updated.")

--- a/packages/interloper-assets/src/interloper_assets/snapchat_ads/schemas/ad_squads.py
+++ b/packages/interloper-assets/src/interloper_assets/snapchat_ads/schemas/ad_squads.py
@@ -3,7 +3,7 @@ from pydantic import Field
 
 
 class AdSquads(Schema):
-    """The Ad Squads Metadata report provides insights into the metadata of ads squads in a campaign. It includes key metrics such as ad squad ID, status, placement, bid strategy, budget, targeting details (demographics, interests, geos), scheduling configurations, and delivery constraints."""
+    """The Ad Squads entity provides insights into the attributes of ads squads in a campaign. It includes key metrics such as ad squad ID, status, placement, bid strategy, budget, targeting details (demographics, interests, geos), scheduling configurations, and delivery constraints."""
 
     id: str | None = Field(default=None, description="The ID of the ad squad")
     updated_at: str | None = Field(default=None, description="The last updated timestamp of the ad squad")

--- a/packages/interloper-assets/src/interloper_assets/snapchat_ads/schemas/ads.py
+++ b/packages/interloper-assets/src/interloper_assets/snapchat_ads/schemas/ads.py
@@ -3,7 +3,7 @@ from pydantic import Field
 
 
 class Ads(Schema):
-    """The Ads Metadata report provides insights into the metadata of indivudal ads in a campaign. It includes key metrics such as ad ID, timestamps for creation and last update, ad name, ad squad ID, creative ID, third-party paid impression tracking URLs, third-party on swipe tracking URLs, ad status, ad type, render type, review status, delivery status, reasons for the review status, and container chain IDs."""
+    """The Ads entity provides insights into the attributes of indivudal ads in a campaign. It includes key metrics such as ad ID, timestamps for creation and last update, ad name, ad squad ID, creative ID, third-party paid impression tracking URLs, third-party on swipe tracking URLs, ad status, ad type, render type, review status, delivery status, reasons for the review status, and container chain IDs."""
 
     id: str | None = Field(default=None, description="The ID of the ad")
     updated_at: str | None = Field(default=None, description="The timestamp when the ad was last updated")

--- a/packages/interloper-assets/src/interloper_assets/snapchat_ads/schemas/campaigns.py
+++ b/packages/interloper-assets/src/interloper_assets/snapchat_ads/schemas/campaigns.py
@@ -3,7 +3,7 @@ from pydantic import Field
 
 
 class Campaigns(Schema):
-    """The Campaigns Metadata report provides insights into the metadata of campaigns. It includes key dimensions such as campaign ID, name, objective, status, start and end times, lifetime spend cap, buy model, delivery status, and creation state."""
+    """The Campaigns entity provides insights into the attributes of campaigns. It includes key dimensions such as campaign ID, name, objective, status, start and end times, lifetime spend cap, buy model, delivery status, and creation state."""
 
     id: str | None = Field(default=None, description="The ID of the campaign")
     updated_at: str | None = Field(default=None, description="The last updated timestamp of the campaign")

--- a/packages/interloper-assets/src/interloper_assets/snapchat_ads/source.py
+++ b/packages/interloper-assets/src/interloper_assets/snapchat_ads/source.py
@@ -57,8 +57,8 @@ class SnapchatStatsNormalizer(DataFrameNormalizer):
         return super().normalize(df)
 
 
-# Metadata records are nested entity dicts; flatten and drop all-null columns.
-_METADATA_NORMALIZER = DataFrameNormalizer(flatten_max_level=3, drop_na_columns=True)
+# Entity records are nested dicts; flatten and drop all-null columns.
+_ENTITY_NORMALIZER = DataFrameNormalizer(flatten_max_level=3, drop_na_columns=True)
 
 
 # ------------------------------------------------------------------
@@ -105,8 +105,8 @@ def _request_report(
     return rows
 
 
-def _metadata_records(connection: SnapchatAdsConnection, path: str, list_key: str, item_key: str) -> list[_RECORD]:
-    """Page a metadata endpoint and unwrap ``page[list_key][i][item_key]`` records."""
+def _entity_records(connection: SnapchatAdsConnection, path: str, list_key: str, item_key: str) -> list[_RECORD]:
+    """Page an entity endpoint and unwrap ``page[list_key][i][item_key]`` records."""
     records: list[_RECORD] = []
     for page in _get_pages(connection, path):
         records.extend(item[item_key] for item in page.get(list_key, []))
@@ -178,39 +178,39 @@ class SnapchatAds(il.Source):
         )
         return _with_date(rows, context.partition_date)
 
-    # --- Entity (metadata) assets (flattening normalizer) ---
+    # --- Entity assets (flattening normalizer) ---
 
-    @il.asset(schema=AdAccount, tags=["Entity"], normalizer=_METADATA_NORMALIZER)
+    @il.asset(schema=AdAccount, tags=["Entity"], normalizer=_ENTITY_NORMALIZER)
     def ad_account(self, connection: SnapchatAdsConnection) -> list[_RECORD]:
-        """Metadata for a single ad account."""
+        """A single ad account with its attributes."""
         path = f"/{constants.API_VERSION}/adaccounts/{self.account_id}"
-        return _metadata_records(connection, path, "adaccounts", "adaccount")
+        return _entity_records(connection, path, "adaccounts", "adaccount")
 
-    @il.asset(schema=AdAccounts, tags=["Entity"], normalizer=_METADATA_NORMALIZER)
+    @il.asset(schema=AdAccounts, tags=["Entity"], normalizer=_ENTITY_NORMALIZER)
     def ad_accounts(self, connection: SnapchatAdsConnection) -> list[_RECORD]:
-        """Metadata for all ad accounts in the organization owning this account."""
+        """All ad accounts in the organization owning this account."""
         account_path = f"/{constants.API_VERSION}/adaccounts/{self.account_id}"
-        accounts = _metadata_records(connection, account_path, "adaccounts", "adaccount")
+        accounts = _entity_records(connection, account_path, "adaccounts", "adaccount")
         organization_id = accounts[0]["organization_id"] if accounts else None
         if organization_id is None:
             return []
         path = f"/{constants.API_VERSION}/organizations/{organization_id}/adaccounts"
-        return _metadata_records(connection, path, "adaccounts", "adaccount")
+        return _entity_records(connection, path, "adaccounts", "adaccount")
 
-    @il.asset(schema=Ads, tags=["Entity"], normalizer=_METADATA_NORMALIZER)
+    @il.asset(schema=Ads, tags=["Entity"], normalizer=_ENTITY_NORMALIZER)
     def ads(self, connection: SnapchatAdsConnection) -> list[_RECORD]:
-        """Metadata for all ads in the ad account."""
+        """All ads in the ad account with their attributes."""
         path = f"/{constants.API_VERSION}/adaccounts/{self.account_id}/ads"
-        return _metadata_records(connection, path, "ads", "ad")
+        return _entity_records(connection, path, "ads", "ad")
 
-    @il.asset(schema=AdSquads, tags=["Entity"], normalizer=_METADATA_NORMALIZER)
+    @il.asset(schema=AdSquads, tags=["Entity"], normalizer=_ENTITY_NORMALIZER)
     def ad_squads(self, connection: SnapchatAdsConnection) -> list[_RECORD]:
-        """Metadata for all ad squads in the ad account."""
+        """All ad squads in the ad account with their attributes."""
         path = f"/{constants.API_VERSION}/adaccounts/{self.account_id}/adsquads"
-        return _metadata_records(connection, path, "adsquads", "adsquad")
+        return _entity_records(connection, path, "adsquads", "adsquad")
 
-    @il.asset(schema=Campaigns, tags=["Entity"], normalizer=_METADATA_NORMALIZER)
+    @il.asset(schema=Campaigns, tags=["Entity"], normalizer=_ENTITY_NORMALIZER)
     def campaigns(self, connection: SnapchatAdsConnection) -> list[_RECORD]:
-        """Metadata for all campaigns in the ad account."""
+        """All campaigns in the ad account with their attributes."""
         path = f"/{constants.API_VERSION}/adaccounts/{self.account_id}/campaigns"
-        return _metadata_records(connection, path, "campaigns", "campaign")
+        return _entity_records(connection, path, "campaigns", "campaign")

--- a/packages/interloper-assets/src/interloper_assets/tiktok_ads/schemas/ads.py
+++ b/packages/interloper-assets/src/interloper_assets/tiktok_ads/schemas/ads.py
@@ -5,7 +5,7 @@ from pydantic import Field
 
 
 class Ads(Schema):
-    """Tiktok Metadata for ads"""
+    """Tiktok ad entities"""
 
     ad_format: str | None = Field(default=None, description="Format of the ad")
     ad_id: str | None = Field(default=None, description="Unique identifier for the ad")

--- a/packages/interloper-assets/src/interloper_assets/tiktok_ads/schemas/advertisers.py
+++ b/packages/interloper-assets/src/interloper_assets/tiktok_ads/schemas/advertisers.py
@@ -3,7 +3,7 @@ from pydantic import Field
 
 
 class Advertisers(Schema):
-    """Tiktok Metadata for advertisers"""
+    """Tiktok advertiser entities"""
 
     address: str | None = Field(default=None, description="Physical address of the advertiser")
     advertiser_id: str | None = Field(default=None, description="Unique identifier for the advertiser")

--- a/packages/interloper-assets/src/interloper_assets/tiktok_ads/schemas/campaigns.py
+++ b/packages/interloper-assets/src/interloper_assets/tiktok_ads/schemas/campaigns.py
@@ -5,7 +5,7 @@ from pydantic import Field
 
 
 class Campaigns(Schema):
-    """Tiktok Metadata for campaigns"""
+    """Tiktok campaign entities"""
 
     modify_time: dt.datetime | None = Field(default=None, description="Last modification timestamp of the campaign")
     special_industries: str | None = Field(default=None, description="Indicates if the campaign belongs to special industries")

--- a/packages/interloper-assets/src/interloper_assets/tiktok_ads/source.py
+++ b/packages/interloper-assets/src/interloper_assets/tiktok_ads/source.py
@@ -54,10 +54,10 @@ class TiktokStatsNormalizer(DataFrameNormalizer):
         return df
 
 
-# Metadata carries list/dict fields (``ad_texts``, ``image_ids``,
+# Entity records carry list/dict fields (``ad_texts``, ``image_ids``,
 # ``special_industries``, …) that the schemas type as strings; the conformer
 # JSON-encodes those nested values when casting to the declared ``str`` type.
-_METADATA_NORMALIZER = DataFrameNormalizer(drop_na_columns=True)
+_ENTITY_NORMALIZER = DataFrameNormalizer(drop_na_columns=True)
 
 
 # ------------------------------------------------------------------
@@ -209,21 +209,21 @@ class TiktokAds(il.Source):
         )
         return _with_date(rows, context.partition_date)
 
-    # --- Entity (metadata) assets (_METADATA_NORMALIZER) ---
+    # --- Entity assets (_ENTITY_NORMALIZER) ---
 
-    @il.asset(schema=Ads, tags=["Entity"], normalizer=_METADATA_NORMALIZER)
+    @il.asset(schema=Ads, tags=["Entity"], normalizer=_ENTITY_NORMALIZER)
     def ads(self, connection: TiktokAdsConnection) -> list[dict[str, Any]]:
-        """Metadata for all ads in the advertiser account."""
+        """All ads in the advertiser account with their attributes."""
         return _paginate(connection, "/ad/get/", {"advertiser_id": self.advertiser_id})
 
-    @il.asset(schema=Campaigns, tags=["Entity"], normalizer=_METADATA_NORMALIZER)
+    @il.asset(schema=Campaigns, tags=["Entity"], normalizer=_ENTITY_NORMALIZER)
     def campaigns(self, connection: TiktokAdsConnection) -> list[dict[str, Any]]:
-        """Metadata for all campaigns in the advertiser account."""
+        """All campaigns in the advertiser account with their attributes."""
         return _paginate(connection, "/campaign/get/", {"advertiser_id": self.advertiser_id})
 
-    @il.asset(schema=Advertisers, tags=["Entity"], normalizer=_METADATA_NORMALIZER)
+    @il.asset(schema=Advertisers, tags=["Entity"], normalizer=_ENTITY_NORMALIZER)
     def advertisers(self, connection: TiktokAdsConnection) -> list[dict[str, Any]]:
-        """Metadata for the advertiser account."""
+        """The advertiser account with its attributes."""
         response = connection.client.get(
             "/advertiser/info/",
             params={

--- a/packages/interloper-assets/src/interloper_assets/tiktok_ads/source.py
+++ b/packages/interloper-assets/src/interloper_assets/tiktok_ads/source.py
@@ -54,24 +54,10 @@ class TiktokStatsNormalizer(DataFrameNormalizer):
         return df
 
 
-class TiktokMetadataNormalizer(DataFrameNormalizer):
-    """Normalize TikTok entity records onto the flat metadata schemas.
-
-    Metadata carries list/dict fields (``ad_texts``, ``image_ids``,
-    ``special_industries``, …) that the schemas type as strings; JSON-encode any
-    non-scalar value so it casts cleanly, then defer to the base normalizer.
-    """
-
-    def normalize(self, data: Any) -> pd.DataFrame:
-        records = data.to_dict("records") if isinstance(data, pd.DataFrame) else data
-        encoded = [
-            {key: (json.dumps(value) if isinstance(value, (list, dict)) else value) for key, value in row.items()}
-            for row in records
-        ]
-        return super().normalize(encoded)
-
-
-_METADATA_NORMALIZER = TiktokMetadataNormalizer(drop_na_columns=True)
+# Metadata carries list/dict fields (``ad_texts``, ``image_ids``,
+# ``special_industries``, …) that the schemas type as strings; the conformer
+# JSON-encodes those nested values when casting to the declared ``str`` type.
+_METADATA_NORMALIZER = DataFrameNormalizer(drop_na_columns=True)
 
 
 # ------------------------------------------------------------------
@@ -223,7 +209,7 @@ class TiktokAds(il.Source):
         )
         return _with_date(rows, context.partition_date)
 
-    # --- Entity (metadata) assets (TiktokMetadataNormalizer) ---
+    # --- Entity (metadata) assets (_METADATA_NORMALIZER) ---
 
     @il.asset(schema=Ads, tags=["Entity"], normalizer=_METADATA_NORMALIZER)
     def ads(self, connection: TiktokAdsConnection) -> list[dict[str, Any]]:

--- a/packages/interloper-assets/tests/test_facebook_ads.py
+++ b/packages/interloper-assets/tests/test_facebook_ads.py
@@ -107,7 +107,7 @@ class TestSpecRoundtripAndReconcile:
         df = pd.DataFrame([{"date_start": "2026-06-10", "account_id": "123", "actions_link_click": 7}])
         representation_for(df).conformer.validate(df, schemas.AdsStats)  # must not raise
 
-    def test_metadata_row_flattens_creative_and_reconciles(self):
+    def test_entity_row_flattens_creative_and_reconciles(self):
         child = self._child("ads")
         rows = [{"id": "456", "name": "My Ad", "creative": {"id": "789", "name": "Creative A"}}]
         normalized = child.normalizer.normalize(rows)

--- a/packages/interloper-assets/tests/test_snapchat_ads.py
+++ b/packages/interloper-assets/tests/test_snapchat_ads.py
@@ -2,7 +2,7 @@
 
 Stats rows nest metrics under a ``stats`` dict (flattened and de-prefixed) or,
 for dimensioned reports, a ``dimension_stats`` list (exploded into one row per
-dimension) — reshaped by ``SnapchatStatsNormalizer``. Metadata records are
+dimension) — reshaped by ``SnapchatStatsNormalizer``. Entity records are
 flattened by a configured ``DataFrameNormalizer``. These tests pin the
 normalizers, that they survive the host→child spec round-trip (the AmazonAds
 failure mode), and that results reconcile against the ported schemas.
@@ -46,7 +46,7 @@ class TestSource:
         for key in ("ads_stats", "campaigns_stats", "ads_stats_by_country", "videos_stats_by_os"):
             assert isinstance(by_key[key].normalizer, SnapchatStatsNormalizer), key
 
-    def test_metadata_assets_use_flattening_normalizer(self):
+    def test_entity_assets_use_flattening_normalizer(self):
         by_key = {type(a).key: a for a in _source().assets}
         for key in ("ads", "ad_squads", "campaigns", "ad_account"):
             norm = by_key[key].normalizer
@@ -90,7 +90,7 @@ class TestSpecRoundtripAndReconcile:
         # The custom subclass must reconstruct in the child (not degrade to the base).
         assert isinstance(self._child("ads_stats").normalizer, SnapchatStatsNormalizer)
 
-    def test_metadata_normalizer_survives_roundtrip(self):
+    def test_entity_normalizer_survives_roundtrip(self):
         norm = self._child("ads").normalizer
         assert isinstance(norm, DataFrameNormalizer) and not isinstance(norm, SnapchatStatsNormalizer)
         assert norm.flatten_max_level == 3 and norm.drop_na_columns is True
@@ -102,7 +102,7 @@ class TestSpecRoundtripAndReconcile:
         out = representation_for(normalized).conformer.reconcile(normalized, schemas.AdsStats)
         assert int(out.loc[0, "impressions"]) == 100
 
-    def test_ads_metadata_conforms_after_roundtrip(self):
+    def test_ads_entity_conforms_after_roundtrip(self):
         child = self._child("ads")
         normalized = child.normalizer.normalize([{"id": "ad1", "name": "My Ad"}])
         representation_for(normalized).conformer.reconcile(normalized, schemas.Ads)  # must not raise

--- a/packages/interloper-assets/tests/test_tiktok_ads.py
+++ b/packages/interloper-assets/tests/test_tiktok_ads.py
@@ -4,10 +4,11 @@ TikTok integrated reports return each row as ``{"dimensions": {...},
 "metrics": {...}}``; the source's ``TiktokStatsNormalizer`` merges both into a
 flat record (de-prefixed) before column normalization. Entity (metadata)
 records carry list/dict fields (``ad_texts``, ``image_ids``, …) that the flat
-schemas type as strings, so ``TiktokMetadataNormalizer`` JSON-encodes any
-non-scalar value first. These tests pin both reshapes, that every asset gets
-the right normalizer, and that the normalizer survives the host→child spec
-round-trip and reconciles against the ported schemas.
+schemas type as strings; the conformer JSON-encodes those nested values when
+casting to the declared ``str`` type, so the metadata assets need no bespoke
+normalizer. These tests pin both reshapes, that every asset gets the right
+normalizer, and that the normalizer survives the host→child spec round-trip and
+reconciles against the ported schemas.
 """
 
 from __future__ import annotations
@@ -17,9 +18,10 @@ from typing import Any
 from interloper.dag.base import DAG
 from interloper.dag.spec import DAGSpec
 from interloper.representation import representation_for
+from interloper_pandas import DataFrameNormalizer
 
 from interloper_assets.tiktok_ads import schemas
-from interloper_assets.tiktok_ads.source import TiktokAds, TiktokMetadataNormalizer, TiktokStatsNormalizer
+from interloper_assets.tiktok_ads.source import TiktokAds, TiktokStatsNormalizer
 
 
 def _source() -> Any:
@@ -51,10 +53,14 @@ class TestSourceNormalizer:
             asset = next(a for a in _source().assets if type(a).key == key)
             assert isinstance(asset.normalizer, TiktokStatsNormalizer), key
 
-    def test_metadata_assets_use_the_metadata_normalizer(self):
+    def test_metadata_assets_use_the_base_normalizer(self):
+        # Entity assets use a plain DataFrameNormalizer (not the stats reshape);
+        # nested str-field encoding is handled downstream by the conformer.
         for key in ("ads", "campaigns", "advertisers"):
             asset = next(a for a in _source().assets if type(a).key == key)
-            assert isinstance(asset.normalizer, TiktokMetadataNormalizer), key
+            assert isinstance(asset.normalizer, DataFrameNormalizer), key
+            assert not isinstance(asset.normalizer, TiktokStatsNormalizer), key
+            assert asset.normalizer.drop_na_columns is True, key
 
 
 class TestStatsNormalizer:
@@ -74,14 +80,6 @@ class TestStatsNormalizer:
         assert df.loc[0, "ad_id"] == "456"
         assert df.loc[0, "spend"] == "12.50"
         assert df.loc[0, "date"] == "2026-06-14"
-
-
-class TestMetadataNormalizer:
-    def test_list_and_dict_fields_are_json_encoded(self):
-        rows = [{"ad_id": "1", "ad_texts": ["a", "b"], "image_ids": ["x"]}]
-        df = TiktokMetadataNormalizer().normalize(rows)
-        assert df.loc[0, "ad_texts"] == '["a", "b"]'
-        assert df.loc[0, "image_ids"] == '["x"]'
 
 
 class TestSpecRoundtripAndReconcile:
@@ -111,8 +109,10 @@ class TestSpecRoundtripAndReconcile:
 
     def test_metadata_row_reconciles_against_ads_metadata_schema(self):
         child = self._child("ads")
-        assert isinstance(child.normalizer, TiktokMetadataNormalizer)
+        assert isinstance(child.normalizer, DataFrameNormalizer)
         rows = [{"ad_id": "456", "ad_name": "My Ad", "ad_texts": ["hello"], "image_ids": ["img1"]}]
         normalized = child.normalizer.normalize(rows)
-        # must not raise; list fields land as JSON strings on the str-typed schema columns
-        representation_for(normalized).conformer.reconcile(normalized, schemas.Ads)
+        # list fields land as JSON strings on the str-typed schema columns
+        reconciled = representation_for(normalized).conformer.reconcile(normalized, schemas.Ads)
+        assert reconciled.loc[0, "ad_texts"] == '["hello"]'
+        assert reconciled.loc[0, "image_ids"] == '["img1"]'

--- a/packages/interloper-assets/tests/test_tiktok_ads.py
+++ b/packages/interloper-assets/tests/test_tiktok_ads.py
@@ -2,11 +2,11 @@
 
 TikTok integrated reports return each row as ``{"dimensions": {...},
 "metrics": {...}}``; the source's ``TiktokStatsNormalizer`` merges both into a
-flat record (de-prefixed) before column normalization. Entity (metadata)
-records carry list/dict fields (``ad_texts``, ``image_ids``, …) that the flat
-schemas type as strings; the conformer JSON-encodes those nested values when
-casting to the declared ``str`` type, so the metadata assets need no bespoke
-normalizer. These tests pin both reshapes, that every asset gets the right
+flat record (de-prefixed) before column normalization. Entity records carry
+list/dict fields (``ad_texts``, ``image_ids``, …) that the flat schemas type as
+strings; the conformer JSON-encodes those nested values when casting to the
+declared ``str`` type, so the entity assets need no bespoke normalizer. These
+tests pin both reshapes, that every asset gets the right
 normalizer, and that the normalizer survives the host→child spec round-trip and
 reconciles against the ported schemas.
 """
@@ -53,7 +53,7 @@ class TestSourceNormalizer:
             asset = next(a for a in _source().assets if type(a).key == key)
             assert isinstance(asset.normalizer, TiktokStatsNormalizer), key
 
-    def test_metadata_assets_use_the_base_normalizer(self):
+    def test_entity_assets_use_the_base_normalizer(self):
         # Entity assets use a plain DataFrameNormalizer (not the stats reshape);
         # nested str-field encoding is handled downstream by the conformer.
         for key in ("ads", "campaigns", "advertisers"):
@@ -107,7 +107,7 @@ class TestSpecRoundtripAndReconcile:
         assert float(reconciled.loc[0, "spend"]) == 12.5
         assert int(reconciled.loc[0, "clicks"]) == 3
 
-    def test_metadata_row_reconciles_against_ads_metadata_schema(self):
+    def test_entity_row_reconciles_against_ads_schema(self):
         child = self._child("ads")
         assert isinstance(child.normalizer, DataFrameNormalizer)
         rows = [{"ad_id": "456", "ad_name": "My Ad", "ad_texts": ["hello"], "image_ids": ["img1"]}]

--- a/packages/interloper-pandas/src/interloper_pandas/conformer.py
+++ b/packages/interloper-pandas/src/interloper_pandas/conformer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime
+import json
 from decimal import Decimal
 from typing import Any
 
@@ -34,6 +35,7 @@ class DataFrameConformer(Conformer):
         Missing values in numeric columns validate correctly against
         nullable fields instead of failing as ``nan`` floats.
         """
+        data = _encode_json_str_columns(data, schema)
         schema.validate_rows(dataframe_to_records(data), strict=strict)
 
     def reconcile(self, data: pd.DataFrame, schema: type[Schema]) -> pd.DataFrame:
@@ -50,6 +52,7 @@ class DataFrameConformer(Conformer):
             SchemaError: If a column cannot be cast to its declared type, or
                 a required non-nullable column is missing.
         """
+        data = _encode_json_str_columns(data, schema)
         columns: dict[str, pd.Series] = {}
         for spec in schema.field_specs():
             if spec.name in data.columns:
@@ -121,6 +124,44 @@ def _to_datetime(series: pd.Series) -> pd.Series:
         return pd.to_datetime(series, errors="raise")
     except ValueError:
         return pd.to_datetime(series, errors="raise", utc=True)
+
+
+def _json_encode_value(value: Any) -> Any:
+    """JSON-encode a ``list``/``dict``; pass scalars (and ``NA``) through."""
+    if isinstance(value, (list, dict)):
+        return json.dumps(value)
+    return value
+
+
+def _encode_json_str_columns(data: pd.DataFrame, schema: type[Schema]) -> pd.DataFrame:
+    """JSON-encode nested values in columns declared as a scalar ``str``.
+
+    A field typed ``str`` that receives a ``list``/``dict`` (e.g. a Facebook
+    ``tracking_specs`` array or TikTok ``ad_texts``) is serialized to a JSON
+    string so it satisfies the declared type — without this, ``validate``
+    rejects the row and ``reconcile``'s ``astype("string")`` would store the
+    Python ``repr`` instead of valid JSON. Repeated/nested fields are left
+    untouched. Only ``object``-dtype columns are scanned, preserving the
+    vectorized fast path; the input frame is copied only when a column is
+    actually rewritten.
+
+    Returns:
+        The frame with nested ``str``-field cells JSON-encoded (the original
+        when nothing needed encoding).
+    """
+    encoded = data
+    for spec in schema.field_specs():
+        if spec.repeated or spec.fields is not None or spec.type is not str:
+            continue
+        if spec.name not in encoded.columns:
+            continue
+        series = encoded[spec.name]
+        if series.dtype != object or not series.map(lambda v: isinstance(v, (list, dict))).any():
+            continue
+        if encoded is data:
+            encoded = data.copy()
+        encoded[spec.name] = series.map(_json_encode_value)
+    return encoded
 
 
 def _cast_series(series: pd.Series, spec: FieldSpec) -> pd.Series:

--- a/packages/interloper-pandas/tests/test_conformer.py
+++ b/packages/interloper-pandas/tests/test_conformer.py
@@ -1,6 +1,7 @@
 """Tests for the DataFrame conformer."""
 
 import datetime
+import json
 
 import pandas as pd
 import pytest
@@ -84,6 +85,41 @@ class TestDataFrameConformerReconcile:
         df = pd.DataFrame({"id": ["abc"], "cost": [1.0], "day": ["2024-01-01"], "name": ["x"]})
         with pytest.raises(SchemaError, match="cannot cast"):
             DataFrameConformer().reconcile(df, TypedSchema)
+
+
+class JsonSchema(Schema):
+    """A scalar ``str`` field that receives nested API values."""
+
+    id: str | None = Field(...)
+    tracking_specs: str | None = Field(...)
+
+
+class TestDataFrameConformerJsonEncoding:
+    """``str``-typed fields receiving list/dict values are JSON-encoded."""
+
+    def test_validate_accepts_list_for_str_field(self):
+        df = pd.DataFrame({"id": ["1"], "tracking_specs": [[{"action.type": ["x"]}]]})
+        DataFrameConformer().validate(df, JsonSchema)
+
+    def test_validate_accepts_dict_for_str_field(self):
+        df = pd.DataFrame({"id": ["1"], "tracking_specs": [{"a": 1}]})
+        DataFrameConformer().validate(df, JsonSchema)
+
+    def test_reconcile_serializes_to_valid_json_not_repr(self):
+        df = pd.DataFrame({"id": ["1"], "tracking_specs": [[{"a": 1}]]})
+        out = DataFrameConformer().reconcile(df, JsonSchema)
+        assert out["tracking_specs"].dtype == "string"
+        encoded = out["tracking_specs"].iloc[0]
+        # Valid JSON (double-quoted) round-trips; a Python repr would not.
+        assert json.loads(encoded) == [{"a": 1}]
+        assert "'" not in encoded
+
+    def test_scalar_strings_and_nulls_pass_through(self):
+        df = pd.DataFrame({"id": ["1", "2"], "tracking_specs": ["plain", None]})
+        DataFrameConformer().validate(df, JsonSchema)
+        out = DataFrameConformer().reconcile(df, JsonSchema)
+        assert out["tracking_specs"].iloc[0] == "plain"
+        assert pd.isna(out["tracking_specs"].iloc[1])
 
 
 class TestDataFrameConformerInfer:


### PR DESCRIPTION
## What

The `DataFrameConformer` now JSON-encodes nested values (`list`/`dict`) when casting them to a field declared as a scalar `str`, in **both** `validate` and `reconcile`. With that in place, the two per-source normalizer shims that worked around the same problem are removed.

## Why

A field typed `str | None` that receives a `list`/`dict` from an API crashed materialization. This surfaced running `interloper run -f manifests/swarovski.yaml` against Facebook Ads:

```
Asset 'ads' failed: Schema validation failed on row 0: 1 validation error for Ads
tracking_specs
  Input should be a valid string [type=string_type, input_value=[{'action.type': [...
```

Facebook's `tracking_specs`/`issues_info`/`recommendations` (and TikTok's `ad_texts`/`image_ids`) are documented as JSON strings, but the SDK returns Python lists and nothing serialized them. Two distinct failure modes:

- **`validate` (STRICT/AUTO)** — pydantic rejects the list with a `string_type` error (the crash above).
- **`reconcile` (RECONCILE)** — `astype("string")` silently stored the Python **`repr`** (single-quoted, not valid JSON), corrupting the column without raising.

The reference connectors (`digitlcloud-connectors`) never hit this because their schemas are passive BigQuery DDL, not a runtime validator. The port turned that DDL into strict pydantic schemas, so the implicit "these are JSON strings" contract now has to be made explicit.

## How

- `_encode_json_str_columns()` (+ `_json_encode_value`) runs at the top of `validate()` and `reconcile()` (`prepare()` runs before the schema is known, so it can't host this).
- **Targeted** — only scalar `str` fields; `repeated`/nested fields pass through untouched, so dict fields like Facebook `creative` still flatten into `creative_*` columns.
- **Correct** — `json.dumps` produces valid JSON, fixing the `reconcile` repr-corruption too.
- **Fast path preserved** — only `object`-dtype columns containing non-scalars are rewritten; the frame is copied lazily.

This generalizes what the shims did per-source:
- **Facebook** needs no source change — the `ads` entity asset now conforms on its own.
- **TikTok** `TiktokMetadataNormalizer` is removed; entity assets use `DataFrameNormalizer(drop_na_columns=True)`.

## Testing

- New `TestDataFrameConformerJsonEncoding`: validate accepts list/dict for `str` fields; reconcile emits valid JSON (asserts `json.loads` round-trip, not repr); scalars/nulls pass through.
- `test_tiktok_ads.py` updated for the removed class; reconcile test now asserts the JSON output (`'["hello"]'`).
- `81 passed` across `interloper-pandas` + `interloper-assets`; ruff + ty clean.
- End-to-end through the real `FacebookActionsNormalizer` + conformer against `schemas.Ads`: original error gone, `tracking_specs` is valid round-trippable JSON, `creative` still flattens.

## Reviewer notes

- The original `swarovski.yaml` run still fails downstream on a **separate** BigQuery table-drift error (`Cannot add fields (field: id)`) on the live `dc-swarovski-dwh-dev.facebook_ads.ads` table — unrelated to this change; needs the drifted dev table recreated.
- Considered porting the reference's `convert_object_columns_to_string` (blanket `select_dtypes("object").astype("string")`) instead and rejected it: wrong layer (typing belongs in the conformer, not the normalizer), too blunt (all object columns), and it produces Python repr rather than JSON.