### PR TITLE
refactor(assets): move bing-ads account to the source and surface API errors

### DIFF
--- a/packages/interloper-assets/src/interloper_assets/bing_ads/connection.py
+++ b/packages/interloper-assets/src/interloper_assets/bing_ads/connection.py
@@ -1,8 +1,41 @@
 from functools import cached_property
 from typing import Any
+from xml.etree import ElementTree as ET
 
+import httpx
 import interloper as il
 from pydantic_settings import SettingsConfigDict
+
+# Microsoft Advertising OAuth + Customer Management SOAP endpoints. These are
+# used only by the ``accounts`` fetch provider, which talks raw SOAP over httpx
+# (see below) instead of the ``bingads`` SDK.
+_TOKEN_URL = "https://login.microsoftonline.com/common/oauth2/v2.0/token"
+_OAUTH_SCOPE = "https://ads.microsoft.com/msads.manage offline_access"
+_CUSTOMER_MANAGEMENT_URL = (
+    "https://clientcenter.api.bingads.microsoft.com/Api/CustomerManagement/v13/CustomerManagementService.svc"
+)
+_CUSTOMER_NS = "https://bingads.microsoft.com/Customer/v13"
+_ENTITIES_NS = "https://bingads.microsoft.com/Customer/v13/Entities"
+
+
+def _local_name(tag: str) -> str:
+    """Strip the ``{namespace}`` prefix ElementTree puts on every tag."""
+    return tag.rsplit("}", 1)[-1]
+
+
+def _child_text(elem: ET.Element, name: str) -> str | None:
+    """Text of the first *direct child* named *name* (not any descendant)."""
+    for child in elem:
+        if _local_name(child.tag) == name:
+            return child.text
+    return None
+
+
+def _first_descendant(root: ET.Element, name: str) -> ET.Element | None:
+    for node in root.iter():
+        if _local_name(node.tag) == name:
+            return node
+    return None
 
 
 @il.connection(
@@ -11,23 +44,24 @@ from pydantic_settings import SettingsConfigDict
     tags=["Advertising"],
 )
 class BingAdsConnection(il.OAuthConnection):
-    """Bing Ads API connection with OAuth2 refresh token auth."""
+    """Bing Ads API connection with OAuth2 refresh token auth.
+
+    Holds only credentials. The account a report targets lives on the
+    ``BingAds`` source (``account_id``), so a single connection can serve any
+    account its token is authorized for.
+    """
 
     model_config = SettingsConfigDict(env_prefix="bing_ads_")
 
     developer_token: str = il.SecretField(description="Bing Ads developer token")
-    customer_id: str = il.InputField(description="Bing Ads customer ID")
-    account_id: str = il.InputField(description="Bing Ads account ID")
 
     @cached_property
-    def client(self) -> il.RESTClient:
-        # Not used directly -- Bing Ads uses the bingads SDK
-        return il.RESTClient("https://bingads.microsoft.com")
+    def _authentication(self) -> Any:
+        """OAuth authentication for the bingads SDK.
 
-    @cached_property
-    def authorization_data(self) -> Any:
-        """Authenticate and return AuthorizationData for the Bing Ads SDK."""
-        from bingads import AuthorizationData, OAuthAuthorization, OAuthWebAuthCodeGrant
+        Cached so the refresh-token exchange happens once per connection.
+        """
+        from bingads import OAuthAuthorization, OAuthWebAuthCodeGrant
 
         oauth_web_auth_code_grant = OAuthWebAuthCodeGrant(
             client_id=self.client_id,
@@ -35,28 +69,119 @@ class BingAdsConnection(il.OAuthConnection):
             redirection_uri=None,
         )
         oauth_tokens = oauth_web_auth_code_grant.request_oauth_tokens_by_refresh_token(self.refresh_token)
+        return OAuthAuthorization(
+            client_id=oauth_web_auth_code_grant.client_id,
+            oauth_tokens=oauth_tokens,
+        )
+
+    def authorization_data(self, account_id: str) -> Any:
+        """Return ``AuthorizationData`` for the Bing Ads SDK scoped to *account_id*.
+
+        The customer id is left unset on purpose: the Reporting service
+        authorizes on the account alone, so the parent customer is not needed
+        to submit or download a report.
+        """
+        from bingads import AuthorizationData
 
         auth_data = AuthorizationData(
             developer_token=self.developer_token,
-            authentication=OAuthAuthorization(
-                client_id=oauth_web_auth_code_grant.client_id,
-                oauth_tokens=oauth_tokens,
-            ),
+            authentication=self._authentication,
         )
-        auth_data.account_id = self.account_id
-        auth_data.customer_id = self.customer_id
+        auth_data.account_id = account_id
         return auth_data
 
-    @cached_property
-    def reporting_service(self) -> Any:
+    def reporting_service(self, account_id: str) -> Any:
         """Return a ReportingService client for building report requests."""
         from bingads import ServiceClient
 
-        return ServiceClient("ReportingService", 13, self.authorization_data)
+        return ServiceClient("ReportingService", 13, self.authorization_data(account_id))
 
-    @cached_property
-    def reporting_service_manager(self) -> Any:
+    def reporting_service_manager(self, account_id: str) -> Any:
         """Return a ReportingServiceManager for downloading reports."""
         from bingads.v13.reporting.reporting_service_manager import ReportingServiceManager
 
-        return ReportingServiceManager(self.authorization_data)
+        return ReportingServiceManager(self.authorization_data(account_id))
+
+    @il.fetch_field_provider
+    async def accounts(self) -> list[dict[str, str]]:
+        """Fetch the accounts this connection's token can access.
+
+        Talks raw SOAP over httpx rather than the ``bingads`` SDK: fetch
+        providers run inside the API process, which installs the connection
+        classes but not the heavy SDK extra. Resolves the authenticated user
+        (``GetUser``) then lists every account they can reach
+        (``SearchAccounts`` filtered by that user id).
+        """
+        async with httpx.AsyncClient(timeout=30) as client:
+            token_response = await client.post(
+                _TOKEN_URL,
+                data={
+                    "grant_type": "refresh_token",
+                    "refresh_token": self.refresh_token,
+                    "client_id": self.client_id,
+                    "client_secret": self.client_secret,
+                    "scope": _OAUTH_SCOPE,
+                },
+            )
+            token_response.raise_for_status()
+            access_token = token_response.json()["access_token"]
+
+            user = await self._soap_call(
+                client,
+                access_token,
+                "GetUser",
+                f'<GetUserRequest xmlns="{_CUSTOMER_NS}"><UserId i:nil="true"/></GetUserRequest>',
+            )
+            user_elem = _first_descendant(user, "User")
+            if user_elem is None:
+                return []
+            user_id = _child_text(user_elem, "Id")
+
+            search_body = (
+                f'<SearchAccountsRequest xmlns="{_CUSTOMER_NS}">'
+                f'<Predicates xmlns:a="{_ENTITIES_NS}">'
+                "<a:Predicate><a:Field>UserId</a:Field><a:Operator>Equals</a:Operator>"
+                f"<a:Value>{user_id}</a:Value></a:Predicate>"
+                "</Predicates>"
+                '<Ordering i:nil="true"/>'
+                f'<PageInfo xmlns:a="{_ENTITIES_NS}"><a:Index>0</a:Index><a:Size>1000</a:Size></PageInfo>'
+                "</SearchAccountsRequest>"
+            )
+            accounts_root = await self._soap_call(client, access_token, "SearchAccounts", search_body)
+
+        return [
+            {
+                "account_id": _child_text(account, "Id") or "",
+                "customer_id": _child_text(account, "ParentCustomerId") or "",
+                "name": f"{_child_text(account, 'Name')} ({_child_text(account, 'Number')})",
+            }
+            for account in accounts_root.iter()
+            if _local_name(account.tag) == "AdvertiserAccount"
+        ]
+
+    async def _soap_call(
+        self,
+        client: httpx.AsyncClient,
+        access_token: str,
+        action: str,
+        body: str,
+    ) -> ET.Element:
+        """POST one Customer Management SOAP action and return the parsed body."""
+        envelope = (
+            '<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" '
+            'xmlns:i="http://www.w3.org/2001/XMLSchema-instance">'
+            f'<s:Header xmlns="{_CUSTOMER_NS}">'
+            f'<Action mustUnderstand="1">{action}</Action>'
+            f"<DeveloperToken>{self.developer_token}</DeveloperToken>"
+            f"<AuthenticationToken>{access_token}</AuthenticationToken>"
+            "</s:Header>"
+            f"<s:Body>{body}</s:Body>"
+            "</s:Envelope>"
+        )
+        response = await client.post(
+            _CUSTOMER_MANAGEMENT_URL,
+            content=envelope,
+            headers={"Content-Type": "text/xml; charset=utf-8", "SOAPAction": action},
+        )
+        response.raise_for_status()
+        return ET.fromstring(response.text)

--- a/packages/interloper-assets/src/interloper_assets/bing_ads/source.py
+++ b/packages/interloper-assets/src/interloper_assets/bing_ads/source.py
@@ -79,7 +79,43 @@ def _build_ad_performance_report_request(
     return request
 
 
-def _download_report(connection: BingAdsConnection, request: Any) -> pd.DataFrame:
+def _translate_soap_fault(error: Exception) -> None:
+    """Re-raise a Bing SOAP ``WebFault`` with its precise operation errors.
+
+    The SDK surfaces a generic ``"Invalid client data"`` ``faultstring``; the
+    actionable reason (e.g. ``AccountNotAuthorized``) lives in the fault detail.
+    Pulls those out into a readable message. Does nothing for other exceptions.
+    """
+    from suds import WebFault
+
+    if not isinstance(error, WebFault):
+        return
+
+    detail = getattr(error.fault, "detail", None)
+    messages: list[str] = []
+    for fault_name in ("ApiFaultDetail", "AdApiFaultDetail"):
+        fault_detail = getattr(detail, fault_name, None)
+        if not fault_detail:
+            continue
+        for group_name, item_name in (
+            ("OperationErrors", "OperationError"),
+            ("BatchErrors", "BatchError"),
+            ("Errors", "AdApiError"),
+        ):
+            group = getattr(fault_detail, group_name, None)
+            if not group or isinstance(group, str):
+                continue
+            items = getattr(group, item_name, [])
+            for item in items if isinstance(items, list) else [items]:
+                code = getattr(item, "ErrorCode", None) or getattr(item, "Code", None)
+                message = getattr(item, "Message", "")
+                messages.append(f"{code}: {message}" if code else str(message))
+
+    if messages:
+        raise RuntimeError("Bing Ads API error -- " + "; ".join(messages)) from error
+
+
+def _download_report(connection: BingAdsConnection, account_id: str, request: Any) -> pd.DataFrame:
     """Download a report request to a temp CSV and return it as a DataFrame."""
     from bingads.v13.reporting.reporting_download_parameters import ReportingDownloadParameters
 
@@ -91,7 +127,11 @@ def _download_report(connection: BingAdsConnection, request: Any) -> pd.DataFram
             overwrite_result_file=True,
             timeout_in_milliseconds=3600000,
         )
-        result_path = connection.reporting_service_manager.download_file(download_parameters)
+        try:
+            result_path = connection.reporting_service_manager(account_id).download_file(download_parameters)
+        except Exception as error:
+            _translate_soap_fault(error)  # raises RuntimeError for a SOAP fault
+            raise
 
         # The SDK returns ``None`` when the report contains no data for the period.
         if not result_path:
@@ -109,16 +149,16 @@ def _download_report(connection: BingAdsConnection, request: Any) -> pd.DataFram
     return df
 
 
-def _ad_performance_report(connection: BingAdsConnection, date: dt.date) -> pd.DataFrame:
+def _ad_performance_report(connection: BingAdsConnection, account_id: str, date: dt.date) -> pd.DataFrame:
     """Request and download the daily Ad Performance report for *date*."""
-    reporting_service = connection.reporting_service
+    reporting_service = connection.reporting_service(account_id)
     report_time = _build_report_time(reporting_service, date)
     request = _build_ad_performance_report_request(
         reporting_service=reporting_service,
         report_time=report_time,
-        account_id=connection.account_id,
+        account_id=account_id,
     )
-    return _download_report(connection, request)
+    return _download_report(connection, account_id, request)
 
 
 # ------------------------------------------------------------------
@@ -133,6 +173,14 @@ def _ad_performance_report(connection: BingAdsConnection, date: dt.date) -> pd.D
 class BingAds(il.Source):
     """Bing Ads (Microsoft Advertising) platform integration."""
 
+    account_id: str = il.FetchField(
+        title="Account ID",
+        description="Bing Ads account",
+        provider="connection.accounts",
+        label_key="name",
+        value_key="account_id",
+    )
+
     @il.asset(
         schema=AdsStats,
         partitioning=il.TimePartitionConfig(column="time_period"),
@@ -140,4 +188,4 @@ class BingAds(il.Source):
     )
     def ads_stats(self, context: il.ExecutionContext, connection: BingAdsConnection) -> pd.DataFrame:
         """Ad performance report with impressions, clicks, conversions, and revenue metrics."""
-        return _ad_performance_report(connection, context.partition_date)
+        return _ad_performance_report(connection, self.account_id, context.partition_date)

--- a/packages/interloper-assets/tests/test_bing_ads.py
+++ b/packages/interloper-assets/tests/test_bing_ads.py
@@ -11,21 +11,24 @@ in prod for AmazonAds; see ``test_amazon_ads.py``).
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any
 
 import pandas as pd
+import pytest
 from interloper.dag.base import DAG
 from interloper.dag.spec import DAGSpec
 from interloper.representation import representation_for
 from interloper_pandas import DataFrameNormalizer
+from suds import WebFault
 
 from interloper_assets.bing_ads import constants
 from interloper_assets.bing_ads.schemas import AdsStats
-from interloper_assets.bing_ads.source import BingAds
+from interloper_assets.bing_ads.source import BingAds, _translate_soap_fault
 
 
 def _source() -> Any:
-    return BingAds(id="src-1")
+    return BingAds(id="src-1", account_id="123")  # ty: ignore[unknown-argument]
 
 
 class TestSourceNormalizer:
@@ -73,3 +76,50 @@ class TestSpecRoundtrip:
         assert normalizer is not None
         normalized = normalizer.normalize(df)
         representation_for(normalized).conformer.validate(normalized, AdsStats)  # must not raise
+
+
+def _web_fault(detail: SimpleNamespace) -> WebFault:
+    return WebFault(SimpleNamespace(faultstring="Invalid client data.", detail=detail), document=None)
+
+
+class TestTranslateSoapFault:
+    """The generic 'Invalid client data' fault must be unpacked into its real cause."""
+
+    def test_operation_error_is_surfaced(self):
+        fault = _web_fault(
+            SimpleNamespace(
+                ApiFaultDetail=SimpleNamespace(
+                    BatchErrors="",
+                    OperationErrors=SimpleNamespace(
+                        OperationError=SimpleNamespace(
+                            Code="2003",
+                            ErrorCode="AccountNotAuthorized",
+                            Message="insufficient privileges",
+                        )
+                    ),
+                )
+            )
+        )
+        with pytest.raises(RuntimeError, match="AccountNotAuthorized: insufficient privileges"):
+            _translate_soap_fault(fault)
+
+    def test_multiple_batch_errors_are_joined(self):
+        fault = _web_fault(
+            SimpleNamespace(
+                ApiFaultDetail=SimpleNamespace(
+                    OperationErrors="",
+                    BatchErrors=SimpleNamespace(
+                        BatchError=[
+                            SimpleNamespace(Code="1", ErrorCode="A", Message="first"),
+                            SimpleNamespace(Code="2", ErrorCode="B", Message="second"),
+                        ]
+                    ),
+                )
+            )
+        )
+        with pytest.raises(RuntimeError, match="A: first; B: second"):
+            _translate_soap_fault(fault)
+
+    def test_non_webfault_is_left_untouched(self):
+        # Returns None (does not raise) so the caller re-raises the original.
+        assert _translate_soap_fault(ValueError("boom")) is None


### PR DESCRIPTION
## Motivation

Two issues with the Bing Ads integration, surfaced while debugging a `swarovski` run that failed with the opaque `suds.WebFault: Server raised fault: 'Invalid client data'`:

1. **`account_id`/`customer_id` lived on the connection.** Unlike every other ad source (Amazon, TikTok, …), the targeted account was baked into the credentials resource instead of the source, so one connection couldn't serve multiple accounts and the config didn't match the rest of the catalog.
2. **API errors were unreadable.** The SDK collapses every report failure into a generic `"Invalid client data"` `faultstring`; the actionable cause (e.g. `AccountNotAuthorized`) is buried in the SOAP fault detail.

## Changes

**`account_id` → source (`FetchField`).** `BingAds` now declares `account_id = FetchField(provider="connection.accounts")`, mirroring `AmazonAds.profile_id` / `TiktokAds.advertiser_id`. The connection holds only credentials, and its `reporting_service` / `reporting_service_manager` / `authorization_data` take an `account_id` argument.

**`customer_id` dropped.** Verified against the live API that the Reporting service authorizes on the account alone — submit/download succeed with the customer id unset — so it was redundant.

**New `accounts` fetch provider.** Lists the accounts a token can reach (`GetUser` → `SearchAccounts`) via raw Customer Management SOAP over **httpx**, not the `bingads` SDK — fetch providers run in the API process, which installs connection classes but not the heavy SDK extra (same constraint Amazon's `profiles` provider follows).

**Precise error surfacing.** `_translate_soap_fault` unpacks `OperationErrors` / `BatchErrors` / `Errors` from the `WebFault` detail into a readable `RuntimeError`. The `swarovski` manifest now fails with:

```
ASSET_FAILED  ads_stats  Asset 'ads_stats' failed: Bing Ads API error --
AccountNotAuthorized: The specified report request contains at least one
account which you have insufficient privileges to access. ...
```

## Verification

Against the live Swarovski token:
- `accounts()` returns the reachable account.
- Valid account → report submits, downloads, and returns a frame.
- Unauthorized account → the precise `AccountNotAuthorized` `RuntimeError` above (manifest end-to-end).

## Tests
- `test_bing_ads.py`: `_translate_soap_fault` (operation error, joined batch errors, non-fault passthrough); `_source()` updated to pass `account_id`.
- `ruff`, `ty`, and the full `interloper-assets` suite pass.

## Migration (config change, not a semver break)

`BingAdsConnection` no longer accepts `customer_id` / `account_id`. Manifests must move `account_id` to the **source** config and drop `customer_id`:

```yaml
- source: bing_ads
  config:
    account_id: "143007073"
    resources:
      connection:
        type: bing_ads_connection
        config:
          refresh_token: ${...}
  select:
    - ads_stats
```