### PR TITLE
feat: in-house developer_token fallback for Bing Ads sign-in

### DIFF
--- a/packages/interloper-assets/src/interloper_assets/bing_ads/connection.py
+++ b/packages/interloper-assets/src/interloper_assets/bing_ads/connection.py
@@ -4,6 +4,7 @@ from xml.etree import ElementTree as ET
 
 import httpx
 import interloper as il
+from pydantic import model_validator
 from pydantic_settings import SettingsConfigDict
 
 # Microsoft Advertising OAuth + Customer Management SOAP endpoints. These are
@@ -42,6 +43,19 @@ def _first_descendant(root: ET.Element, name: str) -> ET.Element | None:
     name="Bing Ads",
     icon="icon:bing",
     tags=["Advertising"],
+    oauth=il.OAuthConfig(
+        "microsoft",
+        scope="offline_access https://ads.microsoft.com/msads.manage",
+        # ``developer_token`` rides the same in-house path as the credential
+        # trio: listing it here hides it in sign-in mode (the form hides every
+        # mapped field), and ``_resolve_developer_token`` fills it from env.
+        fields={
+            "client_id": "client_id",
+            "client_secret": "client_secret",
+            "refresh_token": "refresh_token",
+            "developer_token": "developer_token",
+        },
+    ),
 )
 class BingAdsConnection(il.RefreshTokenOAuthConnection):
     """Bing Ads API connection with OAuth2 refresh token auth.
@@ -53,7 +67,23 @@ class BingAdsConnection(il.RefreshTokenOAuthConnection):
 
     model_config = SettingsConfigDict(env_prefix="bing_ads_")
 
-    developer_token: str = il.SecretField(description="Bing Ads developer token")
+    developer_token: str = il.SecretField("", description="Bing Ads developer token")
+
+    @model_validator(mode="after")
+    def _resolve_developer_token(self) -> "BingAdsConnection":
+        """Fill a blank ``developer_token`` from the in-house env credential.
+
+        Mirrors how ``client_id`` / ``client_secret`` resolve on
+        :class:`RefreshTokenOAuthConnection`: read
+        ``INTERLOPER_MICROSOFT_DEVELOPER_TOKEN`` when the field is left blank, so
+        the in-house token is used automatically and never stored per
+        connection. Setting it explicitly overrides the in-house token.
+
+        Returns:
+            The connection instance (self), with the developer token filled in.
+        """
+        self.developer_token = self.developer_token or self.env_credential("DEVELOPER_TOKEN")
+        return self
 
     @cached_property
     def _authentication(self) -> Any:


### PR DESCRIPTION
## What

Wires the **Bing Ads** connection into the OAuth "Sign in with Microsoft" flow and gives its `developer_token` an **in-house fallback**: when the user leaves it blank, it resolves from `INTERLOPER_MICROSOFT_DEVELOPER_TOKEN`. An explicit value still overrides. This mirrors exactly how `client_id` / `client_secret` already resolve on `RefreshTokenOAuthConnection`.

## Why

`developer_token` was a **required** field with no fallback, so every Bing connection had to enter it manually — even though it's an app-level token Digitl provides. Bing also wasn't wired to the sign-in flow at all (no `oauth=` on the decorator), unlike the other advertising connectors.

## How

`packages/interloper-assets/src/interloper_assets/bing_ads/connection.py`:

- Add `oauth=il.OAuthConfig("microsoft", scope="offline_access https://ads.microsoft.com/msads.manage")` so the sign-in button renders and `client_id` / `client_secret` resolve from env.
- List `developer_token` in `OAuthConfig.fields` so the form **hides it in sign-in mode** (the form hides every mapped field) while keeping it visible in the Manual tab for BYO credentials.
- Make it optional (`SecretField("")`) and add `_resolve_developer_token` (an `after` model-validator) filling a blank value from `env_credential("DEVELOPER_TOKEN")`.

Follows the existing `facebook_ads` precedent (optional field + `env_credential` in a model-validator + renamed fields in `OAuthConfig.fields`). No core or frontend changes needed.

## Reviewer notes

- **Deployment**: for the in-house path to work, set `INTERLOPER_MICROSOFT_CLIENT_ID` / `_CLIENT_SECRET` / `_REDIRECT_URI` (so the sign-in button appears) **and** `INTERLOPER_MICROSOFT_DEVELOPER_TOKEN` — same GSM/ESO path as the other providers.
- The `developer_token` env var is provider-scoped (`INTERLOPER_MICROSOFT_...`) for consistency with the OAuth trio; Bing is the only Microsoft connection, so no collision.
- Heads-up: an older **uncommitted** copy of just the `oauth=microsoft` wiring (plus an unrelated `account_id` refactor) was sitting in a local working tree. This PR is the authoritative version; that local copy should be discarded to avoid a double-apply. The `account_id` refactor was intentionally left out of this PR as unrelated.

## Verification

`ruff` ✓, `ty` ✓, `pytest` ✓ (pre-commit). Behavior confirmed manually: blank → env fallback, explicit → override, neither → blank (no crash), and the generated schema marks `developer_token` not-required with `provider=microsoft` and `developer_token` present in `x-oauth.fields`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)