### PR TITLE
fix: coerce partition values to dates for time-partitioned assets

### DIFF
--- a/packages/interloper-core/src/interloper/asset/context.py
+++ b/packages/interloper-core/src/interloper/asset/context.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from interloper.events import EventLogger
 from interloper.partitioning.base import Partition, PartitionConfig, PartitionWindow
-from interloper.partitioning.time import TimePartitionConfig
+from interloper.partitioning.time import TimePartitionConfig, coerce_to_date
 
 
 class ExecutionContext:
@@ -93,7 +93,7 @@ class ExecutionContext:
                 "Context currently holds a partition window, not a partition."
             )
 
-        return self._partition_or_window.value
+        return coerce_to_date(self._partition_or_window.value)
 
     @property
     def partition_date_window(self) -> tuple[dt.date, dt.date]:
@@ -123,7 +123,8 @@ class ExecutionContext:
             )
 
         if isinstance(self._partition_or_window, Partition):
-            return (self._partition_or_window.value, self._partition_or_window.value)
+            date = coerce_to_date(self._partition_or_window.value)
+            return (date, date)
 
         assert isinstance(self._partition_or_window, PartitionWindow)
-        return (self._partition_or_window.start, self._partition_or_window.end)
+        return (coerce_to_date(self._partition_or_window.start), coerce_to_date(self._partition_or_window.end))

--- a/packages/interloper-core/src/interloper/partitioning/time.py
+++ b/packages/interloper-core/src/interloper/partitioning/time.py
@@ -9,6 +9,39 @@ from dataclasses import dataclass
 from interloper.partitioning.base import Partition, PartitionConfig, PartitionWindow
 
 
+def coerce_to_date(value: object) -> dt.date:
+    """Coerce a partition value to a ``datetime.date``.
+
+    Accepts a ``date``, a ``datetime`` (its date part is used), or an ISO-8601
+    date string. Anything else raises ``TypeError``.
+
+    Args:
+        value: The partition value to coerce.
+
+    Returns:
+        The value as a ``datetime.date``.
+
+    Raises:
+        TypeError: If the value cannot be interpreted as a date.
+    """
+    # `datetime` is a subclass of `date`, so check it first.
+    if isinstance(value, dt.datetime):
+        return value.date()
+    if isinstance(value, dt.date):
+        return value
+    if isinstance(value, str):
+        try:
+            return dt.date.fromisoformat(value)
+        except ValueError as e:
+            raise TypeError(
+                f"Could not parse partition value {value!r} as a date: expected an ISO-8601 date string (YYYY-MM-DD)."
+            ) from e
+    raise TypeError(
+        f"Time partition value must be a `datetime.date` or an ISO-8601 date string, got {type(value).__name__}: "
+        f"{value!r}."
+    )
+
+
 def date_range(start_date: dt.date, end_date: dt.date, reversed: bool = False) -> Generator[dt.date, None, None]:
     """Yield each date from *start_date* to *end_date* inclusive.
 
@@ -39,6 +72,12 @@ class TimePartition(Partition):
     """A single date-based partition."""
 
     value: dt.date
+
+    def __post_init__(self) -> None:
+        """Normalize the value to a ``datetime.date``, coercing strings/datetimes."""
+        coerced = coerce_to_date(self.value)
+        if coerced is not self.value:
+            object.__setattr__(self, "value", coerced)
 
     def __repr__(self) -> str:
         """Return ISO-formatted date string."""

--- a/packages/interloper-core/tests/asset/test_context.py
+++ b/packages/interloper-core/tests/asset/test_context.py
@@ -1,0 +1,47 @@
+"""Tests for ``interloper.asset.context``."""
+
+import datetime as dt
+
+import pytest
+
+from interloper.asset.context import ExecutionContext
+from interloper.partitioning.base import Partition
+from interloper.partitioning.time import TimePartition, TimePartitionConfig, TimePartitionWindow
+
+
+def _context(partition_or_window: object, allow_window: bool = False) -> ExecutionContext:
+    return ExecutionContext(
+        asset_key="asset",
+        partitioning=TimePartitionConfig(column="date", allow_window=allow_window),
+        partition_or_window=partition_or_window,  # ty: ignore[invalid-argument-type]
+    )
+
+
+class TestPartitionDate:
+    def test_returns_date_from_time_partition(self) -> None:
+        ctx = _context(TimePartition(dt.date(2026, 1, 1)))
+        assert ctx.partition_date == dt.date(2026, 1, 1)
+
+    def test_coerces_string_value_from_base_partition(self) -> None:
+        # A base ``Partition`` does not type its value, so a string can slip
+        # through; the context must still hand the asset a real ``date``.
+        ctx = _context(Partition("2026-01-01"))
+        assert ctx.partition_date == dt.date(2026, 1, 1)
+
+    def test_raises_type_error_on_unparseable_value(self) -> None:
+        ctx = _context(Partition("not-a-date"))
+        with pytest.raises(TypeError):
+            ctx.partition_date
+
+
+class TestPartitionDateWindow:
+    def test_returns_dates_from_window(self) -> None:
+        ctx = _context(
+            TimePartitionWindow(start=dt.date(2026, 1, 1), end=dt.date(2026, 1, 3)),
+            allow_window=True,
+        )
+        assert ctx.partition_date_window == (dt.date(2026, 1, 1), dt.date(2026, 1, 3))
+
+    def test_coerces_string_value_from_base_partition(self) -> None:
+        ctx = _context(Partition("2026-01-01"), allow_window=True)
+        assert ctx.partition_date_window == (dt.date(2026, 1, 1), dt.date(2026, 1, 1))

--- a/packages/interloper-core/tests/partitioning/test_time.py
+++ b/packages/interloper-core/tests/partitioning/test_time.py
@@ -1,0 +1,44 @@
+"""Tests for ``interloper.partitioning.time``."""
+
+import datetime as dt
+
+import pytest
+
+from interloper.partitioning.time import TimePartition, coerce_to_date
+
+
+class TestCoerceToDate:
+    def test_returns_date_unchanged(self) -> None:
+        date = dt.date(2026, 1, 1)
+        assert coerce_to_date(date) is date
+
+    def test_datetime_is_reduced_to_date(self) -> None:
+        assert coerce_to_date(dt.datetime(2026, 1, 1, 12, 30, tzinfo=dt.timezone.utc)) == dt.date(2026, 1, 1)
+
+    def test_iso_string_is_parsed(self) -> None:
+        assert coerce_to_date("2026-01-01") == dt.date(2026, 1, 1)
+
+    def test_invalid_string_raises_type_error(self) -> None:
+        with pytest.raises(TypeError, match="ISO-8601 date string"):
+            coerce_to_date("not-a-date")
+
+    def test_unsupported_type_raises_type_error(self) -> None:
+        with pytest.raises(TypeError, match="must be a `datetime.date`"):
+            coerce_to_date(20260101)
+
+
+class TestTimePartition:
+    def test_keeps_date_value(self) -> None:
+        assert TimePartition(dt.date(2026, 1, 1)).value == dt.date(2026, 1, 1)
+
+    def test_coerces_string_value(self) -> None:
+        partition = TimePartition("2026-01-01")  # ty: ignore[invalid-argument-type]
+        assert partition.value == dt.date(2026, 1, 1)
+        assert isinstance(partition.value, dt.date)
+
+    def test_coerces_datetime_value(self) -> None:
+        assert TimePartition(dt.datetime(2026, 1, 1, 9, 0, tzinfo=dt.timezone.utc)).value == dt.date(2026, 1, 1)
+
+    def test_rejects_invalid_value(self) -> None:
+        with pytest.raises(TypeError):
+            TimePartition("nope")  # ty: ignore[invalid-argument-type]


### PR DESCRIPTION
## Problem

`context.partition_date` / `context.partition_date_window` are documented to return `datetime.date`, but they returned the partition's raw value untouched. A base `il.Partition` does **not** type its `value` (it's `Any`), so passing `il.Partition("2026-01-01")` to a time-partitioned asset let a `str` flow straight through to asset code that does date arithmetic — surfacing a confusing `AttributeError: 'str' object has no attribute 'day'` deep in the source.

This is exactly what diverged the two entry points for the same Bing Ads asset:

| entry point | partition object | `partition_date` | failed at |
|---|---|---|---|
| python script | `il.Partition("2026-01-01")` (base, no coercion) | `str` | locally, building the report (`AttributeError`) |
| `interloper run -f manifest.yaml` | `TimePartition(date(...))` (manifest parses `date:` as a `dt.date`) | `dt.date` | remotely, at the API |

## Change

- Add `coerce_to_date` in `partitioning/time.py` — accepts a `date`, a `datetime` (reduced to its date), or an ISO-8601 string; raises a clear `TypeError` otherwise.
- Normalize `TimePartition.value` in `__post_init__` so a `TimePartition` always holds a real `date`.
- Run `context.partition_date` / `partition_date_window` through `coerce_to_date`, enforcing the documented `-> dt.date` contract even when a base `Partition` carries a string.

After this, both entry points behave identically (a bad date string now fails loudly with a `TypeError` instead of an opaque `AttributeError`).

## Tests
- `tests/partitioning/test_time.py` — `coerce_to_date` (date/datetime/string/invalid) and `TimePartition` coercion.
- `tests/asset/test_context.py` — `partition_date` / `partition_date_window` coercing a base `Partition` string and raising on garbage.

`ruff`, `ty`, and the core suite pass (pre-commit green).