### PR TITLE
fix: follow redirects in OAuth token exchange

### DIFF
--- a/packages/interloper-api/src/interloper_api/routes/oauth.py
+++ b/packages/interloper-api/src/interloper_api/routes/oauth.py
@@ -179,7 +179,7 @@ async def exchange_token(
 
     try:
         logger.info("Exchanging auth code for provider %s", provider)
-        async with httpx.AsyncClient(timeout=30) as client:
+        async with httpx.AsyncClient(timeout=30, follow_redirects=True) as client:
             result = await _exchange(client, spec, cfg, body.code)
         logger.info("Successfully exchanged auth code for provider %s", provider)
         return result

--- a/packages/interloper-api/tests/test_oauth.py
+++ b/packages/interloper-api/tests/test_oauth.py
@@ -186,6 +186,24 @@ async def test_exchange_basic_auth_header(monkeypatch: pytest.MonkeyPatch) -> No
     assert captured[0].headers["Authorization"].startswith("Basic ")
 
 
+async def test_exchange_follows_trailing_slash_redirect(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Providers such as TikTok 3xx-redirect to the trailing-slash URL; httpx
+    # must follow it rather than surfacing the redirect page as an error.
+    spec = provider("amazon")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if not request.url.path.endswith("/token/"):
+            return httpx.Response(307, headers={"Location": f"{request.url}/"})
+        return httpx.Response(200, json={"refresh_token": "rt"})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), follow_redirects=True
+    ) as client:
+        result = await oauth_module._exchange(client, spec, _cfg(monkeypatch, "amazon"), "the-code")
+
+    assert result == {"refresh_token": "rt"}
+
+
 async def test_exchange_renamed_params(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: list[httpx.Request] = []
     spec = provider("tiktok")

--- a/packages/interloper-app/app/app/composables/oauth.ts
+++ b/packages/interloper-app/app/app/composables/oauth.ts
@@ -9,6 +9,20 @@
  */
 
 
+/**
+ * Extract a human-readable detail from a failed token-exchange request.
+ *
+ * The backend returns `{ detail: "..." }` on error (surfaced by ofetch as
+ * `error.data`); fall back to the raw message when the shape is unexpected.
+ */
+export function oauthErrorDetail(error: unknown): string {
+    const e = error as { data?: { detail?: unknown }, message?: string }
+    const detail = e?.data?.detail
+    if (typeof detail === 'string' && detail) return detail
+    if (detail != null) return JSON.stringify(detail, null, 2)
+    return e?.message || 'Unknown error'
+}
+
 /** Wait for a single DOM event, returned as a promise. */
 function promiseFromEvent<T extends Event>(target: EventTarget, event: string): Promise<T> {
     return new Promise((resolve) => {
@@ -53,7 +67,7 @@ export function useOAuthPopup() {
         )
 
         if (event.data.type !== OAuthPopupStatus.Success) {
-            throw new Error('OAuth sign-in failed')
+            throw new Error(event.data.error || 'OAuth sign-in failed')
         }
 
         popup.close()
@@ -65,19 +79,32 @@ export function useOAuthPopup() {
      * Posts the result back to the opener window.
      */
     async function exchangeCode(provider: string, code: string) {
-        const tokens = await apiFetch<Record<string, unknown>>(`/oauth/${provider}`, {
-            method: 'POST',
-            body: { code },
-        })
+        try {
+            const tokens = await apiFetch<Record<string, unknown>>(`/oauth/${provider}`, {
+                method: 'POST',
+                body: { code },
+            })
 
-        if (window.opener) {
-            window.opener.postMessage({
-                type: OAuthPopupStatus.Success,
-                tokens,
-            }, '*')
+            if (window.opener) {
+                window.opener.postMessage({
+                    type: OAuthPopupStatus.Success,
+                    tokens,
+                }, '*')
+            }
+
+            return tokens
         }
-
-        return tokens
+        catch (error) {
+            // Notify the opener of the failure so its `signIn` promise rejects
+            // instead of hanging, forwarding the detail for display.
+            if (window.opener) {
+                window.opener.postMessage({
+                    type: OAuthPopupStatus.Failure,
+                    error: oauthErrorDetail(error),
+                }, '*')
+            }
+            throw error
+        }
     }
 
     return { signIn, exchangeCode }

--- a/packages/interloper-app/app/app/pages/auth/[provider].vue
+++ b/packages/interloper-app/app/app/pages/auth/[provider].vue
@@ -20,6 +20,7 @@ const code = route.query.code as string | undefined
 const status = ref<OAuthPopupStatus>(
     code ? OAuthPopupStatus.Loading : OAuthPopupStatus.MissingCode,
 )
+const errorDetail = ref('')
 
 onMounted(async () => {
     if (code) {
@@ -27,7 +28,8 @@ onMounted(async () => {
             await exchangeCode(provider, code)
             status.value = OAuthPopupStatus.Success
         }
-        catch {
+        catch (error) {
+            errorDetail.value = oauthErrorDetail(error)
             status.value = OAuthPopupStatus.Failure
         }
     }
@@ -59,6 +61,21 @@ onMounted(async () => {
                 variant="subtle"
                 icon="i-lucide-circle-x"
                 title="Authentication Failed"
-                description="Something went wrong during authentication. You can close this window." />
+                class="max-w-md">
+            <template #description>
+                <p>Something went wrong during authentication. You can close this window.</p>
+                <UCollapsible v-if="errorDetail"
+                              class="mt-2">
+                    <button class="flex items-center gap-1 group cursor-pointer text-xs font-medium">
+                        <UIcon name="i-lucide-chevron-right"
+                               class="size-3.5 shrink-0 group-data-[state=open]:rotate-90 transition-transform duration-200" />
+                        Details
+                    </button>
+                    <template #content>
+                        <pre class="mt-1.5 max-h-64 overflow-auto whitespace-pre-wrap break-words rounded bg-error/10 p-2 text-xs">{{ errorDetail }}</pre>
+                    </template>
+                </UCollapsible>
+            </template>
+        </UAlert>
     </div>
 </template>


### PR DESCRIPTION
## Problem

The connector OAuth flow failed at the token-exchange step for **TikTok**. The popup showed *"Authentication Failed — Something went wrong during authentication"* and the `POST /api/oauth/tiktok` response `detail` was TikTok's raw HTML `Redirecting...` page:

```
Failed to exchange auth code: <!DOCTYPE HTML ...>
<title>Redirecting...</title> ... target URL:
https://business-api.tiktok.com/open_api/v1.3/oauth2/access_token/ ...
```

## Root cause

TikTok's token endpoint 3xx-redirects. `httpx.AsyncClient` defaults to `follow_redirects=False` (unlike `requests`), so `resp.raise_for_status()` treated the redirect as an error and raised `HTTPStatusError` with the HTML redirect page as the body — which flowed straight into the popup's error `detail`.

## Changes

**Fix the flow**
- Set `follow_redirects=True` on the exchange client so provider redirects are followed instead of surfacing as an error.

**Improve the popup feedback**
- The failure alert now renders a collapsible **Details** section (`UCollapsible`, matching the `AssetPanel` pattern) with the raw backend error in a scrollable `<pre>`.
- New shared `oauthErrorDetail()` helper extracts ofetch's `error.data.detail`.
- Fixed a latent bug: on failure, `exchangeCode` now posts an `OAuthPopupStatus.Failure` message back to the opener. Previously it posted nothing, so the opener's `signIn()` message loop **hung forever** on any failure — it now rejects with the reason.

## Testing

- Added `test_exchange_follows_trailing_slash_redirect` (307 → slash URL → 200).
- `ruff` ✓, `ty` ✓, `pytest` ✓ (full pre-commit suite), frontend `lint` ✓, `nuxt typecheck` ✓.
- Not yet verified live end-to-end: this worktree can't complete the OAuth flow itself (redirect URI is pinned to `:3000`).

## Note for reviewers

The redirect is followed generically rather than hard-coding the slash URL. One caveat: httpx only preserves a POST body across `307`/`308` redirects — for `301`/`302`/`303` it downgrades to GET and drops the body. If TikTok's redirect turns out to be a `302`, following it won't be enough on its own; live verification will confirm. That's the tradeoff vs. pinning the exact `token_url`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)