### PR TITLE
feat: add public /privacy-policy and /terms-of-service pages

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,18 @@ on:
           - stable
           - release-candidate
         default: stable
+      force:
+        description: >-
+          Force a bump when the commits alone don't warrant one (e.g. only
+          chore/refactor since the last release). "auto" = normal
+          commit-driven behaviour.
+        type: choice
+        options:
+          - auto
+          - patch
+          - minor
+          - major
+        default: auto
 
 jobs:
   release:
@@ -72,6 +84,10 @@ jobs:
         with:
           prerelease: ${{ inputs.release_type == 'release-candidate' }}
           prerelease_token: rc
+          # Force a bump level when the commit history alone wouldn't trigger a
+          # release (only chore/refactor since the last tag). Empty = let PSR
+          # decide from the Conventional Commits, the normal path.
+          force: ${{ inputs.force != 'auto' && inputs.force || '' }}
           # Runs the configured build_command (`uv lock`) so the release
           # commit carries a lock file consistent with the stamped versions.
           # The actual package build happens in the publish step below.

--- a/packages/interloper-app/app/app/middleware/auth.global.ts
+++ b/packages/interloper-app/app/app/middleware/auth.global.ts
@@ -3,7 +3,7 @@ export default defineNuxtRouteMiddleware(async (to) => {
         return
 
     // Publicly accessible pages that don't require authentication
-    if (to.path === '/privacy-policy')
+    if (to.path === '/privacy-policy' || to.path === '/terms-of-service')
         return
 
     const userStore = useUserStore()

--- a/packages/interloper-app/app/app/middleware/auth.global.ts
+++ b/packages/interloper-app/app/app/middleware/auth.global.ts
@@ -2,6 +2,10 @@ export default defineNuxtRouteMiddleware(async (to) => {
     if (to.path.startsWith('/auth/'))
         return
 
+    // Publicly accessible pages that don't require authentication
+    if (to.path === '/privacy-policy')
+        return
+
     const userStore = useUserStore()
     const organisationStore = useOrganisationStore()
     const catalogStore = useCatalogStore()

--- a/packages/interloper-app/app/app/pages/privacy-policy.vue
+++ b/packages/interloper-app/app/app/pages/privacy-policy.vue
@@ -70,7 +70,7 @@ definePageMeta({
                 </h2>
                 <p>
                     Our Platform allows users to connect their TikTok accounts through official TikTok API
-                    Services. By using the TikTok connector within the DigitlCloud Connectors hub, you agree
+                    Services. By using the TikTok connector within Interloper, you agree
                     to be bound by the TikTok Terms of Service (accessible at
                     <ULink href="https://www.tiktok.com/legal/terms-of-service"
                            target="_blank"
@@ -82,7 +82,7 @@ definePageMeta({
                 <p>
                     We only access, ingest, and process TikTok data that you explicitly authorize during the
                     OAuth consent flow. You may revoke this access at any time through your TikTok account
-                    security settings or by disconnecting your account within the DigitlCloud dashboard. We
+                    security settings or by disconnecting your account within Interloper. We
                     do not use your TikTok data for any purpose other than providing the requested analytics
                     and reporting services to you.
                 </p>

--- a/packages/interloper-app/app/app/pages/privacy-policy.vue
+++ b/packages/interloper-app/app/app/pages/privacy-policy.vue
@@ -1,0 +1,102 @@
+<script setup lang="ts">
+definePageMeta({
+    title: 'Privacy Policy',
+    layout: false,
+})
+</script>
+
+<template>
+    <div class="min-h-svh w-full py-12 px-6 md:px-10">
+        <article class="mx-auto w-full max-w-3xl flex flex-col gap-6">
+            <h1 class="text-3xl font-semibold">
+                Privacy Policy
+            </h1>
+
+            <p>
+                DiGiTL Cloud GmbH takes the concerns of data protection very seriously and wants to ensure
+                that your privacy is protected by the use of DiGiTL GmbH. We therefore collect, process and
+                use your personal data only with your consent or if a legal provision permits this. We will
+                explain to you below, which personal data we collect, save and use for you, and to which
+                survey, storage and use you declare your consent.
+            </p>
+
+            <section class="flex flex-col gap-2">
+                <h2 class="text-xl font-semibold">
+                    Automatic data collection with the use of cookies and storage with other data
+                </h2>
+                <p>
+                    This page does not collect any personal data and does not set any cookies to analyze
+                    your browser type.
+                </p>
+            </section>
+
+            <section class="flex flex-col gap-2">
+                <h2 class="text-xl font-semibold">
+                    Objection, correction and deletion of data
+                </h2>
+                <p>
+                    You may at any time revoke your consent, which you have given to us for the use,
+                    processing and transmission of your personal data for marketing purposes (e.g.,
+                    electronic newsletters or offers) or any other purpose without effect for a particular
+                    form or term. In addition, as far as we use your data within the legally permissible
+                    framework for, for example, postal marketing measures, you can object to this use. You
+                    may also request the correction of your data if they are incorrect. In all cases, please
+                    contact: DiGiTL Cloud GmbH, An der Alster 6, 20099 Hamburg, Mail
+                    <ULink href="mailto:info@digitlcloud.com" class="text-primary">
+                        info@digitlcloud.com
+                    </ULink>. After a revocation, we will delete your data and refrain from sending further
+                    advertisements.
+                </p>
+            </section>
+
+            <section class="flex flex-col gap-2">
+                <h2 class="text-xl font-semibold">
+                    Information
+                </h2>
+                <p>
+                    You have the right at any time to request free information about your stored data. If
+                    your data are incorrect or unjustly stored, we will gladly correct, block or delete them.
+                    Please also inform us as soon as changes have occurred to your personal data. Please send
+                    your inquiries, questions, complaints or suggestions regarding data protection by mail to:
+                    <ULink href="mailto:info@digitlcloud.com" class="text-primary">
+                        info@digitlcloud.com
+                    </ULink>
+                </p>
+            </section>
+
+            <section class="flex flex-col gap-2">
+                <h2 class="text-xl font-semibold">
+                    TikTok Integration and API Services
+                </h2>
+                <p>
+                    Our Platform allows users to connect their TikTok accounts through official TikTok API
+                    Services. By using the TikTok connector within the DigitlCloud Connectors hub, you agree
+                    to be bound by the TikTok Terms of Service (accessible at
+                    <ULink href="https://www.tiktok.com/legal/terms-of-service"
+                           target="_blank"
+                           rel="noopener noreferrer"
+                           class="text-primary">
+                        https://www.tiktok.com/legal/terms-of-service
+                    </ULink>) and the TikTok Privacy Policy.
+                </p>
+                <p>
+                    We only access, ingest, and process TikTok data that you explicitly authorize during the
+                    OAuth consent flow. You may revoke this access at any time through your TikTok account
+                    security settings or by disconnecting your account within the DigitlCloud dashboard. We
+                    do not use your TikTok data for any purpose other than providing the requested analytics
+                    and reporting services to you.
+                </p>
+            </section>
+
+            <section class="flex flex-col gap-2">
+                <h2 class="text-xl font-semibold">
+                    Agreement
+                </h2>
+                <p>
+                    By confirming this Privacy Policy, you agree to the use of your information as described
+                    in the foregoing Terms.
+                </p>
+            </section>
+        </article>
+    </div>
+</template>

--- a/packages/interloper-app/app/app/pages/privacy-policy.vue
+++ b/packages/interloper-app/app/app/pages/privacy-policy.vue
@@ -25,8 +25,10 @@ definePageMeta({
                     Automatic data collection with the use of cookies and storage with other data
                 </h2>
                 <p>
-                    This page does not collect any personal data and does not set any cookies to analyze
-                    your browser type.
+                    This website does not set any cookies to analyze your browser type and does not collect
+                    personal data about you for its own marketing purposes. Data that Interloper processes on
+                    your behalf when you authorize a connector to a third-party platform is a separate matter
+                    and is described under "Connector integrations and third-party platform data" below.
                 </p>
             </section>
 
@@ -66,6 +68,79 @@ definePageMeta({
 
             <section class="flex flex-col gap-2">
                 <h2 class="text-xl font-semibold">
+                    Connector integrations and third-party platform data
+                </h2>
+                <p>
+                    Interloper lets you connect supported marketing, analytics, commerce, and social media
+                    platforms through their official APIs. When you authorize a connector during an OAuth
+                    consent flow, you instruct us to access, ingest, and process data from that platform on
+                    your behalf. In relation to this connector data we act as a processor acting on your
+                    instructions; you (or the account owner you represent) remain the controller. We only
+                    access the data covered by the scopes you approve, and we use it solely to provide the
+                    analytics, reporting, integration, and support services you requested — never to build
+                    advertising profiles, to sell or rent data, or for any purpose unrelated to your use of
+                    the service.
+                </p>
+                <p>
+                    You can revoke a connector's access at any time by disconnecting it within Interloper or
+                    by removing Interloper's access in the relevant platform's account or security settings.
+                    Your use of each connector is also subject to the terms, developer policies, API rules,
+                    and privacy documentation of the applicable platform, summarized below.
+                </p>
+            </section>
+
+            <section class="flex flex-col gap-2">
+                <h2 class="text-xl font-semibold">
+                    Google API Services
+                </h2>
+                <p>
+                    Connectors for Google Ads, Campaign Manager 360, Display &amp; Video 360, and related
+                    Google services access data through Google APIs, subject to the
+                    <ULink href="https://developers.google.com/terms"
+                           target="_blank"
+                           rel="noopener noreferrer"
+                           class="text-primary">Google APIs Terms of Service</ULink>
+                    and the
+                    <ULink href="https://policies.google.com/privacy"
+                           target="_blank"
+                           rel="noopener noreferrer"
+                           class="text-primary">Google Privacy Policy</ULink>.
+                </p>
+                <p>
+                    Interloper's use and transfer of information received from Google APIs to any other app
+                    will adhere to the
+                    <ULink href="https://developers.google.com/terms/api-services-user-data-policy"
+                           target="_blank"
+                           rel="noopener noreferrer"
+                           class="text-primary">Google API Services User Data Policy</ULink>,
+                    including the Limited Use requirements.
+                </p>
+            </section>
+
+            <section class="flex flex-col gap-2">
+                <h2 class="text-xl font-semibold">
+                    Meta Platform (Facebook and Instagram)
+                </h2>
+                <p>
+                    Connectors for Facebook Ads, Facebook Insights, and Instagram Insights access data
+                    through the Meta APIs, subject to the
+                    <ULink href="https://developers.facebook.com/terms/"
+                           target="_blank"
+                           rel="noopener noreferrer"
+                           class="text-primary">Meta Platform Terms</ULink>
+                    and the
+                    <ULink href="https://www.facebook.com/privacy/policy/"
+                           target="_blank"
+                           rel="noopener noreferrer"
+                           class="text-primary">Meta Privacy Policy</ULink>.
+                    You may disconnect at any time within Interloper or by removing Interloper from the
+                    Business Integrations settings of your Meta account. To request deletion of Meta data we
+                    hold on your behalf, see "Data retention and deletion" below.
+                </p>
+            </section>
+
+            <section class="flex flex-col gap-2">
+                <h2 class="text-xl font-semibold">
                     TikTok Integration and API Services
                 </h2>
                 <p>
@@ -85,6 +160,130 @@ definePageMeta({
                     security settings or by disconnecting your account within Interloper. We
                     do not use your TikTok data for any purpose other than providing the requested analytics
                     and reporting services to you.
+                </p>
+            </section>
+
+            <section class="flex flex-col gap-2">
+                <h2 class="text-xl font-semibold">
+                    Other platform connectors
+                </h2>
+                <p>
+                    The following connectors access data through each platform's official API and are subject
+                    to that platform's terms and privacy documentation. In each case we access only the
+                    scopes you approve, and you may disconnect at any time within Interloper or by revoking
+                    access in the platform's own settings.
+                </p>
+                <ul class="list-disc pl-6 flex flex-col gap-2">
+                    <li>
+                        <strong>LinkedIn</strong> (LinkedIn Ads and LinkedIn Organic) — subject to the
+                        <ULink href="https://legal.linkedin.com/api-terms-of-use"
+                               target="_blank"
+                               rel="noopener noreferrer"
+                               class="text-primary">LinkedIn API Terms of Use</ULink>
+                        and the
+                        <ULink href="https://www.linkedin.com/legal/privacy-policy"
+                               target="_blank"
+                               rel="noopener noreferrer"
+                               class="text-primary">LinkedIn Privacy Policy</ULink>.
+                    </li>
+                    <li>
+                        <strong>Amazon</strong> (Amazon Ads and Amazon Selling Partner) — subject to Amazon's
+                        API license agreement, Acceptable Use Policy, and Data Protection Policy, and the
+                        applicable Amazon privacy notices.
+                    </li>
+                    <li>
+                        <strong>Microsoft Advertising</strong> (Bing Ads) — subject to the Microsoft
+                        Advertising Agreement and the
+                        <ULink href="https://privacy.microsoft.com/privacystatement"
+                               target="_blank"
+                               rel="noopener noreferrer"
+                               class="text-primary">Microsoft Privacy Statement</ULink>.
+                    </li>
+                    <li>
+                        <strong>Pinterest</strong> (Pinterest Ads) — subject to the
+                        <ULink href="https://business.pinterest.com/business-terms-of-service/"
+                               target="_blank"
+                               rel="noopener noreferrer"
+                               class="text-primary">Pinterest Business Terms of Service</ULink>
+                        and the
+                        <ULink href="https://policy.pinterest.com/privacy-policy"
+                               target="_blank"
+                               rel="noopener noreferrer"
+                               class="text-primary">Pinterest Privacy Policy</ULink>.
+                    </li>
+                    <li>
+                        <strong>Snapchat</strong> (Snapchat Ads) — subject to the Snap Business and developer
+                        terms and the
+                        <ULink href="https://snap.com/privacy/privacy-policy"
+                               target="_blank"
+                               rel="noopener noreferrer"
+                               class="text-primary">Snap Privacy Policy</ULink>.
+                    </li>
+                    <li>
+                        <strong>Criteo</strong> — subject to Criteo's applicable API and platform terms and
+                        the
+                        <ULink href="https://www.criteo.com/privacy/"
+                               target="_blank"
+                               rel="noopener noreferrer"
+                               class="text-primary">Criteo Privacy Policy</ULink>.
+                    </li>
+                </ul>
+                <p>
+                    Additional connectors may be supported from time to time; each is used only within the
+                    scopes you approve and subject to the applicable platform's terms.
+                </p>
+            </section>
+
+            <section class="flex flex-col gap-2">
+                <h2 class="text-xl font-semibold">
+                    Data retention and deletion
+                </h2>
+                <p>
+                    We retain connector credentials and connector data only for as long as needed to provide
+                    the requested services, or as required to meet legal obligations. When you disconnect a
+                    connector, revoke access in the platform, or your authorization expires, we stop
+                    accessing new data from that platform and delete or de-provision the stored access
+                    credentials.
+                </p>
+                <p>
+                    You may request deletion of the connector data we hold on your behalf at any time by
+                    disconnecting the relevant connector within Interloper or by emailing
+                    <ULink href="mailto:info@digitlcloud.com" class="text-primary">
+                        info@digitlcloud.com
+                    </ULink>.
+                    We will action verified deletion requests within a reasonable period, except where we are
+                    required to retain certain data by law.
+                </p>
+            </section>
+
+            <section class="flex flex-col gap-2">
+                <h2 class="text-xl font-semibold">
+                    Data storage, security and sub-processors
+                </h2>
+                <p>
+                    Connector credentials and access tokens are encrypted at rest. Connector data and any
+                    derived datasets are hosted on Google Cloud Platform infrastructure (including BigQuery),
+                    which acts as a sub-processor for hosting and storage. We apply appropriate technical and
+                    organizational measures to protect data against unauthorized access, loss, or misuse.
+                    Where personal data is transferred outside the European Economic Area, we rely on
+                    appropriate safeguards such as the European Commission's Standard Contractual Clauses.
+                </p>
+            </section>
+
+            <section class="flex flex-col gap-2">
+                <h2 class="text-xl font-semibold">
+                    Your rights under the GDPR
+                </h2>
+                <p>
+                    Where the EU General Data Protection Regulation applies, you have the right to access,
+                    rectify, erase, restrict, and port your personal data, and to object to its processing.
+                    For connector data we process on your instructions, we act as a processor and will assist
+                    the responsible controller in fulfilling these rights. To exercise any right, or to raise
+                    a data-protection concern, contact DiGiTL Cloud GmbH, An der Alster 6, 20099 Hamburg,
+                    Germany, or
+                    <ULink href="mailto:info@digitlcloud.com" class="text-primary">
+                        info@digitlcloud.com
+                    </ULink>. You also have the right to lodge a complaint with a supervisory authority.
                 </p>
             </section>
 

--- a/packages/interloper-app/app/app/pages/privacy-policy.vue
+++ b/packages/interloper-app/app/app/pages/privacy-policy.vue
@@ -6,7 +6,7 @@ definePageMeta({
 </script>
 
 <template>
-    <div class="min-h-svh w-full py-12 px-6 md:px-10">
+    <div class="h-svh w-full overflow-y-auto py-12 px-6 md:px-10">
         <article class="mx-auto w-full max-w-3xl flex flex-col gap-6">
             <h1 class="text-3xl font-semibold">
                 Privacy Policy

--- a/packages/interloper-app/app/app/pages/privacy-policy.vue
+++ b/packages/interloper-app/app/app/pages/privacy-policy.vue
@@ -66,7 +66,7 @@ definePageMeta({
                 </p>
             </section>
 
-            <section class="flex flex-col gap-2">
+            <section class="flex flex-col gap-4">
                 <h2 class="text-xl font-semibold">
                     Connector integrations and third-party platform data
                 </h2>
@@ -87,95 +87,88 @@ definePageMeta({
                     Your use of each connector is also subject to the terms, developer policies, API rules,
                     and privacy documentation of the applicable platform, summarized below.
                 </p>
-            </section>
 
-            <section class="flex flex-col gap-2">
-                <h2 class="text-xl font-semibold">
-                    Google API Services
-                </h2>
-                <p>
-                    Connectors for Google Ads, Campaign Manager 360, Display &amp; Video 360, and related
-                    Google services access data through Google APIs, subject to the
-                    <ULink href="https://developers.google.com/terms"
-                           target="_blank"
-                           rel="noopener noreferrer"
-                           class="text-primary">Google APIs Terms of Service</ULink>
-                    and the
-                    <ULink href="https://policies.google.com/privacy"
-                           target="_blank"
-                           rel="noopener noreferrer"
-                           class="text-primary">Google Privacy Policy</ULink>.
-                </p>
-                <p>
-                    Interloper's use and transfer of information received from Google APIs to any other app
-                    will adhere to the
-                    <ULink href="https://developers.google.com/terms/api-services-user-data-policy"
-                           target="_blank"
-                           rel="noopener noreferrer"
-                           class="text-primary">Google API Services User Data Policy</ULink>,
-                    including the Limited Use requirements.
-                </p>
-            </section>
+                <section class="flex flex-col gap-2">
+                    <h3 class="text-lg font-semibold">
+                        Google API Services
+                    </h3>
+                    <p>
+                        Connectors for Google Ads, Campaign Manager 360, Display &amp; Video 360, and related
+                        Google services access data through Google APIs, subject to the
+                        <ULink href="https://developers.google.com/terms"
+                               target="_blank"
+                               rel="noopener noreferrer"
+                               class="text-primary">Google APIs Terms of Service</ULink>
+                        and the
+                        <ULink href="https://policies.google.com/privacy"
+                               target="_blank"
+                               rel="noopener noreferrer"
+                               class="text-primary">Google Privacy Policy</ULink>.
+                    </p>
+                    <p>
+                        Interloper's use and transfer of information received from Google APIs to any other
+                        app will adhere to the
+                        <ULink href="https://developers.google.com/terms/api-services-user-data-policy"
+                               target="_blank"
+                               rel="noopener noreferrer"
+                               class="text-primary">Google API Services User Data Policy</ULink>,
+                        including the Limited Use requirements.
+                    </p>
+                </section>
 
-            <section class="flex flex-col gap-2">
-                <h2 class="text-xl font-semibold">
-                    Meta Platform (Facebook and Instagram)
-                </h2>
-                <p>
-                    Connectors for Facebook Ads, Facebook Insights, and Instagram Insights access data
-                    through the Meta APIs, subject to the
-                    <ULink href="https://developers.facebook.com/terms/"
-                           target="_blank"
-                           rel="noopener noreferrer"
-                           class="text-primary">Meta Platform Terms</ULink>
-                    and the
-                    <ULink href="https://www.facebook.com/privacy/policy/"
-                           target="_blank"
-                           rel="noopener noreferrer"
-                           class="text-primary">Meta Privacy Policy</ULink>.
-                    You may disconnect at any time within Interloper or by removing Interloper from the
-                    Business Integrations settings of your Meta account. To request deletion of Meta data we
-                    hold on your behalf, see "Data retention and deletion" below.
-                </p>
-            </section>
+                <section class="flex flex-col gap-2">
+                    <h3 class="text-lg font-semibold">
+                        Meta Platform (Facebook and Instagram)
+                    </h3>
+                    <p>
+                        Connectors for Facebook Ads, Facebook Insights, and Instagram Insights access data
+                        through the Meta APIs, subject to the
+                        <ULink href="https://developers.facebook.com/terms/"
+                               target="_blank"
+                               rel="noopener noreferrer"
+                               class="text-primary">Meta Platform Terms</ULink>
+                        and the
+                        <ULink href="https://www.facebook.com/privacy/policy/"
+                               target="_blank"
+                               rel="noopener noreferrer"
+                               class="text-primary">Meta Privacy Policy</ULink>.
+                        You may disconnect at any time within Interloper or by removing Interloper from the
+                        Business Integrations settings of your Meta account. To request deletion of Meta data
+                        we hold on your behalf, see "Data retention and deletion" below.
+                    </p>
+                </section>
 
-            <section class="flex flex-col gap-2">
-                <h2 class="text-xl font-semibold">
-                    TikTok Integration and API Services
-                </h2>
-                <p>
-                    Our Platform allows users to connect their TikTok accounts through official TikTok API
-                    Services. By using the TikTok connector within Interloper, you agree
-                    to be bound by the TikTok Terms of Service (accessible at
-                    <ULink href="https://www.tiktok.com/legal/terms-of-service"
-                           target="_blank"
-                           rel="noopener noreferrer"
-                           class="text-primary">
-                        https://www.tiktok.com/legal/terms-of-service
-                    </ULink>) and the TikTok Privacy Policy.
-                </p>
-                <p>
-                    We only access, ingest, and process TikTok data that you explicitly authorize during the
-                    OAuth consent flow. You may revoke this access at any time through your TikTok account
-                    security settings or by disconnecting your account within Interloper. We
-                    do not use your TikTok data for any purpose other than providing the requested analytics
-                    and reporting services to you.
-                </p>
-            </section>
+                <section class="flex flex-col gap-2">
+                    <h3 class="text-lg font-semibold">
+                        TikTok Integration and API Services
+                    </h3>
+                    <p>
+                        Our Platform allows users to connect their TikTok accounts through official TikTok API
+                        Services. By using the TikTok connector within Interloper, you agree to be bound by
+                        the TikTok Terms of Service (accessible at
+                        <ULink href="https://www.tiktok.com/legal/terms-of-service"
+                               target="_blank"
+                               rel="noopener noreferrer"
+                               class="text-primary">
+                            https://www.tiktok.com/legal/terms-of-service
+                        </ULink>) and the TikTok Privacy Policy.
+                    </p>
+                    <p>
+                        We only access, ingest, and process TikTok data that you explicitly authorize during
+                        the OAuth consent flow. You may revoke this access at any time through your TikTok
+                        account security settings or by disconnecting your account within Interloper. We do
+                        not use your TikTok data for any purpose other than providing the requested analytics
+                        and reporting services to you.
+                    </p>
+                </section>
 
-            <section class="flex flex-col gap-2">
-                <h2 class="text-xl font-semibold">
-                    Other platform connectors
-                </h2>
-                <p>
-                    The following connectors access data through each platform's official API and are subject
-                    to that platform's terms and privacy documentation. In each case we access only the
-                    scopes you approve, and you may disconnect at any time within Interloper or by revoking
-                    access in the platform's own settings.
-                </p>
-                <ul class="list-disc pl-6 flex flex-col gap-2">
-                    <li>
-                        <strong>LinkedIn</strong> (LinkedIn Ads and LinkedIn Organic) — subject to the
+                <section class="flex flex-col gap-2">
+                    <h3 class="text-lg font-semibold">
+                        LinkedIn
+                    </h3>
+                    <p>
+                        Connectors for LinkedIn Ads and LinkedIn Organic access data through the LinkedIn
+                        APIs, subject to the
                         <ULink href="https://legal.linkedin.com/api-terms-of-use"
                                target="_blank"
                                rel="noopener noreferrer"
@@ -185,22 +178,40 @@ definePageMeta({
                                target="_blank"
                                rel="noopener noreferrer"
                                class="text-primary">LinkedIn Privacy Policy</ULink>.
-                    </li>
-                    <li>
-                        <strong>Amazon</strong> (Amazon Ads and Amazon Selling Partner) — subject to Amazon's
-                        API license agreement, Acceptable Use Policy, and Data Protection Policy, and the
-                        applicable Amazon privacy notices.
-                    </li>
-                    <li>
-                        <strong>Microsoft Advertising</strong> (Bing Ads) — subject to the Microsoft
-                        Advertising Agreement and the
+                    </p>
+                </section>
+
+                <section class="flex flex-col gap-2">
+                    <h3 class="text-lg font-semibold">
+                        Amazon
+                    </h3>
+                    <p>
+                        Connectors for Amazon Ads and Amazon Selling Partner access data through Amazon's
+                        APIs, subject to Amazon's API license agreement, Acceptable Use Policy, and Data
+                        Protection Policy, and the applicable Amazon privacy notices.
+                    </p>
+                </section>
+
+                <section class="flex flex-col gap-2">
+                    <h3 class="text-lg font-semibold">
+                        Microsoft Advertising (Bing Ads)
+                    </h3>
+                    <p>
+                        The Bing Ads connector accesses data through the Microsoft Advertising API, subject to
+                        the Microsoft Advertising Agreement and the
                         <ULink href="https://privacy.microsoft.com/privacystatement"
                                target="_blank"
                                rel="noopener noreferrer"
                                class="text-primary">Microsoft Privacy Statement</ULink>.
-                    </li>
-                    <li>
-                        <strong>Pinterest</strong> (Pinterest Ads) — subject to the
+                    </p>
+                </section>
+
+                <section class="flex flex-col gap-2">
+                    <h3 class="text-lg font-semibold">
+                        Pinterest
+                    </h3>
+                    <p>
+                        The Pinterest Ads connector accesses data through the Pinterest API, subject to the
                         <ULink href="https://business.pinterest.com/business-terms-of-service/"
                                target="_blank"
                                rel="noopener noreferrer"
@@ -210,24 +221,37 @@ definePageMeta({
                                target="_blank"
                                rel="noopener noreferrer"
                                class="text-primary">Pinterest Privacy Policy</ULink>.
-                    </li>
-                    <li>
-                        <strong>Snapchat</strong> (Snapchat Ads) — subject to the Snap Business and developer
-                        terms and the
+                    </p>
+                </section>
+
+                <section class="flex flex-col gap-2">
+                    <h3 class="text-lg font-semibold">
+                        Snapchat
+                    </h3>
+                    <p>
+                        The Snapchat Ads connector accesses data through the Snap Marketing API, subject to
+                        the Snap Business and developer terms and the
                         <ULink href="https://snap.com/privacy/privacy-policy"
                                target="_blank"
                                rel="noopener noreferrer"
                                class="text-primary">Snap Privacy Policy</ULink>.
-                    </li>
-                    <li>
-                        <strong>Criteo</strong> — subject to Criteo's applicable API and platform terms and
-                        the
+                    </p>
+                </section>
+
+                <section class="flex flex-col gap-2">
+                    <h3 class="text-lg font-semibold">
+                        Criteo
+                    </h3>
+                    <p>
+                        The Criteo connector accesses data through the Criteo API, subject to Criteo's
+                        applicable API and platform terms and the
                         <ULink href="https://www.criteo.com/privacy/"
                                target="_blank"
                                rel="noopener noreferrer"
                                class="text-primary">Criteo Privacy Policy</ULink>.
-                    </li>
-                </ul>
+                    </p>
+                </section>
+
                 <p>
                     Additional connectors may be supported from time to time; each is used only within the
                     scopes you approve and subject to the applicable platform's terms.

--- a/packages/interloper-app/app/app/pages/terms-of-service.vue
+++ b/packages/interloper-app/app/app/pages/terms-of-service.vue
@@ -1,0 +1,209 @@
+<script setup lang="ts">
+definePageMeta({
+    title: 'Terms of Service',
+    layout: false,
+})
+</script>
+
+<template>
+    <div class="min-h-svh w-full py-12 px-6 md:px-10">
+        <article class="mx-auto w-full max-w-3xl flex flex-col gap-6">
+            <h1 class="text-3xl font-semibold">
+                Terms of Service
+            </h1>
+
+            <p>
+                These Terms of Service govern your access to and use of the DigitlCloud Connectors portal and
+                related connector authorization flows provided by DiGiTL Cloud GmbH. By using this portal,
+                connecting a third-party platform, or requesting access tokens through the portal, you agree
+                to these Terms.
+            </p>
+
+            <section class="flex flex-col gap-2">
+                <h2 class="text-xl font-semibold">
+                    Scope of the service
+                </h2>
+                <p>
+                    The portal is provided to help customers authorize supported marketing, analytics,
+                    commerce, and social media connectors and to support downstream reporting, data
+                    synchronization, and operational workflows requested by the customer. The portal itself
+                    is a facilitation layer for connector access and does not transfer ownership of any
+                    third-party account, content, or platform data.
+                </p>
+            </section>
+
+            <section class="flex flex-col gap-2">
+                <h2 class="text-xl font-semibold">
+                    Eligibility and authority
+                </h2>
+                <p>
+                    You may only use the portal if you are legally permitted to do so and if you are
+                    authorized to act on behalf of the business, brand, or account owner whose connector
+                    access you submit. You are responsible for ensuring that any consent you grant through an
+                    OAuth flow is accurate, current, and authorized.
+                </p>
+            </section>
+
+            <section class="flex flex-col gap-2">
+                <h2 class="text-xl font-semibold">
+                    Customer responsibilities
+                </h2>
+                <p>
+                    You are responsible for the accuracy of the credentials, account selections, scopes, and
+                    permissions you approve. You must keep your own third-party platform credentials secure,
+                    review requested scopes before approving access, and promptly revoke access if you
+                    believe a connector has been enabled in error or without proper authorization.
+                </p>
+            </section>
+
+            <section class="flex flex-col gap-2">
+                <h2 class="text-xl font-semibold">
+                    Third-party platforms and connector terms
+                </h2>
+                <p>
+                    Your use of any connector is also subject to the terms, developer policies, API rules,
+                    and privacy documentation of the applicable third-party platform. We are not responsible
+                    for the independent acts, outages, policy changes, interface changes, or enforcement
+                    decisions of those third-party providers. If a platform changes its requirements or
+                    disables access, we may need to modify, suspend, or remove the relevant connector
+                    functionality.
+                </p>
+            </section>
+
+            <section class="flex flex-col gap-2">
+                <h2 class="text-xl font-semibold">
+                    TikTok connector terms
+                </h2>
+                <p>
+                    When you connect a TikTok Ads account or TikTok Organic account through this portal, you
+                    acknowledge and agree that your use of those connectors remains subject to the applicable
+                    TikTok Terms of Service (<ULink href="https://www.tiktok.com/legal/terms-of-service"
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                    class="text-primary">https://www.tiktok.com/legal/terms-of-service</ULink>),
+                    developer documentation, API policies, and privacy notices.
+                </p>
+                <p>
+                    You may only connect TikTok accounts for which you have full permission to grant the
+                    requested access scopes. You authorize DigitlCloud to request, receive, process, and
+                    store the TikTok access credentials and TikTok account data that are necessary to provide
+                    the analytics, reporting, integration, and support services you requested.
+                </p>
+                <p>
+                    That authorization is limited to the scopes approved during the OAuth flow and to the
+                    services associated with your customer relationship with DiGiTL Cloud GmbH. You must not
+                    use the TikTok connectors through this portal in a way that violates TikTok rules,
+                    infringes third-party rights, misrepresents account ownership, bypasses access controls,
+                    or enables unlawful targeting, scraping, resale, or misuse of TikTok data.
+                </p>
+                <p>
+                    If TikTok requires user disclosures, additional consent, or revocation mechanisms, you
+                    remain responsible for satisfying those obligations in your own business operations. If
+                    you revoke DigitlCloud access from within TikTok, remove app permissions, or your TikTok
+                    authorization expires, the related connector services may stop working until a new
+                    authorization is completed.
+                </p>
+            </section>
+
+            <section class="flex flex-col gap-2">
+                <h2 class="text-xl font-semibold">
+                    Data use and instructions
+                </h2>
+                <p>
+                    We process connector data only to the extent needed to provide the requested services,
+                    maintain connector functionality, troubleshoot issues, meet legal obligations, and
+                    protect the service against abuse. You instruct us to process the data made available
+                    through the connectors for these purposes when you authorize the connection.
+                </p>
+            </section>
+
+            <section class="flex flex-col gap-2">
+                <h2 class="text-xl font-semibold">
+                    Acceptable use
+                </h2>
+                <p>
+                    You may not use the portal to gain unauthorized access, interfere with service
+                    availability, circumvent platform restrictions, upload malicious content, violate
+                    applicable law, or process data you do not have the right to access. You may not attempt
+                    to reverse engineer, disrupt, or misuse the portal, any connector flow, or any associated
+                    infrastructure.
+                </p>
+            </section>
+
+            <section class="flex flex-col gap-2">
+                <h2 class="text-xl font-semibold">
+                    Availability and changes
+                </h2>
+                <p>
+                    We may update, improve, restrict, or discontinue parts of the portal at any time,
+                    including supported connectors, supported scopes, interface behavior, or security
+                    controls. We do not guarantee uninterrupted availability or continued support for any
+                    specific third-party integration.
+                </p>
+            </section>
+
+            <section class="flex flex-col gap-2">
+                <h2 class="text-xl font-semibold">
+                    Intellectual property
+                </h2>
+                <p>
+                    The portal, its design, and its underlying software remain the property of DiGiTL Cloud
+                    GmbH or its licensors, except for third-party marks, content, and materials that remain
+                    the property of their respective owners. These Terms do not transfer any intellectual
+                    property rights to you other than the limited right to use the portal for its intended
+                    business purpose.
+                </p>
+            </section>
+
+            <section class="flex flex-col gap-2">
+                <h2 class="text-xl font-semibold">
+                    Disclaimer and limitation of liability
+                </h2>
+                <p>
+                    The portal is provided on an as-available basis. To the maximum extent permitted by law,
+                    DiGiTL Cloud GmbH disclaims warranties not expressly stated, including implied warranties
+                    of availability, fitness for a particular purpose, and non-infringement. We are not liable
+                    for losses caused by third-party platform downtime, revoked permissions, policy changes,
+                    incorrect customer configuration, or unauthorized use of third-party accounts outside our
+                    control.
+                </p>
+            </section>
+
+            <section class="flex flex-col gap-2">
+                <h2 class="text-xl font-semibold">
+                    Termination
+                </h2>
+                <p>
+                    We may restrict or terminate access to the portal if necessary to comply with law,
+                    enforce these Terms, respond to a third-party platform requirement, address security
+                    concerns, or prevent abuse. You may stop using the portal at any time and may revoke
+                    connector authorizations through the relevant third-party platform or your DigitlCloud
+                    service contacts where applicable.
+                </p>
+            </section>
+
+            <section class="flex flex-col gap-2">
+                <h2 class="text-xl font-semibold">
+                    Governing law and contact
+                </h2>
+                <p>
+                    These Terms are governed by the laws of Germany, excluding conflict-of-law rules, unless
+                    mandatory law requires otherwise. Questions regarding these Terms may be sent to DiGiTL
+                    Cloud GmbH, An der Alster 6, 20099 Hamburg, Germany, or by email to
+                    <ULink href="mailto:info@digitlcloud.com" class="text-primary">
+                        info@digitlcloud.com
+                    </ULink>.
+                </p>
+            </section>
+
+            <section class="flex flex-col gap-2">
+                <h2 class="text-xl font-semibold">
+                    Effective date
+                </h2>
+                <p>
+                    These Terms of Service apply as of 01 January 2026.
+                </p>
+            </section>
+        </article>
+    </div>
+</template>

--- a/packages/interloper-app/app/app/pages/terms-of-service.vue
+++ b/packages/interloper-app/app/app/pages/terms-of-service.vue
@@ -107,6 +107,83 @@ definePageMeta({
 
             <section class="flex flex-col gap-2">
                 <h2 class="text-xl font-semibold">
+                    Other platform connector terms
+                </h2>
+                <p>
+                    The connector terms above apply, with equal force, to every other platform you connect
+                    through Interloper. You may only connect an account for which you are authorized to grant
+                    the requested scopes, you authorize Interloper to request, receive, process, and store the
+                    credentials and data necessary to provide the services you requested, and that
+                    authorization is limited to the approved scopes and to your customer relationship with
+                    DiGiTL Cloud GmbH. In particular:
+                </p>
+                <ul class="list-disc pl-6 flex flex-col gap-2">
+                    <li>
+                        <strong>Google connectors</strong> (Google Ads, Campaign Manager 360, Display &amp;
+                        Video 360, and related services) are subject to the
+                        <ULink href="https://developers.google.com/terms"
+                               target="_blank"
+                               rel="noopener noreferrer"
+                               class="text-primary">Google APIs Terms of Service</ULink>.
+                        Interloper's use and transfer of information received from Google APIs to any other
+                        app adheres to the
+                        <ULink href="https://developers.google.com/terms/api-services-user-data-policy"
+                               target="_blank"
+                               rel="noopener noreferrer"
+                               class="text-primary">Google API Services User Data Policy</ULink>,
+                        including the Limited Use requirements.
+                    </li>
+                    <li>
+                        <strong>Meta connectors</strong> (Facebook and Instagram) are subject to the
+                        <ULink href="https://developers.facebook.com/terms/"
+                               target="_blank"
+                               rel="noopener noreferrer"
+                               class="text-primary">Meta Platform Terms</ULink>
+                        and Meta's developer policies.
+                    </li>
+                    <li>
+                        <strong>LinkedIn connectors</strong> (LinkedIn Ads and LinkedIn Organic) are subject
+                        to the
+                        <ULink href="https://legal.linkedin.com/api-terms-of-use"
+                               target="_blank"
+                               rel="noopener noreferrer"
+                               class="text-primary">LinkedIn API Terms of Use</ULink>.
+                    </li>
+                    <li>
+                        <strong>Amazon connectors</strong> (Amazon Ads and Amazon Selling Partner) are subject
+                        to Amazon's API license agreement, Acceptable Use Policy, and Data Protection Policy.
+                    </li>
+                    <li>
+                        <strong>Microsoft Advertising</strong> (Bing Ads) is subject to the Microsoft
+                        Advertising Agreement and Microsoft's developer policies.
+                    </li>
+                    <li>
+                        <strong>Pinterest</strong> (Pinterest Ads) is subject to the
+                        <ULink href="https://business.pinterest.com/business-terms-of-service/"
+                               target="_blank"
+                               rel="noopener noreferrer"
+                               class="text-primary">Pinterest Business Terms of Service</ULink>
+                        and developer guidelines.
+                    </li>
+                    <li>
+                        <strong>Snapchat</strong> (Snapchat Ads) is subject to the Snap Business and developer
+                        terms.
+                    </li>
+                    <li>
+                        <strong>Criteo</strong> is subject to Criteo's applicable API and platform terms.
+                    </li>
+                </ul>
+                <p>
+                    You must not use any connector in a way that violates the relevant platform's rules,
+                    infringes third-party rights, misrepresents account ownership, bypasses access controls,
+                    or enables unlawful targeting, scraping, resale, or misuse of platform data. Additional
+                    connectors may be supported from time to time and are governed by these same terms and by
+                    the applicable platform's terms.
+                </p>
+            </section>
+
+            <section class="flex flex-col gap-2">
+                <h2 class="text-xl font-semibold">
                     Data use and instructions
                 </h2>
                 <p>

--- a/packages/interloper-app/app/app/pages/terms-of-service.vue
+++ b/packages/interloper-app/app/app/pages/terms-of-service.vue
@@ -13,9 +13,9 @@ definePageMeta({
             </h1>
 
             <p>
-                These Terms of Service govern your access to and use of the DigitlCloud Connectors portal and
-                related connector authorization flows provided by DiGiTL Cloud GmbH. By using this portal,
-                connecting a third-party platform, or requesting access tokens through the portal, you agree
+                These Terms of Service govern your access to and use of Interloper and
+                related connector authorization flows provided by DiGiTL Cloud GmbH. By using Interloper,
+                connecting a third-party platform, or requesting access tokens through Interloper, you agree
                 to these Terms.
             </p>
 
@@ -24,9 +24,9 @@ definePageMeta({
                     Scope of the service
                 </h2>
                 <p>
-                    The portal is provided to help customers authorize supported marketing, analytics,
+                    Interloper is provided to help customers authorize supported marketing, analytics,
                     commerce, and social media connectors and to support downstream reporting, data
-                    synchronization, and operational workflows requested by the customer. The portal itself
+                    synchronization, and operational workflows requested by the customer. Interloper itself
                     is a facilitation layer for connector access and does not transfer ownership of any
                     third-party account, content, or platform data.
                 </p>
@@ -37,7 +37,7 @@ definePageMeta({
                     Eligibility and authority
                 </h2>
                 <p>
-                    You may only use the portal if you are legally permitted to do so and if you are
+                    You may only use Interloper if you are legally permitted to do so and if you are
                     authorized to act on behalf of the business, brand, or account owner whose connector
                     access you submit. You are responsible for ensuring that any consent you grant through an
                     OAuth flow is accurate, current, and authorized.
@@ -75,7 +75,7 @@ definePageMeta({
                     TikTok connector terms
                 </h2>
                 <p>
-                    When you connect a TikTok Ads account or TikTok Organic account through this portal, you
+                    When you connect a TikTok Ads account or TikTok Organic account through Interloper, you
                     acknowledge and agree that your use of those connectors remains subject to the applicable
                     TikTok Terms of Service (<ULink href="https://www.tiktok.com/legal/terms-of-service"
                                                     target="_blank"
@@ -85,21 +85,21 @@ definePageMeta({
                 </p>
                 <p>
                     You may only connect TikTok accounts for which you have full permission to grant the
-                    requested access scopes. You authorize DigitlCloud to request, receive, process, and
+                    requested access scopes. You authorize Interloper to request, receive, process, and
                     store the TikTok access credentials and TikTok account data that are necessary to provide
                     the analytics, reporting, integration, and support services you requested.
                 </p>
                 <p>
                     That authorization is limited to the scopes approved during the OAuth flow and to the
                     services associated with your customer relationship with DiGiTL Cloud GmbH. You must not
-                    use the TikTok connectors through this portal in a way that violates TikTok rules,
+                    use the TikTok connectors through Interloper in a way that violates TikTok rules,
                     infringes third-party rights, misrepresents account ownership, bypasses access controls,
                     or enables unlawful targeting, scraping, resale, or misuse of TikTok data.
                 </p>
                 <p>
                     If TikTok requires user disclosures, additional consent, or revocation mechanisms, you
                     remain responsible for satisfying those obligations in your own business operations. If
-                    you revoke DigitlCloud access from within TikTok, remove app permissions, or your TikTok
+                    you revoke Interloper access from within TikTok, remove app permissions, or your TikTok
                     authorization expires, the related connector services may stop working until a new
                     authorization is completed.
                 </p>
@@ -122,10 +122,10 @@ definePageMeta({
                     Acceptable use
                 </h2>
                 <p>
-                    You may not use the portal to gain unauthorized access, interfere with service
+                    You may not use Interloper to gain unauthorized access, interfere with service
                     availability, circumvent platform restrictions, upload malicious content, violate
                     applicable law, or process data you do not have the right to access. You may not attempt
-                    to reverse engineer, disrupt, or misuse the portal, any connector flow, or any associated
+                    to reverse engineer, disrupt, or misuse Interloper, any connector flow, or any associated
                     infrastructure.
                 </p>
             </section>
@@ -135,7 +135,7 @@ definePageMeta({
                     Availability and changes
                 </h2>
                 <p>
-                    We may update, improve, restrict, or discontinue parts of the portal at any time,
+                    We may update, improve, restrict, or discontinue parts of Interloper at any time,
                     including supported connectors, supported scopes, interface behavior, or security
                     controls. We do not guarantee uninterrupted availability or continued support for any
                     specific third-party integration.
@@ -147,10 +147,10 @@ definePageMeta({
                     Intellectual property
                 </h2>
                 <p>
-                    The portal, its design, and its underlying software remain the property of DiGiTL Cloud
+                    Interloper, its design, and its underlying software remain the property of DiGiTL Cloud
                     GmbH or its licensors, except for third-party marks, content, and materials that remain
                     the property of their respective owners. These Terms do not transfer any intellectual
-                    property rights to you other than the limited right to use the portal for its intended
+                    property rights to you other than the limited right to use Interloper for its intended
                     business purpose.
                 </p>
             </section>
@@ -160,7 +160,7 @@ definePageMeta({
                     Disclaimer and limitation of liability
                 </h2>
                 <p>
-                    The portal is provided on an as-available basis. To the maximum extent permitted by law,
+                    Interloper is provided on an as-available basis. To the maximum extent permitted by law,
                     DiGiTL Cloud GmbH disclaims warranties not expressly stated, including implied warranties
                     of availability, fitness for a particular purpose, and non-infringement. We are not liable
                     for losses caused by third-party platform downtime, revoked permissions, policy changes,
@@ -174,10 +174,10 @@ definePageMeta({
                     Termination
                 </h2>
                 <p>
-                    We may restrict or terminate access to the portal if necessary to comply with law,
+                    We may restrict or terminate access to Interloper if necessary to comply with law,
                     enforce these Terms, respond to a third-party platform requirement, address security
-                    concerns, or prevent abuse. You may stop using the portal at any time and may revoke
-                    connector authorizations through the relevant third-party platform or your DigitlCloud
+                    concerns, or prevent abuse. You may stop using Interloper at any time and may revoke
+                    connector authorizations through the relevant third-party platform or your Interloper
                     service contacts where applicable.
                 </p>
             </section>

--- a/packages/interloper-app/app/app/pages/terms-of-service.vue
+++ b/packages/interloper-app/app/app/pages/terms-of-service.vue
@@ -6,7 +6,7 @@ definePageMeta({
 </script>
 
 <template>
-    <div class="min-h-svh w-full py-12 px-6 md:px-10">
+    <div class="h-svh w-full overflow-y-auto py-12 px-6 md:px-10">
         <article class="mx-auto w-full max-w-3xl flex flex-col gap-6">
             <h1 class="text-3xl font-semibold">
                 Terms of Service

--- a/packages/interloper-app/app/app/pages/terms-of-service.vue
+++ b/packages/interloper-app/app/app/pages/terms-of-service.vue
@@ -56,7 +56,7 @@ definePageMeta({
                 </p>
             </section>
 
-            <section class="flex flex-col gap-2">
+            <section class="flex flex-col gap-4">
                 <h2 class="text-xl font-semibold">
                     Third-party platforms and connector terms
                 </h2>
@@ -68,59 +68,59 @@ definePageMeta({
                     disables access, we may need to modify, suspend, or remove the relevant connector
                     functionality.
                 </p>
-            </section>
+                <p>
+                    For every platform you connect through Interloper you may only connect an account for
+                    which you are authorized to grant the requested scopes; you authorize Interloper to
+                    request, receive, process, and store the credentials and data necessary to provide the
+                    services you requested; and that authorization is limited to the approved scopes and to
+                    your customer relationship with DiGiTL Cloud GmbH. You must not use any connector in a way
+                    that violates the relevant platform's rules, infringes third-party rights, misrepresents
+                    account ownership, bypasses access controls, or enables unlawful targeting, scraping,
+                    resale, or misuse of platform data. The following platform-specific terms apply.
+                </p>
 
-            <section class="flex flex-col gap-2">
-                <h2 class="text-xl font-semibold">
-                    TikTok connector terms
-                </h2>
-                <p>
-                    When you connect a TikTok Ads account or TikTok Organic account through Interloper, you
-                    acknowledge and agree that your use of those connectors remains subject to the applicable
-                    TikTok Terms of Service (<ULink href="https://www.tiktok.com/legal/terms-of-service"
-                                                    target="_blank"
-                                                    rel="noopener noreferrer"
-                                                    class="text-primary">https://www.tiktok.com/legal/terms-of-service</ULink>),
-                    developer documentation, API policies, and privacy notices.
-                </p>
-                <p>
-                    You may only connect TikTok accounts for which you have full permission to grant the
-                    requested access scopes. You authorize Interloper to request, receive, process, and
-                    store the TikTok access credentials and TikTok account data that are necessary to provide
-                    the analytics, reporting, integration, and support services you requested.
-                </p>
-                <p>
-                    That authorization is limited to the scopes approved during the OAuth flow and to the
-                    services associated with your customer relationship with DiGiTL Cloud GmbH. You must not
-                    use the TikTok connectors through Interloper in a way that violates TikTok rules,
-                    infringes third-party rights, misrepresents account ownership, bypasses access controls,
-                    or enables unlawful targeting, scraping, resale, or misuse of TikTok data.
-                </p>
-                <p>
-                    If TikTok requires user disclosures, additional consent, or revocation mechanisms, you
-                    remain responsible for satisfying those obligations in your own business operations. If
-                    you revoke Interloper access from within TikTok, remove app permissions, or your TikTok
-                    authorization expires, the related connector services may stop working until a new
-                    authorization is completed.
-                </p>
-            </section>
+                <section class="flex flex-col gap-2">
+                    <h3 class="text-lg font-semibold">
+                        TikTok
+                    </h3>
+                    <p>
+                        When you connect a TikTok Ads account or TikTok Organic account through Interloper,
+                        you acknowledge and agree that your use of those connectors remains subject to the
+                        applicable TikTok Terms of Service (<ULink href="https://www.tiktok.com/legal/terms-of-service"
+                                                                   target="_blank"
+                                                                   rel="noopener noreferrer"
+                                                                   class="text-primary">https://www.tiktok.com/legal/terms-of-service</ULink>),
+                        developer documentation, API policies, and privacy notices.
+                    </p>
+                    <p>
+                        You may only connect TikTok accounts for which you have full permission to grant the
+                        requested access scopes. You authorize Interloper to request, receive, process, and
+                        store the TikTok access credentials and TikTok account data that are necessary to
+                        provide the analytics, reporting, integration, and support services you requested.
+                    </p>
+                    <p>
+                        That authorization is limited to the scopes approved during the OAuth flow and to the
+                        services associated with your customer relationship with DiGiTL Cloud GmbH. You must
+                        not use the TikTok connectors through Interloper in a way that violates TikTok rules,
+                        infringes third-party rights, misrepresents account ownership, bypasses access
+                        controls, or enables unlawful targeting, scraping, resale, or misuse of TikTok data.
+                    </p>
+                    <p>
+                        If TikTok requires user disclosures, additional consent, or revocation mechanisms, you
+                        remain responsible for satisfying those obligations in your own business operations.
+                        If you revoke Interloper access from within TikTok, remove app permissions, or your
+                        TikTok authorization expires, the related connector services may stop working until a
+                        new authorization is completed.
+                    </p>
+                </section>
 
-            <section class="flex flex-col gap-2">
-                <h2 class="text-xl font-semibold">
-                    Other platform connector terms
-                </h2>
-                <p>
-                    The connector terms above apply, with equal force, to every other platform you connect
-                    through Interloper. You may only connect an account for which you are authorized to grant
-                    the requested scopes, you authorize Interloper to request, receive, process, and store the
-                    credentials and data necessary to provide the services you requested, and that
-                    authorization is limited to the approved scopes and to your customer relationship with
-                    DiGiTL Cloud GmbH. In particular:
-                </p>
-                <ul class="list-disc pl-6 flex flex-col gap-2">
-                    <li>
-                        <strong>Google connectors</strong> (Google Ads, Campaign Manager 360, Display &amp;
-                        Video 360, and related services) are subject to the
+                <section class="flex flex-col gap-2">
+                    <h3 class="text-lg font-semibold">
+                        Google
+                    </h3>
+                    <p>
+                        Google connectors (Google Ads, Campaign Manager 360, Display &amp; Video 360, and
+                        related services) are subject to the
                         <ULink href="https://developers.google.com/terms"
                                target="_blank"
                                rel="noopener noreferrer"
@@ -132,53 +132,91 @@ definePageMeta({
                                rel="noopener noreferrer"
                                class="text-primary">Google API Services User Data Policy</ULink>,
                         including the Limited Use requirements.
-                    </li>
-                    <li>
-                        <strong>Meta connectors</strong> (Facebook and Instagram) are subject to the
+                    </p>
+                </section>
+
+                <section class="flex flex-col gap-2">
+                    <h3 class="text-lg font-semibold">
+                        Meta (Facebook and Instagram)
+                    </h3>
+                    <p>
+                        Meta connectors are subject to the
                         <ULink href="https://developers.facebook.com/terms/"
                                target="_blank"
                                rel="noopener noreferrer"
                                class="text-primary">Meta Platform Terms</ULink>
                         and Meta's developer policies.
-                    </li>
-                    <li>
-                        <strong>LinkedIn connectors</strong> (LinkedIn Ads and LinkedIn Organic) are subject
-                        to the
+                    </p>
+                </section>
+
+                <section class="flex flex-col gap-2">
+                    <h3 class="text-lg font-semibold">
+                        LinkedIn
+                    </h3>
+                    <p>
+                        LinkedIn connectors (LinkedIn Ads and LinkedIn Organic) are subject to the
                         <ULink href="https://legal.linkedin.com/api-terms-of-use"
                                target="_blank"
                                rel="noopener noreferrer"
                                class="text-primary">LinkedIn API Terms of Use</ULink>.
-                    </li>
-                    <li>
-                        <strong>Amazon connectors</strong> (Amazon Ads and Amazon Selling Partner) are subject
-                        to Amazon's API license agreement, Acceptable Use Policy, and Data Protection Policy.
-                    </li>
-                    <li>
-                        <strong>Microsoft Advertising</strong> (Bing Ads) is subject to the Microsoft
-                        Advertising Agreement and Microsoft's developer policies.
-                    </li>
-                    <li>
-                        <strong>Pinterest</strong> (Pinterest Ads) is subject to the
+                    </p>
+                </section>
+
+                <section class="flex flex-col gap-2">
+                    <h3 class="text-lg font-semibold">
+                        Amazon
+                    </h3>
+                    <p>
+                        Amazon connectors (Amazon Ads and Amazon Selling Partner) are subject to Amazon's API
+                        license agreement, Acceptable Use Policy, and Data Protection Policy.
+                    </p>
+                </section>
+
+                <section class="flex flex-col gap-2">
+                    <h3 class="text-lg font-semibold">
+                        Microsoft Advertising (Bing Ads)
+                    </h3>
+                    <p>
+                        The Bing Ads connector is subject to the Microsoft Advertising Agreement and
+                        Microsoft's developer policies.
+                    </p>
+                </section>
+
+                <section class="flex flex-col gap-2">
+                    <h3 class="text-lg font-semibold">
+                        Pinterest
+                    </h3>
+                    <p>
+                        The Pinterest Ads connector is subject to the
                         <ULink href="https://business.pinterest.com/business-terms-of-service/"
                                target="_blank"
                                rel="noopener noreferrer"
                                class="text-primary">Pinterest Business Terms of Service</ULink>
                         and developer guidelines.
-                    </li>
-                    <li>
-                        <strong>Snapchat</strong> (Snapchat Ads) is subject to the Snap Business and developer
-                        terms.
-                    </li>
-                    <li>
-                        <strong>Criteo</strong> is subject to Criteo's applicable API and platform terms.
-                    </li>
-                </ul>
+                    </p>
+                </section>
+
+                <section class="flex flex-col gap-2">
+                    <h3 class="text-lg font-semibold">
+                        Snapchat
+                    </h3>
+                    <p>
+                        The Snapchat Ads connector is subject to the Snap Business and developer terms.
+                    </p>
+                </section>
+
+                <section class="flex flex-col gap-2">
+                    <h3 class="text-lg font-semibold">
+                        Criteo
+                    </h3>
+                    <p>
+                        The Criteo connector is subject to Criteo's applicable API and platform terms.
+                    </p>
+                </section>
+
                 <p>
-                    You must not use any connector in a way that violates the relevant platform's rules,
-                    infringes third-party rights, misrepresents account ownership, bypasses access controls,
-                    or enables unlawful targeting, scraping, resale, or misuse of platform data. Additional
-                    connectors may be supported from time to time and are governed by these same terms and by
-                    the applicable platform's terms.
+                    Additional connectors may be supported from time to time and are governed by these same
+                    terms and by the applicable platform's terms.
                 </p>
             </section>
 


### PR DESCRIPTION
## What

Adds two public legal pages to the interloper-app SPA:

- **[`privacy-policy.vue`](packages/interloper-app/app/app/pages/privacy-policy.vue)** — DiGiTL Cloud GmbH privacy policy at `/privacy-policy`, including a TikTok Integration and API Services section.
- **[`terms-of-service.vue`](packages/interloper-app/app/app/pages/terms-of-service.vue)** — DigitlCloud Connectors portal terms at `/terms-of-service`, including TikTok connector terms.

Both use `layout: false` (standalone, like `login.vue`) so they render without the authenticated app shell, and both paths are exempted from the global auth guard in [`auth.global.ts`](packages/interloper-app/app/app/middleware/auth.global.ts) so they are reachable without logging in.

## Why

TikTok's app review process requires publicly reachable privacy policy and terms of service URLs disclosing how TikTok API data is accessed and handled. These will be live at `https://app.interloper.dev/privacy-policy` and `https://app.interloper.dev/terms-of-service`.

## Reviewer notes

- Content is verbatim as supplied by the business; email addresses and the TikTok ToS link are rendered as links.
- These are client-side SPA routes — nginx already rewrites unknown paths to `index.html`, so the deep links resolve with a 200.
- Lint: 0 errors. Typecheck: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)