### PR TITLE
feat(chart): add extraEnvFrom hook for api and scheduler

### DIFF
--- a/chart/interloper/templates/api-deployment.yaml
+++ b/chart/interloper/templates/api-deployment.yaml
@@ -45,6 +45,10 @@ spec:
             - name: http
               containerPort: {{ .Values.config.server.port | default 3000 }}
               protocol: TCP
+          {{- with .Values.api.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             {{- include "interloper.commonEnv" . | nindent 12 }}
             {{- with .Values.api.forwardedAllowIps }}

--- a/chart/interloper/templates/scheduler-deployment.yaml
+++ b/chart/interloper/templates/scheduler-deployment.yaml
@@ -46,6 +46,10 @@ spec:
           {{- with .Values.securityContext }}
           securityContext: {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.scheduler.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             {{- include "interloper.commonEnv" . | nindent 12 }}
             {{- with .Values.scheduler.extraEnv }}

--- a/chart/interloper/values.yaml
+++ b/chart/interloper/values.yaml
@@ -40,6 +40,10 @@ scheduler:
   affinity: {}
   podAnnotations: {}
   extraEnv: []
+  # Extra `envFrom` sources (secretRef / configMapRef) injected verbatim. Use
+  # this to bulk-map a Secret whose keys already match the desired env var
+  # names (e.g. connector OAuth provider creds) instead of one entry per key.
+  extraEnvFrom: []
 
 # ── Worker (per-asset Job target; only consumed when config.runner.type=kubernetes (or legacy alias k8s)) ─
 # Not deployed as a workload — this image is referenced by the Kubernetes
@@ -83,6 +87,10 @@ api:
   affinity: {}
   podAnnotations: {}
   extraEnv: []
+  # Extra `envFrom` sources (secretRef / configMapRef) injected verbatim. Use
+  # this to bulk-map a Secret whose keys already match the desired env var
+  # names (e.g. connector OAuth provider creds) instead of one entry per key.
+  extraEnvFrom: []
 
 # ── Frontend (nginx serving the pre-built Nuxt SPA) ────────────────────────
 frontend:


### PR DESCRIPTION
## What

Adds `api.extraEnvFrom` and `scheduler.extraEnvFrom` (lists of `envFrom` sources) to the chart, rendered as a container-level `envFrom` block before `env`.

## Why

The prod deployment currently maps connector OAuth provider credentials with a `secretKeyRef` entry **per key** (~2 lines × 2 fields × N providers in `api.extraEnv`). Since the `interloper-app` Secret already has keys named exactly `INTERLOPER_<PROVIDER>_CLIENT_ID` / `_CLIENT_SECRET`, a single `envFrom.secretRef` injects them all. This also makes adding a new provider credential (e.g. `INTERLOPER_MICROSOFT_DEVELOPER_TOKEN`) a **Secret-only change** — no manifest edit.

## How

- `api.extraEnvFrom` / `scheduler.extraEnvFrom` default to `[]` in `values.yaml` (documented).
- Templates emit `envFrom:` **before** `env:`, so Kubernetes precedence keeps the chart's explicit `commonEnv` values (`INTERLOPER_ENCRYPTION_KEY`, `INTERLOPER_POSTGRES_PASSWORD`, `INTERLOPER_AUTH_GOOGLE_CLIENT_SECRET`) winning over any same-named key pulled from the secret. No behavior change when `extraEnvFrom` is unset.

## Verification

- `helm lint chart/interloper` passes.
- `helm template` with `extraEnvFrom` set renders `envFrom.secretRef` at container level on both the api and scheduler deployments, ahead of `env`.

## Follow-up

Consumed by the `interloper-kubernetes` HelmRelease, which will bump to the chart version this releases and collapse its per-key `extraEnv` block to one `extraEnvFrom: [secretRef: interloper-app]` plus the public `REDIRECT_URI` literals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)