### PR TITLE
feat(app): add run summary header card

### DIFF
--- a/packages/interloper-app/app/app/components/executions/RunSummary.vue
+++ b/packages/interloper-app/app/app/components/executions/RunSummary.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import type { Run } from '~/types/run'
+import type { AssetExecution } from '~/types/asset_execution'
+
+const props = defineProps<{
+    run: Run
+    assetExecutions: AssetExecution[]
+}>()
+
+const stats = useRunStats(toRef(props, 'run'), toRef(props, 'assetExecutions'))
+
+/** One-line breakdown, omitting empty buckets (e.g. "11 succeeded · 1 failed · 3 not run"). */
+const summaryLine = computed(() => {
+    const s = stats.value
+    const parts: string[] = []
+    if (s.succeeded) parts.push(`${s.succeeded} succeeded`)
+    if (s.running) parts.push(`${s.running} running`)
+    if (s.failed) parts.push(`${s.failed} failed`)
+    if (s.notRun) parts.push(`${s.notRun} not run`)
+    return parts.join(' · ') || 'No assets'
+})
+
+const barSegments = computed(() => stats.value.buckets.filter(b => b.count > 0))
+const legendBuckets = computed(() => stats.value.buckets.filter(b => b.core || b.count > 0))
+
+function clockTime(value: string | null): string {
+    if (!value) return '—'
+    return new Date(value).toLocaleTimeString('en-US', { hour12: false })
+}
+
+const metaItems = computed(() => [
+    { label: 'Duration', icon: 'i-lucide-timer', value: stats.value.duration ?? '—' },
+    { label: 'Started', icon: 'i-lucide-play', value: clockTime(props.run.started_at) },
+    { label: 'Job', icon: 'i-lucide-calendar-clock', value: props.run.job?.name ?? 'Manual' },
+    { label: 'Attempt', icon: 'i-lucide-rotate-ccw', value: String(props.run.attempt) },
+])
+</script>
+
+<template>
+    <div class="flex flex-col gap-4 rounded-lg border border-default bg-muted p-4 lg:flex-row lg:items-stretch">
+        <!-- Counts + proportion bar + legend -->
+        <div class="flex flex-1 flex-col justify-between gap-3">
+            <div class="flex items-baseline justify-between gap-3">
+                <div class="flex items-baseline gap-2">
+                    <span class="text-3xl font-semibold tabular-nums">{{ stats.total }}</span>
+                    <span class="text-sm text-muted">assets</span>
+                </div>
+                <span class="text-sm text-muted">{{ summaryLine }}</span>
+            </div>
+
+            <div class="flex h-2 w-full overflow-hidden rounded-full bg-accented">
+                <div v-for="seg in barSegments"
+                     :key="seg.key"
+                     :class="seg.colorClass"
+                     :style="{ width: seg.percent + '%' }" />
+            </div>
+
+            <div class="flex flex-wrap gap-1.5">
+                <div v-for="b in legendBuckets"
+                     :key="b.key"
+                     class="flex items-center gap-1.5 rounded-md bg-accented px-2 py-1 text-xs">
+                    <span class="size-2 rounded-full"
+                          :class="b.colorClass" />
+                    <span class="text-muted">{{ b.label }}</span>
+                    <span class="font-medium tabular-nums">{{ b.count }}</span>
+                </div>
+            </div>
+        </div>
+
+        <!-- Meta grid -->
+        <div class="grid shrink-0 grid-cols-2 gap-2 lg:w-80">
+            <div v-for="m in metaItems"
+                 :key="m.label"
+                 class="flex flex-col gap-1 rounded-md border border-default bg-default px-3 py-2">
+                <div class="flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-wide text-muted">
+                    <UIcon :name="m.icon"
+                           class="size-3" />
+                    {{ m.label }}
+                </div>
+                <span class="truncate text-sm font-medium"
+                      :title="m.value">{{ m.value }}</span>
+            </div>
+        </div>
+    </div>
+</template>

--- a/packages/interloper-app/app/app/composables/runStats.ts
+++ b/packages/interloper-app/app/app/composables/runStats.ts
@@ -1,0 +1,79 @@
+import type { Ref } from 'vue'
+import type { Run } from '~/types/run'
+import type { AssetExecution, ExecutionStatus } from '~/types/asset_execution'
+
+interface StatusMeta {
+    key: string
+    label: string
+    statuses: ExecutionStatus[]
+    /** Tailwind background class for the dot and the proportion-bar segment. */
+    colorClass: string
+}
+
+/** Bucket order also drives the proportion-bar segment order and the legend. */
+const STATUS_META: StatusMeta[] = [
+    { key: 'success', label: 'Success', statuses: ['success'], colorClass: 'bg-green-500' },
+    { key: 'running', label: 'Running', statuses: ['running'], colorClass: 'bg-blue-500' },
+    { key: 'failed', label: 'Failed', statuses: ['failed'], colorClass: 'bg-red-500' },
+    { key: 'canceled', label: 'Canceled', statuses: ['canceled'], colorClass: 'bg-amber-500' },
+    { key: 'skipped', label: 'Skipped', statuses: ['skipped'], colorClass: 'bg-gray-400' },
+    { key: 'pending', label: 'Pending', statuses: ['pending', 'queued'], colorClass: 'bg-gray-600' },
+]
+
+/** Always shown in the legend, even at zero. Pending only appears when present. */
+const CORE_KEYS = new Set(['success', 'running', 'failed', 'canceled', 'skipped'])
+
+export interface RunStatusBucket {
+    key: string
+    label: string
+    count: number
+    colorClass: string
+    /** Share of the total run, 0–100. */
+    percent: number
+    /** Part of the always-on legend (shown even at zero). */
+    core: boolean
+}
+
+export interface RunStats {
+    total: number
+    succeeded: number
+    failed: number
+    running: number
+    /** Assets that produced nothing: canceled + skipped + pending/queued. */
+    notRun: number
+    buckets: RunStatusBucket[]
+    /** Formatted run duration (elapsed so far when still running), or null. */
+    duration: string | null
+}
+
+/** Derive per-status counts and run-level stats from the asset executions. */
+export function useRunStats(run: Ref<Run | null>, executions: Ref<AssetExecution[]>) {
+    return computed<RunStats>(() => {
+        const counts: Record<string, number> = {}
+        for (const ex of executions.value) counts[ex.status] = (counts[ex.status] ?? 0) + 1
+
+        const total = executions.value.length
+        const buckets: RunStatusBucket[] = STATUS_META.map((m) => {
+            const count = m.statuses.reduce((sum, st) => sum + (counts[st] ?? 0), 0)
+            return {
+                key: m.key,
+                label: m.label,
+                count,
+                colorClass: m.colorClass,
+                percent: total ? (count / total) * 100 : 0,
+                core: CORE_KEYS.has(m.key),
+            }
+        })
+        const get = (k: string) => buckets.find(b => b.key === k)?.count ?? 0
+
+        return {
+            total,
+            succeeded: get('success'),
+            failed: get('failed'),
+            running: get('running'),
+            notRun: get('canceled') + get('skipped') + get('pending'),
+            buckets,
+            duration: run.value?.started_at ? formatElapsed(run.value.started_at, run.value.completed_at) : null,
+        }
+    })
+}

--- a/packages/interloper-app/app/app/pages/executions/runs/[run].vue
+++ b/packages/interloper-app/app/app/pages/executions/runs/[run].vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import type { DropdownMenuItem } from '@nuxt/ui'
 import type { RunEvent } from '~/stores/events'
 import type { Run } from '~/types/run'
 import type { ExecutionStatus } from '~/types/asset_execution'
@@ -51,19 +50,6 @@ async function onRetry(scope: 'all' | 'failed') {
     }
 }
 
-const retryItems = computed<DropdownMenuItem[]>(() => [
-    {
-        label: 'Retry failed assets only',
-        icon: 'i-lucide-list-restart',
-        onSelect: () => onRetry('failed'),
-    },
-    {
-        label: 'Retry all assets',
-        icon: 'i-lucide-rotate-ccw',
-        onSelect: () => onRetry('all'),
-    },
-])
-
 const fetchError = ref<unknown>(null)
 
 onMounted(async () => {
@@ -95,30 +81,41 @@ onUnmounted(() => {
              :error="fetchError"
              back-to="/executions?tab=runs"
              resource-label="run">
-        <div>
-            <div class="flex items-center gap-3 mb-4 shrink-0 px-4 pt-4">
-            <NuxtLink to="/executions?tab=runs"
-                      class="text-sm text-muted hover:text-default">
-                Runs
-            </NuxtLink>
-            <span class="text-sm text-muted">/</span>
-            <span class="text-sm font-medium font-mono">{{ runId }}</span>
-            <UBadge v-if="run"
-                    :color="statusColor(run.status)">
-                {{ statusLabel(run.status) }}
-            </UBadge>
-            <UDropdownMenu v-if="run?.status === 'failed'"
-                           :items="retryItems"
-                           class="ml-auto">
-                <UButton icon="i-lucide-rotate-ccw"
-                         label="Retry"
-                         color="neutral"
-                         variant="outline"
-                         size="sm"
-                         trailing-icon="i-lucide-chevron-down"
-                         :loading="retrying" />
-            </UDropdownMenu>
-        </div>
+        <div class="flex flex-col h-full min-h-0">
+            <div class="flex flex-col gap-4 mb-4 shrink-0 px-4 pt-4">
+                <div class="flex items-center gap-3">
+                    <NuxtLink to="/executions?tab=runs"
+                              class="text-sm text-muted hover:text-default">
+                        Runs
+                    </NuxtLink>
+                    <span class="text-sm text-muted">/</span>
+                    <span class="text-sm font-medium font-mono">{{ runId }}</span>
+                    <UBadge v-if="run"
+                            :color="statusColor(run.status)">
+                        {{ statusLabel(run.status) }}
+                    </UBadge>
+                    <div v-if="run?.status === 'failed'"
+                         class="ml-auto flex items-center gap-2">
+                        <UButton label="Retry failed"
+                                 icon="i-lucide-list-restart"
+                                 color="neutral"
+                                 variant="outline"
+                                 size="sm"
+                                 :loading="retrying"
+                                 @click="onRetry('failed')" />
+                        <UButton label="Retry all"
+                                 icon="i-lucide-rotate-ccw"
+                                 color="neutral"
+                                 variant="outline"
+                                 size="sm"
+                                 :loading="retrying"
+                                 @click="onRetry('all')" />
+                    </div>
+                </div>
+                <ExecutionsRunSummary v-if="run"
+                                      :run="run"
+                                      :asset-executions="assetExecutions" />
+            </div>
 
         <SplitterGroup direction="vertical"
                        auto-save-id="run-panels"


### PR DESCRIPTION
First of four incremental PRs reworking the run detail page toward the new design.

## What

Replaces the run page's bare breadcrumb header with a **summary card** that surfaces the run's shape at a glance:

- Large **asset count** with a `N succeeded · N failed · N not run` breakdown (empty buckets omitted).
- A **status proportion bar** (success / running / failed / canceled / skipped / pending).
- A **status legend** with per-status counts (the five core statuses always shown, pending only when present).
- A **meta grid**: Duration, Started, Job, Attempt.

Also splits the failed-run **retry dropdown into two explicit buttons** ("Retry failed" / "Retry all"), matching the design.

## How

- New `useRunStats()` composable ([runStats.ts](packages/interloper-app/app/app/composables/runStats.ts)) buckets the asset executions by status — folding `queued` into pending, and grouping canceled + skipped + pending as **"not run"** — and computes proportions and the run duration.
- New `ExecutionsRunSummary` component ([RunSummary.vue](packages/interloper-app/app/app/components/executions/RunSummary.vue)).
- All figures are derived **client-side** from the asset executions + run record — **no new API**.

## Scope / sequence

This is PR 1 of the agreed plan. Upcoming: (2) timeline name-gutter + duration labels, (3) events filter tabs, (4) run graph tab. Row counts (the mockup's "1.1M rows") are intentionally **out of scope** — no backing data today.

## Reviewer notes

- Lint passes (no new warnings). `nuxt typecheck` is unrunnable in-tree (pre-existing `vue-router/volar` config crash), so this hasn't been type-checked.
- **Not yet verified live** — it's a visual card; worth a glance against a real failed run (the screenshotted `daily_sync` case) for the proportion bar, legend wrapping, and the responsive `lg` two-column split.
- The outer page wrapper gained explicit `flex flex-col` classes; these mirror what the default layout already injects onto the slot child, so layout/height behavior is unchanged.