### PR TITLE
fix(app): require OAuth credential fields in manual connection entry

### DIFF
--- a/packages/interloper-app/app/app/components/SchemaForm.vue
+++ b/packages/interloper-app/app/app/components/SchemaForm.vue
@@ -126,6 +126,21 @@ const oauthFieldKeys = computed<Set<string>>(() => {
     return new Set(Object.values(oauthMeta.value.fields))
 })
 
+/** Manual-entry mode: no OAuth for this schema, or the Manual tab is active. */
+const manualMode = computed(() => !oauthAvailable.value || activeTab.value === 'manual')
+
+/**
+ * Field keys required in the current mode. Always the schema's `required`; in
+ * manual mode also the OAuth credential fields, which are schema-optional only
+ * so sign-in can resolve them from env / the flow. Entering credentials by hand
+ * means providing all of them (client_id / client_secret / token).
+ */
+const requiredKeys = computed<Set<string>>(() => {
+    const req = new Set(props.schema?.required ?? [])
+    if (manualMode.value) for (const key of oauthFieldKeys.value) req.add(key)
+    return req
+})
+
 /** Whether sign-in has completed — the token field is filled. */
 const oauthFilled = computed(() => {
     const field = oauthTokenField.value
@@ -321,7 +336,7 @@ function resolveOptions(prop: JsonSchemaProperty): unknown[] | undefined {
 /** Compute field descriptors from the schema. */
 const fields = computed(() => {
     const properties = props.schema?.properties ?? {}
-    const required = new Set(props.schema?.required ?? [])
+    const required = requiredKeys.value
     const excluded = new Set(props.exclude ?? ['id'])
 
     return Object.entries(properties)
@@ -409,13 +424,14 @@ watch(
     { immediate: true, deep: true },
 )
 
-/** Validate: all required fields must have a non-empty value. */
+/** Validate: all required fields must have a non-empty value. Re-runs on tab
+ * switch too, since manual mode requires the OAuth credential fields. */
 watch(
-    data,
-    (val) => {
+    [data, requiredKeys],
+    () => {
         isValid.value = fields.value
             .filter(f => f.required)
-            .every(f => val[f.key] !== undefined && val[f.key] !== '')
+            .every(f => data.value[f.key] !== undefined && data.value[f.key] !== '')
     },
     { deep: true, immediate: true },
 )


### PR DESCRIPTION
## Review outcome

Reviewed field requirements across all 27 connections. **The connection definitions are correct** — every credential field is required except the OAuth `client_id`/`client_secret` (and facebook `app_id`/`app_secret`, bing `developer_token`), which are intentionally schema-optional so sign-in mode can resolve them from the in-house `INTERLOPER_<PROVIDER>_*` env creds. The token (`refresh_token`/`access_token`) is already required everywhere.

The gap was in the **form**, not the models: `SchemaForm` validated only schema-`required` fields, so the **Manual** tab accepted an empty `client_id`/`client_secret` and silently fell back to in-house creds — when entering credentials by hand you should supply all of them.

## What

Make `SchemaForm` validation mode-aware:

- **Manual mode** (no OAuth for the schema, or the *Manual* tab active): the OAuth credential fields — every value in the `x-oauth` `fields` mapping — become required, on top of the schema's own required fields (shows the required asterisk and blocks submit).
- **Sign-in mode**: unchanged — those fields stay hidden and are resolved from env / the flow; the token is still required so sign-in must complete.
- Validation now re-runs on tab switch, since the required set depends on the active mode.

The connection **models stay optional** — the runtime in-house env fallback depends on that; this is purely a form-validation refinement.

## Why not change the models

Marking `client_id`/`client_secret` required at the model level would make them `required` in the JSON schema, breaking sign-in mode (hidden-but-required fields) and the blank→env resolution. Manual-vs-sign-in is a UI distinction, so it belongs in the form.

## Verification

`pnpm run lint` (no new warnings; `SchemaForm.vue` clean) and `pnpm exec nuxt typecheck` (no TS errors) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)