### PR TITLE
feat: filter run assets and events by status

### DIFF
--- a/packages/interloper-api/src/interloper_api/routes/runs.py
+++ b/packages/interloper-api/src/interloper_api/routes/runs.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import datetime as dt
-from typing import Literal
+from typing import Annotated, Literal
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Response
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from interloper.errors import NotFoundError
 from interloper_db import Profile, Store
 from interloper_db.models import Event, Run
@@ -244,23 +244,24 @@ def list_run_events(
     response: Response,
     limit: int = 100,
     offset: int = 0,
-    asset_id: UUID | None = None,
+    asset_id: Annotated[list[UUID] | None, Query()] = None,
     user: Profile = Depends(get_current_user),
     store: Store = Depends(get_store),
 ) -> list[EventResponse]:
     """List events for a run, oldest first.
 
     Events are ordered ``timestamp ASC`` and paged with ``limit``/``offset``.
-    ``asset_id`` narrows the listing to one asset's events. The total number
-    of matching events (ignoring ``limit``/``offset``, honouring ``asset_id``)
-    is returned in the ``X-Total-Count`` response header so clients can page
-    through every event — including the terminal/outcome events
-    (``asset_completed``, ``asset_failed``, ``run_failed``, …) that sort last.
+    ``asset_id`` may be repeated to narrow the listing to one or more assets'
+    events (e.g. every asset sharing a status). The total number of matching
+    events (ignoring ``limit``/``offset``, honouring ``asset_id``) is returned
+    in the ``X-Total-Count`` response header so clients can page through every
+    event — including the terminal/outcome events (``asset_completed``,
+    ``asset_failed``, ``run_failed``, …) that sort last.
     """
     _load_authorized_run(run_id, user, store)
     limit = max(1, min(limit, MAX_EVENTS_PAGE_SIZE))
     offset = max(0, offset)
-    total = store.count_events(run_id=run_id, asset_id=asset_id)
+    total = store.count_events(run_id=run_id, asset_ids=asset_id)
     response.headers["X-Total-Count"] = str(total)
-    events = store.list_events(run_id=run_id, asset_id=asset_id, limit=limit, offset=offset)
+    events = store.list_events(run_id=run_id, asset_ids=asset_id, limit=limit, offset=offset)
     return [_event_to_response(e) for e in events]

--- a/packages/interloper-api/tests/test_run_events.py
+++ b/packages/interloper-api/tests/test_run_events.py
@@ -33,7 +33,7 @@ class FakeStore:
     def __init__(self, total: int = 777) -> None:
         self.total = total
         self.list_calls: list[tuple] = []
-        self.count_calls: list[UUID | None] = []
+        self.count_calls: list[list[UUID] | None] = []
 
     def get_run(self, run_id: UUID):
         return SimpleNamespace(id=run_id, org_id=_ORG_ID)
@@ -46,9 +46,9 @@ class FakeStore:
         *,
         run_id: UUID | None = None,
         org_id: UUID | None = None,
-        asset_id: UUID | None = None,
+        asset_ids: list[UUID] | None = None,
     ) -> int:
-        self.count_calls.append(asset_id)
+        self.count_calls.append(asset_ids)
         return self.total
 
     def list_events(
@@ -56,11 +56,11 @@ class FakeStore:
         *,
         run_id: UUID | None = None,
         org_id: UUID | None = None,
-        asset_id: UUID | None = None,
+        asset_ids: list[UUID] | None = None,
         limit: int = 100,
         offset: int = 0,
     ) -> list:
-        self.list_calls.append((run_id, limit, offset, asset_id))
+        self.list_calls.append((run_id, limit, offset, asset_ids))
         # Return as many fake events as the page would hold, capped at the total.
         n = max(0, min(limit, self.total - offset))
         return [
@@ -109,9 +109,19 @@ def test_forwards_asset_filter_to_list_and_count(store: FakeStore) -> None:
     asset_id = uuid4()
     resp = _client(store).get(f"/{_RUN_ID}/events?asset_id={asset_id}")
     assert resp.status_code == 200
-    assert store.list_calls[-1] == (_RUN_ID, 100, 0, asset_id)
+    # A single asset_id arrives as a one-element list.
+    assert store.list_calls[-1] == (_RUN_ID, 100, 0, [asset_id])
     # X-Total-Count must reflect the same filter the listing used.
-    assert store.count_calls[-1] == asset_id
+    assert store.count_calls[-1] == [asset_id]
+
+
+def test_forwards_multiple_asset_filters(store: FakeStore) -> None:
+    a, b = uuid4(), uuid4()
+    resp = _client(store).get(f"/{_RUN_ID}/events?asset_id={a}&asset_id={b}")
+    assert resp.status_code == 200
+    # Repeated asset_id params filter the listing to the whole set (e.g. one status).
+    assert store.list_calls[-1] == (_RUN_ID, 100, 0, [a, b])
+    assert store.count_calls[-1] == [a, b]
 
 
 def test_invalid_asset_filter_is_rejected(store: FakeStore) -> None:

--- a/packages/interloper-app/app/app/components/executions/RunSummary.vue
+++ b/packages/interloper-app/app/app/components/executions/RunSummary.vue
@@ -1,13 +1,23 @@
 <script setup lang="ts">
 import type { Run } from '~/types/run'
 import type { AssetExecution } from '~/types/asset_execution'
+import type { RunStatusBucket } from '~/composables/runStats'
 
 const props = defineProps<{
     run: Run
     assetExecutions: AssetExecution[]
 }>()
 
+/** Active status bucket key (e.g. "failed"); filters the assets + events. */
+const statusFilter = defineModel<string | null>('statusFilter', { default: null })
+
 const stats = useRunStats(toRef(props, 'run'), toRef(props, 'assetExecutions'))
+
+/** Toggle a status filter; empty buckets aren't selectable (nothing to show). */
+function toggleStatus(bucket: RunStatusBucket) {
+    if (bucket.count === 0) return
+    statusFilter.value = statusFilter.value === bucket.key ? null : bucket.key
+}
 
 /** One-line breakdown, omitting empty buckets (e.g. "11 succeeded · 1 failed · 3 not run"). */
 const summaryLine = computed(() => {
@@ -56,14 +66,25 @@ const metaItems = computed(() => [
             </div>
 
             <div class="flex flex-wrap gap-1.5">
-                <div v-for="b in legendBuckets"
-                     :key="b.key"
-                     class="flex items-center gap-1.5 rounded-md bg-accented px-2 py-1 text-xs">
+                <button v-for="b in legendBuckets"
+                        :key="b.key"
+                        type="button"
+                        :disabled="b.count === 0"
+                        :aria-pressed="statusFilter === b.key"
+                        class="flex items-center gap-1.5 rounded-md px-2 py-1 text-xs transition-colors"
+                        :class="[
+                            b.count === 0 ? 'cursor-default opacity-50' : 'cursor-pointer hover:bg-elevated',
+                            statusFilter === b.key
+                                ? 'bg-elevated ring-1 ring-inset ring-primary'
+                                : 'bg-accented',
+                            statusFilter && statusFilter !== b.key ? 'opacity-60' : '',
+                        ]"
+                        @click="toggleStatus(b)">
                     <span class="size-2 rounded-full"
                           :class="b.colorClass" />
                     <span class="text-muted">{{ b.label }}</span>
                     <span class="font-medium tabular-nums">{{ b.count }}</span>
-                </div>
+                </button>
             </div>
         </div>
 

--- a/packages/interloper-app/app/app/composables/runStats.ts
+++ b/packages/interloper-app/app/app/composables/runStats.ts
@@ -23,6 +23,11 @@ const STATUS_META: StatusMeta[] = [
 /** Always shown in the legend, even at zero. Pending only appears when present. */
 const CORE_KEYS = new Set(['success', 'running', 'failed', 'canceled', 'skipped'])
 
+/** Execution statuses grouped under a bucket key (e.g. pending → pending+queued). */
+export function statusesForKey(key: string): ExecutionStatus[] {
+    return STATUS_META.find(m => m.key === key)?.statuses ?? []
+}
+
 export interface RunStatusBucket {
     key: string
     label: string

--- a/packages/interloper-app/app/app/pages/executions/runs/[run].vue
+++ b/packages/interloper-app/app/app/pages/executions/runs/[run].vue
@@ -25,11 +25,35 @@ const assetExecutions = computed(() => assetExecutionsStore.assetExecutions)
 const run = computed(() => runsStore.findById(runId) ?? initialRun.value)
 
 const selectedAsset = ref<string | null>(null)
+const statusFilter = ref<string | null>(null)
 const eventInFocus = ref<RunEvent | null>(null)
 
-// The events table is paged from the server, so the asset filter is applied
-// there (re-paged from offset 0) rather than over the loaded pages only.
-watch(selectedAsset, asset => eventsStore.filterByAsset(asset))
+/** Execution statuses behind the active status pill (e.g. pending → pending+queued). */
+const filterStatuses = computed(() => statusFilter.value ? statusesForKey(statusFilter.value) : null)
+
+/** Timeline rows, narrowed to the active status pill. */
+const filteredAssetExecutions = computed(() => {
+    const statuses = filterStatuses.value
+    if (!statuses) return assetExecutions.value
+    return assetExecutions.value.filter(e => statuses.includes(e.status))
+})
+
+// Selecting a single asset narrows to it; otherwise the active status pill's
+// asset set drives the filter. Events are paged from the server, so the filter
+// is applied there (re-paged from offset 0) rather than over the loaded pages.
+const eventAssetIds = computed<string[] | null>(() => {
+    if (selectedAsset.value) return [selectedAsset.value]
+    const statuses = filterStatuses.value
+    if (!statuses) return null
+    return assetExecutions.value
+        .filter(e => statuses.includes(e.status) && e.asset_id)
+        .map(e => e.asset_id!)
+})
+watch(eventAssetIds, ids => eventsStore.filterByAssets(ids))
+
+// Switching the status pill clears any single-asset drill-down.
+watch(statusFilter, () => { selectedAsset.value = null })
+
 const markerTime = computed(() => eventInFocus.value?.timestamp ? new Date(eventInFocus.value.timestamp) : null)
 const highlightedAsset = computed(() => eventInFocus.value?.asset_id ?? null)
 
@@ -113,6 +137,7 @@ onUnmounted(() => {
                     </div>
                 </div>
                 <ExecutionsRunSummary v-if="run"
+                                      v-model:status-filter="statusFilter"
                                       :run="run"
                                       :asset-executions="assetExecutions" />
             </div>
@@ -127,7 +152,7 @@ onUnmounted(() => {
                            class="overflow-hidden py-4 pl-4">
                 <ChartExecutionTimeline v-if="run?.status !== 'queued'"
                                         v-model:selected-asset="selectedAsset"
-                                        :asset-executions="assetExecutions"
+                                        :asset-executions="filteredAssetExecutions"
                                         :status="(run?.status as ExecutionStatus)"
                                         :marker-time="markerTime"
                                         :highlighted-asset="highlightedAsset" />

--- a/packages/interloper-app/app/app/stores/events.ts
+++ b/packages/interloper-app/app/app/stores/events.ts
@@ -26,10 +26,11 @@ export const useEventsStore = defineStore('events', () => {
      * State
      **********************/
     const runId = ref<string | null>(null)
-    // Server-side asset filter. Events are paged from the server, so filtering
-    // must happen there too — filtering only the loaded pages client-side would
-    // hide every matching event that hasn't been scrolled into view yet.
-    const assetId = ref<string | null>(null)
+    // Server-side asset filter — one or more assets (e.g. every asset sharing a
+    // status). Events are paged from the server, so filtering must happen there
+    // too — filtering only the loaded pages client-side would hide every
+    // matching event that hasn't been scrolled into view yet.
+    const assetIds = ref<string[] | null>(null)
     const events = ref<RunEvent[]>([])
     const total = ref(0)
     const loading = ref(false) // initial page load
@@ -62,6 +63,15 @@ export const useEventsStore = defineStore('events', () => {
         events.value.sort((a, b) => a.timestamp.localeCompare(b.timestamp) || a.id.localeCompare(b.id))
     }
 
+    /** Order-insensitive equality of two asset-id filters. */
+    function _sameAssetFilter(a: string[] | null, b: string[] | null): boolean {
+        if (a === b) return true
+        if (!a || !b || a.length !== b.length) return false
+        const sa = [...a].sort()
+        const sb = [...b].sort()
+        return sa.every((v, i) => v === sb[i])
+    }
+
     function _upsert(event: RunEvent) {
         const idx = events.value.findIndex(e => e.id === event.id)
         if (idx >= 0) {
@@ -92,7 +102,7 @@ export const useEventsStore = defineStore('events', () => {
             limit: String(EVENTS_PAGE_SIZE),
             offset: String(nextOffset.value),
         })
-        if (assetId.value) params.set('asset_id', assetId.value)
+        for (const aid of assetIds.value ?? []) params.append('asset_id', aid)
         const res = await apiFetchRaw<RunEvent[]>(`/runs/${id}/events?${params}`)
         if (epoch !== fetchEpoch) return // state was reset while in flight
         const page = res._data ?? []
@@ -110,7 +120,7 @@ export const useEventsStore = defineStore('events', () => {
         table: 'events',
         scope: () => runId.value ? orgStore.organisation?.id : null,
         shouldHandle: (record: Record<string, any>) =>
-            record.run_id === runId.value && (!assetId.value || record.asset_id === assetId.value),
+            record.run_id === runId.value && (!assetIds.value || assetIds.value.includes(record.asset_id)),
         onInsert: (record: Record<string, any>) => _upsert(record as RunEvent),
     })
 
@@ -125,9 +135,9 @@ export const useEventsStore = defineStore('events', () => {
      * The table reaches them by infinite-scrolling — see `loadMore` — rather
      * than loading the whole history up front.
      */
-    async function fetchForRun(id: string, asset: string | null = null) {
+    async function fetchForRun(id: string, assets: string[] | null = null) {
         runId.value = id
-        assetId.value = asset
+        assetIds.value = assets
         fetchEpoch++
         events.value = []
         total.value = 0
@@ -145,10 +155,10 @@ export const useEventsStore = defineStore('events', () => {
         }
     }
 
-    /** Re-page from the start with an asset filter (`null` clears it). */
-    async function filterByAsset(asset: string | null) {
-        if (!runId.value || asset === assetId.value) return
-        await fetchForRun(runId.value, asset)
+    /** Re-page from the start filtered to a set of assets (`null` clears it). */
+    async function filterByAssets(assets: string[] | null) {
+        if (!runId.value || _sameAssetFilter(assets, assetIds.value)) return
+        await fetchForRun(runId.value, assets)
     }
 
     /** Load the next page of events. Safe to call repeatedly (infinite scroll). */
@@ -179,7 +189,7 @@ export const useEventsStore = defineStore('events', () => {
 
     function $reset() {
         runId.value = null
-        assetId.value = null
+        assetIds.value = null
         fetchEpoch++
         events.value = []
         total.value = 0
@@ -191,7 +201,7 @@ export const useEventsStore = defineStore('events', () => {
 
     return {
         runId,
-        assetId,
+        assetIds,
         events,
         total,
         loading,
@@ -199,7 +209,7 @@ export const useEventsStore = defineStore('events', () => {
         hasMore,
         error,
         fetchForRun,
-        filterByAsset,
+        filterByAssets,
         loadMore,
         findById,
         byAssetKey,

--- a/packages/interloper-db/src/interloper_db/store/runs.py
+++ b/packages/interloper-db/src/interloper_db/store/runs.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime as dt
 import logging
+from collections.abc import Sequence
 from datetime import datetime, timedelta, timezone
 from uuid import UUID, uuid4
 
@@ -99,11 +100,11 @@ class RunMixin:
         *,
         run_id: UUID | None = None,
         org_id: UUID | None = None,
-        asset_id: UUID | None = None,
+        asset_ids: Sequence[UUID] | None = None,
         limit: int = 100,
         offset: int = 0,
     ) -> list[Event]:
-        """List events, optionally filtered by run and/or asset.
+        """List events, optionally filtered by run and/or asset(s).
 
         Ordering is ``timestamp ASC, id ASC`` — stable and deterministic so
         ``offset``/``limit`` paging never skips or repeats a row when several
@@ -112,7 +113,7 @@ class RunMixin:
         Args:
             run_id: Optional run filter.
             org_id: Optional org filter.
-            asset_id: Optional asset filter.
+            asset_ids: Optional filter to events of any of these assets.
             limit: Max results (default 100).
             offset: Pagination offset.
 
@@ -125,8 +126,8 @@ class RunMixin:
                 statement = statement.where(Event.run_id == run_id)
             if org_id:
                 statement = statement.where(Event.org_id == org_id)
-            if asset_id:
-                statement = statement.where(Event.asset_id == asset_id)
+            if asset_ids:
+                statement = statement.where(col(Event.asset_id).in_(asset_ids))
             statement = (
                 statement.order_by(col(Event.timestamp).asc(), col(Event.id).asc()).offset(offset).limit(limit)
             )
@@ -137,14 +138,14 @@ class RunMixin:
         *,
         run_id: UUID | None = None,
         org_id: UUID | None = None,
-        asset_id: UUID | None = None,
+        asset_ids: Sequence[UUID] | None = None,
     ) -> int:
         """Count events matching the same filters as :meth:`list_events`.
 
         Args:
             run_id: Optional run filter.
             org_id: Optional org filter.
-            asset_id: Optional asset filter.
+            asset_ids: Optional filter to events of any of these assets.
 
         Returns:
             Total number of matching events (ignoring limit/offset).
@@ -155,8 +156,8 @@ class RunMixin:
                 statement = statement.where(Event.run_id == run_id)
             if org_id:
                 statement = statement.where(Event.org_id == org_id)
-            if asset_id:
-                statement = statement.where(Event.asset_id == asset_id)
+            if asset_ids:
+                statement = statement.where(col(Event.asset_id).in_(asset_ids))
             return session.exec(statement).one()
 
     def list_asset_executions(self, run_id: UUID) -> list[dict]:

--- a/packages/interloper-db/tests/test_run_events.py
+++ b/packages/interloper-db/tests/test_run_events.py
@@ -137,17 +137,30 @@ def test_asset_filter_lists_and_counts_only_that_asset(store: RunMixin) -> None:
     _seed(_make_events(150, asset_id=asset_a))
     _seed(_make_events(30, start=150, asset_id=asset_b))
 
-    assert store.count_events(run_id=_RUN_ID, asset_id=asset_a) == 150
-    assert store.count_events(run_id=_RUN_ID, asset_id=asset_b) == 30
+    assert store.count_events(run_id=_RUN_ID, asset_ids=[asset_a]) == 150
+    assert store.count_events(run_id=_RUN_ID, asset_ids=[asset_b]) == 30
 
     # Paging honours the filter: asset_a events past the first unfiltered
     # page are reachable through the filtered offsets.
-    page2 = store.list_events(run_id=_RUN_ID, asset_id=asset_a, limit=100, offset=100)
+    page2 = store.list_events(run_id=_RUN_ID, asset_ids=[asset_a], limit=100, offset=100)
     assert len(page2) == 50
     assert all(e.asset_id == asset_a for e in page2)
 
     # asset_b's events all live beyond the first 150 rows of the run, yet its
     # filtered first page surfaces them.
-    page_b = store.list_events(run_id=_RUN_ID, asset_id=asset_b, limit=100, offset=0)
+    page_b = store.list_events(run_id=_RUN_ID, asset_ids=[asset_b], limit=100, offset=0)
     assert len(page_b) == 30
     assert all(e.asset_id == asset_b for e in page_b)
+
+
+def test_asset_filter_accepts_multiple_assets(store: RunMixin) -> None:
+    asset_a, asset_b, asset_c = uuid4(), uuid4(), uuid4()
+    _seed(_make_events(10, asset_id=asset_a))
+    _seed(_make_events(5, start=10, asset_id=asset_b))
+    _seed(_make_events(7, start=15, asset_id=asset_c))
+
+    # A set of asset ids (e.g. every asset of one status) is the union of each.
+    assert store.count_events(run_id=_RUN_ID, asset_ids=[asset_a, asset_b]) == 15
+    page = store.list_events(run_id=_RUN_ID, asset_ids=[asset_a, asset_b], limit=100, offset=0)
+    assert len(page) == 15
+    assert all(e.asset_id in {asset_a, asset_b} for e in page)


### PR DESCRIPTION
Follow-up to the run summary header ([#79](https://github.com/digitl-cloud/interloper/pull/79)).

## What

The run summary's **status legend pills are now interactive**. Clicking a pill (e.g. **Failed**) filters the run to that status — narrowing **both the timeline and the events table** — and clicking it again clears the filter.

- Single status at a time; the active pill gets a primary ring, others dim.
- **Empty buckets aren't selectable** (nothing to show).
- Selecting a single asset still narrows *within* the active status; switching status clears that drill-down.

## How

**Backend — events filter by an asset set (server-side):**
- Events are paged from the server, so per-status filtering must happen there. The events endpoint's `asset_id` query param is now **repeatable** (`?asset_id=a&asset_id=b`), mapping to a SQL `IN` over the selected status's asset ids. A single `asset_id` (the existing per-asset filter) still works as a one-element set — no behavior change there.
- `store.list_events` / `count_events`: `asset_id: UUID` → `asset_ids: Sequence[UUID]`.
- Tests updated + new multi-asset coverage in both the API and DB test suites.

**Frontend:**
- `RunSummary`: legend chips → toggle buttons with a `v-model:statusFilter`.
- Events store: `filterByAsset` → `filterByAssets(string[] | null)` (incl. realtime + the re-page dedup guard).
- `runStats`: exposes `statusesForKey()` so a bucket maps to its statuses (pending → pending + queued).
- Run page: the active pill filters the **timeline at the page level** (a filtered execution list passed to the unchanged timeline component — so this doesn't collide with the in-flight timeline-gutter work) and drives the **events** asset set.

## Checks
ruff ✓, ty ✓, pytest ✓ (full suite via pre-commit; +3 new events tests), frontend lint ✓.

## Reviewer notes
- **Verified the build runs** against the seeded demo instance (server boots, run page loads, all event API calls 200). The demo seed is all-success, so only the **Success** pill has data to exercise end-to-end; the multi-asset filter path is covered by unit tests.
- The timeline **rescales** to the filtered subset (it receives a smaller list) — intended for a "filter," but happy to switch to dimming-with-full-axis if preferred.
- `frontend nuxt typecheck` remains unrunnable in-tree (pre-existing `vue-router/volar` config crash), so the TS side is lint-checked only.