### PR TITLE
feat: documentation site at docs.interloper.dev

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -79,10 +79,13 @@ jobs:
       matrix:
         # role  → dockerfile target + image name (interloper-<role>)
         # flavor → tag suffix; api_extras/scheduler_extras feed the build args
+        # file   → dockerfile to build (defaults to the multi-target dockerfile;
+        #          docs has its own standalone docs.dockerfile)
         include:
           - { role: api,       flavor: "",       api_extras: "",      scheduler_extras: "" }
           - { role: api,       flavor: agent,    api_extras: "agent", scheduler_extras: "" }
           - { role: frontend,  flavor: "",       api_extras: "",      scheduler_extras: "" }
+          - { role: docs,      flavor: "",       api_extras: "",      scheduler_extras: "", file: docs.dockerfile }
           - { role: worker,    flavor: "",       api_extras: "",      scheduler_extras: "" }
           - { role: scheduler, flavor: "",       api_extras: "",      scheduler_extras: "" }
           - { role: scheduler, flavor: k8s,      api_extras: "",      scheduler_extras: "k8s" }
@@ -126,7 +129,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: dockerfile
+          file: ${{ matrix.file || 'dockerfile' }}
           target: ${{ matrix.role }}
           platforms: linux/amd64,linux/arm64
           push: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,8 @@ examples/                    runnable usage examples
 chart/                       Helm chart
 docker/                      uv-sync.sh helper and nginx template
 dockerfile                   multi-target build (core / scheduler / worker / api / frontend)
+docs.dockerfile              standalone build for the static documentation site (zensical)
+docs/                        documentation site (zensical) served at docs.interloper.dev
 ```
 
 The frontend lives at `packages/interloper-app/app/` and has its own toolchain (pnpm + Nuxt) and its own [AGENTS.md](packages/interloper-app/app/AGENTS.md). `make build-app` builds the SPA and copies it into `packages/interloper-app/src/interloper_app/static/`.

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ ASSETS_EXTRAS ?= bing,facebook,google
 # plus the matching "latest" / "latest-<flavor>" tags on stable releases.
 # NOTE: the `docker` job matrix in .github/workflows/publish.yaml mirrors this
 # catalog — update both together when adding or removing a role or flavor.
-ROLES := api frontend worker scheduler
+ROLES := api frontend worker scheduler docs
 
 # Flavors per role, and the build-arg that carries a flavor's extra. A role
 # with no FLAVORS_<role> builds only its base image.
@@ -68,7 +68,7 @@ EXTRAS_ARG_scheduler := SCHEDULER_EXTRAS
 ALL_FLAVORS := $(sort $(foreach r,$(ROLES),$(FLAVORS_$(r))))
 
 # Concrete target stems built by `docker-build`: every role plus each
-# "<role>-<flavor>" pair → api api-agent frontend worker scheduler
+# "<role>-<flavor>" pair → api api-agent frontend worker scheduler docs
 # scheduler-k8s scheduler-docker.
 TARGETS := $(ROLES) \
            $(foreach r,$(ROLES),$(foreach f,$(FLAVORS_$(r)),$(r)-$(f)))
@@ -89,10 +89,15 @@ latest_of = latest$(if $(call flavor_of,$(1)),-$(call flavor_of,$(1)))
 # (SCHEDULER_EXTRAS defaults to "docker" there).
 extras_arg = $(if $(EXTRAS_ARG_$(call role_of,$(1))),--build-arg $(EXTRAS_ARG_$(call role_of,$(1)))=$(call flavor_of,$(1)))
 
+# Dockerfile per role. The static docs site is independent of the Python
+# workspace, so it has its own standalone docs.dockerfile; every other role
+# is a target in the multi-target dockerfile.
+dockerfile_of = $(if $(filter docs,$(call role_of,$(1))),docs.dockerfile,dockerfile)
+
 # Pattern rules. Order matters on macOS' GNU make 3.81 (no shortest-stem):
 # the more specific docker-build-linux-% must come first.
 docker-build-linux-%:
-	docker build --target $(call role_of,$*) --platform linux/amd64 \
+	docker build --target $(call role_of,$*) -f $(call dockerfile_of,$*) --platform linux/amd64 \
 		--build-arg CORE_EXTRAS=$(CORE_EXTRAS) \
 		--build-arg ASSETS_EXTRAS=$(ASSETS_EXTRAS) \
 		$(call extras_arg,$*) \
@@ -102,7 +107,7 @@ docker-build-linux-%:
 		-t $(REGISTRY)/$(call image_of,$*):$(call latest_of,$*) .
 
 docker-build-%:
-	docker build --target $(call role_of,$*) \
+	docker build --target $(call role_of,$*) -f $(call dockerfile_of,$*) \
 		--build-arg CORE_EXTRAS=$(CORE_EXTRAS) \
 		--build-arg ASSETS_EXTRAS=$(ASSETS_EXTRAS) \
 		$(call extras_arg,$*) \

--- a/docker/docs.nginx.conf
+++ b/docker/docs.nginx.conf
@@ -1,0 +1,43 @@
+# nginx config for the static documentation site (zensical build output).
+# Pure static files — no API upstream — so this is a plain conf.d drop-in
+# (no envsubst template needed). It replaces the stock default.conf.
+
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Liveness/readiness endpoint for the Kubernetes probes and the GKE
+    # Gateway HealthCheckPolicy.
+    location = /healthz {
+        access_log off;
+        add_header Content-Type text/plain;
+        return 200 "ok\n";
+    }
+
+    # zensical emits clean URLs as directories (e.g. /features/runners/).
+    # Keep nginx's trailing-slash redirects relative so the browser resolves
+    # them against the current scheme/host/port.
+    absolute_redirect off;
+
+    # Serve the styled 404 page (with the correct status) for unknown paths.
+    error_page 404 /404.html;
+
+    location / {
+        try_files $uri $uri/ =404;
+    }
+
+    # Build assets are content-hashed — cache them hard.
+    location /assets/ {
+        access_log off;
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # HTML must always be revalidated so new builds are picked up promptly.
+    location ~* \.html$ {
+        add_header Cache-Control "no-cache";
+    }
+}

--- a/dockerfile
+++ b/dockerfile
@@ -10,6 +10,8 @@
 #   api        core + db + api (assets installed; SDK extras skipped)
 #   frontend   pre-built Nuxt SPA served by nginx
 #
+# The static documentation site has its own standalone build: docs.dockerfile.
+#
 # Tagging convention: one image per role, flavors ride the tag.
 #   docker build --target scheduler -t interloper-scheduler:0.2.0 .        # base
 #   docker build --target scheduler --build-arg SCHEDULER_EXTRAS=k8s \

--- a/docs.dockerfile
+++ b/docs.dockerfile
@@ -1,0 +1,40 @@
+# ================================================================
+# Interloper docs — static documentation site (zensical)
+# ================================================================
+#
+# Standalone image. The docs are independent of the Python workspace, so they
+# get their own dockerfile rather than a target in the multi-target dockerfile.
+#
+#   docker build -f docs.dockerfile --target docs -t interloper-docs .
+#
+# Published as ghcr.io/digitl-cloud/interloper-docs by the `docs` entry in the
+# Makefile image catalog and the publish workflow matrix.
+# ================================================================
+
+# ── build (zensical) ──────────────────────────────────────────
+# Like the SPA build, the output is architecture-independent static HTML/CSS,
+# so pin this stage to the *build* platform — there's no reason to run the
+# zensical build under QEMU for the linux/arm64 target. Only the trivial nginx
+# runtime stage below is built per-target-arch (a COPY).
+#
+# zensical is run from an ephemeral, isolated environment (`uv run --no-project
+# --with`), so this stage needs only the docs sources and the site config. The
+# version is pinned to match the dev dependency group in pyproject.toml.
+FROM --platform=$BUILDPLATFORM ghcr.io/astral-sh/uv:python3.12-alpine AS build-docs
+
+WORKDIR /docs
+ENV UV_LINK_MODE=copy
+# Mirror the repo layout: zensical.toml at the root, docs/ alongside it
+# (docs_dir defaults to ./docs relative to the config). Output -> /docs/site.
+COPY zensical.toml ./
+COPY docs/ docs/
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv run --no-project --with "zensical>=0.0.24" zensical build
+
+
+# ── runtime (nginx serving the pre-built static site) ─────────
+# Pure static site — no API proxy, so a plain conf.d drop-in (no envsubst).
+FROM nginx:1.27-alpine-slim AS docs
+COPY --from=build-docs /docs/site/ /usr/share/nginx/html/
+COPY docker/docs.nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,94 @@
+# FAQ
+
+### Why another data framework?
+
+Because the existing ones are either too opinionated, too bloated, or just don't get out of your
+way.
+
+* ETL tools force rigid workflows.
+* Orchestration frameworks overcomplicate simple jobs.
+* DIY pipelines break the moment your schema changes.
+
+Interloper sits in between:
+
+* **Simple when you want it**: write a function, materialize an asset.
+* **Powerful when you need it**: define dependencies, automatically reconcile schemas, partition
+  and backfill, run anywhere from a single thread to Kubernetes.
+
+In terms of concepts and design, Interloper draws inspiration from modern orchestrators while
+staying a lightweight, embeddable library.
+
+
+### What is the difference between an asset definition and an `Asset`?
+
+The `@asset` decorator produces an immutable **definition** (a class) that describes *what* an
+asset does. Calling it creates a runtime `Asset` instance, which carries runtime configuration
+like destinations, resources, and dependency wiring.
+
+```py
+@il.asset
+def my_asset():       # this is the definition
+    return "hello"
+
+instance = my_asset()  # this is an Asset instance
+```
+
+
+### Why are `run()` and `materialize()` coroutines?
+
+The execution engine is async-native. Both `run()` and `materialize()` return coroutines — call
+them with `await` inside an event loop, or `asyncio.run(...)` at the top level. Synchronous asset
+functions are offloaded to threads automatically, so you never have to make your asset `async`
+just to satisfy the engine.
+
+
+### What is the difference between `run()` and `materialize()`?
+
+`run()` executes the asset function and returns the result (normalized and conformed to its
+schema if configured) **without** writing anywhere. `materialize()` does the same and then writes
+the result to all configured destinations.
+
+
+### How does dependency resolution work?
+
+Within a source, if an asset's parameter name matches a sibling asset's key, the dependency is
+resolved automatically. For cross-source dependencies or name mismatches, use `requires` (or
+`optional_requires`) on the `@asset` decorator. See [Upstream Assets](features/upstream-assets.md).
+
+
+### Can I use Interloper without a DAG?
+
+Yes. You can run or materialize individual assets directly:
+
+```py
+result = await my_asset().run()
+await my_asset(destination=il.FileDestination("./data")).materialize()
+```
+
+A DAG is only needed when you have multiple assets with dependencies.
+
+
+### What destinations are available?
+
+Built-in (core library): `MemoryDestination` (default), `FileDestination`, `CSVDestination`. Via
+`interloper-google-cloud`: `BigQueryDestination`. You can build your own by subclassing
+`il.Destination` — or `il.DatabaseDestination` for SQL-style stores. See
+[Destinations](features/destinations.md).
+
+> Earlier versions exposed an "IO" concept (`FileIO`, `MemoryIO`, an `interloper-sql` package).
+> That has been replaced by Destinations; there is no longer a bundled Postgres/MySQL/SQLite
+> backend.
+
+
+### What's the difference between a Config and a Connection?
+
+Both are [resources](features/resources.md) injected into asset functions and both load from the
+environment. Use a [Config](features/config.md) for plain settings and a
+[Connection](features/connections.md) for service credentials — connections add secret handling
+and an OAuth connect flow.
+
+
+### How do I run a backfill?
+
+Pass a `TimePartitionWindow` to a runner (or `dag.materialize()`). There's no separate backfiller
+object. See [Backfilling](features/backfilling.md).

--- a/docs/features/assets-sources.md
+++ b/docs/features/assets-sources.md
@@ -1,0 +1,173 @@
+# Assets & Sources
+
+## Standalone assets
+
+The simplest way to define an asset is with the `@asset` decorator on a function:
+
+```py
+import interloper as il
+
+@il.asset
+def my_asset():
+    return [{"key": "value"}]
+```
+
+The decorator returns an asset **definition** (a class) -- an immutable blueprint. To create a runtime `Asset` instance, call it:
+
+```py
+asset_instance = my_asset()
+result = await asset_instance.run()
+```
+
+Asset functions can be synchronous or asynchronous. Synchronous functions are offloaded to a
+worker thread automatically; `async def` functions are awaited natively on the event loop.
+
+### Decorator options
+
+The `@asset` decorator accepts several options:
+
+```py
+@il.asset(
+    name="custom_name",                 # Human-readable name
+    key="custom_key",                    # Override the asset key (defaults to snake_case fn name)
+    schema=MySchema,                     # Schema for validation/reconciliation
+    partitioning=il.TimePartitionConfig(column="date"),
+    normalizer=il.Normalizer(),          # Data normalization
+    materialization_strategy=il.MaterializationStrategy.RECONCILE,
+    destinations=[il.FileDestination],   # Destination types this asset writes to
+    resources={"conn": MyConnection},    # Named resource dependencies (injected)
+    requires={"data": "other_source.raw"},        # Explicit upstream mapping
+    optional_requires={"extra": "other.maybe"},   # Optional upstream (None if absent)
+    tags=["daily", "api"],               # Arbitrary tags
+    icon="icon:database",                # Icon identifier (for the UI)
+)
+def my_asset():
+    ...
+```
+
+### Running an asset
+
+`run()` executes the asset function and returns the result (normalized and conformed to its
+schema if configured) **without** writing to any destination:
+
+```py
+result = await my_asset().run()
+```
+
+### Materializing an asset
+
+`materialize()` executes the asset **and** writes the result to all configured destinations:
+
+```py
+asset_instance = my_asset(destination=il.FileDestination("./data"))
+await asset_instance.materialize()
+```
+
+Both `run()` and `materialize()` are coroutines. Outside an event loop, drive them with
+`asyncio.run(...)`.
+
+## Sources
+
+A source groups related assets together. It is a **function** decorated with `@il.source` that
+returns the list of asset definitions it contains:
+
+```py
+@il.source
+def my_source():
+    @il.asset
+    def asset_a():
+        return [{"key": "A"}]
+
+    @il.asset
+    def asset_b():
+        return [{"key": "B"}]
+
+    return [asset_a, asset_b]
+```
+
+!!! note "Class-based sources"
+
+    A class-based form is also supported (`@il.source class MySource(il.Source): ...` with
+    `@il.asset`-decorated methods), and is used by some pre-built sources in
+    `interloper-assets`. The functional form above is the recommended default for new code.
+
+### Source decorator options
+
+```py
+@il.source(
+    name="custom_name",
+    key="custom_key",
+    destinations=[il.FileDestination],            # Shared destination types
+    resources={"conn": MyConnection},             # Shared resource dependencies
+    dataset="my_dataset",                         # Default dataset for assets
+    default_destination_key="primary",            # Which destination assets read from
+    normalizer=il.Normalizer(),                   # Applied to all assets without their own
+    materialization_strategy=il.MaterializationStrategy.AUTO,
+    materializable=True,
+    tags=["production"],
+)
+def my_source():
+    ...
+```
+
+Configuration set on the source **trickles down** to its assets: an asset that doesn't define
+its own `destination`, `dataset`, `normalizer` or strategy inherits the source's.
+
+### Instantiating a source
+
+Call the source definition to create a runtime `Source`:
+
+```py
+source = my_source()                                       # Default resources from env
+source = my_source(destination=il.FileDestination("./data"))
+source = my_source(resources={"conn": MyConnection(...)})  # With explicit resources
+```
+
+### Accessing assets
+
+Assets are available as attributes on both the definition and the instance:
+
+```py
+# On the definition (returns the asset definition class)
+my_source.asset_a
+
+# On the instance (returns the runtime Asset)
+source = my_source(destination=il.FileDestination("./data"))
+await source.asset_a.run()
+await source.asset_b.materialize()
+```
+
+### Reconfiguring a source
+
+Calling an existing source instance returns a reconfigured copy, leaving the original
+untouched:
+
+```py
+source = my_source(destination=il.FileDestination("./data"))
+
+# A copy whose assets won't be written during materialization
+read_only = source(materializable=False)
+```
+
+## DAG
+
+A `DAG` (Directed Acyclic Graph) orchestrates the execution of multiple assets, respecting their dependencies:
+
+```py
+source = my_source(destination=il.FileDestination("./data"))
+dag = il.DAG(source)
+await dag.materialize()
+```
+
+A DAG can be built from any combination of assets and sources (instances or definitions):
+
+```py
+dag = il.DAG(source_a, source_b, standalone_asset)
+```
+
+At construction the DAG validates the graph: it rejects duplicate assets, missing dependencies
+(`DependencyNotFoundError`), cycles (`CircularDependencyError`), and a non-partitioned asset
+depending on a partitioned one.
+
+`dag.materialize(partition_or_window=...)` runs the DAG with the default `AsyncRunner`. For
+other execution strategies, see [Runners](runners.md).

--- a/docs/features/backfilling.md
+++ b/docs/features/backfilling.md
@@ -1,0 +1,96 @@
+# Backfilling
+
+Backfilling means processing a range of partitions. In Interloper there is **no separate
+backfiller object** — you simply run a DAG over a `TimePartitionWindow`, and the runner iterates
+the window for you.
+
+## Running a backfill
+
+Pass a window to any runner's `run()` (or to `dag.materialize()`). The runner walks the window
+**from most recent to oldest**, running the DAG once per partition:
+
+```py
+import asyncio
+import datetime as dt
+import interloper as il
+
+@il.source
+def my_source():
+    @il.asset(partitioning=il.TimePartitionConfig(column="date"))
+    def daily_data(context: il.ExecutionContext):
+        date = context.partition_date
+        return [{"date": date.isoformat(), "value": 42}]
+
+    return [daily_data]
+
+source = my_source(destination=il.FileDestination("./data"))
+dag = il.DAG(source)
+
+window = il.TimePartitionWindow(
+    start=dt.date(2025, 1, 1),
+    end=dt.date(2025, 1, 7),
+)
+
+result = asyncio.run(il.AsyncRunner(max_workers=4).run(dag, window))
+print(result.status)
+```
+
+This produces seven runs, one per day.
+
+## Windowed backfill (single run)
+
+When an asset declares `allow_window=True`, the entire window is handed to it as a single run
+instead of being split into one run per date — let the asset fetch the whole range at once:
+
+```py
+@il.asset(partitioning=il.TimePartitionConfig(column="date", allow_window=True))
+def weekly_data(context: il.ExecutionContext):
+    start, end = context.partition_date_window
+    return fetch_range(start, end)
+```
+
+## Stopping on failure
+
+By default the in-process runners stop the current run on the first asset failure
+(`fail_fast=True`). Set `fail_fast=False` to keep going and collect every result:
+
+```py
+runner = il.AsyncRunner(fail_fast=False)
+result = asyncio.run(runner.run(dag, window))
+```
+
+## Progress monitoring
+
+Pass an `on_event` callback to the runner, or subscribe to the global event bus, to track
+progress across a backfill:
+
+```py
+def on_event(event: il.Event):
+    if event.type is il.EventType.RUN_COMPLETED:
+        print(f"Completed: {event.metadata.get('partition_or_window')}")
+
+result = asyncio.run(il.AsyncRunner(on_event=on_event).run(dag, window))
+```
+
+See [Events](events.md) for the full event model.
+
+## Distributed backfilling
+
+For large backfills, use the Docker or Kubernetes runners. They use the same window mechanism —
+each asset (with its ancestors) runs in an isolated container or Job:
+
+```py
+from interloper_docker.runner import DockerRunner
+
+runner = DockerRunner(image="interloper:latest-worker", max_containers=4)
+asyncio.run(runner.run(dag, window))
+```
+
+```py
+from interloper_k8s.runner import KubernetesRunner
+
+runner = KubernetesRunner(image="my-repo/interloper:latest", namespace="data", max_jobs=4)
+asyncio.run(runner.run(dag, window))
+```
+
+See [Runners](runners.md) for all execution strategies and their options.

--- a/docs/features/catalog.md
+++ b/docs/features/catalog.md
@@ -1,0 +1,54 @@
+# Catalog
+
+A **catalog** is a registry of component definitions — sources, assets, connections,
+destinations, and configs — keyed by their component key. It's how Interloper introspects what's
+available without instantiating or executing anything: the API, the web UI, and the declarative
+[run manifests](cli.md) all read catalog metadata.
+
+## Building a catalog
+
+From a list of source/asset classes:
+
+```py
+import interloper as il
+from interloper_assets import DemoSource
+
+catalog = il.Catalog.from_assets([DemoSource])
+```
+
+From a list of import paths (resources and destinations referenced by the components are
+discovered automatically):
+
+```py
+catalog = il.Catalog.from_paths([
+    "interloper_assets.facebook_ads.source.FacebookAds",
+    "interloper_assets.google_ads.source.GoogleAds",
+])
+```
+
+From application settings (the `catalog` list in [`interloper.yaml`](cli.md#interloperyaml),
+falling back to entry-point discovery):
+
+```py
+catalog = il.Catalog.from_settings()
+```
+
+Or discover everything registered under the `interloper.components` entry-point group:
+
+```py
+catalog = il.Catalog.discover()
+```
+
+## Working with a catalog
+
+```py
+catalog.components            # dict[str, ComponentDefinition]
+catalog.get("facebook_ads")   # a ComponentDefinition, or None
+catalog.to_paths()            # sorted list of component import paths
+catalog.dump()                # JSON-serializable dict of all definitions
+```
+
+Each entry is a `ComponentDefinition` carrying the component's metadata — its key, name, tags,
+config schema, declared resources and destinations, and (for assets) schema and partitioning.
+This is the same metadata the API serves and the manifest loader resolves component `type`
+references against.

--- a/docs/features/cli.md
+++ b/docs/features/cli.md
@@ -1,0 +1,123 @@
+# CLI & Manifests
+
+Interloper includes a command-line interface for running DAGs and operating an instance.
+
+```sh
+interloper <command> [options]
+```
+
+| Command | Purpose |
+|---------|---------|
+| `run` | Materialize a DAG, from import paths or a manifest |
+| `db` | Database operations (`init`, `reset`, `upgrade`, `downgrade`) — needs `interloper-db` |
+| `app` | Start application services (API, cron, worker, reaper) — needs `interloper-db` |
+| `launch <run_id>` | Execute a single persisted run by id |
+| `agent` | Launch the agent development UI — needs `interloper-agent` |
+
+This page focuses on `run`; the others belong to a deployed instance.
+
+## Running a DAG
+
+Run one or more components by import path:
+
+```sh
+interloper run interloper_assets.demo.source.DemoSource
+```
+
+### Partitions
+
+```sh
+interloper run <target> --date 2025-01-15                       # single partition
+interloper run <target> --start-date 2025-01-01 --end-date 2025-01-07   # window (backfill)
+```
+
+### Other options
+
+| Option | Description |
+|--------|-------------|
+| `-f, --file PATH` | Run a declarative manifest (see below) |
+| `--dry-run` | Validate and print the plan without executing |
+| `--date ISO` | Single partition date |
+| `--start-date ISO` / `--end-date ISO` | Partition window |
+| `--events [pretty\|json]` | Event output format (default `pretty`) |
+| `--run-id ID` | Optional run identifier forwarded to the runner |
+| `-q, --quiet` / `-v, --verbose` | Decrease / increase log verbosity |
+
+## Run manifests
+
+A **run manifest** is a YAML file that declares a DAG to materialize — sources, their config and
+destinations, an optional asset selection, the runner, and the partition — without writing any
+Python. It is loaded by `RunManifest`, compiled into a `RunPlan` (a ready `DAG` + partition +
+runner), and executed.
+
+```sh
+interloper run -f manifest.yaml --dry-run   # validate + print the plan
+interloper run -f manifest.yaml             # materialize
+```
+
+```yaml
+name: demo-manifest
+
+runner:
+  type: serial          # serial | async | multi_process | docker | kubernetes
+  # config: { max_workers: 4 }
+
+# Reusable components referenced by alias with {ref: <alias>}.
+resources:
+  gcp:
+    type: google_cloud_connection
+    config:
+      service_account_key: ${GCP_KEY}   # ${VAR} is interpolated from the environment
+
+destinations:
+  files:
+    type: interloper.destination.file.FileDestination
+    config:
+      base_path: /tmp/interloper-demo
+
+assets:
+  - source: interloper_assets.demo.source.DemoSource
+    config:
+      hello: manifest
+    destinations: [{ref: files}]    # one or more; writes fan out to each
+    select: [a, b]                  # subset of the source's assets; omit to run all
+
+partition:
+  date: 2026-01-01
+  # or a window:
+  # start: 2026-01-01
+  # end: 2026-01-31
+```
+
+A component `type` is either a **catalog key** (resolved against the `catalog` in
+`interloper.yaml`) or a fully qualified import path. The `runner` and `partition` blocks are
+overridden by the CLI `--date` / `--start-date` / `--end-date` flags when present.
+
+In Python:
+
+```py
+import interloper as il
+
+plan = il.RunManifest.from_yaml_file("manifest.yaml").compile()
+await plan.dag.materialize(partition_or_window=plan.partition)
+```
+
+## interloper.yaml
+
+A repository-root `interloper.yaml` configures a deployed instance: the Postgres connection, the
+default runner and launcher, the server/cron/worker/reaper services, and the **catalog** — the
+list of component import paths to enable. Every field also has an `INTERLOPER_*` environment
+variable equivalent.
+
+```yaml
+runner:
+  type: async
+
+catalog:
+  - interloper_assets.facebook_ads.source.FacebookAds
+  - interloper_assets.google_ads.source.GoogleAds
+  # ...
+```
+
+The catalog defined here is what `il.Catalog.from_settings()` loads and what manifest `type`
+keys resolve against. See [Catalog](catalog.md).

--- a/docs/features/config.md
+++ b/docs/features/config.md
@@ -1,0 +1,85 @@
+# Configuration
+
+## Config class
+
+`il.Config` is a [resource](resources.md) for arbitrary settings. It extends
+[Pydantic Settings](https://docs.pydantic.dev/latest/concepts/pydantic_settings/), providing
+environment-variable resolution, type validation, and defaults. Define one by subclassing
+`il.Config` or decorating a plain class with `@il.config`:
+
+```py
+import interloper as il
+
+class MyConfig(il.Config):
+    api_key: str
+    base_url: str = "https://api.example.com"
+    timeout: int = 30
+```
+
+```py
+@il.config
+class MyConfig:
+    api_key: str
+    base_url: str = "https://api.example.com"
+    timeout: int = 30
+```
+
+!!! tip "Config vs. Connection"
+
+    Use `Config` for plain settings (base URLs, limits, feature flags). Use a
+    [Connection](connections.md) for service **credentials** — it adds secret handling and an
+    OAuth connect flow. Both are resources and are injected the same way.
+
+## Environment variable resolution
+
+Config fields are resolved from environment variables automatically:
+
+```sh
+export API_KEY="my-secret-key"
+export BASE_URL="https://custom.api.com"
+```
+
+```py
+config = MyConfig()        # Resolves from the environment
+print(config.api_key)      # "my-secret-key"
+print(config.base_url)     # "https://custom.api.com"
+```
+
+## Injecting config into assets
+
+A config is injected into an asset function by **type annotation** — the framework inspects the
+signature and resolves the resource at run time:
+
+```py
+@il.asset
+def my_asset(config: MyConfig):
+    return fetch_data(config.api_key, base_url=config.base_url)
+```
+
+This works for source assets too:
+
+```py
+@il.source
+def my_source():
+    @il.asset
+    def data(config: MyConfig):
+        return fetch(config.base_url)
+
+    return [data]
+```
+
+## Providing config explicitly
+
+When auto-resolution from the environment isn't what you want, supply an instance via the
+`resources` mapping (keyed by the parameter name):
+
+```py
+asset_instance = my_asset(resources={"config": MyConfig(api_key="explicit-key")})
+
+# Or shared across a source's assets:
+source = my_source(resources={"config": MyConfig(base_url="https://staging.api.com")})
+```
+
+You can also declare resources up front on the decorator with `resources={...}` and let the
+type annotation bind them at call time. See [Resources](resources.md) for the full resolution
+cascade.

--- a/docs/features/connections.md
+++ b/docs/features/connections.md
@@ -1,0 +1,110 @@
+# Connections
+
+A **connection** holds the credentials and client setup for an external service. It is a
+[resource](resources.md): you declare it once and Interloper injects it into the asset functions
+that need it. Connections extend both Pydantic Settings (so values load from the environment) and
+the resource system (so they can be injected and described to the UI).
+
+## Defining a connection
+
+Subclass `il.Connection`, or decorate a plain class with `@il.connection`:
+
+```py
+import interloper as il
+
+@il.connection(name="My API", icon="icon:database", tags=["Integration"])
+class MyConnection(il.Connection):
+    host: str = "localhost"
+    port: int = 5432
+    username: str = il.InputField()
+    password: str = il.SecretField()
+```
+
+Field helpers like `il.InputField` and `il.SecretField` declare how each field is rendered in
+the connect form (a plain input vs. a masked secret). See [Resources](resources.md#field-types)
+for the full set.
+
+Values resolve from constructor arguments, a `.env` file, or environment variables — the same
+precedence as any Pydantic Settings model.
+
+## Injecting a connection into assets
+
+Declare the connection as a typed parameter on the asset function. Interloper inspects the
+signature, resolves the connection, and passes the instance in:
+
+```py
+@il.asset
+def users(connection: MyConnection):
+    return connection.client.get("/users").json()
+```
+
+A common pattern is to expose a ready-to-use HTTP client from the connection via
+`functools.cached_property`, so every asset shares one configured client:
+
+```py
+from functools import cached_property
+
+@il.connection(name="My API")
+class MyConnection(il.Connection):
+    api_key: str = il.SecretField()
+
+    @cached_property
+    def client(self) -> il.AsyncRESTClient:
+        return il.AsyncRESTClient(
+            "https://api.example.com",
+            auth=il.HTTPBearerAuth(self.api_key),
+        )
+
+@il.source(resources={"connection": MyConnection})
+def my_source():
+    @il.asset
+    async def users(connection: MyConnection):
+        async for page in connection.client.paginate("/users", il.PageNumberPaginator()):
+            ...
+
+    return [users]
+```
+
+See [REST & Pagination](rest.md) for building API clients.
+
+## Providing a connection explicitly
+
+Resolution follows a cascade — asset's own `resources`, then the source's, then
+auto-instantiation from the environment. To supply one explicitly, pass it via `resources`
+(keyed by the parameter name):
+
+```py
+source = my_source(resources={"connection": MyConnection(api_key="...")})
+```
+
+## OAuth connections
+
+For services behind OAuth, base your connection on `il.OAuthConnection` and attach an
+`il.OAuthConfig`. `OAuthConnection` declares the standard credential trio
+(`client_id` / `client_secret` / `refresh_token`):
+
+```py
+@il.connection(
+    name="LinkedIn Ads",
+    oauth=il.OAuthConfig("linkedin", scope="r_ads"),
+)
+class LinkedinAdsConnection(il.OAuthConnection):
+    account_id: str = il.InputField()
+```
+
+- The **app credentials** (`client_id`, `client_secret`) are resolved from
+  `LINKEDIN_CLIENT_ID` / `LINKEDIN_CLIENT_SECRET` environment variables and never travel
+  through the browser or per-connection storage.
+- The per-user **refresh token** is filled in by the OAuth sign-in flow.
+
+When a token's shape doesn't match the standard trio (e.g. a single long-lived `access_token`),
+subclass `il.OAuthConnectionBase` instead and declare your own fields, mapping them in the
+config's `fields`:
+
+```py
+@il.connection(oauth=il.OAuthConfig("facebook", scope="ads_read", fields={"access_token": "access_token"}))
+class FacebookAdsConnection(il.OAuthConnectionBase):
+    access_token: str = il.SecretField()
+```
+
+See [OAuth](oauth.md) for providers and the connect flow.

--- a/docs/features/data-validation.md
+++ b/docs/features/data-validation.md
@@ -1,0 +1,72 @@
+# Data Validation
+
+Interloper provides several layers of data validation.
+
+## Schema validation
+
+When a `schema` is declared on an asset, the (normalized) data is conformed to the schema during
+materialization according to the asset's [materialization strategy](schema.md#materialization-strategy):
+
+```py
+import interloper as il
+
+class UserSchema(il.Schema):
+    id: int
+    name: str
+
+@il.asset(schema=UserSchema, materialization_strategy=il.MaterializationStrategy.STRICT)
+def users():
+    return [{"id": 1, "name": "Alice"}]
+```
+
+If the data doesn't satisfy the schema, a `SchemaError` is raised. If a strategy requires a
+schema but none is declared (or the data is non-tabular), an `AssetError` is raised.
+
+## Materialization strategies
+
+The `MaterializationStrategy` controls **how strictly** schemas are enforced. See
+[Schema & Normalizer](schema.md) for full details.
+
+| Strategy | Schema required | Behavior |
+|----------|-----------------|----------|
+| `AUTO` | No | Infers a schema if missing; validates if present (no coercion) |
+| `STRICT` | Yes | Fails on any mismatch (extras, missing, wrong types) |
+| `RECONCILE` | Yes | Aligns columns and coerces values to the schema's types |
+
+## Schema inference
+
+Under `AUTO` with no explicit schema, a schema is inferred from the data — each key becomes an
+optional field whose type is widened across observed rows:
+
+```py
+@il.asset  # AUTO strategy, no schema
+def users():
+    return [{"id": 1, "name": "Alice"}]
+    # Inferred: id: int | None, name: str | None
+```
+
+## DAG validation
+
+The DAG validates structural constraints at construction time:
+
+- A non-partitioned asset **cannot** depend on a partitioned asset (raises `DAGError`)
+- Circular dependencies are detected and raise a `CircularDependencyError`
+- Missing dependencies raise a `DependencyNotFoundError`
+- Duplicate assets raise a `DAGError`
+
+```py
+# This raises a DAGError at construction time:
+@il.source
+def invalid():
+    @il.asset(partitioning=il.TimePartitionConfig(column="date"))
+    def partitioned(context: il.ExecutionContext):
+        return [{"date": str(context.partition_date)}]
+
+    @il.asset  # non-partitioned depending on a partitioned asset
+    def summary(partitioned):
+        return [{"count": len(partitioned)}]
+
+    return [partitioned, summary]
+
+il.DAG(invalid(...))  # -> DAGError
+```

--- a/docs/features/destinations.md
+++ b/docs/features/destinations.md
@@ -1,0 +1,191 @@
+# Destinations
+
+A **destination** controls **where** and **how** asset data is stored. A destination is
+completely separate from how data is produced, so you can swap backends without changing asset
+logic.
+
+!!! note "Renamed from IO"
+
+    Earlier versions called this concept "IO" (`il.IO`, `il.FileIO`, …). It is now
+    **Destination** (`il.Destination`, `il.FileDestination`, …). The read/write context is
+    still called `IOContext`.
+
+## Configuring a destination
+
+### On a source
+
+```py
+source = my_source(destination=il.FileDestination(base_path="./data"))
+```
+
+### On an individual asset
+
+```py
+asset_instance = my_asset(destination=il.FileDestination(base_path="./data"))
+```
+
+### Declaring destination types up front
+
+The `@asset`/`@source` decorators accept `destinations=[...]` to declare the destination
+**types** an asset supports. Instances are then supplied via the `destination=` argument at
+instantiation:
+
+```py
+@il.asset(destinations=[il.FileDestination, il.CSVDestination])
+def my_asset():
+    return [{"x": 1}]
+```
+
+### Multiple destinations
+
+Write to several destinations at once by assigning a list. Each destination is identified by
+its `id`:
+
+```py
+asset_instance = my_asset(
+    destination=[
+        il.FileDestination(id="file", base_path="./data"),
+        il.CSVDestination(id="csv", base_path="./exports"),
+    ],
+    default_destination_key="file",
+)
+```
+
+When an asset has multiple destinations, downstream assets read their upstream input from the
+one named by `default_destination_key` (matched against each destination's `id`).
+
+## Built-in destinations
+
+### MemoryDestination
+
+In-memory storage backed by a class-level dict. Useful for tests and quick experiments.
+
+```py
+asset_instance = my_asset(destination=il.MemoryDestination())
+await asset_instance.materialize()
+```
+
+All instances share the same storage. Clear it between tests:
+
+```py
+il.MemoryDestination.clear()
+```
+
+### FileDestination
+
+Pickle-based storage on the local filesystem.
+
+```py
+asset_instance = my_asset(destination=il.FileDestination(base_path="./data"))
+await asset_instance.materialize()
+# Writes to ./data/{dataset}/{asset_key}/data.pkl
+```
+
+With partitioning, files are organized by partition value:
+
+```
+./data/{dataset}/{asset_key}/{column}={partition_id}/data.pkl
+```
+
+### CSVDestination
+
+CSV files on the local filesystem, with the same path layout as `FileDestination` (`data.csv`
+instead of `data.pkl`). Because CSV is untyped, reads reconcile rows against the asset's schema
+to restore declared types.
+
+```py
+asset_instance = my_asset(destination=il.CSVDestination(base_path="./data"))
+```
+
+## IOContext
+
+Every `read`/`write` call receives an immutable `IOContext`:
+
+- `context.asset` -- the asset being read/written (carries `id`, `dataset`, `partitioning`)
+- `context.partition_or_window` -- the current partition or window (`None` if unpartitioned)
+- `context.schema` -- the effective schema of the data (declared or inferred), or `None`
+- `context.metadata` -- run metadata
+
+## Custom destinations
+
+Create a custom destination by subclassing `il.Destination` (a pydantic model) and implementing
+`read`/`write`, or use the `@il.destination` decorator on a plain class:
+
+```py
+import json
+from pathlib import Path
+from typing import Any
+import interloper as il
+
+@il.destination(name="JSON")
+class JSONDestination(il.Destination):
+    base_path: str = ""
+
+    def write(self, context: il.IOContext, data: Any) -> None:
+        path = Path(self.base_path) / f"{context.asset.key}.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(data))
+
+    def read(self, context: il.IOContext) -> Any:
+        path = Path(self.base_path) / f"{context.asset.key}.json"
+        return json.loads(path.read_text())
+```
+
+### Partition-aware destinations
+
+For backends that store one scope per partition, subclass `il.PartitionedDestination`. It
+implements partition/window dispatch once; you implement two hooks:
+
+```py
+class PartitionedJSONDestination(il.PartitionedDestination):
+    base_path: str = ""
+
+    def _write_scope(self, context, partition, data) -> None:
+        ...
+
+    def _read_scope(self, context, partition) -> Any:
+        ...
+```
+
+`MemoryDestination` and `CSVDestination` are built on `PartitionedDestination`.
+
+### Database destinations
+
+For SQL-style stores, subclass `il.DatabaseDestination` (itself a `PartitionedDestination`).
+It turns reads/writes into a small set of abstract row operations — `_insert`, `_delete_all`,
+`_delete_partition`, `_select_all`, `_select_partition`, `_count_by_partition` — and handles
+write dispositions (`REPLACE` deletes the matching scope before insert, `APPEND` does not).
+`BigQueryDestination` (below) is implemented this way.
+
+## interloper-google-cloud
+
+The BigQuery destination. Install with:
+
+```sh
+pip install interloper-google-cloud
+```
+
+```py
+from interloper_google_cloud import BigQueryDestination, GoogleCloudConnection
+
+asset_instance = my_asset(
+    destination=BigQueryDestination(
+        id="bq",
+        connection=GoogleCloudConnection(...),
+        project="my-gcp-project",
+        location="EU",
+        default_dataset="my_dataset",
+    ),
+)
+```
+
+`BigQueryDestination` writes to `{project}.{dataset}.{asset_key}`, applies daily time
+partitioning when the partition column is a date/timestamp, and uses the effective schema for
+typed loads. It returns pandas DataFrames on read. It requires a `GoogleCloudConnection`
+resource carrying the service-account credentials (see [Connections](connections.md)).
+
+!!! note
+
+    The core library ships `FileDestination`, `CSVDestination` and `MemoryDestination`;
+    `interloper-google-cloud` adds `BigQueryDestination`. There is no built-in
+    Postgres/MySQL/SQLite destination — implement one by subclassing `il.DatabaseDestination`.

--- a/docs/features/events.md
+++ b/docs/features/events.md
@@ -1,0 +1,99 @@
+# Events
+
+Interloper has a built-in event system for monitoring asset execution, destination I/O, and run
+lifecycle. Events flow through a process-wide `EventBus`.
+
+## Subscribing to events
+
+Subscribe and unsubscribe handlers with the `EventBus` class methods:
+
+```py
+import interloper as il
+
+def on_event(event: il.Event):
+    print(f"[{event.type.value}] {event.metadata}")
+
+il.EventBus.subscribe(on_event)
+
+await dag.materialize()
+
+il.EventBus.unsubscribe(on_event)
+```
+
+Limit a handler to specific event types by passing `event_types`:
+
+```py
+il.EventBus.subscribe(on_event, event_types=[il.EventType.RUN_COMPLETED])
+```
+
+You can also receive events without subscribing globally by passing `on_event` to a runner —
+see [Runners](runners.md).
+
+## Event types
+
+| Event | Description |
+|-------|-------------|
+| `ASSET_QUEUED` | Asset queued for execution |
+| `ASSET_STARTED` | Asset materialization started |
+| `ASSET_COMPLETED` | Asset materialization completed |
+| `ASSET_FAILED` | Asset materialization failed |
+| `ASSET_CANCELED` | Asset canceled (downstream of a failure) |
+| `ASSET_EXEC_STARTED` | Asset function execution started |
+| `ASSET_EXEC_COMPLETED` | Asset function execution completed |
+| `ASSET_EXEC_FAILED` | Asset function execution failed |
+| `DEST_READ_STARTED` | Destination read started (upstream dependency) |
+| `DEST_READ_COMPLETED` | Destination read completed |
+| `DEST_READ_FAILED` | Destination read failed |
+| `DEST_WRITE_STARTED` | Destination write started |
+| `DEST_WRITE_COMPLETED` | Destination write completed |
+| `DEST_WRITE_FAILED` | Destination write failed |
+| `RUN_STARTED` | Runner started a run |
+| `RUN_COMPLETED` | Runner completed a run |
+| `RUN_FAILED` | Runner run failed |
+| `BACKFILL_STARTED` | Backfill started |
+| `BACKFILL_COMPLETED` | Backfill completed |
+| `BACKFILL_FAILED` | Backfill failed |
+| `LOG` | User-emitted log message |
+
+## Event object
+
+```py
+event.type        # EventType enum
+event.timestamp   # datetime when the event was emitted
+event.metadata    # dict with event-specific data
+event.id          # unique event id
+```
+
+Metadata typically includes `asset_key`, `run_id`, `partition_or_window`, and for failures,
+`error` and `traceback`. Events serialize with `event.to_dict()` / `event.to_json()` and parse
+back with `Event.from_dict()` / `Event.from_json()`.
+
+## Emitting events
+
+Inside asset functions, use `context.logger` to emit `LOG` events:
+
+```py
+@il.asset
+def my_asset(context: il.ExecutionContext):
+    context.logger.info("Starting data fetch...")
+    context.logger.warning("Rate limited, retrying...")
+    context.logger.error("Something went wrong")
+    context.logger.debug("Detailed debug info")
+    return [{"key": "value"}]
+```
+
+Each call emits a `LOG` event whose metadata carries the `message`, `level`, and `asset_key`, so
+it reaches every subscriber.
+
+To emit a custom event programmatically:
+
+```py
+il.EventBus.emit(il.EventType.LOG, metadata={"message": "hello", "level": "INFO"})
+```
+
+## Distributed runs
+
+The Docker and Kubernetes runners execute assets in child containers/Jobs and **forward their
+events back to the host** over stderr, where they are parsed and re-emitted on the host's
+`EventBus`. Subscribers and `on_event` callbacks therefore see a unified event stream regardless
+of where assets actually ran.

--- a/docs/features/oauth.md
+++ b/docs/features/oauth.md
@@ -1,0 +1,89 @@
+# OAuth
+
+Many connectors authenticate with OAuth2. Interloper drives the "Sign in with X" flow from two
+pieces:
+
+- **`OAuthProvider`** — the identity and token-exchange spec for a provider (auth URL, token
+  URL, how the exchange request is shaped). Providers are registered via entry points; the core
+  library ships built-ins for the common platforms.
+- **`OAuthConfig`** — per-connection OAuth settings: which provider to use, the scope to
+  request, and how token-response keys map onto connection fields.
+
+You attach an `OAuthConfig` to a [connection](connections.md) and Interloper does the rest:
+it injects an `x-oauth` extension into the connection's schema so the web UI renders a sign-in
+button, and after sign-in it maps the returned tokens onto the connection's fields.
+
+## Configuring OAuth on a connection
+
+```py
+import interloper as il
+
+@il.connection(
+    name="LinkedIn Ads",
+    oauth=il.OAuthConfig("linkedin", scope="r_ads"),
+)
+class LinkedinAdsConnection(il.OAuthConnection):
+    account_id: str = il.InputField()
+```
+
+By default `OAuthConfig` maps only `{"refresh_token": "refresh_token"}` — the per-user refresh
+token. `OAuthConnection` already declares the `client_id` / `client_secret` / `refresh_token`
+trio that this targets. App credentials (`client_id`, `client_secret`) are resolved from
+`<PROVIDER>_CLIENT_ID` / `<PROVIDER>_CLIENT_SECRET` environment variables at run time.
+
+### Custom token shapes
+
+When the token response doesn't match the standard refresh-token trio, base the connection on
+`il.OAuthConnectionBase`, declare your own fields, and map them via `fields`:
+
+```py
+@il.connection(oauth=il.OAuthConfig("facebook", scope="ads_read", fields={"access_token": "access_token"}))
+class FacebookAdsConnection(il.OAuthConnectionBase):
+    access_token: str = il.SecretField()
+```
+
+## OAuthConfig
+
+```py
+il.OAuthConfig(
+    provider="linkedin",        # provider key in the registry
+    scope="r_ads",              # OAuth scope to request
+    fields={"refresh_token": "refresh_token"},  # token key -> connection field
+    auth_url="",                # override (required only for unregistered providers)
+    label="",                   # display label override
+    icon="",                    # icon override
+)
+```
+
+If you reference an unregistered provider key without supplying `auth_url`, a `ConfigError` is
+raised.
+
+## Built-in providers
+
+The core library registers providers for: **Amazon**, **Facebook**, **Google**, **LinkedIn**,
+**Microsoft**, **Pinterest**, **Snapchat**, and **TikTok**. Reference one by its key (e.g.
+`"google"`).
+
+## Custom providers
+
+Define an `OAuthProvider` and register it under the `interloper.oauth_providers` entry-point
+group so it joins the registry:
+
+```py
+import interloper as il
+
+ACME = il.OAuthProvider(
+    key="acme",
+    auth_url="https://auth.acme.com/oauth/authorize",
+    token_url="https://auth.acme.com/oauth/token",
+    label="ACME",
+    icon="icon:acme",
+    token_encoding="form",   # "json" (default) or "form"
+    token_method="post",     # "post" (default) or "get"
+)
+```
+
+`OAuthProvider.token_params` controls the logical→wire parameter names of the exchange request;
+the `token_params(*omit, **rename)` helper builds it from sensible defaults when a provider uses
+non-standard names (TikTok, for instance, renames `code` to `auth_code` and `client_id` to
+`app_id`).

--- a/docs/features/partitioning.md
+++ b/docs/features/partitioning.md
@@ -1,0 +1,99 @@
+# Partitioning
+
+Partitioning lets assets process data in slices, typically by date. This enables incremental
+processing and efficient backfilling.
+
+## Time partitioning
+
+Add `partitioning` to an asset and access the partition date via `context.partition_date`:
+
+```py
+import datetime as dt
+import interloper as il
+
+@il.source
+def my_source():
+    @il.asset(partitioning=il.TimePartitionConfig(column="date"))
+    def daily_data(context: il.ExecutionContext):
+        date = context.partition_date
+        return [{"date": date.isoformat(), "value": 42}]
+
+    return [daily_data]
+```
+
+Run for a specific date:
+
+```py
+source = my_source(destination=il.FileDestination("./data"))
+dag = il.DAG(source)
+await dag.materialize(partition_or_window=il.TimePartition(dt.date(2025, 1, 15)))
+```
+
+Data is stored in partition-aware paths:
+
+```
+./data/{dataset}/{asset_key}/date=2025-01-15/data.pkl
+```
+
+## Windowed partitioning
+
+Some assets can process a range of dates in a single execution. Enable this with
+`allow_window=True` and read the bounds from `context.partition_date_window`:
+
+```py
+@il.asset(partitioning=il.TimePartitionConfig(column="date", allow_window=True))
+def weekly_summary(context: il.ExecutionContext):
+    start, end = context.partition_date_window
+    return [{"start": start.isoformat(), "end": end.isoformat(), "value": 100}]
+```
+
+Run with a window:
+
+```py
+await dag.materialize(
+    partition_or_window=il.TimePartitionWindow(
+        start=dt.date(2025, 1, 1),
+        end=dt.date(2025, 1, 7),
+    ),
+)
+```
+
+!!! note
+
+    `context.partition_date` is only available for single-partition runs.
+    `context.partition_date_window` is only available when `allow_window=True` and a window is
+    passed. Accessing the wrong one raises `AttributeError`.
+
+## TimePartitionConfig
+
+```py
+il.TimePartitionConfig(
+    column="date",          # Column carrying the partition value
+    allow_window=False,     # Whether the asset supports windowed runs
+    start_date=None,        # Optional lower bound (dt.date)
+)
+```
+
+## Partition types
+
+| Type | Description |
+|------|-------------|
+| `TimePartition(value=date)` | A single date partition (also accepts an ISO string or datetime) |
+| `TimePartitionWindow(start, end)` | A date range (inclusive) |
+
+A `TimePartitionWindow` is iterable. It yields `TimePartition` values **from most recent to
+oldest**:
+
+```py
+window = il.TimePartitionWindow(start=dt.date(2025, 1, 1), end=dt.date(2025, 1, 3))
+for partition in window:
+    print(partition)
+    # 2025-01-03
+    # 2025-01-02
+    # 2025-01-01
+
+window.partition_count()  # 3
+```
+
+For non-time domains, the generic `il.Partition`, `il.PartitionWindow` and `il.PartitionConfig`
+base types are available to build custom partition schemes.

--- a/docs/features/resources.md
+++ b/docs/features/resources.md
@@ -1,0 +1,129 @@
+# Resources
+
+A **resource** is an injectable dependency that Interloper resolves and passes into asset
+functions at run time. [Config](config.md) and [Connection](connections.md) are the two built-in
+resource kinds, and you can define your own for any reusable service (a cache, an SDK client, a
+warehouse handle, …).
+
+## Defining a resource
+
+Subclass `il.Resource` and add whatever fields and methods your assets need:
+
+```py
+import interloper as il
+
+class MyCache(il.Resource):
+    host: str = "localhost"
+    port: int = 6379
+
+    def get(self, key: str): ...
+    def set(self, key: str, value): ...
+```
+
+## Injecting resources
+
+Resources are bound to assets either by **type annotation** or by an explicit `resources`
+mapping on the decorator:
+
+```py
+# By type annotation — inferred from the signature
+@il.asset
+def my_asset(cache: MyCache):
+    return cache.get("data")
+
+# By explicit mapping — name -> resource type
+@il.asset(resources={"cache": MyCache})
+def my_asset(cache: MyCache):
+    return cache.get("data")
+```
+
+## Resolution cascade
+
+When an asset runs, each resource is resolved in order:
+
+1. An instance set on the **asset** (`my_asset(resources={"cache": MyCache(...)})`)
+2. An instance set on the **source** the asset belongs to
+3. **Auto-instantiated** from the declared resource type (loading any settings from the
+   environment)
+
+This means a resource "just works" from environment variables in development, while production
+can inject fully configured instances at the source or asset level.
+
+## Declaring resources on components
+
+Destinations and sources can declare resource dependencies too. The cleanest way is a typed
+class attribute, which the component framework turns into a resource slot automatically:
+
+```py
+class BigQueryDestination(il.Destination):
+    connection: GoogleCloudConnection   # becomes a resource slot named "connection"
+    ...
+```
+
+For an explicit, typed accessor you can use `il.ResourceRef`:
+
+```py
+class BigQueryDestination(il.Destination):
+    connection = il.ResourceRef(GoogleCloudConnection)
+    config = il.ResourceRef(BigQueryConfig, required=True)
+```
+
+## Field types
+
+Resource fields use helpers that both set Pydantic defaults and describe how the field is
+rendered in the connect/configure form (Interloper's web UI). They emit JSON-Schema extensions
+the frontend reads.
+
+| Helper | Renders as | Use for |
+|--------|-----------|---------|
+| `il.InputField()` | Text input | Plain string settings (IDs, hosts) |
+| `il.SecretField()` | Masked password input | API keys, tokens, passwords |
+| `il.TextField()` | Multi-line textarea | Long strings (queries, keys) |
+| `il.JsonField()` | JSON editor | Object/dict settings |
+| `il.SelectField(options=[...])` | Dropdown | A fixed set of choices |
+| `il.FetchField(provider="...")` | Dynamic dropdown | Choices fetched live from the service |
+
+```py
+@il.connection(name="Amazon Ads")
+class AmazonAdsConnection(il.OAuthConnection):
+    region: str = il.SelectField(
+        options=[{"label": "North America", "value": "na"}, {"label": "Europe", "value": "eu"}],
+    )
+```
+
+### Fetched options
+
+`SelectField(options_from="...")` resolves its choices from other configured components (e.g.
+the configured destinations), while `FetchField` calls a method on a resource to fetch live
+options at form-render time. The provider string is `"<slot>.<method>"`, and the target method
+must be allow-listed with `@il.fetch_field_provider`:
+
+```py
+@il.connection(name="Facebook Ads", oauth=il.OAuthConfig("facebook", scope="ads_read"))
+class FacebookAdsConnection(il.OAuthConnectionBase):
+    access_token: str = il.SecretField()
+
+    @il.fetch_field_provider
+    async def accounts(self) -> list[dict]:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                "https://graph.facebook.com/v19.0/me/adaccounts",
+                params={"access_token": self.access_token},
+            )
+        return resp.json()["data"]
+
+@il.source(resources={"connection": FacebookAdsConnection})
+def facebook_ads():
+    @il.asset
+    def campaigns(
+        connection: FacebookAdsConnection,
+        account_id: str = il.FetchField(provider="connection.accounts", label_key="name", value_key="id"),
+    ):
+        ...
+
+    return [campaigns]
+```
+
+Only methods decorated with `@il.fetch_field_provider` may be invoked this way — it is the
+allow-list that stops the browser from calling arbitrary attributes. Use
+`il.is_fetch_field_provider(obj)` to check whether a callable is a provider.

--- a/docs/features/rest.md
+++ b/docs/features/rest.md
@@ -1,0 +1,126 @@
+# REST & Pagination
+
+Most connectors fetch data from paginated REST APIs. Interloper ships a small, composable REST
+toolkit — an HTTP client, pluggable authentication, and a set of paginators — so connectors can
+page through an endpoint without hand-rolling the loop. It is built on
+[httpx](https://www.python-httpx.org/).
+
+## Clients
+
+`il.RESTClient` (sync) and `il.AsyncRESTClient` (async) share the same constructor:
+
+```py
+import interloper as il
+
+client = il.AsyncRESTClient(
+    "https://api.example.com",
+    auth=il.HTTPBearerAuth("my-token"),
+    timeout=30.0,
+    headers={"Accept": "application/json"},
+    params={"locale": "en"},
+)
+```
+
+Any extra keyword arguments are forwarded to the underlying `httpx.Client` /
+`httpx.AsyncClient`.
+
+## Paginating
+
+`paginate()` yields one page of data at a time. Give it a path, a paginator, and a
+`data_selector` describing where the records live in each response:
+
+```py
+paginator = il.OffsetPaginator(limit=50, total_path="meta.total")
+
+async for page in client.paginate("/users", paginator, data_selector="data"):
+    for row in page:
+        ...
+```
+
+The sync `RESTClient.paginate()` returns an iterator; the async `AsyncRESTClient.paginate()`
+returns an async iterator. For range-style paginators (those that know the total up front), the
+async client fetches pages concurrently (bounded by `concurrency`, default 8).
+
+### Data selectors
+
+`data_selector` extracts the records from a response:
+
+| Value | Behaviour |
+|-------|-----------|
+| `None` | `response.json()` (the whole body) |
+| `"data"` | `response.json()["data"]` |
+| `"items.list"` | nested lookup `response.json()["items"]["list"]` |
+| `lambda r: r.json()["rows"]` | custom callable |
+
+## Authentication
+
+Pass one of the auth helpers as `auth=`:
+
+```py
+il.HTTPBearerAuth(token)
+
+il.OAuth2ClientCredentialsAuth(
+    base_url, client_id, client_secret,
+    scope=None, token_endpoint="/oauth2/token",
+)
+
+il.OAuth2RefreshTokenAuth(
+    base_url, client_id, client_secret, refresh_token,
+    scope=None, token_endpoint="/oauth2/token",
+)
+```
+
+`OAuth2ClientCredentialsAuth` and `OAuth2RefreshTokenAuth` obtain and refresh access tokens
+automatically. `il.OAuth2Auth` is the shared base if you need a custom grant.
+
+## Paginators
+
+Pick the paginator that matches the API's pagination scheme:
+
+| Paginator | Scheme |
+|-----------|--------|
+| `il.SinglePagePaginator()` | No pagination — one request |
+| `il.PageNumberPaginator(page_param="page", base_page=1, total_path=None, ...)` | `?page=1`, `?page=2`, … |
+| `il.OffsetPaginator(limit, offset_param="offset", limit_param="limit", total_path=None, ...)` | `?offset=0&limit=100`, … |
+| `il.HeaderLinkPaginator(rel="next")` | RFC 5988 `Link` header |
+| `il.JSONLinkPaginator(next_url_path)` | Next-page URL at a JSON path |
+| `il.JSONCursorPaginator(cursor_path, cursor_param)` | Cursor carried from response to next request |
+| `il.RangePaginator` | Base for paginators that know the total up front (enables concurrent fetch) |
+
+`PageNumberPaginator` and `OffsetPaginator` accept `total_path` (a JSON path to the total count)
+and stop on an empty page by default (`stop_on_empty=True`).
+
+## Putting it together
+
+A connection that exposes a configured client, consumed by an async asset:
+
+```py
+from functools import cached_property
+import interloper as il
+
+@il.connection(name="My API")
+class MyConnection(il.Connection):
+    api_key: str = il.SecretField()
+
+    @cached_property
+    def client(self) -> il.AsyncRESTClient:
+        return il.AsyncRESTClient(
+            "https://api.example.com",
+            auth=il.HTTPBearerAuth(self.api_key),
+        )
+
+@il.source(resources={"connection": MyConnection})
+def my_source():
+    @il.asset
+    async def users(connection: MyConnection):
+        rows: list[dict] = []
+        paginator = il.PageNumberPaginator(total_path="meta.total")
+        async for page in connection.client.paginate("/users", paginator, data_selector="data"):
+            rows.extend(page)
+        return rows
+
+    return [users]
+```
+
+See [Connections](connections.md) for wiring credentials and [OAuth](oauth.md) for the sign-in
+flow.

--- a/docs/features/runners.md
+++ b/docs/features/runners.md
@@ -1,0 +1,140 @@
+# Runners
+
+Runners orchestrate the execution of assets in a DAG. They handle dependency ordering,
+concurrency, and error handling. The execution engine is **async-native**: `runner.run(...)` is
+a coroutine, so `await` it inside an event loop or drive it with `asyncio.run(...)`.
+
+## Quick start
+
+The simplest way to run a DAG is `dag.materialize()`, which uses an `AsyncRunner` internally:
+
+```py
+import asyncio
+
+dag = il.DAG(source)
+result = asyncio.run(dag.materialize())
+```
+
+For more control, use a runner directly:
+
+```py
+result = asyncio.run(il.SerialRunner().run(dag))
+```
+
+All runners take a partition or window as the second argument to `run()`:
+
+```py
+result = await il.AsyncRunner().run(dag, il.TimePartition(dt.date(2025, 1, 15)))
+```
+
+## SerialRunner
+
+Executes assets one at a time in dependency order. Best for debugging and deterministic
+execution. It's an `AsyncRunner` pinned to a single worker.
+
+```py
+result = await il.SerialRunner().run(dag)
+```
+
+## AsyncRunner
+
+The default. Runs independent assets concurrently on the event loop, bounded by `max_workers`.
+Synchronous asset functions are offloaded to threads; `async def` assets run natively.
+
+```py
+result = await il.AsyncRunner(max_workers=4).run(dag)
+```
+
+Assets are scheduled dynamically: as soon as an asset's dependencies are satisfied, it is
+submitted for execution.
+
+## MultiProcessRunner
+
+Executes assets in separate processes. Useful for CPU-bound workloads or to bypass the GIL.
+
+```py
+result = await il.MultiProcessRunner(max_workers=4).run(dag)
+```
+
+!!! note
+
+    The multi-process runner serializes each asset (and its ancestors) to send it across the
+    process boundary, then reconstructs and materializes it in the child. All assets and
+    destinations must be serializable. Run it under `if __name__ == "__main__":`.
+
+## Docker & Kubernetes runners
+
+Available via extension packages; each asset (with its ancestors) executes in an isolated
+container or Job, streaming events back to the host.
+
+```py
+from interloper_docker.runner import DockerRunner
+
+runner = DockerRunner(image="interloper:latest-worker", max_containers=4)
+result = await runner.run(dag)
+```
+
+```py
+from interloper_k8s.runner import KubernetesRunner
+
+runner = KubernetesRunner(image="my-repo/interloper:latest", namespace="data", max_jobs=4)
+result = await runner.run(dag)
+```
+
+## Options
+
+Common runner options:
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `max_workers` | `4` (`1` for `SerialRunner`) | Concurrency (named `max_containers` / `max_jobs` for Docker/K8s) |
+| `fail_fast` | `True` (`False` for Docker/K8s) | Stop the run on the first failure vs. continue |
+| `reraise` | `False` | Re-raise exceptions vs. capture them in the result |
+| `on_event` | `None` | Callback invoked for each lifecycle event |
+
+```py
+runner = il.AsyncRunner(max_workers=8, fail_fast=False, on_event=print)
+result = await runner.run(dag)
+```
+
+## RunResult
+
+Every runner returns a `RunResult`:
+
+```py
+result.status            # ExecutionStatus (COMPLETED, FAILED, ...)
+result.execution_time    # Total execution time in seconds
+result.partition_or_window
+result.asset_executions  # dict[str, AssetExecutionInfo] keyed by asset id
+
+result.completed_assets  # list[str] of asset keys that completed
+result.failed_assets     # list[str] of asset keys that failed
+result.canceled_assets   # list[str] of asset keys canceled downstream of a failure
+```
+
+Each `AssetExecutionInfo` carries:
+
+```py
+info.asset_key
+info.status            # ExecutionStatus
+info.start_time        # datetime | None
+info.end_time          # datetime | None
+info.execution_time    # seconds (end - start) | None
+info.error             # error message if failed
+info.traceback         # traceback string if failed
+```
+
+`ExecutionStatus` members: `QUEUED`, `READY`, `RUNNING`, `COMPLETED`, `FAILED`, `SKIPPED`,
+`CANCELED`.
+
+## Partitioned & backfilled runs
+
+Pass a partition or window to the runner. A `TimePartitionWindow` runs the DAG once per date —
+see [Backfilling](backfilling.md):
+
+```py
+result = await il.SerialRunner().run(
+    dag,
+    il.TimePartition(dt.date(2025, 1, 15)),
+)
+```

--- a/docs/features/schema.md
+++ b/docs/features/schema.md
@@ -1,0 +1,157 @@
+# Schema & Normalizer
+
+## Normalizer
+
+The `Normalizer` coerces arbitrary asset return types into `list[dict]` and applies optional
+transformations.
+
+### Supported input types
+
+The normalizer accepts: `dict`, `list[dict]`, `BaseModel`, `list[BaseModel]`, `Generator`, and
+(with `interloper-pandas` installed) `pandas.DataFrame`.
+
+### Usage
+
+```py
+import interloper as il
+
+@il.asset(normalizer=il.Normalizer())
+def my_asset():
+    return [{"UserName": "alice", "Address": {"City": "NYC"}}]
+```
+
+With column normalization on and flattening enabled, the data becomes:
+
+```py
+[{"user_name": "alice", "address_city": "NYC"}]
+```
+
+### Options
+
+```py
+il.Normalizer(
+    normalize_columns_names=True,   # Convert column names to snake_case
+    flatten_max_level=0,            # 0=disabled, None=unlimited, N=N levels deep
+    flatten_separator="_",          # Separator for flattened keys
+    fill_missing=True,              # Fill missing keys with None across rows
+    drop_na_columns=False,          # Drop columns that are entirely None
+    snake_case_digits=False,        # "acosClicks14d" -> "acos_clicks_14d"
+    replace_empty_dicts=False,      # {} -> None
+    replace_empty_strings=False,    # "" -> None
+    column_overrides={},            # Raw name -> normalized name
+)
+```
+
+The normalizer can be set at the **source level** (applies to all assets) or at the **asset
+level** (overrides the source-level one):
+
+```py
+@il.source(normalizer=il.Normalizer())
+def my_source():
+    @il.asset  # inherits the source normalizer
+    def asset_a():
+        ...
+
+    @il.asset(normalizer=il.Normalizer(flatten_max_level=None))  # overrides
+    def asset_b():
+        ...
+
+    return [asset_a, asset_b]
+```
+
+### pandas
+
+The `interloper-pandas` package provides `DataFrameNormalizer`, a `Normalizer` subclass that
+operates on `pandas.DataFrame` natively (vectorized) and returns a DataFrame. Assets can return
+DataFrames anywhere — the framework detects the representation and conforms it the same way as
+row dicts.
+
+```py
+from interloper_pandas import DataFrameNormalizer
+
+@il.asset(normalizer=DataFrameNormalizer(flatten_max_level=1))
+def my_asset():
+    return pd.DataFrame(...)
+```
+
+## Schema
+
+A schema declares the expected output structure of an asset. Define one by subclassing
+`il.Schema` (a Pydantic `BaseModel`) or by decorating a plain class with `@il.schema`:
+
+```py
+class UserSchema(il.Schema):
+    id: int
+    name: str
+    email: str | None = None
+```
+
+```py
+@il.schema
+class UserSchema:
+    id: int
+    name: str
+    email: str | None = None
+```
+
+Both forms are equivalent. Attach a schema to an asset with `schema=`:
+
+```py
+@il.asset(schema=UserSchema, normalizer=il.Normalizer())
+def users():
+    return [{"id": 1, "name": "Alice", "email": "alice@example.com"}]
+```
+
+Schemas are backend-agnostic: integration packages translate them into native type systems
+(BigQuery fields, pandas dtypes, …) via the schema's field specs.
+
+## Materialization strategy
+
+The `MaterializationStrategy` controls how schemas are enforced. Set it via the
+`materialization_strategy=` option on `@asset` or `@source`:
+
+### AUTO (default)
+
+If a schema is provided, validates data against it without coercion. If none is provided, a
+schema is inferred from the data (best-effort).
+
+```py
+@il.asset(materialization_strategy=il.MaterializationStrategy.AUTO)
+def my_asset():
+    ...
+```
+
+### STRICT
+
+Requires a schema. Validates data and **fails** on any mismatch (extra fields, missing required
+fields, wrong types).
+
+```py
+@il.asset(
+    schema=UserSchema,
+    materialization_strategy=il.MaterializationStrategy.STRICT,
+)
+def my_asset():
+    ...
+```
+
+### RECONCILE
+
+Requires a schema. Aligns columns to the schema (drops extras, adds missing as `None`) and
+coerces values to the schema's types.
+
+```py
+@il.asset(
+    schema=UserSchema,
+    materialization_strategy=il.MaterializationStrategy.RECONCILE,
+)
+def my_asset():
+    ...
+```
+
+## Schema inference
+
+Under the `AUTO` strategy with no declared schema, a schema is inferred from the data: each key
+becomes an optional field whose type is widened across observed rows (e.g. `int`+`float` →
+`float`). The inferred schema is attached to the asset for downstream use (e.g. typed
+destination loads).

--- a/docs/features/upstream-assets.md
+++ b/docs/features/upstream-assets.md
@@ -1,0 +1,108 @@
+# Upstream Assets
+
+Interloper supports asset dependencies -- an asset can consume data produced by another asset.
+When an asset runs inside a DAG, each upstream dependency is read back from its destination and
+passed in as a function argument.
+
+## Automatic dependency resolution
+
+Within a source, dependencies are resolved **automatically** by matching parameter names to
+sibling asset keys:
+
+```py
+@il.source
+def my_source():
+    @il.asset
+    def users():
+        return [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]
+
+    @il.asset
+    def user_count(users):  # 'users' matches the asset above
+        return [{"count": len(users)}]
+
+    return [users, user_count]
+```
+
+When the DAG executes, `users` runs first, its result is written to its destination, then read
+back and passed as the `users` argument to `user_count`.
+
+```py
+source = my_source(destination=il.FileDestination("./data"))
+dag = il.DAG(source)
+await dag.materialize()
+```
+
+## Explicit dependency mapping
+
+When a parameter name doesn't match the upstream asset key, use `requires` in the `@asset`
+decorator to declare the mapping (parameter name → upstream asset key, bare or qualified):
+
+```py
+@il.source
+def my_source():
+    @il.asset
+    def raw_data():
+        return [{"value": 42}]
+
+    @il.asset(requires={"data": "raw_data"})
+    def processed(data):  # 'data' doesn't match 'raw_data'
+        return [{"result": data[0]["value"] * 2}]
+
+    return [raw_data, processed]
+```
+
+Use `optional_requires` the same way for dependencies that may be absent — the parameter is set
+to `None` when the upstream asset isn't part of the DAG.
+
+## Cross-source dependencies
+
+Assets from different sources can depend on each other as long as they are in the same DAG. Use
+a qualified key in `requires`:
+
+```py
+@il.source
+def source_a():
+    @il.asset
+    def data():
+        return [{"id": 1}]
+    return [data]
+
+@il.source
+def source_b():
+    @il.asset(requires={"data": "source_a.data"})
+    def report(data):
+        return [{"count": len(data)}]
+    return [report]
+
+dag = il.DAG(source_a(...), source_b(...))
+await dag.materialize()
+```
+
+## Runtime dependency overrides
+
+Each runtime asset carries a `deps` dict mapping a parameter name to an upstream asset's
+**instance id**. You can wire dependencies imperatively — useful for connecting a standalone
+asset to a source asset:
+
+```py
+@il.asset
+def extra():
+    return "x"
+
+extra_asset = extra(destination=dest)
+source.report.deps["data"] = extra_asset.id
+
+dag = il.DAG(source, extra_asset)
+```
+
+## Dependency resolution order
+
+The DAG resolves each parameter in this order:
+
+1. **Explicit mapping** via `asset.deps` / `requires`
+2. **Same-source implicit** -- parameter name matches a sibling asset key
+3. **Renamed-asset alias** -- parameter name matches the original key of a renamed asset
+4. **Standalone implicit** -- parameter name matches a standalone asset key
+
+Resources (connections, configs) injected by type annotation are resolved separately and are
+never treated as upstream assets.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,95 @@
+# Getting started
+
+## Installation
+
+```sh
+pip install interloper
+```
+
+Or with [uv](https://docs.astral.sh/uv/):
+
+```sh
+uv add interloper
+```
+
+### Optional packages
+
+```sh
+pip install interloper-pandas         # pandas DataFrame normalizer/adapter
+pip install interloper-google-cloud   # BigQuery destination
+pip install interloper-assets         # Pre-built source definitions
+pip install interloper-docker         # Docker runner
+pip install interloper-k8s            # Kubernetes runner
+```
+
+## Quick example
+
+### Define an asset
+
+An asset is a function that produces data. Decorate it with `@asset`:
+
+```py
+import interloper as il
+
+@il.asset
+def greetings():
+    return [
+        {"name": "Alice", "message": "Hello"},
+        {"name": "Bob", "message": "Hi"},
+    ]
+```
+
+### Run it
+
+`run()` executes the asset function and returns the result. The execution engine is
+**async-native**, so `run()` is a coroutine — `await` it, or drive it with `asyncio.run()`:
+
+```py
+import asyncio
+
+result = asyncio.run(greetings().run())
+print(result)
+# [{'name': 'Alice', 'message': 'Hello'}, {'name': 'Bob', 'message': 'Hi'}]
+```
+
+### Materialize it
+
+Add a destination and materialize -- this runs the asset **and** writes the result:
+
+```py
+greetings_asset = greetings(destination=il.FileDestination("./data"))
+asyncio.run(greetings_asset.materialize())
+# Data is written to ./data/greetings/data.pkl
+```
+
+### Group assets in a source
+
+A source groups related assets. It is a **function** decorated with `@il.source` that
+returns the list of asset definitions it contains:
+
+```py
+@il.source
+def my_source():
+    @il.asset
+    def users():
+        return [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]
+
+    @il.asset
+    def orders():
+        return [{"id": 1, "user_id": 1, "total": 99.90}]
+
+    return [users, orders]
+```
+
+### Build a DAG and materialize everything
+
+```py
+source = my_source(destination=il.FileDestination("./data"))
+dag = il.DAG(source)
+asyncio.run(dag.materialize())
+```
+
+## Next steps
+
+- Follow the [Tutorial](tutorial.md) for a hands-on walkthrough
+- Explore [Features](features/assets-sources.md) for in-depth documentation

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,94 @@
+---
+hide:
+    - navigation
+    - toc
+---
+
+<div class="title center" markdown>
+# Interloper
+## The ultra-portable data asset framework
+</div>
+
+Interloper is a Python data-asset framework that makes defining, configuring and materializing data assets effortless.
+It combines the flexibility of a very lightweight library with powerful execution features inspired by modern orchestrators — and an **async-native** execution engine.
+
+---
+
+## Core concepts
+
+- **Everything is an asset** -- In Interloper, an asset is a first-class entity. It **produces data**, which is then **materialized independently**. The framework provides a simple, structured way to define assets without unnecessary complexity.
+- **Destination-driven materialization** -- Asset materialization is **driven by destination configuration**, completely separate from how the data is produced. This allows for clean, flexible execution.
+- **Framework-agnostic data outputs** -- Interloper **does not enforce metadata dependencies** on destinations. Your data is written and mutated in a **deterministic, transparent way**, ensuring full control over your pipelines.
+
+## Features
+
+- **Asset & source definition** -- Define structured, reusable data assets using decorators.
+- **Multi-destination materialization** -- Write the same asset to multiple destinations at once.
+- **Schema & normalizer** -- Normalize, validate and reconcile data structures automatically.
+- **Upstream asset dependencies** -- Build logical relationships between assets with automatic dependency resolution.
+- **Data validation** -- Ensure data integrity before and during materialization.
+- **Partitioning & backfilling** -- Efficiently process and reprocess historical data.
+- **Async-native runners** -- Execute assets serially, concurrently with asyncio, across processes, in Docker, or on Kubernetes.
+- **Connections & resources** -- Inject credentials and reusable services into assets, with a built-in OAuth connect flow.
+- **REST & pagination** -- Build connectors against paginated REST APIs with composable clients, auth and paginators.
+- **Event system** -- Subscribe to lifecycle events for monitoring and observability.
+- **Catalog & manifests** -- Introspect a catalog of components and materialize DAGs declaratively from YAML.
+- **CLI** -- Run and backfill DAGs from the command line.
+
+---
+
+<div class="center" markdown>
+# Destinations
+Interloper ships with built-in destinations and additional packages for external systems.
+</div>
+
+<div class="grid cards center" markdown>
+- :material-file-outline: **FileDestination**
+    Pickle-based local filesystem storage. Ships with the core library.
+- :material-file-delimited-outline: **CSVDestination**
+    CSV files on the local filesystem. Ships with the core library.
+- :material-memory: **MemoryDestination**
+    In-memory storage for testing and development. Ships with the core library.
+- :material-cloud: **BigQueryDestination**
+    Google BigQuery materialization via `interloper-google-cloud`.
+</div>
+
+Need a custom backend? Subclass `il.Destination` (or `il.DatabaseDestination` for SQL-style stores) and implement `read`/`write`. See [Destinations](features/destinations.md).
+
+---
+<div class="center" markdown>
+# Asset Library
+
+Alongside Interloper, we maintain a **pre-built collection of sources** that pull data from well-known platforms -- ranging from **social media to digital marketing and beyond**. These ready-to-use sources help you **bootstrap your data stack instantly** without reinventing the wheel.
+
+Install via `pip install interloper-assets`.
+</div>
+
+<div class="grid cards center" markdown>
+- :material-advertisements: **Adservice**
+- :material-advertisements: **Adup**
+- :fontawesome-brands-amazon: **Amazon Ads**
+- :fontawesome-brands-amazon: **Amazon Selling Partner**
+- :material-link-variant: **Awin**
+- :fontawesome-brands-microsoft: **Bing Ads**
+- :material-chart-line: **Brandwatch**
+- :fontawesome-brands-google: **Campaign Manager 360**
+- :material-target: **Criteo**
+- :fontawesome-brands-google: **Display Video 360**
+- :fontawesome-brands-google: **DoubleClick Bid Manager**
+- :fontawesome-brands-facebook: **Facebook Ads**
+- :fontawesome-brands-facebook: **Facebook Insights**
+- :fontawesome-brands-google: **Google Ads**
+- :material-link-variant: **Impact**
+- :fontawesome-brands-instagram: **Instagram Insights**
+- :fontawesome-brands-linkedin: **LinkedIn Ads**
+- :fontawesome-brands-linkedin: **LinkedIn Organic**
+- :fontawesome-brands-pinterest: **Pinterest Ads**
+- :fontawesome-brands-google: **Search Ads 360**
+- :fontawesome-brands-google: **Search Console**
+- :fontawesome-brands-snapchat: **Snapchat Ads**
+- :material-advertisements: **Teads**
+- :material-advertisements: **The Trade Desk**
+- :fontawesome-brands-tiktok: **TikTok Ads**
+- :material-cookie: **Usercentrics**
+</div>

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,134 @@
+/* ==========================================================================
+   Interloper brand palette
+   Mirrors the console: light chrome, emerald-green brand accent, blue links,
+   dark-navy code surfaces.
+   ========================================================================== */
+
+:root {
+    --il-emerald: #10b981;
+    --il-emerald-dark: #059669;
+    --il-emerald-light: #34d399;
+    --il-blue: #2563eb;
+    --il-blue-dark: #1d4ed8;
+    --il-navy: #0d1526;
+    --il-slate-900: #0f172a;
+    --il-slate-600: #475569;
+    --il-gray-100: #f1f5f9;
+    --il-gray-50: #f7f8f9;
+}
+
+/* Custom primary (emerald) — drives active states, the tab indicator, etc. */
+[data-md-color-primary=custom] {
+    --md-primary-fg-color: var(--il-emerald);
+    --md-primary-fg-color--light: var(--il-emerald-light);
+    --md-primary-fg-color--dark: var(--il-emerald-dark);
+    --md-primary-bg-color: #ffffff;
+    --md-primary-bg-color--light: rgba(255, 255, 255, 0.7);
+}
+
+/* Custom accent (blue) — link hover and interactive accents. */
+[data-md-color-accent=custom] {
+    --md-accent-fg-color: var(--il-blue);
+    --md-accent-fg-color--transparent: rgba(37, 99, 235, 0.1);
+    --md-accent-bg-color: #ffffff;
+}
+
+/* Blue links, like the console. */
+:root {
+    --md-typeset-a-color: var(--il-blue);
+}
+
+/* --------------------------------------------------------------------------
+   White header + tabs bar with dark text (console top bar), decoupled from
+   the emerald primary so the green still drives the active tab underline.
+   -------------------------------------------------------------------------- */
+.md-header {
+    background-color: #ffffff;
+    color: var(--il-slate-900);
+    box-shadow: 0 0 0.2rem rgba(0, 0, 0, 0.05), 0 0.2rem 0.4rem rgba(0, 0, 0, 0.05);
+}
+
+.md-tabs {
+    background-color: #ffffff;
+    color: var(--il-slate-900);
+    border-bottom: 0.05rem solid rgba(0, 0, 0, 0.07);
+}
+
+/* Active / hovered tab uses the emerald accent. */
+.md-tabs__link--active,
+.md-tabs__link:hover {
+    color: var(--il-emerald-dark);
+    opacity: 1;
+}
+
+/* Gray search field, like the console's "Search… ⌘K". */
+.md-search__form {
+    background-color: var(--il-gray-100);
+    color: var(--il-slate-900);
+    border-radius: 0.4rem;
+}
+
+.md-search__form:hover {
+    background-color: #e7ebf0;
+}
+
+.md-search__input::placeholder,
+.md-search__icon {
+    color: var(--il-slate-600);
+}
+
+/* --------------------------------------------------------------------------
+   Dark-navy code surfaces, echoing the console terminal and cards.
+   Syntax tokens are tuned for the dark background (these vars are only ever
+   consumed inside code blocks, so overriding them globally is safe).
+   -------------------------------------------------------------------------- */
+[data-md-color-scheme=default] {
+    --md-code-bg-color: var(--il-navy);
+    --md-code-fg-color: #cdd6e4;
+    --md-code-hl-color: #2977ff;
+    --md-code-hl-color--light: #2977ff1a;
+    --md-code-hl-comment-color: #8a94a7;
+    --md-code-hl-operator-color: #8a94a7;
+    --md-code-hl-punctuation-color: #8a94a7;
+    --md-code-hl-generic-color: #8a94a7;
+    --md-code-hl-variable-color: #8a94a7;
+    --md-code-hl-constant-color: #9383e2;
+    --md-code-hl-function-color: #c973d9;
+    --md-code-hl-keyword-color: #6791e0;
+    --md-code-hl-number-color: #e6695b;
+    --md-code-hl-special-color: #f06090;
+    --md-code-hl-string-color: #2fb170;
+    --md-code-hl-name-color: var(--md-code-fg-color);
+}
+
+.md-typeset pre > code,
+.md-typeset .highlight {
+    border-radius: 0.4rem;
+}
+
+/* Keep inline code light so it stays legible inside body text. */
+.md-typeset code:not(pre code) {
+    background-color: var(--il-gray-100);
+    color: var(--il-slate-900);
+}
+
+/* ==========================================================================
+   Landing page helpers
+   ========================================================================== */
+.center {
+    text-align: center;
+}
+
+.title {
+
+    h1 {
+        font-size: 3em;
+        margin-bottom: 0.5em;
+    }
+
+    h2 {
+        font-size: 3em;
+        font-weight: bold;
+        margin: 0 0 1.5em;
+    }
+}

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1,0 +1,264 @@
+# Tutorial
+
+## Your first asset
+
+At the most basic level, an `asset` is simply a function that returns data.
+Any kind of data, whether it's a string, a list of dictionaries, a Pandas dataframe, etc.
+
+Let's create our first asset that pulls today's Berlin weather forecast data from [Open Meteo](https://open-meteo.com/):
+
+```py
+import datetime as dt
+import httpx
+import interloper as il
+
+@il.asset
+def forecast():
+    url = "https://historical-forecast-api.open-meteo.com/v1/forecast"
+    params = {
+        "latitude": 52.5244,
+        "longitude": 13.4105,
+        "start_date": dt.date.today().isoformat(),
+        "end_date": dt.date.today().isoformat(),
+        "hourly": ["temperature_2m", "relative_humidity_2m", "dew_point_2m", "precipitation", "wind_speed_10m"],
+    }
+    response = httpx.get(url, params=params)
+    data = response.json()["hourly"]
+    return data
+```
+
+We can execute our asset by instantiating it and calling `run()`. The execution engine is
+**async-native**, so `run()` is a coroutine — `await` it inside an event loop, or drive it
+with `asyncio.run()`:
+
+```py
+import asyncio
+
+result = asyncio.run(forecast().run())
+```
+
+!!! note
+
+    The `@il.asset` decorator returns an asset **definition** (a class). Calling it (e.g.
+    `forecast()`) creates a runtime `Asset` instance. This separation between definition and
+    instance is a core concept in Interloper.
+
+Synchronous asset functions like the one above run on a worker thread automatically, so they
+never block the event loop. If you prefer, you can write the asset as a coroutine and
+Interloper will await it natively:
+
+```py
+@il.asset
+async def forecast():
+    async with httpx.AsyncClient() as client:
+        response = await client.get(url, params=params)
+    return response.json()["hourly"]
+```
+
+## Adding context
+
+Assets that need access to partition information or a logger can request an `ExecutionContext`:
+
+```py
+@il.asset
+def forecast(context: il.ExecutionContext):
+    context.logger.info("Fetching forecast data...")
+    url = "https://historical-forecast-api.open-meteo.com/v1/forecast"
+    params = {
+        "latitude": 52.5244,
+        "longitude": 13.4105,
+        "start_date": dt.date.today().isoformat(),
+        "end_date": dt.date.today().isoformat(),
+        "hourly": ["temperature_2m", "relative_humidity_2m", "dew_point_2m", "precipitation", "wind_speed_10m"],
+    }
+    response = httpx.get(url, params=params)
+    return response.json()["hourly"]
+```
+
+## Materialization
+
+Interloper starts to make sense when we introduce the concept of **materialization**.
+
+An asset can be **materialized**, meaning that based on a `Destination` configuration, its result is **written to** that destination.
+
+Interloper ships with built-in destinations and additional ones via extension packages.
+
+Let's materialize our asset using `FileDestination`, which pickles the data on the filesystem:
+
+```py
+forecast_asset = forecast(destination=il.FileDestination("./data"))
+asyncio.run(forecast_asset.materialize())
+```
+
+The materialization handles the execution of the asset and saves the data as a pickle file under `./data/forecast/data.pkl`.
+
+## Defining a source
+
+Pulling data from a data source isn't typically limited to a single asset. We might fetch data from several API endpoints while reusing common configuration or a shared HTTP client.
+
+Interloper allows you to define `sources`, which group related assets together. A source is a
+**function** decorated with `@il.source` that returns the list of assets it contains:
+
+```py
+@il.source
+def open_meteo():
+    @il.asset
+    def forecast():
+        url = "https://historical-forecast-api.open-meteo.com/v1/forecast"
+        params = {
+            "latitude": 52.5244,
+            "longitude": 13.4105,
+            "start_date": dt.date.today().isoformat(),
+            "end_date": dt.date.today().isoformat(),
+            "hourly": ["temperature_2m", "relative_humidity_2m", "dew_point_2m", "precipitation", "wind_speed_10m"],
+        }
+        response = httpx.get(url, params=params)
+        return response.json()["hourly"]
+
+    @il.asset
+    def air_quality():
+        url = "https://air-quality-api.open-meteo.com/v1/air-quality"
+        params = {
+            "latitude": 52.5244,
+            "longitude": 13.4105,
+            "start_date": dt.date.today().isoformat(),
+            "end_date": dt.date.today().isoformat(),
+            "hourly": ["pm10", "pm2_5", "dust", "uv_index"],
+        }
+        response = httpx.get(url, params=params)
+        return response.json()["hourly"]
+
+    return [forecast, air_quality]
+```
+
+Instantiate the source and access individual assets by name:
+
+```py
+source = open_meteo(destination=il.FileDestination("./data"))
+asyncio.run(source.forecast.run())
+asyncio.run(source.air_quality.materialize())
+```
+
+## DAG
+
+When you want to materialize multiple assets together, respecting their dependencies, use a `DAG`:
+
+```py
+source = open_meteo(destination=il.FileDestination("./data"))
+dag = il.DAG(source)
+asyncio.run(dag.materialize())
+```
+
+`dag.materialize()` runs the DAG with the default `AsyncRunner`. For more control, use a runner directly:
+
+```py
+result = asyncio.run(il.SerialRunner().run(dag))
+
+print(result.status)           # ExecutionStatus.COMPLETED
+print(result.execution_time)   # Total time in seconds
+```
+
+## Configuration
+
+Sources often need external configuration like base URLs or feature flags. Define a `Config`,
+which extends [Pydantic Settings](https://docs.pydantic.dev/latest/concepts/pydantic_settings/)
+for environment-based resolution, and **inject it into your asset functions** by type
+annotation:
+
+```py
+class OpenMeteoConfig(il.Config):
+    latitude: float = 52.5244
+    longitude: float = 13.4105
+
+@il.source
+def open_meteo():
+    @il.asset
+    def forecast(config: OpenMeteoConfig):
+        url = "https://historical-forecast-api.open-meteo.com/v1/forecast"
+        params = {
+            "latitude": config.latitude,
+            "longitude": config.longitude,
+            "start_date": dt.date.today().isoformat(),
+            "end_date": dt.date.today().isoformat(),
+            "hourly": ["temperature_2m"],
+        }
+        response = httpx.get(url, params=params)
+        return response.json()["hourly"]
+
+    return [forecast]
+```
+
+The config is automatically resolved from environment variables when the asset runs. You can
+also provide it explicitly via the `resources` mapping:
+
+```py
+source = open_meteo()
+configured = source.forecast(resources={"config": OpenMeteoConfig(latitude=48.8566, longitude=2.3522)})
+```
+
+For service **credentials** (API keys, OAuth tokens), use a [Connection](features/connections.md)
+instead of a plain `Config` — same injection mechanism, plus secret handling and an OAuth
+connect flow.
+
+## Partitioning
+
+Many data pipelines need to process data by date. Interloper supports time-based partitioning:
+
+```py
+@il.source
+def open_meteo():
+    @il.asset(partitioning=il.TimePartitionConfig(column="date"))
+    def forecast(context: il.ExecutionContext):
+        date = context.partition_date
+        url = "https://historical-forecast-api.open-meteo.com/v1/forecast"
+        params = {
+            "latitude": 52.5244,
+            "longitude": 13.4105,
+            "start_date": date.isoformat(),
+            "end_date": date.isoformat(),
+            "hourly": ["temperature_2m"],
+        }
+        response = httpx.get(url, params=params)
+        return response.json()["hourly"]
+
+    return [forecast]
+```
+
+Materialize for a specific date:
+
+```py
+source = open_meteo(destination=il.FileDestination("./data"))
+dag = il.DAG(source)
+asyncio.run(dag.materialize(partition_or_window=il.TimePartition(dt.date.today())))
+```
+
+## Backfilling
+
+To process a range of dates, pass a `TimePartitionWindow` to a runner. The runner iterates the
+window and runs the DAG once per date:
+
+```py
+import datetime as dt
+
+window = il.TimePartitionWindow(
+    start=dt.date(2025, 1, 1),
+    end=dt.date(2025, 1, 7),
+)
+asyncio.run(il.AsyncRunner().run(dag, window))
+```
+
+There is no separate "backfiller" object — backfilling is just running a DAG over a window,
+and every runner (serial, async, multi-process, Docker, Kubernetes) supports it.
+
+## Next steps
+
+- [Assets & Sources](features/assets-sources.md) -- Detailed definition patterns
+- [Destinations](features/destinations.md) -- All available destinations
+- [Runners](features/runners.md) -- Execution strategies
+- [Schema & Normalizer](features/schema.md) -- Data normalization and validation
+- [Connections](features/connections.md) -- Credentials and the OAuth connect flow
+- [Partitioning](features/partitioning.md) -- Time-based partitioning
+- [Backfilling](features/backfilling.md) -- Historical data processing
+- [Configuration](features/config.md) -- Environment-based config
+- [Events](features/events.md) -- Lifecycle event system
+- [CLI & Manifests](features/cli.md) -- Command-line interface and declarative runs

--- a/zensical.toml
+++ b/zensical.toml
@@ -1,0 +1,81 @@
+# ============================================================================
+# Zensical configuration for the Interloper documentation site.
+# Build with `uv run zensical build` (or serve with `uv run zensical serve`)
+# from the repository root.
+# ============================================================================
+
+[project]
+
+site_name = "Interloper"
+site_description = "The ultra-portable data asset framework"
+site_author = "Digitl Cloud"
+
+#site_url = "https://www.example.com/"
+
+repo_url = "https://github.com/digitl-cloud/interloper"
+
+copyright = """
+Copyright &copy; 2026 Digitl Cloud
+"""
+
+nav = [
+    { "Home" = "index.md" },
+    { "Getting started" = "getting-started.md" },
+    { "Tutorial" = "tutorial.md" },
+    { "Features" = [
+        { "Assets & Sources" = "features/assets-sources.md" },
+        { "Destinations" = "features/destinations.md" },
+        { "Schema & Normalizer" = "features/schema.md" },
+        { "Upstream Assets" = "features/upstream-assets.md" },
+        { "Data Validation" = "features/data-validation.md" },
+        { "Partitioning" = "features/partitioning.md" },
+        { "Backfilling" = "features/backfilling.md" },
+        { "Connections" = "features/connections.md" },
+        { "Resources" = "features/resources.md" },
+        { "OAuth" = "features/oauth.md" },
+        { "REST & Pagination" = "features/rest.md" },
+        { "Configuration" = "features/config.md" },
+        { "Runners" = "features/runners.md" },
+        { "Events" = "features/events.md" },
+        { "Catalog" = "features/catalog.md" },
+        { "CLI & Manifests" = "features/cli.md" },
+    ] },
+    { "FAQ" = "faq.md" },
+]
+
+extra_css = ["stylesheets/extra.css"]
+
+# ----------------------------------------------------------------------------
+# Theme
+# ----------------------------------------------------------------------------
+[project.theme]
+
+language = "en"
+
+features = [
+    "announce.dismiss",
+    "content.code.annotate",
+    "content.code.copy",
+    "content.code.select",
+    "content.footnote.tooltips",
+    "content.tabs.link",
+    "content.tooltips",
+    "navigation.footer",
+    "navigation.indexes",
+    "navigation.instant",
+    "navigation.instant.prefetch",
+    "navigation.path",
+    "navigation.sections",
+    "navigation.tabs",
+    "navigation.tabs.sticky",
+    "navigation.top",
+    "navigation.tracking",
+    "search.highlight",
+    "toc.follow",
+    "toc.integrate",
+]
+
+[[project.theme.palette]]
+scheme = "default"
+primary = "custom"
+accent = "custom"


### PR DESCRIPTION
## What

Migrates the framework documentation from the old mk2 zensical site into this monorepo (`docs/`), **fully rewritten against the current API**, and ships it as a deployable static site at **docs.interloper.dev**.

### Docs content (`docs/`)
Rewritten for today's framework — the mk2 docs were largely obsolete:
- Async-native engine (`run()`/`materialize()`/runners are coroutines)
- Sources as functions returning a list of assets
- `IO` → **Destinations** (File/CSV/Memory + BigQuery; no more `interloper-sql`)
- New subsystems: **Connections**, **Resources** & form fields, **OAuth**, **REST & pagination**, **Catalog**, **run manifests**
- `MultiThreadRunner` → `AsyncRunner`; backfilling via a window passed to any runner; `EventBus.subscribe`
- Brand palette (`zensical.toml` + `extra.css`) matched to the console UI: light theme, emerald accent, blue links, navy code surfaces

### Image + CI
- `dockerfile`: `build-docs` stage (zensical build, pinned to `$BUILDPLATFORM` like the SPA) + `docs` nginx runtime stage
- `docker/docs.nginx.conf`: `/healthz`, clean-URL handling, hashed-asset caching, styled 404
- `Makefile` + `.github/workflows/publish.yaml`: add the `docs` role to the image catalog/matrix → `ghcr.io/digitl-cloud/interloper-docs`

## Verification
- `uv run zensical build` → no issues
- `docker build --target docs` builds; container smoke-tested (`/healthz`, index, clean URLs, trailing-slash redirect, 404)

## Deploy
The Kubernetes workload (`docs.interloper.dev`) is a **separate MR** on the interloper-kubernetes repo. The `interloper-docs` image is published on the next release (the `publish` workflow triggers on `release: published`); it can also be built for an existing tag via `workflow_dispatch`.

> Note: `docs:`-only changes don't trigger semantic-release; this is typed `feat:` so a release cuts and the image is published.