### PR TITLE
feat(assets): Google Ads OAuth sign-in; per-connection developer tokens

### DIFF
--- a/packages/interloper-assets/src/interloper_assets/bing_ads/connection.py
+++ b/packages/interloper-assets/src/interloper_assets/bing_ads/connection.py
@@ -1,3 +1,4 @@
+import os
 from functools import cached_property
 from typing import Any
 from xml.etree import ElementTree as ET
@@ -48,7 +49,7 @@ def _first_descendant(root: ET.Element, name: str) -> ET.Element | None:
         scope="offline_access https://ads.microsoft.com/msads.manage",
         # ``developer_token`` rides the same in-house path as the credential
         # trio: listing it here hides it in sign-in mode (the form hides every
-        # mapped field), and ``_resolve_developer_token`` fills it from env.
+        # mapped field), and ``resolve_credentials`` fills it from env.
         fields={
             "client_id": "client_id",
             "client_secret": "client_secret",
@@ -71,22 +72,22 @@ class BingAdsConnection(il.RefreshTokenOAuthConnection):
 
     @model_validator(mode="before")
     @classmethod
-    def resolve_developer_token(cls, data: Any) -> Any:
-        """Inject a blank ``developer_token`` from the in-house env credential.
+    def resolve_credentials(cls, data: Any) -> Any:
+        """Inject blank credentials from the in-house env before validation.
 
-        Mirrors how ``client_id`` / ``client_secret`` resolve on
-        :class:`RefreshTokenOAuthConnection`: read
-        ``INTERLOPER_MICROSOFT_DEVELOPER_TOKEN`` before validation when the field
-        is absent, so the required token is satisfied by the in-house app and
-        never stored per connection. An explicit value overrides it.
+        Overrides the base to also resolve ``developer_token``, which — unlike
+        the provider-scoped OAuth trio (``INTERLOPER_MICROSOFT_*``) — is a
+        Bing-specific token read from ``INTERLOPER_BING_ADS_DEVELOPER_TOKEN``.
+        An explicit value overrides the in-house one; when neither the caller
+        nor env supplies one, the required check fails.
 
         Returns:
             The (possibly augmented) input data.
         """
         if isinstance(data, dict):
-            developer_token = cls.env_credential("DEVELOPER_TOKEN")
-            if developer_token and not data.get("developer_token"):
-                data["developer_token"] = developer_token
+            cls.resolve_field(data, "client_id", cls.env_credential("CLIENT_ID"))
+            cls.resolve_field(data, "client_secret", cls.env_credential("CLIENT_SECRET"))
+            cls.resolve_field(data, "developer_token", os.environ.get("INTERLOPER_BING_ADS_DEVELOPER_TOKEN"))
         return data
 
     @cached_property

--- a/packages/interloper-assets/src/interloper_assets/facebook_ads/connection.py
+++ b/packages/interloper-assets/src/interloper_assets/facebook_ads/connection.py
@@ -43,12 +43,8 @@ class FacebookAdsConnection(il.OAuthConnection):
     def resolve_credentials(cls, data: Any) -> Any:
         """Inject blank ``app_id`` / ``app_secret`` from the in-house env creds."""
         if isinstance(data, dict):
-            app_id = cls.env_credential("CLIENT_ID")
-            if app_id and not data.get("app_id"):
-                data["app_id"] = app_id
-            app_secret = cls.env_credential("CLIENT_SECRET")
-            if app_secret and not data.get("app_secret"):
-                data["app_secret"] = app_secret
+            cls.resolve_field(data, "app_id", cls.env_credential("CLIENT_ID"))
+            cls.resolve_field(data, "app_secret", cls.env_credential("CLIENT_SECRET"))
         return data
 
     @cached_property

--- a/packages/interloper-assets/src/interloper_assets/google_ads/connection.py
+++ b/packages/interloper-assets/src/interloper_assets/google_ads/connection.py
@@ -1,8 +1,10 @@
+import os
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
 import httpx
 import interloper as il
+from pydantic import model_validator
 from pydantic_settings import SettingsConfigDict
 
 from interloper_assets.google_ads.constants import API_VERSION
@@ -18,6 +20,19 @@ _BASE_URL = "https://googleads.googleapis.com/v20"
     name="Google Ads",
     icon="logos:google-ads",
     tags=["Advertising"],
+    oauth=il.OAuthConfig(
+        "google",
+        scope="https://www.googleapis.com/auth/adwords",
+        # ``developer_token`` rides the same in-house path as the credential
+        # trio: listing it here hides it in sign-in mode, and
+        # ``resolve_credentials`` fills it from env.
+        fields={
+            "client_id": "client_id",
+            "client_secret": "client_secret",
+            "refresh_token": "refresh_token",
+            "developer_token": "developer_token",
+        },
+    ),
 )
 class GoogleAdsConnection(il.RefreshTokenOAuthConnection):
     """Google Ads API connection using the Google Ads Python client library."""
@@ -25,6 +40,26 @@ class GoogleAdsConnection(il.RefreshTokenOAuthConnection):
     model_config = SettingsConfigDict(env_prefix="google_ads_")
 
     developer_token: str = il.SecretField(description="Google Ads API developer token")
+
+    @model_validator(mode="before")
+    @classmethod
+    def resolve_credentials(cls, data: Any) -> Any:
+        """Inject blank credentials from the in-house env before validation.
+
+        Overrides the base to also resolve ``developer_token``, a Google-Ads-
+        specific token read from ``INTERLOPER_GOOGLE_ADS_DEVELOPER_TOKEN`` (the
+        OAuth trio comes from the provider-scoped ``INTERLOPER_GOOGLE_*``). An
+        explicit value overrides the in-house one; when neither the caller nor
+        env supplies one, the required check fails.
+
+        Returns:
+            The (possibly augmented) input data.
+        """
+        if isinstance(data, dict):
+            cls.resolve_field(data, "client_id", cls.env_credential("CLIENT_ID"))
+            cls.resolve_field(data, "client_secret", cls.env_credential("CLIENT_SECRET"))
+            cls.resolve_field(data, "developer_token", os.environ.get("INTERLOPER_GOOGLE_ADS_DEVELOPER_TOKEN"))
+        return data
 
     @cached_property
     def client(self) -> "GoogleAdsClient":

--- a/packages/interloper-core/src/interloper/connection/base.py
+++ b/packages/interloper-core/src/interloper/connection/base.py
@@ -96,6 +96,17 @@ class OAuthConnection(Connection):
             return None
         return os.environ.get(f"INTERLOPER_{cls.oauth.provider.upper()}_{suffix}")
 
+    @staticmethod
+    def resolve_field(data: dict[str, Any], field: str, value: str | None) -> None:
+        """Fill ``data[field]`` from ``value`` when the field is blank and value is set.
+
+        A ``mode="before"`` ``resolve_credentials`` validator uses this per field.
+        Leaves the field absent when there is no value, so a required field fails
+        with "Field required" rather than being satisfied by an empty value.
+        """
+        if value and not data.get(field):
+            data[field] = value
+
 
 class RefreshTokenOAuthConnection(OAuthConnection):
     """A connection using the standard OAuth2 refresh-token flow.
@@ -138,10 +149,6 @@ class RefreshTokenOAuthConnection(OAuthConnection):
             The (possibly augmented) input data.
         """
         if isinstance(data, dict):
-            client_id = cls.env_credential("CLIENT_ID")
-            if client_id and not data.get("client_id"):
-                data["client_id"] = client_id
-            client_secret = cls.env_credential("CLIENT_SECRET")
-            if client_secret and not data.get("client_secret"):
-                data["client_secret"] = client_secret
+            cls.resolve_field(data, "client_id", cls.env_credential("CLIENT_ID"))
+            cls.resolve_field(data, "client_secret", cls.env_credential("CLIENT_SECRET"))
         return data


### PR DESCRIPTION
Builds on #100 (OAuth credentials required), which merged to main.

## Changes

**google_ads — now supports the "Sign in with Google" button.**
- `oauth=OAuthConfig("google", scope="https://www.googleapis.com/auth/adwords")`, with `developer_token` in the `fields` mapping so it hides in sign-in mode.
- `resolve_credentials` fills `developer_token` from `INTERLOPER_GOOGLE_ADS_DEVELOPER_TOKEN`.
- The frontend already sends `access_type=offline` + `prompt=consent` for the google provider, so sign-in returns a refresh token.

**bing_ads — developer token is now connection-scoped.**
- `developer_token` resolves from `INTERLOPER_BING_ADS_DEVELOPER_TOKEN` (a Bing-specific token) instead of the provider-scoped `INTERLOPER_MICROSOFT_DEVELOPER_TOKEN`. The OAuth client creds stay provider-scoped (`INTERLOPER_MICROSOFT_*`).
- Validator renamed `resolve_developer_token` → `resolve_credentials`; since that overrides the base validator, it now fills the OAuth trio **and** the developer token.

**core — shared helper.**
- `OAuthConnection.resolve_field(data, field, value)`: the guarded per-field setter (writes only when env has a value and the field is blank, so a missing value stays `Field required`, not an empty string). `base` and `facebook_ads` `resolve_credentials` now use it.

Rule of thumb established: OAuth **client** creds are provider-scoped (`INTERLOPER_<PROVIDER>_CLIENT_ID/SECRET`, shared across a provider's connections); connection-specific **developer tokens** are connection-scoped (`INTERLOPER_<CONNECTION>_DEVELOPER_TOKEN`).

## ⚠️ Deployment note

The prod in-house Bing developer token must move from `INTERLOPER_MICROSOFT_DEVELOPER_TOKEN` to **`INTERLOPER_BING_ADS_DEVELOPER_TOKEN`** in the GSM `interloper-app` bundle. Add `INTERLOPER_GOOGLE_ADS_DEVELOPER_TOKEN` too if the in-house Google Ads developer token should be offered.

## Verification

`ruff` + `ty` + full `pytest` (pre-commit) pass. Behavior confirmed: bing/google_ads fill client creds from the provider-scoped vars and developer tokens from the connection-scoped vars; both required (`Field required` when absent); explicit values override; `google_ads` advertises `x-oauth` provider `google`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)