### PR TITLE
fix(chart): make INTERLOPER_POSTGRES_PASSWORD secret ref optional

### DIFF
--- a/chart/interloper/templates/_helpers.tpl
+++ b/chart/interloper/templates/_helpers.tpl
@@ -174,6 +174,7 @@ Contains Postgres connection info + the encryption key secret.
     secretKeyRef:
       name: {{ include "interloper.secretName" . }}
       key: INTERLOPER_POSTGRES_PASSWORD
+      optional: true
 - name: INTERLOPER_ENCRYPTION_KEY
   valueFrom:
     secretKeyRef:


### PR DESCRIPTION
## What

Adds `optional: true` to the `INTERLOPER_POSTGRES_PASSWORD` `secretKeyRef` in `commonEnv` ([_helpers.tpl](chart/interloper/templates/_helpers.tpl)), matching `INTERLOPER_ENCRYPTION_KEY` and `INTERLOPER_AUTH_GOOGLE_CLIENT_SECRET` right beside it.

## Why

The password ref was the only **non-optional** one in `commonEnv`. In a passwordless setup (prod uses Cloud SQL **IAM auth**, so the password value is unused), removing the empty key from the backing secret makes the required ref unresolvable and the kubelet fails container creation:

```
CreateContainerConfigError: couldn't find key INTERLOPER_POSTGRES_PASSWORD in Secret interloper/interloper-app
```

This forced an empty placeholder key to exist purely to satisfy the reference. Marking it optional lets the key be genuinely absent — the env var is simply unset, which is correct for IAM auth.

## Verification

`helm lint` passes; `helm template` renders the password `secretKeyRef` with `optional: true`. No behaviour change when the key is present.

## Note

Patch release (`fix:`), so this bumps `0.25.0 → 0.25.1`. The prod `interloper-kubernetes` HelmRelease can bump to `0.25.1` to drop the empty `INTERLOPER_POSTGRES_PASSWORD` placeholder from the GSM bundle for good. Until then, keeping the empty key in place also works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)