### PR TITLE
refactor(assets): move awin advertiser id to a source FetchField

### DIFF
--- a/packages/interloper-assets/src/interloper_assets/awin/connection.py
+++ b/packages/interloper-assets/src/interloper_assets/awin/connection.py
@@ -17,8 +17,24 @@ class AwinConnection(il.Connection):
     model_config = SettingsConfigDict(env_prefix="awin_")
 
     access_token: str = il.SecretField(description="Awin API access token")
-    publisher_id: str = il.InputField(description="Awin publisher or advertiser ID")
 
     @cached_property
     def client(self) -> il.AsyncRESTClient:
         return il.AsyncRESTClient(BASE_URL, auth=il.HTTPBearerAuth(self.access_token))
+
+    @il.fetch_field_provider
+    async def advertisers(self) -> list[dict[str, str]]:
+        """List the advertiser accounts this token can access, sorted by name.
+
+        Backs the source's ``advertiser_id`` ``FetchField``. Reuses ``self.client``
+        (bearer auth is all Awin's ``/accounts`` endpoint needs) so it runs in the
+        API process over the lightweight ``AsyncRESTClient``.
+        """
+        response = await self.client.get("/accounts", params={"type": "advertiser"})
+        response.raise_for_status()
+        accounts = response.json().get("accounts", [])
+        results = [
+            {"advertiser_id": str(a["accountId"]), "name": a.get("accountName") or str(a["accountId"])}
+            for a in accounts
+        ]
+        return sorted(results, key=lambda a: a["name"].lower())

--- a/packages/interloper-assets/src/interloper_assets/awin/source.py
+++ b/packages/interloper-assets/src/interloper_assets/awin/source.py
@@ -107,11 +107,17 @@ async def get_advertiser_reports_by_publisher(
     resources={"connection": AwinConnection},
     tags=["Affiliate"],
     icon="icon:awin",
-    # Awin returns camelCase fields (publisherId, commissionAmount, …); snake-case them.
     normalizer=DataFrameNormalizer(),
 )
 class Awin(il.Source):
     """Awin affiliate network integration for transaction and publisher reporting."""
+
+    advertiser_id: str = il.FetchField(
+        provider="connection.advertisers",
+        label_key="name",
+        value_key="advertiser_id",
+        description="Awin advertiser account",
+    )
 
     @il.asset(
         schema=Transactions,
@@ -123,7 +129,7 @@ class Awin(il.Source):
         """Advertiser transactions including commissions, sales amounts, and click attribution."""
         data = await get_advertiser_transactions(
             client=connection.client,
-            advertiser_id=connection.publisher_id,
+            advertiser_id=self.advertiser_id,
             start_date=context.partition_date,
             end_date=context.partition_date,
         )
@@ -138,7 +144,7 @@ class Awin(il.Source):
         """Advertiser performance reports aggregated by publisher."""
         data = await get_advertiser_reports_by_publisher(
             client=connection.client,
-            advertiser_id=connection.publisher_id,
+            advertiser_id=self.advertiser_id,
             start_date=context.partition_date,
             end_date=context.partition_date,
         )

--- a/packages/interloper-assets/tests/test_awin.py
+++ b/packages/interloper-assets/tests/test_awin.py
@@ -25,7 +25,7 @@ from interloper_assets.awin.source import Awin, AwinTransactionsNormalizer, _res
 
 
 def _source() -> Any:
-    return Awin(id="src-1")
+    return Awin(id="src-1", advertiser_id="12345")  # ty: ignore[unknown-argument]
 
 
 class TestSourceNormalizer:


### PR DESCRIPTION
## What

Awin carried its account id as a `publisher_id` **InputField on the connection**. Every other ads/affiliate connector (TikTok, Facebook, LinkedIn, Google Ads, Snapchat, Criteo, …) instead exposes the account as a source **`FetchField`** backed by a connection **`@fetch_field_provider`**, giving the UI a live account picker instead of a free-text id. This brings Awin in line.

- **connection.py**: drop `publisher_id`; add an `advertisers` `@fetch_field_provider` that lists advertiser accounts via `GET /accounts?type=advertiser`. Bearer auth is all that endpoint needs, so it reuses `self.client` and runs in the API process (no SDK extras).
- **source.py**: add an `advertiser_id` `FetchField(provider="connection.advertisers", …)`; both assets now read `self.advertiser_id` instead of `connection.publisher_id`.
- Renamed `publisher_id` → `advertiser_id` to match the API path (`/advertisers/{id}/…`) and the TikTok precedent — both assets already targeted the `/advertisers/` endpoints.
- **test_awin.py**: fixture now supplies the required `advertiser_id`.

## Why

Consistency with the ~13 other connectors that already use this pattern, and a better UX (dropdown of real accounts vs. free-text id).

## Reviewer notes

- ⚠️ **Not yet live-verified**: the `/accounts` request and its response shape (`accounts[].accountId` / `accountName`) follow Awin's documented API but haven't been confirmed against a real token. Worth a live check before relying on it — this connector has had a fictional-schema slip before.
- **Behavioral change**: the account id moves from a connection env var (`AWIN_PUBLISHER_ID`, via `env_prefix="awin_"`) to a per-source config field chosen in the UI. Any deployment/manifest that set `AWIN_PUBLISHER_ID` needs updating to set the source's `advertiser_id`.

## Checks

`ruff` ✅ · `ty` ✅ · `pytest` ✅ (pre-commit ran the full suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)