### PR TITLE
fix: expose annotation-declared resource slots in component definitions

### DIFF
--- a/packages/interloper-core/src/interloper/destination/base.py
+++ b/packages/interloper-core/src/interloper/destination/base.py
@@ -63,10 +63,11 @@ class Destination(Component):
         from interloper.utils.imports import get_object_path
 
         raw = cls.model_json_schema() if hasattr(cls, "model_json_schema") else {}
-        res_types: dict[str, type[Resource]] = cls.__dict__.get("resource_types", {})
-        # Validate against the resolved resource map (annotation-declared slots
-        # are not in ``__dict__``); matches how the resolver finds the connection.
-        validate_fetch_field_providers(cls, cls.resource_types)
+        # Resolved resource map (includes annotation-declared slots, not just
+        # ``__dict__``) so the DestinationDefinition's ``resources`` and its
+        # FetchField pickers work for both declaration styles.
+        res_types: dict[str, type[Resource]] = cls.resource_types
+        validate_fetch_field_providers(cls, res_types)
         return DestinationDefinition(
             kind=cls.kind,
             key=cls.key,

--- a/packages/interloper-core/src/interloper/source/base.py
+++ b/packages/interloper-core/src/interloper/source/base.py
@@ -433,12 +433,14 @@ class Source(Component):
         """
         from interloper.resource.fields import strip_internal_fields
 
-        res_types: dict[str, type[Resource]] = cls.__dict__.get("resource_types", {})
-        # Validate against the *resolved* resource map (``cls.resource_types``),
-        # which includes slots declared via typed annotations (``connection:
-        # XConnection``) — not just those in ``__dict__`` — matching how the
-        # resolver looks up the connection class at runtime.
-        validate_fetch_field_providers(cls, cls.resource_types)
+        # Use the *resolved* resource map: it includes slots declared via typed
+        # annotations (``connection: XConnection``), not just those set in
+        # ``__dict__`` by the ``@source(resources=...)`` decorator. This is what
+        # ``Catalog.from_paths`` and the FetchField resolver read, so the
+        # SourceDefinition's ``resources`` (and the connection step / fetch
+        # fields the frontend builds from it) stay consistent for both styles.
+        res_types: dict[str, type[Resource]] = cls.resource_types
+        validate_fetch_field_providers(cls, res_types)
 
         # Build config schema from Source's own fields, excluding framework
         # internals (resources, assets, etc.) and base Source fields.

--- a/packages/interloper-core/tests/resource/test_fields.py
+++ b/packages/interloper-core/tests/resource/test_fields.py
@@ -41,11 +41,13 @@ class TestFetchField:
         with pytest.raises(ValueError, match="<slot>.<method>"):
             il.FetchField(provider="things")
 
-    def test_validates_annotation_declared_slot(self):
-        """A slot declared via a typed annotation (not ``resources=``) validates.
+    def test_annotation_declared_slot_validates_and_is_exposed(self):
+        """A slot declared via a typed annotation (not ``resources=``) works.
 
         Such slots live on the resolved ``resource_types`` but not in the
-        class ``__dict__``; validation must resolve against the former.
+        class ``__dict__``. Both validation and the definition's ``resources``
+        map must resolve against the former — otherwise the frontend gets an
+        empty ``resources`` and the FetchField degrades to a plain input.
         """
 
         @il.source()
@@ -53,11 +55,10 @@ class TestFetchField:
             connection: Conn
             thing_id: str = il.FetchField(provider="connection.things", value_key="id")
 
-        # Should not raise — the 'connection' slot comes from the annotation,
-        # resolved via Src.resource_types even though it's absent from __dict__.
         defn = Src.definition()
         assert defn.config_schema["properties"]["thing_id"]["x-fetch"]["provider"] == "connection.things"
-        assert "connection" in Src.resource_types
+        # The annotation-declared slot must be exposed in the catalog resources.
+        assert defn.resources == {"connection": Conn.key}
 
 
 class TestValidation:


### PR DESCRIPTION
## Summary

Follow-up to #83. Amazon Ads' `profile_id` FetchField rendered as a plain text input instead of fetching the profile list. Same for any connector that declares its connection via a typed annotation (TikTok Ads, BigQuery, …).

## Root cause

`Source.definition()` / `Destination.definition()` built the `resources` map from `cls.__dict__.get("resource_types", {})`. That only contains slots set by the `@source(resources=...)` decorator. Connectors using the annotation form — `connection: AmazonAdsConnection` — keep that slot on the **resolved** `cls.resource_types` attribute, never in `__dict__`. So their `SourceDefinition.resources` came out empty.

With no resource slot, the frontend stepper shows no connection step, and the FetchField has no connection to resolve against — so it falls back to a plain input. (The field schema itself was correct: `x-widget: "fetch"`, proper `x-fetch`.)

This was latent before #83; the provider-based fetch flow surfaced it.

## Fix

Build both the `resources` map and provider validation from the resolved `cls.resource_types` — the same view `Catalog.from_paths` and the `/external/resolve` resolver already use. Decorator-style sources are unchanged (identical result); annotation-style sources now expose their slot.

Verified `AmazonAds.definition().resources == {"connection": "amazon_ads_connection"}` (and TikTok / BigQuery). Added a regression test asserting the annotation-declared slot appears in `definition().resources`.

## Verification

`ruff` ✓ · `ty` ✓ · `pytest` (full suite 691 passed) · pre-commit hooks ✓
