### PR TITLE
chore(ci): add optional force bump input to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,18 @@ on:
           - stable
           - release-candidate
         default: stable
+      force:
+        description: >-
+          Force a bump when the commits alone don't warrant one (e.g. only
+          chore/refactor since the last release). "auto" = normal
+          commit-driven behaviour.
+        type: choice
+        options:
+          - auto
+          - patch
+          - minor
+          - major
+        default: auto
 
 jobs:
   release:
@@ -72,6 +84,10 @@ jobs:
         with:
           prerelease: ${{ inputs.release_type == 'release-candidate' }}
           prerelease_token: rc
+          # Force a bump level when the commit history alone wouldn't trigger a
+          # release (only chore/refactor since the last tag). Empty = let PSR
+          # decide from the Conventional Commits, the normal path.
+          force: ${{ inputs.force != 'auto' && inputs.force || '' }}
           # Runs the configured build_command (`uv lock`) so the release
           # commit carries a lock file consistent with the stamped versions.
           # The actual package build happens in the publish step below.


### PR DESCRIPTION
## What

Adds an optional `force` input (`auto` / `patch` / `minor` / `major`) to the `Release` workflow's `workflow_dispatch`, wired to python-semantic-release's `force` action input:

```yaml
force: ${{ inputs.force != 'auto' && inputs.force || '' }}
```

`auto` (default) passes an empty string, so behaviour is unchanged — PSR decides the bump from Conventional Commits. Any other value forces that bump level.

## Why

PSR only cuts a release when the commits since the last tag warrant one (`feat`/`fix`/breaking). When a release cycle contains only `chore`/`refactor` commits, it reports *"no release will be made"*. That recently pushed us to hand-bump versions and tags locally (`semantic-release version --patch`), which drifted the git tags, GitHub release, and PyPI away from the already-published chart/images — a split-brain that had to be reconciled by hand.

Forcing the bump **through the CI action** keeps every artifact on the single atomic code path: stamp all `pyproject.toml`s + `Chart.yaml` → `chore(release)` commit → `vX.Y.Z` tag → changelog → GitHub release → PyPI, after which the release event fires the `Publish` workflow for Docker + Helm.

## Reviewer notes

- Composes with `release_type`: `release-candidate` + `force: patch` forces a patch-level RC.
- `force` overrides the computed level even when real `feat`/`fix` commits exist — leave it on `auto` for normal releases; only reach for it on chore/refactor-only cycles.
- Input name verified against the pinned `python-semantic-release/python-semantic-release@v10` `action.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)