### PR TITLE
fix: hide OAuth app credentials in sign-in mode

### DIFF
--- a/packages/interloper-app/app/app/components/SchemaForm.vue
+++ b/packages/interloper-app/app/app/components/SchemaForm.vue
@@ -36,6 +36,8 @@ interface JsonSchemaProperty {
     'x-options'?: { label: string, value: string }[]
     'x-options-from'?: string
     'x-fetch'?: FetchMeta
+    /** Field resolved by the OAuth flow — hidden in sign-in mode. */
+    'x-oauth-managed'?: boolean
     minimum?: number
     maximum?: number
     minLength?: number
@@ -113,16 +115,30 @@ const oauthTabs = computed<TabsItem[]>(() => [
     { label: 'Manual', value: 'manual', icon: 'i-lucide-keyboard' },
 ])
 
-/** The set of field keys that are auto-filled by OAuth. */
-const oauthFieldKeys = computed<Set<string>>(() => {
+/** Field keys auto-filled by the OAuth token exchange (used for the fill check). */
+const oauthTokenFieldKeys = computed<Set<string>>(() => {
     if (!oauthMeta.value) return new Set()
     return new Set(Object.values(oauthMeta.value.fields))
+})
+
+/**
+ * Field keys hidden in sign-in mode: everything the OAuth flow resolves for
+ * the user — token-filled fields plus app credentials from env (e.g. client_id
+ * / client_secret). The backend tags these with `x-oauth-managed`; falls back
+ * to the token fields if none are tagged.
+ */
+const oauthFieldKeys = computed<Set<string>>(() => {
+    if (!oauthMeta.value) return new Set()
+    const tagged = Object.entries(props.schema?.properties ?? {})
+        .filter(([, prop]) => prop['x-oauth-managed'])
+        .map(([key]) => key)
+    return new Set(tagged.length ? tagged : [...oauthTokenFieldKeys.value])
 })
 
 /** Whether OAuth fields have been filled (sign-in completed). */
 const oauthFilled = computed(() => {
     if (!oauthMeta.value) return false
-    return [...oauthFieldKeys.value].every(
+    return [...oauthTokenFieldKeys.value].every(
         key => data.value[key] !== undefined && data.value[key] !== '',
     )
 })

--- a/packages/interloper-app/app/app/types/oauth.ts
+++ b/packages/interloper-app/app/app/types/oauth.ts
@@ -24,5 +24,6 @@ export interface OAuthFieldMeta {
     scope: string
     label: string
     icon: string
+    /** Token-response-key → model-field-name mapping, filled on sign-in. */
     fields: Record<string, string>
 }

--- a/packages/interloper-assets/src/interloper_assets/facebook_ads/connection.py
+++ b/packages/interloper-assets/src/interloper_assets/facebook_ads/connection.py
@@ -24,8 +24,14 @@ _GRAPH_URL = f"https://graph.facebook.com/v{constants.API_VERSION}"
         },
     ),
 )
-class FacebookAdsConnection(il.Connection):
-    """Facebook Ads (Meta Marketing) API connection."""
+class FacebookAdsConnection(il.OAuthConnection):
+    """Facebook Ads (Meta Marketing) API connection.
+
+    Facebook names its app credentials ``app_id`` / ``app_secret`` and uses a
+    long-lived ``access_token``, so it declares those fields and maps them via
+    ``OAuthConfig.fields``, leaving ``OAuthConnection``'s optional credential
+    trio unused.
+    """
 
     model_config = SettingsConfigDict(env_prefix="facebook_ads_")
 

--- a/packages/interloper-assets/src/interloper_assets/facebook_insights/connection.py
+++ b/packages/interloper-assets/src/interloper_assets/facebook_insights/connection.py
@@ -15,14 +15,15 @@ from interloper_assets.facebook_insights import constants
         scope="pages_show_list,pages_read_engagement,pages_read_user_content,read_insights",
     ),
 )
-class FacebookInsightsConnection(il.Connection):
-    """Facebook Insights API connection with OAuth2 refresh token auth."""
+class FacebookInsightsConnection(il.OAuthConnection):
+    """Facebook Insights API connection with OAuth2 refresh token auth.
+
+    Uses the standard ``client_id`` / ``client_secret`` / ``refresh_token``
+    trio from ``OAuthConnection``; ``refresh_token`` holds a long-lived access
+    token used directly as the bearer.
+    """
 
     model_config = SettingsConfigDict(env_prefix="facebook_insights_")
-
-    client_id: str = il.InputField(description="Facebook App ID")
-    client_secret: str = il.SecretField(description="Facebook App Secret")
-    refresh_token: str = il.SecretField(description="OAuth2 long-lived access token")
 
     @cached_property
     def client(self) -> il.AsyncRESTClient:

--- a/packages/interloper-assets/src/interloper_assets/instagram_insights/connection.py
+++ b/packages/interloper-assets/src/interloper_assets/instagram_insights/connection.py
@@ -15,14 +15,15 @@ from interloper_assets.instagram_insights import constants
         scope="instagram_basic,instagram_manage_insights,pages_show_list,pages_read_engagement",
     ),
 )
-class InstagramInsightsConnection(il.Connection):
-    """Instagram Insights API connection with OAuth2 refresh token auth via Facebook Graph API."""
+class InstagramInsightsConnection(il.OAuthConnection):
+    """Instagram Insights API connection with OAuth2 refresh token auth via Facebook Graph API.
+
+    Uses the standard ``client_id`` / ``client_secret`` / ``refresh_token``
+    trio from ``OAuthConnection``; ``refresh_token`` holds a long-lived access
+    token.
+    """
 
     model_config = SettingsConfigDict(env_prefix="instagram_insights_")
-
-    client_id: str = il.InputField(description="Facebook App ID")
-    client_secret: str = il.SecretField(description="Facebook App Secret")
-    refresh_token: str = il.SecretField(description="OAuth2 long-lived access token")
 
     @cached_property
     def client(self) -> il.AsyncRESTClient:

--- a/packages/interloper-assets/src/interloper_assets/tiktok_ads/connection.py
+++ b/packages/interloper-assets/src/interloper_assets/tiktok_ads/connection.py
@@ -13,12 +13,13 @@ from interloper_assets.tiktok_ads.constants import BASE_URL
     tags=["Advertising"],
     oauth=il.OAuthConfig("tiktok", fields={"access_token": "access_token"}),
 )
-class TiktokAdsConnection(il.Connection):
+class TiktokAdsConnection(il.OAuthConnection):
     """TikTok Ads (Business API) connection authenticated with a long-lived access token.
 
     TikTok's token exchange returns a single long-lived ``access_token`` (no
-    refresh token), so this stays a plain ``Connection`` with a custom
-    ``OAuthConfig.fields`` mapping rather than subclassing ``OAuthConnection``.
+    refresh token), so it declares its own ``access_token`` field with a custom
+    ``OAuthConfig.fields`` mapping and leaves ``OAuthConnection``'s optional
+    credential trio unused.
     """
 
     model_config = SettingsConfigDict(env_prefix="tiktok_ads_")

--- a/packages/interloper-core/src/interloper/connection/base.py
+++ b/packages/interloper-core/src/interloper/connection/base.py
@@ -9,7 +9,7 @@ from pydantic import model_validator
 from pydantic_settings import BaseSettings
 
 from interloper.oauth import OAuthConfig
-from interloper.resource import InputField, Resource, SecretField
+from interloper.resource import InputField, Resource, ResourceDefinition, SecretField
 
 
 def validate_oauth_fields(cls: type[Connection]) -> None:
@@ -52,18 +52,50 @@ class Connection(BaseSettings, Resource):
         # Loads USERNAME, PASSWORD from environment if not passed explicitly
         conn = MyConnection()
 
-    Connections that support OAuth declare it via the decorator::
-
-        @connection(oauth=OAuthConfig("amazon", scope="..."))
-        class AmazonAdsConnection(OAuthConnection):
-            ...
-
-    (An ``oauth: ClassVar[OAuthConfig]`` in the class body is equivalent.)
+    Connections that support OAuth subclass ``OAuthConnection`` rather than
+    ``Connection``; the ``oauth`` config lives there, not on this base.
     """
 
     kind: ClassVar[str] = "connection"
     tags: ClassVar[list[str]] = []
+
+
+class OAuthConnection(Connection):
+    """A connection authenticated via OAuth — the home for all OAuth support.
+
+    Declares the standard credential trio (``client_id`` / ``client_secret`` /
+    ``refresh_token``) that ``OAuthConfig``'s default ``fields`` mapping
+    targets, so OAuth-enabled connections only add their own fields::
+
+        @connection(oauth=OAuthConfig("linkedin", scope="r_ads"))
+        class LinkedinAdsConnection(OAuthConnection):
+            account_id: str
+
+    The ``oauth`` config (provider, scope, token→field mapping) is declared
+    via the ``@connection(oauth=...)`` decorator kwarg or an equivalent
+    ``oauth: ClassVar[OAuthConfig]`` in the class body. Only ``OAuthConnection``
+    subclasses carry it — ``definition()`` injects the ``x-oauth`` schema
+    extension and tags the resolved credential fields so the form can render a
+    "Sign in with X" button.
+
+    The whole trio is optional (defaults to ``""``) so connections with a
+    non-standard token shape — a single long-lived ``access_token`` and no
+    refresh token, or differently named app credentials — can still subclass
+    this base and add their own fields.
+
+    ``client_id`` / ``client_secret`` are the *app* credentials. Left blank,
+    they default to the in-house per-provider credentials resolved from the
+    ``<PROVIDER>_CLIENT_ID`` / ``<PROVIDER>_CLIENT_SECRET`` environment (the
+    same vars the API's token-exchange endpoint reads), so the in-house secret
+    is never sent to the browser or stored per connection. Setting them
+    explicitly overrides the in-house app — e.g. to use your own OAuth client.
+    """
+
     oauth: ClassVar[OAuthConfig | None] = None
+
+    client_id: str = InputField("")
+    client_secret: str = SecretField("")
+    refresh_token: str = SecretField("")
 
     @classmethod
     def __pydantic_init_subclass__(cls, **kwargs: Any) -> None:
@@ -71,34 +103,44 @@ class Connection(BaseSettings, Resource):
         super().__pydantic_init_subclass__(**kwargs)
         validate_oauth_fields(cls)
 
+    @classmethod
+    def definition(cls) -> ResourceDefinition:
+        """Augment the resource definition with the OAuth schema metadata.
 
-class OAuthConnection(Connection):
-    """A connection authenticated via the standard OAuth2 refresh-token flow.
+        Injects the ``x-oauth`` extension from the ``oauth`` config and tags
+        the fields the sign-in flow resolves with ``x-oauth-managed`` so the
+        form hides them in sign-in mode, surfacing them only for manual entry.
 
-    Declares the credential trio that ``OAuthConfig``'s default ``fields``
-    mapping targets, so OAuth-enabled connections only add their own
-    fields::
+        Returns:
+            The resource definition, enriched when ``oauth`` is configured.
+        """
+        definition = super().definition()
+        if isinstance(cls.oauth, OAuthConfig):
+            schema = definition.config_schema
+            schema["x-oauth"] = cls.oauth.to_schema_ext()
+            properties = schema.get("properties", {})
+            for name in cls.oauth_managed_fields():
+                if name in properties:
+                    properties[name] = {**properties[name], "x-oauth-managed": True}
+            definition.provider = cls.oauth.provider
+        return definition
 
-        @connection(oauth=OAuthConfig("linkedin", scope="r_ads"))
-        class LinkedinAdsConnection(OAuthConnection):
-            account_id: str
+    @classmethod
+    def oauth_managed_fields(cls) -> list[str]:
+        """Credential fields the OAuth flow resolves — hidden in sign-in mode.
 
-    Connections with a non-standard token response shape (e.g. Facebook's
-    app_id/app_secret/access_token) declare their own fields on a plain
-    ``Connection`` and pass a custom ``fields=`` mapping to ``OAuthConfig``.
+        The standard trio ``OAuthConnection`` adds over a plain ``Connection``
+        (``client_id`` / ``client_secret`` from env, ``refresh_token`` from
+        sign-in), unioned with the token-mapped fields a custom-shaped
+        connection declares (e.g. a long-lived ``access_token``). Derived from
+        the model, so the names live only at their declaration above.
 
-    ``client_id`` / ``client_secret`` are the *app* credentials. They are
-    optional and default to the in-house per-provider credentials resolved
-    from the ``<PROVIDER>_CLIENT_ID`` / ``<PROVIDER>_CLIENT_SECRET``
-    environment (the same vars the API's token-exchange endpoint reads), so
-    the in-house secret is never sent to the browser or stored per
-    connection. Setting them explicitly overrides the in-house app — e.g. to
-    use your own OAuth client.
-    """
-
-    client_id: str = InputField("")
-    client_secret: str = SecretField("")
-    refresh_token: str = SecretField()
+        Returns:
+            The credential field names, deduplicated in declaration order.
+        """
+        credentials = [f for f in OAuthConnection.model_fields if f not in Connection.model_fields]
+        token_fields = cls.oauth.fields.values() if isinstance(cls.oauth, OAuthConfig) else ()
+        return list(dict.fromkeys([*credentials, *token_fields]))
 
     @model_validator(mode="after")
     def _resolve_app_credentials(self) -> OAuthConnection:

--- a/packages/interloper-core/src/interloper/connection/decorator.py
+++ b/packages/interloper-core/src/interloper/connection/decorator.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 from typing import Any, TypeVar, overload
 
 from interloper.component.build import build_component_class
-from interloper.connection.base import Connection, validate_oauth_fields
+from interloper.connection.base import Connection, OAuthConnection, validate_oauth_fields
 from interloper.oauth import OAuthConfig
 
 # Bounded TypeVar so that classes already extending Connection preserve their
@@ -86,6 +86,12 @@ def connection(
 
     def build(cls: type) -> type[Connection]:
         result = build_component_class(cls, base=Connection, classvars=classvars)
+        # OAuth lives on OAuthConnection only — reject it on a plain Connection,
+        # which carries neither the credential trio nor the schema injection.
+        if oauth is not None and not issubclass(result, OAuthConnection):
+            raise TypeError(
+                f"{result.__name__}: oauth=... requires subclassing OAuthConnection, not Connection."
+            )
         # Classes already extending Connection get classvars stamped after
         # model build, so the __pydantic_init_subclass__ hook ran without
         # the decorator's oauth — validate the final class explicitly.

--- a/packages/interloper-core/src/interloper/resource/base.py
+++ b/packages/interloper-core/src/interloper/resource/base.py
@@ -49,25 +49,14 @@ class Resource(Component):
         """Produce a structured definition of this resource class.
 
         The config schema is inlined as it belongs to the resource itself.
-        If the class declares an ``oauth`` ClassVar, its metadata is
-        injected as an ``x-oauth`` extension at the schema root.
 
         Returns:
             A ResourceDefinition with metadata and JSON Schema.
         """
-        from interloper.oauth import OAuthConfig
         from interloper.resource.fields import strip_internal_fields
         from interloper.utils.imports import get_object_path
 
         raw = cls.model_json_schema() if hasattr(cls, "model_json_schema") else {}
-        schema = strip_internal_fields(raw)
-
-        # Inject x-oauth from ClassVar if present.
-        oauth_cfg: OAuthConfig | None = getattr(cls, "oauth", None)
-        provider: str | None = None
-        if isinstance(oauth_cfg, OAuthConfig):
-            schema["x-oauth"] = oauth_cfg.to_schema_ext()
-            provider = oauth_cfg.provider
 
         return ResourceDefinition(
             kind=cls.kind,
@@ -77,6 +66,5 @@ class Resource(Component):
             icon=cls.icon,
             description=cls.__doc__ or "",
             tags=list(getattr(cls, 'tags', [])),
-            config_schema=schema,
-            provider=provider,
+            config_schema=strip_internal_fields(raw),
         )

--- a/packages/interloper-core/tests/connection/test_base.py
+++ b/packages/interloper-core/tests/connection/test_base.py
@@ -19,33 +19,53 @@ class TestConnection:
         assert definition.provider is None
         assert "x-oauth" not in definition.config_schema
 
-    def test_oauth_classvar_injected_into_schema(self):
+    def test_plain_connection_ignores_oauth_classvar(self):
+        # oauth lives on OAuthConnection; a plain Connection neither validates
+        # nor injects x-oauth, so the schema stays oauth-free.
         class WithOAuth(Connection):
-            oauth: ClassVar[OAuthConfig] = OAuthConfig(
-                "facebook",
-                scope="ads_read",
-                fields={"access_token": "access_token"},
-            )
+            oauth: ClassVar[OAuthConfig] = OAuthConfig("facebook", scope="ads_read")
 
             access_token: str = "t"
 
         definition = WithOAuth.definition()
 
-        assert definition.provider == "facebook"
-        assert definition.config_schema["x-oauth"]["scope"] == "ads_read"
-
-    def test_oauth_fields_mapping_validated_at_class_build(self):
-        with pytest.raises(TypeError, match=r"Broken: OAuthConfig.fields .* \['nope'\]"):
-
-            class Broken(Connection):
-                oauth: ClassVar[OAuthConfig] = OAuthConfig("amazon", fields={"refresh_token": "nope"})
-
-                client_id: str = "x"
+        assert definition.provider is None
+        assert "x-oauth" not in definition.config_schema
 
 
 class TestOAuthConnection:
     def test_declares_standard_trio(self):
         assert {"client_id", "client_secret", "refresh_token"} <= set(OAuthConnection.model_fields)
+
+    def test_oauth_injected_into_schema(self):
+        class MyConn(OAuthConnection):
+            oauth: ClassVar[OAuthConfig] = OAuthConfig("facebook", scope="ads_read")
+
+        definition = MyConn.definition()
+
+        assert definition.provider == "facebook"
+        assert definition.config_schema["x-oauth"]["scope"] == "ads_read"
+
+    def test_custom_token_shape_tags_its_own_field(self):
+        # A long-lived-access-token connection declares its own field and maps
+        # it; the union tags it for hiding alongside the (unused) trio.
+        class TokenOnly(OAuthConnection):
+            oauth: ClassVar[OAuthConfig] = OAuthConfig(
+                "facebook", scope="ads_read", fields={"access_token": "access_token"},
+            )
+
+            access_token: str = "t"
+
+        properties = TokenOnly.definition().config_schema["properties"]
+
+        assert properties["access_token"]["x-oauth-managed"] is True
+        assert TokenOnly.oauth_managed_fields() == ["client_id", "client_secret", "refresh_token", "access_token"]
+
+    def test_oauth_fields_mapping_validated_at_class_build(self):
+        with pytest.raises(TypeError, match=r"Broken: OAuthConfig.fields .* \['nope'\]"):
+
+            class Broken(OAuthConnection):
+                oauth: ClassVar[OAuthConfig] = OAuthConfig("amazon", fields={"refresh_token": "nope"})
 
     def test_subclass_satisfies_default_mapping(self):
         class MyConn(OAuthConnection):
@@ -59,6 +79,21 @@ class TestOAuthConnection:
         properties = definition.config_schema["properties"]
         assert {"client_id", "client_secret", "refresh_token", "account_id"} <= set(properties)
         assert properties["client_secret"]["x-widget"] == "password"
+
+    def test_managed_fields_cover_app_credentials_and_token(self):
+        # Sign-in mode hides the whole credential trio: the app credentials
+        # resolved from env plus the token-filled refresh_token. The set is
+        # derived from the model — only the connection's own fields stay shown.
+        class MyConn(OAuthConnection):
+            oauth: ClassVar[OAuthConfig] = OAuthConfig("linkedin", scope="r_ads")
+
+            account_id: str = "a"
+
+        assert MyConn.oauth_managed_fields() == ["client_id", "client_secret", "refresh_token"]
+
+        properties = MyConn.definition().config_schema["properties"]
+        assert all(properties[f]["x-oauth-managed"] is True for f in ("client_id", "client_secret", "refresh_token"))
+        assert "x-oauth-managed" not in properties["account_id"]
 
     def test_default_mapping_auto_fills_only_refresh_token(self):
         # The app credentials are not pulled from the token exchange; only the

--- a/packages/interloper-core/tests/connection/test_decorator.py
+++ b/packages/interloper-core/tests/connection/test_decorator.py
@@ -36,17 +36,14 @@ class TestConnectionDecorator:
         assert definition.provider == "linkedin"
         assert definition.config_schema["x-oauth"]["auth_url"] == "https://www.linkedin.com/oauth/v2/authorization"
 
-    def test_oauth_kwarg_on_plain_class(self):
-        # The with-kwargs overload is typed for Connection subclasses;
-        # plain classes are still supported at runtime.
-        @connection(oauth=OAuthConfig("amazon"))  # ty: ignore[invalid-argument-type]
-        class MyConn:
-            client_id: str = "i"
-            client_secret: str = "s"
-            refresh_token: str = "r"
+    def test_oauth_kwarg_rejected_on_plain_connection(self):
+        # OAuth lives on OAuthConnection; a class that resolves to a plain
+        # Connection (here a bare class) is rejected.
+        with pytest.raises(TypeError, match=r"requires subclassing OAuthConnection"):
 
-        assert issubclass(MyConn, Connection)
-        assert MyConn.definition().provider == "amazon"
+            @connection(oauth=OAuthConfig("amazon"))  # ty: ignore[invalid-argument-type]
+            class MyConn:
+                host: str = "h"
 
     def test_oauth_kwarg_does_not_become_model_field(self):
         @connection(oauth=OAuthConfig("amazon"))
@@ -57,10 +54,10 @@ class TestConnectionDecorator:
         assert "oauth" not in MyConn.definition().config_schema.get("properties", {})
 
     def test_oauth_fields_mapping_validated_on_subclass_path(self):
-        # ClassVars are stamped on already-built Connection subclasses after
-        # the pydantic hooks ran -- the decorator must still validate.
+        # ClassVars are stamped on already-built OAuthConnection subclasses
+        # after the pydantic hooks ran -- the decorator must still validate.
         with pytest.raises(TypeError, match=r"Broken: OAuthConfig.fields .* \['nope'\]"):
 
             @connection(oauth=OAuthConfig("amazon", fields={"refresh_token": "nope"}))
-            class Broken(Connection):
-                client_id: str = "x"
+            class Broken(OAuthConnection):
+                pass


### PR DESCRIPTION
## What

Fixes the "Sign in with X" form rendering `client_id` / `client_secret` inputs even though the OAuth flow resolves them from env. They now stay hidden in sign-in mode and surface only under Manual entry.

Along the way, OAuth handling is consolidated so the generic resource layer no longer carries it.

## Why

Sign-in mode hid only the fields in `OAuthConfig.fields` (the token-mapped set — `refresh_token` by default). The app credentials (`client_id`/`client_secret`) are resolved from env (`<PROVIDER>_CLIENT_ID/SECRET`) and never round-trip to the browser, so they should be hidden in sign-in mode too.

## How

**Frontend** — the backend tags the OAuth-resolved fields with a per-field `x-oauth-managed` hint (same convention as `x-widget` / `x-fetch`); `SchemaForm.vue` hides tagged fields in sign-in mode, falling back to the token-mapped fields when nothing is tagged. The "connected" check keys off only the token-filled fields, so env-resolved blank credentials never block it.

**Backend — OAuth consolidated onto `OAuthConnection`:**
- `Resource.definition()` is OAuth-agnostic again (no `OAuthConfig` import, no x-oauth, no provider logic).
- `Connection` is a plain credential base — the `oauth` ClassVar and validation hook are gone.
- `OAuthConnection` owns everything: the `oauth` config, validation, the `definition()` override that injects the `x-oauth` ext + tags `oauth_managed_fields`, and the `provider`. The credential trio is now **optional** so non-standard token shapes can subclass it.
- `@connection(oauth=...)` raises unless the class is an `OAuthConnection` subclass.

**Sources reparented** to `OAuthConnection`:
- `facebook_insights`, `instagram_insights` — already declared the standard trio, so they now just inherit it.
- `tiktok_ads` (single long-lived `access_token`), `facebook_ads` (`app_id`/`app_secret`/`access_token`) — keep their bespoke fields and leave the inherited optional trio unused.

## Notes for reviewers

- `tiktok_ads` / `facebook_ads` now carry the inherited (unused) trio; it's hidden in sign-in mode but would appear under Manual entry. Cleaning that up fully means per-source field surgery (e.g. renaming Facebook's `app_id`→`client_id`) with data-migration implications, so it's left as follow-up.
- Edits the frontend source — the bundled SPA under `interloper-app/src/.../static/` needs `make build-app` for a built deployment.

## Tests / checks

737 tests pass; `ruff` + `ty` clean; frontend `nuxt typecheck` clean.