### PR TITLE
chore: prune over-eager comments per the comment-sparingly convention

### DIFF
--- a/chart/interloper/templates/_helpers.tpl
+++ b/chart/interloper/templates/_helpers.tpl
@@ -158,7 +158,6 @@ Postgres host: either the bundled subchart service or external config.
 
 {{/*
 Environment variables shared by all interloper pods (scheduler, api, frontend).
-Contains Postgres connection info + the encryption key secret.
 */}}
 {{- define "interloper.commonEnv" -}}
 - name: INTERLOPER_POSTGRES_HOST

--- a/chart/interloper/templates/db-init-job.yaml
+++ b/chart/interloper/templates/db-init-job.yaml
@@ -42,8 +42,8 @@ spec:
           {{- with .Values.securityContext }}
           securityContext: {{- toYaml . | nindent 12 }}
           {{- end }}
-          # No config mount: pre-install hooks run before the ConfigMap is
-          # created. Postgres connection comes from env vars (commonEnv).
+          # No config mount: db init only needs the Postgres connection, which
+          # comes from env vars (commonEnv).
           env:
             {{- include "interloper.commonEnv" . | nindent 12 }}
           resources: {{- toYaml .Values.dbInit.resources | nindent 12 }}

--- a/chart/interloper/templates/scheduler-deployment.yaml
+++ b/chart/interloper/templates/scheduler-deployment.yaml
@@ -34,8 +34,7 @@ spec:
           image: {{ include "interloper.image" (dict "root" . "component" "scheduler" "image" .Values.scheduler.image "flavor" (include "interloper.schedulerFlavor" .)) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["interloper"]
-          # Singleton: cron reconciler + queue worker + reaper run together.
-          # replicaCount must stay at 1 (cron + reaper are singletons).
+          # replicaCount must stay at 1 — cron + reaper are singletons.
           args:
             - app
             - --no-api

--- a/packages/interloper-agent/src/interloper_agent/tools/lineage.py
+++ b/packages/interloper-agent/src/interloper_agent/tools/lineage.py
@@ -144,7 +144,6 @@ def impact_analysis(asset_id: str, tool_context: ToolContext) -> dict[str, Any]:
                 if neighbor not in visited:
                     queue.append((neighbor, depth + 1))
 
-        # Group by source
         by_source: dict[str, list[dict[str, Any]]] = defaultdict(list)
         for item in affected:
             by_source[item.get("source_key", "unknown")].append(item)
@@ -228,7 +227,6 @@ def _build_adjacency(
         if a.source and a.source_id:
             source_keys[a.source_id] = a.source.key
 
-    # Add source_key to asset_info
     for uid, info in asset_info.items():
         sid_str = info["source_id"]
         if sid_str:

--- a/packages/interloper-app/app/app/composables/agentChat.ts
+++ b/packages/interloper-app/app/app/composables/agentChat.ts
@@ -46,14 +46,12 @@ export function useAgentChat(sessionId: Ref<string>) {
 
         error.value = null
 
-        // Add user message
         messages.value.push({
             id: crypto.randomUUID(),
             role: 'user',
             text,
         })
 
-        // Add placeholder for assistant response
         const assistantId = crypto.randomUUID()
         messages.value.push({
             id: assistantId,
@@ -123,7 +121,6 @@ export function useAgentChat(sessionId: Ref<string>) {
             }
         }
         finally {
-            // Ensure loading state is cleared
             const msg = messages.value.find(m => m.id === assistantId)
             if (msg) msg.loading = false
             streaming.value = false

--- a/packages/interloper-core/src/interloper/dag/base.py
+++ b/packages/interloper-core/src/interloper/dag/base.py
@@ -56,10 +56,8 @@ class DAG:
             else:
                 raise DAGError(f"Expected Asset or Source, got {type(item)}")
 
-        # Build asset map keyed by instance id
         self.asset_map = {asset.id: asset for asset in self.assets}
 
-        # Check for duplicate ids
         if len(self.asset_map) != len(self.assets):
             seen: set[str] = set()
             duplicates: list[str] = []
@@ -69,11 +67,9 @@ class DAG:
                 seen.add(asset.id)
             raise DAGError(f"Duplicate asset id found: {duplicates}")
 
-        # Initialize successors with empty lists
         for asset in self.assets:
             self.successors[asset.id] = []
 
-        # Build dependency graph from resolved deps
         for asset in self.assets:
             if not asset.materializable:
                 continue
@@ -306,7 +302,6 @@ class DAG:
                 continue
             source_assets.setdefault(source.id, []).append(asset)
 
-        # For each source, build a spec using the DAG's asset states
         for assets in source_assets.values():
             source = assets[0]._source
             assert source is not None

--- a/packages/interloper-core/src/interloper/utils/data.py
+++ b/packages/interloper-core/src/interloper/utils/data.py
@@ -30,11 +30,9 @@ def coerce_to_records(data: Any) -> list[dict[str, Any]]:
     if isinstance(data, (Generator, Iterator, types.GeneratorType)):
         return coerce_to_records(list(data))
 
-    # Single Pydantic model
     if isinstance(data, BaseModel):
         return [data.model_dump()]
 
-    # list
     if isinstance(data, list):
         if not data:
             return []
@@ -47,7 +45,6 @@ def coerce_to_records(data: Any) -> list[dict[str, Any]]:
             f"Normalizer received list[{type(first).__name__}], expected list[dict] or list[BaseModel]."
         )
 
-    # Single dict
     if isinstance(data, dict):
         return [data]
 

--- a/packages/interloper-db/src/interloper_db/store/auth.py
+++ b/packages/interloper-db/src/interloper_db/store/auth.py
@@ -470,7 +470,6 @@ class AuthMixin:
                 session.commit()
                 return None
 
-            # Check if already a member
             existing_membership = session.exec(
                 select(UserOrganisation).where(
                     UserOrganisation.user_id == user_id,

--- a/packages/interloper-docker/src/interloper_docker/launcher.py
+++ b/packages/interloper-docker/src/interloper_docker/launcher.py
@@ -168,16 +168,13 @@ class DockerLauncher(Launcher):
         state = container.attrs.get("State", {}) if container.attrs else {}
         docker_status = (state.get("Status") or container.status or "").lower()
 
-        # "running", "created", "restarting", "paused" — still alive
         if docker_status in ("running", "created", "restarting", "paused"):
             return RunState(status=RunStatus.RUNNING)
 
-        # Terminal states: "exited", "dead", "removing"
         exit_code = state.get("ExitCode")
         if exit_code == 0:
             return RunState(status=RunStatus.SUCCEEDED)
 
-        # Anything else is a failure
         parts = [f"Container {container.short_id} status={docker_status}"]
         if exit_code is not None:
             parts.append(f"exit_code={exit_code}")

--- a/packages/interloper-google-cloud/tests/test_bigquery.py
+++ b/packages/interloper-google-cloud/tests/test_bigquery.py
@@ -38,7 +38,6 @@ def _make_destination(**overrides: Any) -> tuple[BigQueryDestination, MagicMock]
     mock_client.project = project
     mock_client.location = "EU"
 
-    # Build mock connection resource
     conn = MagicMock(spec=GoogleCloudConnection)
     conn.service_account_key = _SA_KEY
 

--- a/packages/interloper-pandas/src/interloper_pandas/normalizer.py
+++ b/packages/interloper-pandas/src/interloper_pandas/normalizer.py
@@ -45,7 +45,6 @@ class DataFrameNormalizer(Normalizer):
         if isinstance(data, pd.DataFrame):
             df = data
         else:
-            # Coerce to list[dict] using base class, then convert to DataFrame
             rows = self._coerce(data)
             df = pd.DataFrame(rows)
 

--- a/packages/interloper-scheduler/src/interloper_scheduler/cron.py
+++ b/packages/interloper-scheduler/src/interloper_scheduler/cron.py
@@ -131,12 +131,10 @@ class CronController:
                     session.flush()
                     continue
 
-                # Update next_run_at
                 job.next_run_at = next_run_at
                 session.add(job)
                 session.flush()
 
-                # Create runs
                 if job.partitioned and job.backfill_days:
                     end_date = now.date() - dt.timedelta(days=1)
                     start_date = end_date - dt.timedelta(days=job.backfill_days - 1)


### PR DESCRIPTION
## What

A full-project pass applying the **comment-sparingly** convention added to `AGENTS.md` (PR #97): a comment earns its place only when it explains a non-obvious *why* for the exact code it sits on — not restating the code, not describing other subsystems, not narrating external behavior that drifts.

Scope covered: Python (`packages/*/src` and `tests`), the Helm chart (`chart/interloper`), and the Nuxt frontend (`packages/interloper-app/app/app`).

**21 comments removed or tightened across 12 files.** The bias throughout was conservatism — borderline comments were left. Docstrings, `# noqa`/`# type: ignore`/eslint pragmas, TODO/FIXME markers, section-divider banners, and every genuine why/gotcha/invariant comment were preserved.

## Categories

**1. Restating the code (removed)** — the bulk of the changes. Comments that narrate the line directly below them:
- `dag/base.py` — `# Build asset map keyed by instance id`, `# Check for duplicate ids`, `# Initialize successors with empty lists`, `# Build dependency graph from resolved deps`, and one loop label (5).
- `utils/data.py` — `# Single Pydantic model`, `# list`, `# Single dict` above their matching `isinstance` branches (3).
- `docker/launcher.py` — `# Anything else is a failure` and two lines re-enumerating docker's own status vocabulary (3).
- `cron.py` — `# Update next_run_at`, `# Create runs` (2).
- `store/auth.py` — `# Check if already a member` (1); `pandas/normalizer.py` — a line narrating the coerce→DataFrame calls (1); `agent/tools/lineage.py` — `# Group by source`, `# Add source_key to asset_info` (2).
- Frontend `composables/agentChat.ts` — `// Add user message`, `// Add placeholder for assistant response`, `// Ensure loading state is cleared` (3).
- Test `test_bigquery.py` — `# Build mock connection resource` (1).

**2. Out-of-scope architecture (trimmed)**
- `chart/_helpers.tpl` — dropped a line in the `commonEnv` helper that enumerated what the env block "contains" (already stale — it omitted the OAuth client secret the block also emits).

**3. Stale / drift-prone (tightened)**
- `chart/db-init-job.yaml` — the "no config mount" comment justified itself with a former hook-based design that contradicted the file's own header; retightened to the accurate local reason.
- `chart/scheduler-deployment.yaml` — collapsed two lines into the load-bearing one (`replicaCount must stay at 1 — cron + reaper are singletons`), dropping the half that narrated the `--cron --worker --reaper` args.

## Deliberately left (borderline — kept per the conservative bias)

- **Tests**: near-total keep. Test comments that name the scenario/edge-case under test or explain why a fixture/input is shaped a certain way are the primary way a reader understands what a test pins — only one pure-restatement comment was removed across ~50 test files.
- **`interloper-assets` / `interloper-api` / OAuth flow**: field-grain vendor-quirk comments, and the OAuth-callback step markers (`# Exchange code for tokens`, `# Fetch user info`, `# Upsert profile`) — the latter signpost stages of a protocol flow and one carries a genuine *why* in a parenthetical, so trimming a subset would read worse than leaving them.
- **`values.yaml` doc comments** that document a knob's meaning (the chart's user-facing API), including ones that reference the ingress/HTTPRoute to justify a default.
- Genuine gotchas kept everywhere, e.g. the BigQuery concurrent-create `Conflict` / date-only-serialization notes, the deterministic-event-id rationale, the psycopg2 masked-password note, the PGDATA `lost+found` subdir note, and the Nuxt full-refetch rationale.

## Checks

`make check` equivalent all green: `ruff check` clean, `ty check` clean, `pytest` **735 passed**, frontend lint 0 errors, `nuxt typecheck` clean. `uv.lock` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)