### PR TITLE
feat: add All / Lifecycle / Errors / Logs tabs to run events

### DIFF
--- a/packages/interloper-api/src/interloper_api/routes/runs.py
+++ b/packages/interloper-api/src/interloper_api/routes/runs.py
@@ -245,23 +245,27 @@ def list_run_events(
     limit: int = 100,
     offset: int = 0,
     asset_id: Annotated[list[UUID] | None, Query()] = None,
+    event_type: Annotated[list[str] | None, Query()] = None,
     user: Profile = Depends(get_current_user),
     store: Store = Depends(get_store),
 ) -> list[EventResponse]:
     """List events for a run, oldest first.
 
     Events are ordered ``timestamp ASC`` and paged with ``limit``/``offset``.
-    ``asset_id`` may be repeated to narrow the listing to one or more assets'
-    events (e.g. every asset sharing a status). The total number of matching
-    events (ignoring ``limit``/``offset``, honouring ``asset_id``) is returned
-    in the ``X-Total-Count`` response header so clients can page through every
-    event — including the terminal/outcome events (``asset_completed``,
-    ``asset_failed``, ``run_failed``, …) that sort last.
+    ``asset_id`` and ``event_type`` may each be repeated to narrow the listing
+    to one or more assets (e.g. every asset sharing a status) and/or event
+    types (e.g. a "Lifecycle"/"Errors"/"Logs" tab); the two compose. The total
+    number of matching events (ignoring ``limit``/``offset``, honouring the
+    filters) is returned in the ``X-Total-Count`` response header so clients can
+    page through every event — including the terminal/outcome events
+    (``asset_completed``, ``asset_failed``, ``run_failed``, …) that sort last.
     """
     _load_authorized_run(run_id, user, store)
     limit = max(1, min(limit, MAX_EVENTS_PAGE_SIZE))
     offset = max(0, offset)
-    total = store.count_events(run_id=run_id, asset_ids=asset_id)
+    total = store.count_events(run_id=run_id, asset_ids=asset_id, event_types=event_type)
     response.headers["X-Total-Count"] = str(total)
-    events = store.list_events(run_id=run_id, asset_ids=asset_id, limit=limit, offset=offset)
+    events = store.list_events(
+        run_id=run_id, asset_ids=asset_id, event_types=event_type, limit=limit, offset=offset
+    )
     return [_event_to_response(e) for e in events]

--- a/packages/interloper-api/tests/test_run_events.py
+++ b/packages/interloper-api/tests/test_run_events.py
@@ -33,7 +33,7 @@ class FakeStore:
     def __init__(self, total: int = 777) -> None:
         self.total = total
         self.list_calls: list[tuple] = []
-        self.count_calls: list[list[UUID] | None] = []
+        self.count_calls: list[tuple] = []
 
     def get_run(self, run_id: UUID):
         return SimpleNamespace(id=run_id, org_id=_ORG_ID)
@@ -47,8 +47,9 @@ class FakeStore:
         run_id: UUID | None = None,
         org_id: UUID | None = None,
         asset_ids: list[UUID] | None = None,
+        event_types: list[str] | None = None,
     ) -> int:
-        self.count_calls.append(asset_ids)
+        self.count_calls.append((asset_ids, event_types))
         return self.total
 
     def list_events(
@@ -57,10 +58,11 @@ class FakeStore:
         run_id: UUID | None = None,
         org_id: UUID | None = None,
         asset_ids: list[UUID] | None = None,
+        event_types: list[str] | None = None,
         limit: int = 100,
         offset: int = 0,
     ) -> list:
-        self.list_calls.append((run_id, limit, offset, asset_ids))
+        self.list_calls.append((run_id, limit, offset, asset_ids, event_types))
         # Return as many fake events as the page would hold, capped at the total.
         n = max(0, min(limit, self.total - offset))
         return [
@@ -97,7 +99,7 @@ def test_returns_total_count_header(store: FakeStore) -> None:
 def test_forwards_limit_and_offset(store: FakeStore) -> None:
     resp = _client(store).get(f"/{_RUN_ID}/events?limit=100&offset=200")
     assert resp.status_code == 200
-    assert store.list_calls[-1] == (_RUN_ID, 100, 200, None)
+    assert store.list_calls[-1] == (_RUN_ID, 100, 200, None, None)
 
 
 def test_limit_is_clamped_to_max_page_size(store: FakeStore) -> None:
@@ -110,9 +112,9 @@ def test_forwards_asset_filter_to_list_and_count(store: FakeStore) -> None:
     resp = _client(store).get(f"/{_RUN_ID}/events?asset_id={asset_id}")
     assert resp.status_code == 200
     # A single asset_id arrives as a one-element list.
-    assert store.list_calls[-1] == (_RUN_ID, 100, 0, [asset_id])
+    assert store.list_calls[-1] == (_RUN_ID, 100, 0, [asset_id], None)
     # X-Total-Count must reflect the same filter the listing used.
-    assert store.count_calls[-1] == [asset_id]
+    assert store.count_calls[-1] == ([asset_id], None)
 
 
 def test_forwards_multiple_asset_filters(store: FakeStore) -> None:
@@ -120,8 +122,16 @@ def test_forwards_multiple_asset_filters(store: FakeStore) -> None:
     resp = _client(store).get(f"/{_RUN_ID}/events?asset_id={a}&asset_id={b}")
     assert resp.status_code == 200
     # Repeated asset_id params filter the listing to the whole set (e.g. one status).
-    assert store.list_calls[-1] == (_RUN_ID, 100, 0, [a, b])
-    assert store.count_calls[-1] == [a, b]
+    assert store.list_calls[-1] == (_RUN_ID, 100, 0, [a, b], None)
+    assert store.count_calls[-1] == ([a, b], None)
+
+
+def test_forwards_event_type_filter_to_list_and_count(store: FakeStore) -> None:
+    resp = _client(store).get(f"/{_RUN_ID}/events?event_type=log&event_type=asset_failed")
+    assert resp.status_code == 200
+    # Repeated event_type params filter to that set (e.g. a "Logs"/"Errors" tab).
+    assert store.list_calls[-1] == (_RUN_ID, 100, 0, None, ["log", "asset_failed"])
+    assert store.count_calls[-1] == (None, ["log", "asset_failed"])
 
 
 def test_invalid_asset_filter_is_rejected(store: FakeStore) -> None:
@@ -131,7 +141,7 @@ def test_invalid_asset_filter_is_rejected(store: FakeStore) -> None:
 
 def test_limit_and_offset_are_clamped_to_lower_bounds(store: FakeStore) -> None:
     _client(store).get(f"/{_RUN_ID}/events?limit=0&offset=-5")
-    _, limit, offset, _ = store.list_calls[-1]
+    _, limit, offset, _, _ = store.list_calls[-1]
     assert limit == 1
     assert offset == 0
 

--- a/packages/interloper-app/app/app/pages/executions/runs/[run].vue
+++ b/packages/interloper-app/app/app/pages/executions/runs/[run].vue
@@ -2,6 +2,7 @@
 import type { RunEvent } from '~/stores/events'
 import type { Run } from '~/types/run'
 import type { ExecutionStatus } from '~/types/asset_execution'
+import type { EventCategory } from '~/utils/events'
 import { SplitterGroup, SplitterPanel, SplitterResizeHandle } from 'reka-ui'
 
 // orgSwitchTarget: this page is bespoke to one org's run — switching org from
@@ -53,6 +54,16 @@ watch(eventAssetIds, ids => eventsStore.filterByAssets(ids))
 
 // Switching the status pill clears any single-asset drill-down.
 watch(statusFilter, () => { selectedAsset.value = null })
+
+// Event category tab (All / Lifecycle / Errors / Logs), filtered server-side.
+const eventCategory = ref<EventCategory>('all')
+const eventTabs: { key: EventCategory; label: string; icon: string }[] = [
+    { key: 'all', label: 'All', icon: 'i-lucide-list' },
+    { key: 'lifecycle', label: 'Lifecycle', icon: 'i-lucide-activity' },
+    { key: 'errors', label: 'Errors', icon: 'i-lucide-circle-alert' },
+    { key: 'logs', label: 'Logs', icon: 'i-lucide-scroll-text' },
+]
+watch(eventCategory, cat => eventsStore.filterByEventTypes(eventTypesForCategory(cat)))
 
 const markerTime = computed(() => eventInFocus.value?.timestamp ? new Date(eventInFocus.value.timestamp) : null)
 const highlightedAsset = computed(() => eventInFocus.value?.asset_id ?? null)
@@ -174,7 +185,21 @@ onUnmounted(() => {
                            :min-size="20"
                            class="flex flex-col min-h-0">
                 <div class="flex items-center gap-2 px-4 py-2 shrink-0">
-                    <span class="text-xs font-medium uppercase tracking-wide text-muted">Events</span>
+                    <div class="flex items-center gap-0.5 rounded-md bg-elevated p-0.5">
+                        <button v-for="tab in eventTabs"
+                                :key="tab.key"
+                                type="button"
+                                class="flex items-center gap-1.5 rounded px-2 py-1 text-xs transition-colors cursor-pointer"
+                                :class="eventCategory === tab.key
+                                    ? 'bg-default text-default shadow-sm'
+                                    : 'text-muted hover:text-default'"
+                                @click="eventCategory = tab.key">
+                            <UIcon :name="tab.icon"
+                                   class="size-3.5" />
+                            {{ tab.label }}
+                        </button>
+                    </div>
+                    <span class="ml-auto text-xs font-medium uppercase tracking-wide text-muted">Events</span>
                     <UBadge v-if="!eventsStore.loading"
                             color="neutral"
                             variant="subtle"

--- a/packages/interloper-app/app/app/stores/events.ts
+++ b/packages/interloper-app/app/app/stores/events.ts
@@ -31,6 +31,9 @@ export const useEventsStore = defineStore('events', () => {
     // too — filtering only the loaded pages client-side would hide every
     // matching event that hasn't been scrolled into view yet.
     const assetIds = ref<string[] | null>(null)
+    // Server-side event-type filter — the category tab (Lifecycle / Errors /
+    // Logs). Composes with the asset filter; same server-paging rationale.
+    const eventTypes = ref<string[] | null>(null)
     const events = ref<RunEvent[]>([])
     const total = ref(0)
     const loading = ref(false) // initial page load
@@ -63,8 +66,8 @@ export const useEventsStore = defineStore('events', () => {
         events.value.sort((a, b) => a.timestamp.localeCompare(b.timestamp) || a.id.localeCompare(b.id))
     }
 
-    /** Order-insensitive equality of two asset-id filters. */
-    function _sameAssetFilter(a: string[] | null, b: string[] | null): boolean {
+    /** Order-insensitive equality of two filter lists. */
+    function _sameFilter(a: string[] | null, b: string[] | null): boolean {
         if (a === b) return true
         if (!a || !b || a.length !== b.length) return false
         const sa = [...a].sort()
@@ -103,6 +106,7 @@ export const useEventsStore = defineStore('events', () => {
             offset: String(nextOffset.value),
         })
         for (const aid of assetIds.value ?? []) params.append('asset_id', aid)
+        for (const et of eventTypes.value ?? []) params.append('event_type', et)
         const res = await apiFetchRaw<RunEvent[]>(`/runs/${id}/events?${params}`)
         if (epoch !== fetchEpoch) return // state was reset while in flight
         const page = res._data ?? []
@@ -120,24 +124,17 @@ export const useEventsStore = defineStore('events', () => {
         table: 'events',
         scope: () => runId.value ? orgStore.organisation?.id : null,
         shouldHandle: (record: Record<string, any>) =>
-            record.run_id === runId.value && (!assetIds.value || assetIds.value.includes(record.asset_id)),
+            record.run_id === runId.value
+            && (!assetIds.value || assetIds.value.includes(record.asset_id))
+            && (!eventTypes.value || eventTypes.value.includes(record.event_type)),
         onInsert: (record: Record<string, any>) => _upsert(record as RunEvent),
     })
 
     /**********************
      * Actions
      **********************/
-    /**
-     * Load the first page of events for a run, optionally filtered to one asset.
-     *
-     * Events are ordered oldest-first, so the terminal/outcome events
-     * (`asset_completed`, `asset_failed`, `run_failed`, …) live at the end.
-     * The table reaches them by infinite-scrolling — see `loadMore` — rather
-     * than loading the whole history up front.
-     */
-    async function fetchForRun(id: string, assets: string[] | null = null) {
-        runId.value = id
-        assetIds.value = assets
+    /** Reset paging and load the first page with the current filters. */
+    async function _reload() {
         fetchEpoch++
         events.value = []
         total.value = 0
@@ -155,10 +152,33 @@ export const useEventsStore = defineStore('events', () => {
         }
     }
 
+    /**
+     * Load the first page of events for a run (clearing any active filters).
+     *
+     * Events are ordered oldest-first, so the terminal/outcome events
+     * (`asset_completed`, `asset_failed`, `run_failed`, …) live at the end.
+     * The table reaches them by infinite-scrolling — see `loadMore` — rather
+     * than loading the whole history up front.
+     */
+    async function fetchForRun(id: string) {
+        runId.value = id
+        assetIds.value = null
+        eventTypes.value = null
+        await _reload()
+    }
+
     /** Re-page from the start filtered to a set of assets (`null` clears it). */
     async function filterByAssets(assets: string[] | null) {
-        if (!runId.value || _sameAssetFilter(assets, assetIds.value)) return
-        await fetchForRun(runId.value, assets)
+        if (!runId.value || _sameFilter(assets, assetIds.value)) return
+        assetIds.value = assets
+        await _reload()
+    }
+
+    /** Re-page from the start filtered to a set of event types (`null` clears it). */
+    async function filterByEventTypes(types: string[] | null) {
+        if (!runId.value || _sameFilter(types, eventTypes.value)) return
+        eventTypes.value = types
+        await _reload()
     }
 
     /** Load the next page of events. Safe to call repeatedly (infinite scroll). */
@@ -190,6 +210,7 @@ export const useEventsStore = defineStore('events', () => {
     function $reset() {
         runId.value = null
         assetIds.value = null
+        eventTypes.value = null
         fetchEpoch++
         events.value = []
         total.value = 0
@@ -202,6 +223,7 @@ export const useEventsStore = defineStore('events', () => {
     return {
         runId,
         assetIds,
+        eventTypes,
         events,
         total,
         loading,
@@ -210,6 +232,7 @@ export const useEventsStore = defineStore('events', () => {
         error,
         fetchForRun,
         filterByAssets,
+        filterByEventTypes,
         loadMore,
         findById,
         byAssetKey,

--- a/packages/interloper-app/app/app/utils/events.ts
+++ b/packages/interloper-app/app/app/utils/events.ts
@@ -54,6 +54,44 @@ const labelMap: Record<EventType, string> = {
     log: 'Log',
 }
 
+export type EventCategory = 'all' | 'lifecycle' | 'errors' | 'logs'
+
+/** All known event types, derived from the icon map so this can't drift. */
+const ALL_EVENT_TYPES = Object.keys(iconMap) as EventType[]
+
+/**
+ * High-level orchestration milestones (run/asset/backfill state machine).
+ * Excludes the granular `*_exec_*` / `dest_*` IO events and `log`.
+ */
+const LIFECYCLE_TYPES: EventType[] = [
+    'run_dispatched',
+    'run_started',
+    'run_completed',
+    'run_failed',
+    'asset_queued',
+    'asset_skipped',
+    'asset_started',
+    'asset_completed',
+    'asset_failed',
+    'asset_canceled',
+    'backfill_started',
+    'backfill_completed',
+    'backfill_failed',
+]
+
+/** Every failure event, derived so new `*_failed` types are picked up automatically. */
+const ERROR_TYPES: EventType[] = ALL_EVENT_TYPES.filter(t => t.endsWith('_failed'))
+
+/** Event types backing a category tab; `all` returns null (no filter). */
+export function eventTypesForCategory(category: EventCategory): EventType[] | null {
+    switch (category) {
+        case 'lifecycle': return LIFECYCLE_TYPES
+        case 'errors': return ERROR_TYPES
+        case 'logs': return ['log']
+        default: return null
+    }
+}
+
 export function eventTypeIcon(eventType: EventType): string {
     return iconMap[eventType] ?? 'i-lucide-align-left'
 }

--- a/packages/interloper-db/src/interloper_db/store/runs.py
+++ b/packages/interloper-db/src/interloper_db/store/runs.py
@@ -101,10 +101,11 @@ class RunMixin:
         run_id: UUID | None = None,
         org_id: UUID | None = None,
         asset_ids: Sequence[UUID] | None = None,
+        event_types: Sequence[str] | None = None,
         limit: int = 100,
         offset: int = 0,
     ) -> list[Event]:
-        """List events, optionally filtered by run and/or asset(s).
+        """List events, optionally filtered by run, asset(s) and/or type(s).
 
         Ordering is ``timestamp ASC, id ASC`` — stable and deterministic so
         ``offset``/``limit`` paging never skips or repeats a row when several
@@ -114,6 +115,7 @@ class RunMixin:
             run_id: Optional run filter.
             org_id: Optional org filter.
             asset_ids: Optional filter to events of any of these assets.
+            event_types: Optional filter to events of any of these types.
             limit: Max results (default 100).
             offset: Pagination offset.
 
@@ -128,6 +130,8 @@ class RunMixin:
                 statement = statement.where(Event.org_id == org_id)
             if asset_ids:
                 statement = statement.where(col(Event.asset_id).in_(asset_ids))
+            if event_types:
+                statement = statement.where(col(Event.event_type).in_(event_types))
             statement = (
                 statement.order_by(col(Event.timestamp).asc(), col(Event.id).asc()).offset(offset).limit(limit)
             )
@@ -139,6 +143,7 @@ class RunMixin:
         run_id: UUID | None = None,
         org_id: UUID | None = None,
         asset_ids: Sequence[UUID] | None = None,
+        event_types: Sequence[str] | None = None,
     ) -> int:
         """Count events matching the same filters as :meth:`list_events`.
 
@@ -146,6 +151,7 @@ class RunMixin:
             run_id: Optional run filter.
             org_id: Optional org filter.
             asset_ids: Optional filter to events of any of these assets.
+            event_types: Optional filter to events of any of these types.
 
         Returns:
             Total number of matching events (ignoring limit/offset).
@@ -158,6 +164,8 @@ class RunMixin:
                 statement = statement.where(Event.org_id == org_id)
             if asset_ids:
                 statement = statement.where(col(Event.asset_id).in_(asset_ids))
+            if event_types:
+                statement = statement.where(col(Event.event_type).in_(event_types))
             return session.exec(statement).one()
 
     def list_asset_executions(self, run_id: UUID) -> list[dict]:

--- a/packages/interloper-db/tests/test_run_events.py
+++ b/packages/interloper-db/tests/test_run_events.py
@@ -153,6 +153,34 @@ def test_asset_filter_lists_and_counts_only_that_asset(store: RunMixin) -> None:
     assert all(e.asset_id == asset_b for e in page_b)
 
 
+def test_event_type_filter_lists_and_counts_only_those_types(store: RunMixin) -> None:
+    # _make_events emits n-1 "asset_materializing" then one "asset_completed".
+    _seed(_make_events(5))
+
+    assert store.count_events(run_id=_RUN_ID, event_types=["asset_completed"]) == 1
+    assert store.count_events(run_id=_RUN_ID, event_types=["asset_materializing"]) == 4
+    # A set of types is the union of each.
+    assert store.count_events(run_id=_RUN_ID, event_types=["asset_completed", "asset_materializing"]) == 5
+
+    completed = store.list_events(run_id=_RUN_ID, event_types=["asset_completed"])
+    assert len(completed) == 1
+    assert all(e.event_type == "asset_completed" for e in completed)
+
+
+def test_asset_and_event_type_filters_compose(store: RunMixin) -> None:
+    asset_a, asset_b = uuid4(), uuid4()
+    _seed(_make_events(5, asset_id=asset_a))
+    _seed(_make_events(5, start=5, asset_id=asset_b))
+
+    # Each asset has exactly one "asset_completed"; narrowing to asset_a's set
+    # of one type yields just that asset's completion.
+    assert store.count_events(run_id=_RUN_ID, asset_ids=[asset_a], event_types=["asset_completed"]) == 1
+    page = store.list_events(run_id=_RUN_ID, asset_ids=[asset_a], event_types=["asset_completed"])
+    assert len(page) == 1
+    assert page[0].asset_id == asset_a
+    assert page[0].event_type == "asset_completed"
+
+
 def test_asset_filter_accepts_multiple_assets(store: RunMixin) -> None:
     asset_a, asset_b, asset_c = uuid4(), uuid4(), uuid4()
     _seed(_make_events(10, asset_id=asset_a))


### PR DESCRIPTION
PR 3 of the run-page redesign — scoped strictly to the event category tabs.

## What

A category selector above the run events table: **All / Lifecycle / Errors / Logs**. Each tab filters the events; All clears it.

- **Lifecycle** — the run/asset/backfill state-machine events (excludes the granular `*_exec_*` / `dest_*` IO events and `log`).
- **Errors** — every `*_failed` event.
- **Logs** — `log`.

## How — server-side filter

Events are paged from the server, so the filter is applied there (mirroring the `asset_id` filter). **The Errors tab makes this non-negotiable**: failures are terminal events that sort *last*, so a client-side filter over loaded pages would show an empty Errors tab until you scrolled to the very end.

- The events endpoint's `event_type` query param is now **repeatable** → SQL `IN`, and **composes with the `asset_id` filter** (so a status pill + a category tab both apply).
- `store.list_events` / `count_events`: new `event_types: Sequence[str]` param.
- Events store: new `filterByEventTypes()`; the run page maps the active tab → event types and re-pages.
- The category → event-type mapping lives frontend-side in [utils/events.ts](packages/interloper-app/app/app/utils/events.ts); **Errors is derived from the `*_failed` suffix** so new failure types are picked up automatically.

## Tests
New coverage in both suites: API (`event_type` forwarded to list + count) and DB (event-type filter, and asset + type filters composing). ruff ✓, ty ✓, full pytest ✓ (via pre-commit), frontend lint ✓.

## Reviewer notes
- **Not yet verified live.** It's straightforward to exercise but worth a look — on the all-success demo run, the **Errors** tab should come back empty (no failures) and **Logs** likewise, while **Lifecycle** trims the per-exec/dest IO noise. `nuxt typecheck` remains unrunnable in-tree (pre-existing `vue-router/volar` crash), so TS is lint-checked only.
- Tabs are a small custom segmented control in the events header; happy to swap to a shared component if there's a canonical one you'd prefer.