### PR TITLE
feat(app): add a run dependency graph view

### DIFF
--- a/packages/interloper-app/app/app/components/executions/RunGraph.vue
+++ b/packages/interloper-app/app/app/components/executions/RunGraph.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+import type { Asset } from '~/types/asset'
+import type { SourceAsset } from '~/types/source'
+import type { GraphModel } from '~/types/graph'
+
+/**
+ * Run dependency graph: the run's assets laid out as a left-to-right DAG,
+ * coloured by live execution status. Reuses the catalog <GraphCanvas> via the
+ * run model seam; read-only (no dependency editing). Clicking a node selects
+ * that asset, which the page mirrors to the events filter.
+ */
+const props = defineProps<{ runId: string }>()
+const selectedAsset = defineModel<string | null>('selectedAsset')
+
+const { model } = useRunGraph(() => props.runId)
+const assetExecutionsStore = useAssetExecutionsStore()
+
+/** asset_id → formatted run duration, shown on each node. */
+const durationByAssetId = computed(() => {
+    const map = new Map<string, string>()
+    for (const ex of assetExecutionsStore.assetExecutions) {
+        if (ex.asset_id && ex.started_at) map.set(ex.asset_id, formatElapsed(ex.started_at, ex.completed_at))
+    }
+    return map
+})
+
+/**
+ * Flatten to a plain asset DAG: a run cares about the asset dependency flow,
+ * not source grouping, so every asset renders as a top-level node (no source
+ * container cards) coloured by its execution status, with its duration.
+ */
+const flatModel = computed<GraphModel>(() => ({
+    sources: [],
+    assets: model.value.assets.map(a => ({
+        ...a,
+        source: null,
+        status: a.status ? { ...a.status, label: durationByAssetId.value.get(a.asset.id) } : undefined,
+    })),
+    dependencies: model.value.dependencies,
+}))
+
+function onAssetClick(asset: SourceAsset | Asset) {
+    selectedAsset.value = selectedAsset.value === asset.id ? null : asset.id
+}
+</script>
+
+<template>
+    <GraphCanvas :model="flatModel"
+                 view-mode="status"
+                 direction="LR"
+                 compact
+                 fit-to-content
+                 :show-new-source-button="false"
+                 :selected-id="selectedAsset ?? null"
+                 @asset-click="onAssetClick"
+                 @pane-click="selectedAsset = null" />
+</template>

--- a/packages/interloper-app/app/app/components/graph/GraphCanvas.vue
+++ b/packages/interloper-app/app/app/components/graph/GraphCanvas.vue
@@ -25,6 +25,12 @@ const props = withDefaults(defineProps<{
     showNewSourceButton?: boolean
     /** Asset id whose detail panel is open — the only node that gets the selection highlight. */
     selectedId?: string | null
+    /** Top-level layout flow: 'TB' (catalog default) or 'LR' (run pipeline). */
+    direction?: 'TB' | 'LR'
+    /** Zoom out to fit the whole graph instead of snapping to 100% after layout. */
+    fitToContent?: boolean
+    /** Render assets as small status nodes (run graph) instead of catalog cards. */
+    compact?: boolean
 }>(), {
     editable: false,
     expandMode: 'nodes',
@@ -34,6 +40,9 @@ const props = withDefaults(defineProps<{
     materializingAssetIds: undefined,
     showNewSourceButton: true,
     selectedId: null,
+    direction: 'TB',
+    fitToContent: false,
+    compact: false,
 })
 
 const emit = defineEmits<{
@@ -64,9 +73,9 @@ function toggleSource(sourceId: string) {
     expandedSources.value = next
 }
 
-// Layout constants
-const ASSET_W = 220
-const ASSET_H = 160
+// Layout constants (assets render smaller in compact / run mode)
+const ASSET_W = props.compact ? 200 : 220
+const ASSET_H = props.compact ? 44 : 160
 const SRC_PADDING = 26
 const SRC_HEADER_H = 50
 const COLLAPSED_W = 244
@@ -223,7 +232,13 @@ const sourceLayout = computed(() => {
         })),
     ]
 
-    return layoutDag(layoutNodes, topLevelEdges.value, { gapX: 60, gapY: 60 })
+    return layoutDag(layoutNodes, topLevelEdges.value, {
+        // gapX = within-layer, gapY = between-layer. For the LR run graph that
+        // means a tight vertical stack within a rank, wider spacing between ranks.
+        gapX: props.compact ? 22 : 60,
+        gapY: props.compact ? 80 : 60,
+        direction: props.direction,
+    })
 })
 
 /** Structural edges (id/source/target/handles); styling + focus applied in `edges`. */
@@ -426,7 +441,7 @@ vueFlow.onNodesInitialized(() => {
     }
 
     vueFlow.fitView({ padding: 0.25 })
-    vueFlow.zoomTo(1)
+    if (!props.fitToContent) vueFlow.zoomTo(1)
 })
 
 // ── Connection plumbing provided to child node components ──
@@ -570,7 +585,15 @@ function onEdgeContextMenu({ edge, event }: { edge: Edge; event: MouseEvent | To
                                  @asset-click="(a, d, s) => emit('asset-click', a, d, s)" />
             </template>
             <template #node-asset="{ data }">
-                <GraphAssetNode :asset="data.asset"
+                <GraphRunNode v-if="compact"
+                              :asset="data.asset"
+                              :asset-defn="data.assetDefn"
+                              :status="data.status"
+                              :view-mode="viewMode"
+                              :selected="data.asset.id === selectedId"
+                              @view="emit('asset-click', data.asset, data.assetDefn, data.source)" />
+                <GraphAssetNode v-else
+                                :asset="data.asset"
                                 :asset-defn="data.assetDefn"
                                 :status="data.status"
                                 :view-mode="viewMode"

--- a/packages/interloper-app/app/app/components/graph/RunNode.vue
+++ b/packages/interloper-app/app/app/components/graph/RunNode.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import { Handle, Position, useNodeConnections } from '@vue-flow/core'
+
+/**
+ * Compact run-graph node: status dot + type icon + name + duration, sized for
+ * a dense left-to-right DAG. Left/Right handles match the LR flow (the catalog
+ * AssetNode is large and uses Top/Bottom handles, made for the TB catalog).
+ */
+const props = defineProps<{
+    asset: SourceAsset
+    assetDefn: AssetDefinition | undefined
+    status?: NodeStatus
+    viewMode?: ViewMode
+    /** VueFlow selection state — drives the selection ring. */
+    selected?: boolean
+}>()
+
+defineEmits<{ view: [] }>()
+
+const icon = computed(() => props.assetDefn ? componentIcon(props.assetDefn.key) : 'i-lucide-box')
+const label = computed(() => props.assetDefn?.name ?? props.asset.key)
+const state = computed<GraphNodeState>(() => props.status?.state ?? 'idle')
+
+const sourceConnections = useNodeConnections({ handleType: 'source' })
+const targetConnections = useNodeConnections({ handleType: 'target' })
+const hasUpstream = computed(() => targetConnections.value.length > 0)
+const hasDownstream = computed(() => sourceConnections.value.length > 0)
+
+const ringClass = computed(() => props.selected ? 'ring-2 ring-primary' : statusRingClass(state.value))
+</script>
+
+<template>
+    <div class="relative w-[190px]">
+        <Handle v-if="hasUpstream"
+                type="target"
+                :position="Position.Left"
+                :connectable="false" />
+
+        <div class="flex items-center gap-2 rounded-lg border border-[var(--ui-border-accented)] bg-muted px-3 py-2 shadow-[0_8px_24px_-12px_rgba(0,0,0,0.55)]"
+             :class="ringClass">
+            <span class="size-2 shrink-0 rounded-full"
+                  :class="statusDotClass(state)" />
+            <UIcon :name="icon"
+                   class="size-4 shrink-0 text-muted" />
+            <span class="min-w-0 flex-1 truncate text-xs font-medium text-highlighted">{{ label }}</span>
+            <span v-if="status?.label"
+                  class="shrink-0 text-[11px] tabular-nums text-muted">{{ status.label }}</span>
+        </div>
+
+        <Handle v-if="hasDownstream"
+                type="source"
+                :position="Position.Right"
+                :connectable="false" />
+    </div>
+</template>

--- a/packages/interloper-app/app/app/composables/graph.ts
+++ b/packages/interloper-app/app/app/composables/graph.ts
@@ -123,58 +123,50 @@ export function useGraphLayout() {
 
         const sortedRanks = [...layers.keys()].sort((a, b) => a - b)
 
-        // Compute max layer width for centering
-        const layerWidths = sortedRanks.map((r) => {
+        const isVertical = direction === 'TB'
+        // Extent along the within-layer axis (X for TB, Y for LR) and the
+        // layer-advance axis (Y for TB, X for LR). Swapping these by direction
+        // is what makes 'LR' actually flow left-to-right.
+        const crossExtent = (n: LayoutNode) => (isVertical ? n.width : n.height)
+        const mainExtent = (n: LayoutNode) => (isVertical ? n.height : n.width)
+
+        // Cross-axis span of each layer, for centering.
+        const layerSpans = sortedRanks.map((r) => {
             const ids = layers.get(r)!
-            return ids.reduce((sum, id) => sum + nodeMap.get(id)!.width, 0)
+            return ids.reduce((sum, id) => sum + crossExtent(nodeMap.get(id)!), 0)
                 + (ids.length - 1) * gapX
         })
-        const maxLayerWidth = Math.max(...layerWidths)
+        const maxLayerSpan = Math.max(...layerSpans)
 
         // Position nodes
-        let totalHeight = 0
-        const isVertical = direction === 'TB'
+        let mainCursor = 0
 
         for (let i = 0; i < sortedRanks.length; i++) {
             const r = sortedRanks[i]!
             const ids = layers.get(r)!
-            const layerWidth = layerWidths[i]!
+            const layerSpan = layerSpans[i]!
 
-            // Center this layer within the max width
-            const offsetX = (maxLayerWidth - layerWidth) / 2
-
-            let cursor = offsetX
-            const maxNodeHeight = Math.max(...ids.map(id => nodeMap.get(id)!.height))
+            // Center this layer within the widest layer.
+            let cross = (maxLayerSpan - layerSpan) / 2
+            const maxMain = Math.max(...ids.map(id => mainExtent(nodeMap.get(id)!)))
 
             for (const id of ids) {
                 const node = nodeMap.get(id)!
-                if (isVertical) {
-                    positions.set(id, {
-                        x: cursor,
-                        y: totalHeight,
-                    })
-                }
-                else {
-                    positions.set(id, {
-                        x: totalHeight,
-                        y: cursor,
-                    })
-                }
-                cursor += node.width + gapX
+                if (isVertical) positions.set(id, { x: cross, y: mainCursor })
+                else positions.set(id, { x: mainCursor, y: cross })
+                cross += crossExtent(node) + gapX
             }
 
-            totalHeight += maxNodeHeight + gapY
+            mainCursor += maxMain + gapY
         }
 
         // Remove trailing gap
-        totalHeight -= gapY
-
-        const totalWidth = maxLayerWidth
+        mainCursor -= gapY
 
         return {
             positions,
-            width: isVertical ? totalWidth : totalHeight,
-            height: isVertical ? totalHeight : totalWidth,
+            width: isVertical ? maxLayerSpan : mainCursor,
+            height: isVertical ? mainCursor : maxLayerSpan,
         }
     }
 

--- a/packages/interloper-app/app/app/pages/executions/runs/[run].vue
+++ b/packages/interloper-app/app/app/pages/executions/runs/[run].vue
@@ -16,6 +16,7 @@ const runsStore = useRunsStore()
 const eventsStore = useEventsStore()
 const assetExecutionsStore = useAssetExecutionsStore()
 const sourcesStore = useSourcesStore()
+const assetsStore = useAssetsStore()
 const catalogStore = useCatalogStore()
 const toast = useToast()
 
@@ -65,6 +66,13 @@ const eventTabs: { key: EventCategory; label: string; icon: string }[] = [
 ]
 watch(eventCategory, cat => eventsStore.filterByEventTypes(eventTypesForCategory(cat)))
 
+// Top-panel view: the Gantt timeline or the run dependency graph.
+const view = ref<'timeline' | 'graph'>('timeline')
+const viewTabs: { key: 'timeline' | 'graph'; label: string; icon: string }[] = [
+    { key: 'timeline', label: 'Timeline', icon: 'i-lucide-gantt-chart' },
+    { key: 'graph', label: 'Graph', icon: 'i-lucide-workflow' },
+]
+
 const markerTime = computed(() => eventInFocus.value?.timestamp ? new Date(eventInFocus.value.timestamp) : null)
 const highlightedAsset = computed(() => eventInFocus.value?.asset_id ?? null)
 
@@ -94,6 +102,8 @@ onMounted(async () => {
             eventsStore.fetchForRun(runId),
             assetExecutionsStore.fetchForRun(runId),
             sourcesStore.sources.length === 0 ? sourcesStore.fetch() : Promise.resolve(),
+            // Asset dependencies back the Graph view's edges.
+            assetsStore.dependencies.length === 0 ? assetsStore.fetch() : Promise.resolve(),
             catalogStore.loaded ? Promise.resolve() : catalogStore.fetchCatalog(),
         ])
         initialRun.value = fetchedRun
@@ -160,16 +170,36 @@ onUnmounted(() => {
                  aligned with the events table's scrollbar below. -->
             <SplitterPanel :default-size="40"
                            :min-size="15"
-                           class="overflow-hidden py-4 pl-4">
-                <ChartExecutionTimeline v-if="run?.status !== 'queued'"
+                           class="flex flex-col overflow-hidden pt-4 pl-4">
+                <div class="mb-2 mr-4 flex items-center gap-0.5 self-start rounded-md bg-elevated p-0.5">
+                    <button v-for="tab in viewTabs"
+                            :key="tab.key"
+                            type="button"
+                            class="flex items-center gap-1.5 rounded px-2 py-1 text-xs transition-colors cursor-pointer"
+                            :class="view === tab.key
+                                ? 'bg-default text-default shadow-sm'
+                                : 'text-muted hover:text-default'"
+                            @click="view = tab.key">
+                        <UIcon :name="tab.icon"
+                               class="size-3.5" />
+                        {{ tab.label }}
+                    </button>
+                </div>
+
+                <div class="flex min-h-0 flex-1 flex-col">
+                    <div v-if="run?.status === 'queued'"
+                         class="flex h-full items-center justify-center text-muted">
+                        <span class="text-sm">Run is currently queued...</span>
+                    </div>
+                    <ChartExecutionTimeline v-else-if="view === 'timeline'"
+                                            v-model:selected-asset="selectedAsset"
+                                            :asset-executions="filteredAssetExecutions"
+                                            :status="(run?.status as ExecutionStatus)"
+                                            :marker-time="markerTime"
+                                            :highlighted-asset="highlightedAsset" />
+                    <ExecutionsRunGraph v-else
                                         v-model:selected-asset="selectedAsset"
-                                        :asset-executions="filteredAssetExecutions"
-                                        :status="(run?.status as ExecutionStatus)"
-                                        :marker-time="markerTime"
-                                        :highlighted-asset="highlightedAsset" />
-                <div v-else
-                     class="flex h-full items-center justify-center text-muted">
-                    <span class="text-sm">Run is currently queued...</span>
+                                        :run-id="runId" />
                 </div>
             </SplitterPanel>
 


### PR DESCRIPTION
PR 4 of the run-page redesign — the Graph tab.

## What

Adds a **Timeline | Graph** toggle to the run page. The Graph view renders the run's assets as a **compact left-to-right DAG, coloured by live execution status** — each node shows its type icon, a status dot/ring, and its duration. Clicking a node selects that asset (blue ring + highlighted edges) and **filters the events table**, the same cross-filter as clicking a timeline bar.

| | |
|---|---|
| Status colours | success/failed/running/skipped/canceled via the shared node-status map |
| Layout | left-to-right, fit-to-content, dependency edges |
| Selection | node ↔ `selectedAsset`, mirrored to the events filter |

## How

Reuses the catalog `<GraphCanvas>` via the existing `useRunGraph` model seam. The run-specific bits live in new components (`ExecutionsRunGraph` flattens the model to a plain asset DAG and injects durations; `GraphRunNode` is the compact node). The shared renderer gained three **opt-in** props, so the catalog graph is byte-for-byte unchanged in behaviour (verified live — no regression):

- **`direction`** (`'TB'` default | `'LR'`) threaded to the top-level layout. This also **fixes a latent `layoutDag` bug**: the `'LR'` path used node *height* for rank spacing and *width* for within-rank spacing (swapped), so `'LR'` never actually flowed left-to-right. Now the main/cross extents swap by direction.
- **`fitToContent`** — zoom-to-fit instead of snapping to 100%.
- **`compact`** — render assets as small run nodes (new `RunNode`, Left/Right handles) instead of the large catalog cards (Top/Bottom handles).

The run page also now loads asset dependencies (the graph's edges).

## Verified live
Toggle, LR compact status DAG, durations, node-click → events cross-filter, and the catalog `/graph` page (no regression) all checked on the seeded instance. Frontend lint clean; no Python touched.

## Notes
- The demo seed has 3 duplicate "Demo Source" instances, so the run DAG shows one connected component (`a → b,c,d`) prominently; a real single-source run reads as one clean pipeline.
- `nuxt typecheck` remains unrunnable in-tree (pre-existing `vue-router/volar` crash), so TS is lint-checked only.
- This completes the four-PR plan. (PR 2, the timeline name-gutter, is still uncommitted in its own worktree — separate track.)