### PR TITLE
feat!: sync-callable run/materialize entrypoints backed by an il.run bridge

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -34,12 +34,14 @@ instance = my_asset()  # this is an Asset instance
 ```
 
 
-### Why are `run()` and `materialize()` coroutines?
+### Do I need `asyncio` to run assets?
 
-The execution engine is async-native. Both `run()` and `materialize()` return coroutines — call
-them with `await` inside an event loop, or `asyncio.run(...)` at the top level. Synchronous asset
-functions are offloaded to threads automatically, so you never have to make your asset `async`
-just to satisfy the engine.
+No. `run()`, `materialize()`, and `dag.materialize()` are plain synchronous calls — they work
+as-is in scripts, the REPL, and notebook cells. Under the hood the execution engine is
+async-native: the sync entrypoints drive it on a persistent background event loop (see
+`il.run`). Async code uses the `*_async` counterparts (`run_async()`, `materialize_async()`)
+and `await`s them. Synchronous asset functions are offloaded to threads automatically, so you
+never have to make your asset `async` just to satisfy the engine.
 
 
 ### What is the difference between `run()` and `materialize()`?
@@ -61,8 +63,8 @@ resolved automatically. For cross-source dependencies or name mismatches, use `r
 Yes. You can run or materialize individual assets directly:
 
 ```py
-result = await my_asset().run()
-await my_asset(destination=il.FileDestination("./data")).materialize()
+result = my_asset().run()
+my_asset(destination=il.FileDestination("./data")).materialize()
 ```
 
 A DAG is only needed when you have multiple assets with dependencies.

--- a/docs/features/assets-sources.md
+++ b/docs/features/assets-sources.md
@@ -16,7 +16,7 @@ The decorator returns an asset **definition** (a class) -- an immutable blueprin
 
 ```py
 asset_instance = my_asset()
-result = await asset_instance.run()
+result = asset_instance.run()
 ```
 
 Asset functions can be synchronous or asynchronous. Synchronous functions are offloaded to a
@@ -51,7 +51,7 @@ def my_asset():
 schema if configured) **without** writing to any destination:
 
 ```py
-result = await my_asset().run()
+result = my_asset().run()
 ```
 
 ### Materializing an asset
@@ -60,11 +60,12 @@ result = await my_asset().run()
 
 ```py
 asset_instance = my_asset(destination=il.FileDestination("./data"))
-await asset_instance.materialize()
+asset_instance.materialize()
 ```
 
-Both `run()` and `materialize()` are coroutines. Outside an event loop, drive them with
-`asyncio.run(...)`.
+Both `run()` and `materialize()` are plain synchronous calls — they work in scripts, the
+REPL, and notebooks. Async code awaits their coroutine counterparts, `run_async()` and
+`materialize_async()`.
 
 ## Sources
 
@@ -133,8 +134,8 @@ my_source.asset_a
 
 # On the instance (returns the runtime Asset)
 source = my_source(destination=il.FileDestination("./data"))
-await source.asset_a.run()
-await source.asset_b.materialize()
+source.asset_a.run()
+source.asset_b.materialize()
 ```
 
 ### Reconfiguring a source
@@ -156,7 +157,7 @@ A `DAG` (Directed Acyclic Graph) orchestrates the execution of multiple assets, 
 ```py
 source = my_source(destination=il.FileDestination("./data"))
 dag = il.DAG(source)
-await dag.materialize()
+dag.materialize()
 ```
 
 A DAG can be built from any combination of assets and sources (instances or definitions):

--- a/docs/features/backfilling.md
+++ b/docs/features/backfilling.md
@@ -10,7 +10,6 @@ Pass a window to any runner's `run()` (or to `dag.materialize()`). The runner wa
 **from most recent to oldest**, running the DAG once per partition:
 
 ```py
-import asyncio
 import datetime as dt
 import interloper as il
 
@@ -31,7 +30,7 @@ window = il.TimePartitionWindow(
     end=dt.date(2025, 1, 7),
 )
 
-result = asyncio.run(il.AsyncRunner(max_workers=4).run(dag, window))
+result = il.run(il.AsyncRunner(max_workers=4).run(dag, window))
 print(result.status)
 ```
 
@@ -56,7 +55,7 @@ By default the in-process runners stop the current run on the first asset failur
 
 ```py
 runner = il.AsyncRunner(fail_fast=False)
-result = asyncio.run(runner.run(dag, window))
+result = il.run(runner.run(dag, window))
 ```
 
 ## Progress monitoring
@@ -69,7 +68,7 @@ def on_event(event: il.Event):
     if event.type is il.EventType.RUN_COMPLETED:
         print(f"Completed: {event.metadata.get('partition_or_window')}")
 
-result = asyncio.run(il.AsyncRunner(on_event=on_event).run(dag, window))
+result = il.run(il.AsyncRunner(on_event=on_event).run(dag, window))
 ```
 
 See [Events](events.md) for the full event model.
@@ -83,14 +82,14 @@ each asset (with its ancestors) runs in an isolated container or Job:
 from interloper_docker.runner import DockerRunner
 
 runner = DockerRunner(image="interloper:latest-worker", max_containers=4)
-asyncio.run(runner.run(dag, window))
+il.run(runner.run(dag, window))
 ```
 
 ```py
 from interloper_k8s.runner import KubernetesRunner
 
 runner = KubernetesRunner(image="my-repo/interloper:latest", namespace="data", max_jobs=4)
-asyncio.run(runner.run(dag, window))
+il.run(runner.run(dag, window))
 ```
 
 See [Runners](runners.md) for all execution strategies and their options.

--- a/docs/features/cli.md
+++ b/docs/features/cli.md
@@ -99,7 +99,7 @@ In Python:
 import interloper as il
 
 plan = il.RunManifest.from_yaml_file("manifest.yaml").compile()
-await plan.dag.materialize(partition_or_window=plan.partition)
+plan.dag.materialize(partition_or_window=plan.partition)
 ```
 
 ## interloper.yaml

--- a/docs/features/destinations.md
+++ b/docs/features/destinations.md
@@ -62,7 +62,7 @@ In-memory storage backed by a class-level dict. Useful for tests and quick exper
 
 ```py
 asset_instance = my_asset(destination=il.MemoryDestination())
-await asset_instance.materialize()
+asset_instance.materialize()
 ```
 
 All instances share the same storage. Clear it between tests:
@@ -77,7 +77,7 @@ Pickle-based storage on the local filesystem.
 
 ```py
 asset_instance = my_asset(destination=il.FileDestination(base_path="./data"))
-await asset_instance.materialize()
+asset_instance.materialize()
 # Writes to ./data/{dataset}/{asset_key}/data.pkl
 ```
 

--- a/docs/features/events.md
+++ b/docs/features/events.md
@@ -15,7 +15,7 @@ def on_event(event: il.Event):
 
 il.EventBus.subscribe(on_event)
 
-await dag.materialize()
+dag.materialize()
 
 il.EventBus.unsubscribe(on_event)
 ```

--- a/docs/features/partitioning.md
+++ b/docs/features/partitioning.md
@@ -26,7 +26,7 @@ Run for a specific date:
 ```py
 source = my_source(destination=il.FileDestination("./data"))
 dag = il.DAG(source)
-await dag.materialize(partition_or_window=il.TimePartition(dt.date(2025, 1, 15)))
+dag.materialize(partition_or_window=il.TimePartition(dt.date(2025, 1, 15)))
 ```
 
 Data is stored in partition-aware paths:
@@ -50,7 +50,7 @@ def weekly_summary(context: il.ExecutionContext):
 Run with a window:
 
 ```py
-await dag.materialize(
+dag.materialize(
     partition_or_window=il.TimePartitionWindow(
         start=dt.date(2025, 1, 1),
         end=dt.date(2025, 1, 7),

--- a/docs/features/upstream-assets.md
+++ b/docs/features/upstream-assets.md
@@ -29,7 +29,7 @@ back and passed as the `users` argument to `user_count`.
 ```py
 source = my_source(destination=il.FileDestination("./data"))
 dag = il.DAG(source)
-await dag.materialize()
+dag.materialize()
 ```
 
 ## Explicit dependency mapping
@@ -75,7 +75,7 @@ def source_b():
     return [report]
 
 dag = il.DAG(source_a(...), source_b(...))
-await dag.materialize()
+dag.materialize()
 ```
 
 ## Runtime dependency overrides

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -41,13 +41,12 @@ def greetings():
 
 ### Run it
 
-`run()` executes the asset function and returns the result. The execution engine is
-**async-native**, so `run()` is a coroutine — `await` it, or drive it with `asyncio.run()`:
+`run()` executes the asset function and returns the result — a plain synchronous call that
+works in scripts, the REPL, and notebooks (the engine is async-native under the hood; async
+code awaits `run_async()` instead):
 
 ```py
-import asyncio
-
-result = asyncio.run(greetings().run())
+result = greetings().run()
 print(result)
 # [{'name': 'Alice', 'message': 'Hello'}, {'name': 'Bob', 'message': 'Hi'}]
 ```
@@ -58,7 +57,7 @@ Add a destination and materialize -- this runs the asset **and** writes the resu
 
 ```py
 greetings_asset = greetings(destination=il.FileDestination("./data"))
-asyncio.run(greetings_asset.materialize())
+greetings_asset.materialize()
 # Data is written to ./data/greetings/data.pkl
 ```
 
@@ -86,7 +85,7 @@ def my_source():
 ```py
 source = my_source(destination=il.FileDestination("./data"))
 dag = il.DAG(source)
-asyncio.run(dag.materialize())
+dag.materialize()
 ```
 
 ## Next steps

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -27,14 +27,12 @@ def forecast():
     return data
 ```
 
-We can execute our asset by instantiating it and calling `run()`. The execution engine is
-**async-native**, so `run()` is a coroutine — `await` it inside an event loop, or drive it
-with `asyncio.run()`:
+We can execute our asset by instantiating it and calling `run()` — a plain synchronous call
+that works in scripts, the REPL, and notebooks alike (the async-native engine runs on a
+background event loop; async code awaits `run_async()` instead):
 
 ```py
-import asyncio
-
-result = asyncio.run(forecast().run())
+result = forecast().run()
 ```
 
 !!! note
@@ -87,7 +85,7 @@ Let's materialize our asset using `FileDestination`, which pickles the data on t
 
 ```py
 forecast_asset = forecast(destination=il.FileDestination("./data"))
-asyncio.run(forecast_asset.materialize())
+forecast_asset.materialize()
 ```
 
 The materialization handles the execution of the asset and saves the data as a pickle file under `./data/forecast/data.pkl`.
@@ -135,8 +133,8 @@ Instantiate the source and access individual assets by name:
 
 ```py
 source = open_meteo(destination=il.FileDestination("./data"))
-asyncio.run(source.forecast.run())
-asyncio.run(source.air_quality.materialize())
+source.forecast.run()
+source.air_quality.materialize()
 ```
 
 ## DAG
@@ -146,13 +144,14 @@ When you want to materialize multiple assets together, respecting their dependen
 ```py
 source = open_meteo(destination=il.FileDestination("./data"))
 dag = il.DAG(source)
-asyncio.run(dag.materialize())
+dag.materialize()
 ```
 
-`dag.materialize()` runs the DAG with the default `AsyncRunner`. For more control, use a runner directly:
+`dag.materialize()` runs the DAG with the default `AsyncRunner`. For more control, use a runner
+directly — runners are async-native, so drive them with `il.run` from sync code:
 
 ```py
-result = asyncio.run(il.SerialRunner().run(dag))
+result = il.run(il.SerialRunner().run(dag))
 
 print(result.status)           # ExecutionStatus.COMPLETED
 print(result.execution_time)   # Total time in seconds
@@ -229,7 +228,7 @@ Materialize for a specific date:
 ```py
 source = open_meteo(destination=il.FileDestination("./data"))
 dag = il.DAG(source)
-asyncio.run(dag.materialize(partition_or_window=il.TimePartition(dt.date.today())))
+dag.materialize(partition_or_window=il.TimePartition(dt.date.today()))
 ```
 
 ## Backfilling
@@ -244,7 +243,7 @@ window = il.TimePartitionWindow(
     start=dt.date(2025, 1, 1),
     end=dt.date(2025, 1, 7),
 )
-asyncio.run(il.AsyncRunner().run(dag, window))
+il.run(il.AsyncRunner().run(dag, window))
 ```
 
 There is no separate "backfiller" object — backfilling is just running a DAG over a window,

--- a/examples/source.py
+++ b/examples/source.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from typing import Any
 
 import interloper as il
@@ -60,7 +59,7 @@ if __name__ == "__main__":
 
     print("\n=== Run ===")
     for a in s.assets:
-        print(f"{a.key}: {asyncio.run(a.run())}")
+        print(f"{a.key}: {a.run()}")
 
     print("\n=== Reconfigure ===")
     disabled = s(materializable=False)

--- a/packages/interloper-core/src/interloper/__init__.py
+++ b/packages/interloper-core/src/interloper/__init__.py
@@ -56,7 +56,7 @@ from interloper.rest import (
 from interloper.runner import AsyncRunner, MultiProcessRunner, Runner, RunResult, SerialRunner
 from interloper.schema import Schema, schema
 from interloper.source import Source, SourceDefinition, source
-from interloper.utils import bounded_gather
+from interloper.utils import bounded_gather, run
 
 __all__ = [
     "DAG",
@@ -131,6 +131,7 @@ __all__ = [
     "destination",
     "fetch_field_provider",
     "is_fetch_field_provider",
+    "run",
     "schema",
     "source",
 ]

--- a/packages/interloper-core/src/interloper/asset/base.py
+++ b/packages/interloper-core/src/interloper/asset/base.py
@@ -22,6 +22,7 @@ from interloper.partitioning import Partition, PartitionConfig, PartitionWindow
 from interloper.representation import representation_for
 from interloper.resource import Resource
 from interloper.schema import Schema
+from interloper.utils import concurrency
 from interloper.utils.concurrency import invoke
 from interloper.utils.data import is_empty
 from interloper.utils.imports import get_object_path
@@ -287,7 +288,33 @@ class Asset(Component):
             overrides["deps"] = deps
         return self.model_copy(update=overrides)
 
-    async def run(
+    def run(
+        self,
+        partition_or_window: Partition | PartitionWindow | None = None,
+        dag: DAG | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> Any:
+        """Execute the asset and return the result without writing to destination.
+
+        Sync entrypoint for scripts, REPLs, and notebooks — drives
+        :meth:`run_async` to completion on the bridge loop
+        (see :func:`interloper.run`)::
+
+            data = asset.run()
+
+        Async code awaits :meth:`run_async` instead.
+
+        Args:
+            partition_or_window: Partition or PartitionWindow for this run.
+            dag: DAG for dependency resolution (required if asset has deps).
+            metadata: Arbitrary metadata dict (e.g. run_id, backfill_id).
+
+        Returns:
+            The raw execution result.
+        """
+        return concurrency.run(self.run_async(partition_or_window, dag, metadata))
+
+    async def run_async(
         self,
         partition_or_window: Partition | PartitionWindow | None = None,
         dag: DAG | None = None,
@@ -350,7 +377,33 @@ class Asset(Component):
 
         return result
 
-    async def materialize(
+    def materialize(
+        self,
+        partition_or_window: Partition | PartitionWindow | None = None,
+        dag: DAG | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> Any:
+        """Execute the asset and write the result to all configured destinations.
+
+        Sync entrypoint for scripts, REPLs, and notebooks — drives
+        :meth:`materialize_async` to completion on the bridge loop
+        (see :func:`interloper.run`)::
+
+            asset.materialize()
+
+        Async code awaits :meth:`materialize_async` instead.
+
+        Args:
+            partition_or_window: Partition or PartitionWindow for this run.
+            dag: DAG for dependency resolution (required if asset has deps).
+            metadata: Arbitrary metadata dict (e.g. run_id, backfill_id).
+
+        Returns:
+            The execution result, or ``None`` if the asset is not materializable.
+        """
+        return concurrency.run(self.materialize_async(partition_or_window, dag, metadata))
+
+    async def materialize_async(
         self,
         partition_or_window: Partition | PartitionWindow | None = None,
         dag: DAG | None = None,
@@ -370,7 +423,7 @@ class Asset(Component):
             return None
 
         metadata = metadata or {}
-        result = await self.run(partition_or_window, dag, metadata)
+        result = await self.run_async(partition_or_window, dag, metadata)
         await self._destination_write(partition_or_window, metadata, result)
         return result
 

--- a/packages/interloper-core/src/interloper/dag/base.py
+++ b/packages/interloper-core/src/interloper/dag/base.py
@@ -255,17 +255,32 @@ class DAG:
     # Materialization
     # ------------------------------------------------------------------
 
-    async def materialize(
+    def materialize(
         self,
         partition_or_window: Partition | PartitionWindow | None = None,
     ) -> RunResult:
         """Execute all assets in dependency order using a default ``AsyncRunner``.
 
-        Async-native; ``await`` it from async code, or drive it from a sync
-        entrypoint with ``asyncio.run``::
+        Sync entrypoint for scripts, REPLs, and notebooks — drives
+        :meth:`materialize_async` to completion on the bridge loop
+        (see :func:`interloper.run`)::
 
-            result = await dag.materialize(partition)        # async
-            result = asyncio.run(dag.materialize(partition))  # sync edge
+            result = dag.materialize(partition)
+
+        Async code awaits :meth:`materialize_async` instead.
+
+        Returns:
+            The result of the DAG execution.
+        """
+        from interloper.utils import concurrency
+
+        return concurrency.run(self.materialize_async(partition_or_window))
+
+    async def materialize_async(
+        self,
+        partition_or_window: Partition | PartitionWindow | None = None,
+    ) -> RunResult:
+        """Execute all assets in dependency order using a default ``AsyncRunner``.
 
         Returns:
             The result of the DAG execution.

--- a/packages/interloper-core/src/interloper/runner/async_runner.py
+++ b/packages/interloper-core/src/interloper/runner/async_runner.py
@@ -35,8 +35,8 @@ class AsyncRunner(Runner):
         # async
         result = await AsyncRunner(max_workers=2, on_event=log_event).run(dag)
 
-        # sync edge (scripts, CLI, scheduler worker)
-        result = asyncio.run(AsyncRunner(on_event=log_event).run(dag))
+        # sync edge (scripts, REPL, notebooks)
+        result = il.run(AsyncRunner(on_event=log_event).run(dag))
     """
 
     max_workers: int = 4
@@ -152,7 +152,7 @@ class AsyncRunner(Runner):
 
         try:
             effective_partition = asset.effective_partition(partition_or_window)
-            result = await asset.materialize(
+            result = await asset.materialize_async(
                 partition_or_window=effective_partition,
                 dag=self.state.dag,
                 metadata=self.state.metadata,

--- a/packages/interloper-core/src/interloper/runner/base.py
+++ b/packages/interloper-core/src/interloper/runner/base.py
@@ -71,10 +71,10 @@ class Runner(Component):
     Async-native: :meth:`run` is a coroutine. It owns the ``on_event``
     subscription lifecycle and delegates the actual DAG walk to the
     subclass :meth:`_run`. ``await`` it from async code, or drive it from a
-    sync entrypoint with ``asyncio.run``::
+    sync entrypoint with :func:`interloper.run`::
 
-        result = await runner.run(dag)        # async
-        result = asyncio.run(runner.run(dag))  # sync edge
+        result = await runner.run(dag)     # async
+        result = il.run(runner.run(dag))   # sync edge
     """
 
     fail_fast: bool = False

--- a/packages/interloper-core/src/interloper/runner/multi_process.py
+++ b/packages/interloper-core/src/interloper/runner/multi_process.py
@@ -39,7 +39,7 @@ def _worker(
             partition_or_window = None
 
         asyncio.run(
-            asset.materialize(
+            asset.materialize_async(
                 partition_or_window=partition_or_window,
                 dag=dag,
                 metadata=metadata,
@@ -62,7 +62,7 @@ class MultiProcessRunner(SyncRunner):
     you need true parallelism (bypassing the GIL)::
 
         result = await MultiProcessRunner(max_workers=2, on_event=log_event).run(dag)
-        # or, from a sync edge: asyncio.run(MultiProcessRunner().run(dag))
+        # or, from a sync edge: il.run(MultiProcessRunner().run(dag))
     """
 
     max_workers: int = 4

--- a/packages/interloper-core/src/interloper/runner/serial.py
+++ b/packages/interloper-core/src/interloper/runner/serial.py
@@ -13,7 +13,7 @@ class SerialRunner(AsyncRunner):
     asset in flight::
 
         result = await SerialRunner(on_event=log_event).run(dag)
-        # or, from a sync edge: asyncio.run(SerialRunner().run(dag))
+        # or, from a sync edge: il.run(SerialRunner().run(dag))
     """
 
     max_workers: int = 1

--- a/packages/interloper-core/src/interloper/utils/__init__.py
+++ b/packages/interloper-core/src/interloper/utils/__init__.py
@@ -1,6 +1,6 @@
 """Shared utility helpers for concurrency, data, imports, and text processing."""
 
-from interloper.utils.concurrency import bounded_gather, invoke
+from interloper.utils.concurrency import bounded_gather, invoke, run
 from interloper.utils.data import is_empty
 from interloper.utils.imports import get_object_path, import_from_path
 from interloper.utils.text import to_label, to_slug_case, to_snake_case, validate_key
@@ -11,6 +11,7 @@ __all__ = [
     "import_from_path",
     "invoke",
     "is_empty",
+    "run",
     "to_label",
     "to_slug_case",
     "to_snake_case",

--- a/packages/interloper-core/src/interloper/utils/concurrency.py
+++ b/packages/interloper-core/src/interloper/utils/concurrency.py
@@ -3,11 +3,94 @@
 from __future__ import annotations
 
 import asyncio
+import atexit
 import inspect
+import threading
 from collections.abc import Coroutine, Iterable
 from typing import Any, TypeVar
 
 _T = TypeVar("_T")
+
+# The background event loop backing ``run()``. Started lazily on first use and
+# kept for the lifetime of the process so that loop-bound state created by one
+# ``run()`` call — an ``AsyncRESTClient``'s connection pool, most notably —
+# remains valid for the next one. A per-call ``asyncio.run`` would bind that
+# state to a loop that no longer exists.
+_loop: asyncio.AbstractEventLoop | None = None
+_loop_thread: threading.Thread | None = None
+_loop_lock = threading.Lock()
+
+
+def _shutdown_loop() -> None:
+    """Stop the background loop at interpreter exit (best-effort)."""
+    global _loop, _loop_thread
+    if _loop is not None and _loop.is_running():
+        _loop.call_soon_threadsafe(_loop.stop)
+    if _loop_thread is not None and _loop_thread.is_alive():
+        _loop_thread.join(timeout=2.0)
+    _loop = None
+    _loop_thread = None
+
+
+def _ensure_loop() -> asyncio.AbstractEventLoop:
+    """Return the background event loop, starting its daemon thread on first use."""
+    global _loop, _loop_thread
+    with _loop_lock:
+        if _loop is None or not _loop.is_running():
+            loop = asyncio.new_event_loop()
+            thread = threading.Thread(target=loop.run_forever, name="interloper-run", daemon=True)
+            thread.start()
+            _loop = loop
+            _loop_thread = thread
+            atexit.register(_shutdown_loop)
+        return _loop
+
+
+def run(coro: Coroutine[Any, Any, _T]) -> _T:
+    """Run a coroutine to completion from synchronous code.
+
+    The sync bridge to the async-native engine. It backs the sync
+    entrypoints — ``asset.run()``, ``asset.materialize()``,
+    ``dag.materialize()`` — and can be called directly to drive any other
+    framework coroutine (e.g. a configured runner) from a script, a REPL,
+    or a notebook cell without touching ``asyncio``::
+
+        import interloper as il
+
+        result = il.run(il.AsyncRunner(max_workers=8).run(dag))
+
+    Unlike ``asyncio.run``, this works where an event loop is already
+    running (Jupyter) and reuses one persistent background loop across
+    calls, so loop-bound clients cached on connections stay valid from one
+    invocation to the next. Async code should ``await`` the coroutine
+    directly instead.
+
+    Ctrl-C cancels the coroutine before re-raising ``KeyboardInterrupt``.
+
+    Args:
+        coro: The coroutine to execute.
+
+    Returns:
+        The coroutine's result.
+
+    Raises:
+        RuntimeError: If called from code already running on the bridge's
+            own loop (``await`` instead — blocking would deadlock).
+        KeyboardInterrupt: Re-raised after cancelling the coroutine.
+    """
+    loop = _ensure_loop()
+    if threading.current_thread() is _loop_thread:
+        coro.close()
+        raise RuntimeError(
+            "il.run() called from code already running on its own event loop; use 'await' instead."
+        )
+
+    future = asyncio.run_coroutine_threadsafe(coro, loop)
+    try:
+        return future.result()
+    except KeyboardInterrupt:
+        future.cancel()
+        raise
 
 
 async def bounded_gather(coros: Iterable[Coroutine[Any, Any, _T]], *, limit: int) -> list[_T]:

--- a/packages/interloper-core/tests/asset/test_base.py
+++ b/packages/interloper-core/tests/asset/test_base.py
@@ -516,7 +516,7 @@ class TestDestinationWrite:
             return []
 
         asset = empty(id="empty", destination=mem)
-        logs = await _capture_log_events(asset.materialize())
+        logs = await _capture_log_events(asset.materialize_async())
 
         # Nothing was written.
         assert mem._storage == {}
@@ -539,7 +539,7 @@ class TestDestinationWrite:
             return [{"a": 1}]
 
         asset = full(id="full", destination=mem)
-        logs = await _capture_log_events(asset.materialize())
+        logs = await _capture_log_events(asset.materialize_async())
 
         # Data was written and no "no data" warning was emitted.
         assert mem._storage
@@ -570,7 +570,7 @@ class TestAsyncAndSyncData:
             return [{"id": 1}]
 
         assert not asyncio.iscoroutinefunction(users().data)
-        assert await users().run() == [{"id": 1}]
+        assert await users().run_async() == [{"id": 1}]
 
     async def test_async_data_function_is_awaited_natively(self):
         @il.asset
@@ -581,7 +581,33 @@ class TestAsyncAndSyncData:
         # would offload a sync wrapper to a thread and return an un-awaited
         # coroutine instead of the data.
         assert asyncio.iscoroutinefunction(users().data)
-        assert await users().run() == [{"id": 1}]
+        assert await users().run_async() == [{"id": 1}]
+
+    def test_run_is_callable_directly_from_sync_code(self):
+        # The manual script/REPL/notebook path: run() drives the async
+        # engine on the bridge loop, no asyncio.run required.
+        @il.asset
+        def users() -> list[dict[str, Any]]:
+            return [{"id": 1}]
+
+        assert users().run() == [{"id": 1}]
+
+    def test_materialize_is_callable_directly_from_sync_code(self):
+        captured: dict[str, Any] = {}
+
+        class CapturingDestination(il.Destination):
+            def read(self, context: Any) -> Any:  # pragma: no cover - not exercised
+                return None
+
+            def write(self, context: Any, data: Any) -> None:
+                captured["data"] = data
+
+        @il.asset
+        def users() -> list[dict[str, Any]]:
+            return [{"id": 1}]
+
+        users(destination=CapturingDestination(id="sync-dest")).materialize()
+        assert captured["data"] == [{"id": 1}]
 
     async def test_async_destination_write_is_awaited(self):
         # A destination may implement ``write`` as ``async def``; materialize
@@ -600,7 +626,7 @@ class TestAsyncAndSyncData:
             return [{"id": 1}]
 
         asset = users(destination=AsyncDestination(id="async-dest"))
-        await asset.materialize()
+        await asset.materialize_async()
         assert captured["data"] == [{"id": 1}]
 
 
@@ -612,7 +638,7 @@ class TestConform:
         def users() -> list[dict[str, Any]]:
             return [{"user_id": 1, "name": "a"}]
 
-        assert await users().run() == [{"user_id": 1, "name": "a"}]
+        assert await users().run_async() == [{"user_id": 1, "name": "a"}]
 
     async def test_mismatched_data_fails_fast(self):
         from interloper.errors import SchemaError
@@ -622,7 +648,7 @@ class TestConform:
             return [{"user_id": "not-an-int", "name": "a"}]
 
         with pytest.raises(SchemaError):
-            await users().run()
+            await users().run_async()
 
     async def test_dataframe_validated_without_normalizer(self):
         pd = pytest.importorskip("pandas")
@@ -633,7 +659,7 @@ class TestConform:
             return pd.DataFrame([{"userId": 1, "Name": "a"}])  # wrong casing -> required fields missing
 
         with pytest.raises(SchemaError):
-            await users().run()
+            await users().run_async()
 
     async def test_dataframe_with_nan_validates_against_nullable_fields(self):
         pd = pytest.importorskip("pandas")
@@ -643,7 +669,7 @@ class TestConform:
         def users() -> Any:
             return pd.DataFrame([{"user_id": np.nan, "name": "a"}])
 
-        result = await users().run()
+        result = await users().run_async()
         assert isinstance(result, pd.DataFrame)
 
     async def test_strategy_requires_schema(self):
@@ -654,7 +680,7 @@ class TestConform:
             return [{"a": 1}]
 
         with pytest.raises(AssetError, match="requires a schema"):
-            await users().run()
+            await users().run_async()
 
     async def test_reconcile_without_normalizer(self):
         from interloper.normalizer import MaterializationStrategy
@@ -663,14 +689,14 @@ class TestConform:
         def users() -> list[dict[str, Any]]:
             return [{"user_id": "1", "name": "a", "extra": True}]
 
-        assert await users().run() == [{"user_id": 1, "name": "a"}]
+        assert await users().run_async() == [{"user_id": 1, "name": "a"}]
 
     async def test_generator_with_schema_is_coerced(self):
         @il.asset(schema=ConformSchema)
         def users() -> Any:
             yield {"user_id": 1, "name": "a"}
 
-        assert await users().run() == [{"user_id": 1, "name": "a"}]
+        assert await users().run_async() == [{"user_id": 1, "name": "a"}]
 
     async def test_non_tabular_data_with_schema_fails(self):
         @il.asset(schema=ConformSchema)
@@ -678,7 +704,7 @@ class TestConform:
             return "not tabular"
 
         with pytest.raises(AssetError, match="cannot[\\s\\S]*be checked"):
-            await users().run()
+            await users().run_async()
 
     async def test_auto_without_schema_infers_effective_schema(self):
         @il.asset
@@ -686,7 +712,7 @@ class TestConform:
             return [{"user_id": 1, "name": "a"}]
 
         asset = users()
-        await asset.run()
+        await asset.run_async()
         assert asset._effective_schema is not None
         names = [s.name for s in asset._effective_schema.field_specs()]
         assert names == ["user_id", "name"]
@@ -706,7 +732,7 @@ class TestConform:
             return [{"user_id": 1, "name": "a"}]
 
         asset = users(destination=CapturingDestination(id="cap"))
-        await asset.materialize()
+        await asset.materialize_async()
         assert captured["schema"] is ConformSchema
 
     async def test_iocontext_carries_inferred_schema_when_undeclared(self):
@@ -724,6 +750,6 @@ class TestConform:
             return [{"user_id": 1}]
 
         asset = users(destination=CapturingDestination(id="cap"))
-        await asset.materialize()
+        await asset.materialize_async()
         assert captured["schema"] is not None
         assert [s.name for s in captured["schema"].field_specs()] == ["user_id"]

--- a/packages/interloper-core/tests/dag/test_base.py
+++ b/packages/interloper-core/tests/dag/test_base.py
@@ -21,6 +21,7 @@ from interloper.errors import (
     DependencyNotFoundError,
 )
 from interloper.partitioning.base import PartitionConfig
+from interloper.runner.results import ExecutionStatus
 
 # ---------------------------------------------------------------------------
 # Minimal asset/source fixtures used by small-topology tests
@@ -717,3 +718,25 @@ class TestSerialization:
                 f"materializable assets after round-trip, expected 1"
             )
             assert type(materializable[0]).key == type(asset).key
+
+
+class TestMaterialize:
+    """DAG materialization through the default engine."""
+
+    def test_materialize_is_callable_directly_from_sync_code(self):
+        # The manual script/REPL/notebook path: materialize() drives the
+        # async engine on the bridge loop, no asyncio.run required.
+        @il.asset
+        def users() -> list[dict[str, Any]]:
+            return [{"id": 1}]
+
+        result = DAG(users()).materialize()
+        assert result.status is ExecutionStatus.COMPLETED
+
+    async def test_materialize_async_is_awaitable(self):
+        @il.asset
+        def users() -> list[dict[str, Any]]:
+            return [{"id": 1}]
+
+        result = await DAG(users()).materialize_async()
+        assert result.status is ExecutionStatus.COMPLETED

--- a/packages/interloper-core/tests/utils/test_concurrency.py
+++ b/packages/interloper-core/tests/utils/test_concurrency.py
@@ -7,7 +7,7 @@ import threading
 
 import pytest
 
-from interloper.utils.concurrency import bounded_gather, invoke
+from interloper.utils.concurrency import bounded_gather, invoke, run
 
 
 class TestBoundedGather:
@@ -81,3 +81,52 @@ class TestInvoke:
             return (a, b, c)
 
         assert await invoke(fn, 1, 2, c=3) == (1, 2, 3)
+
+
+class TestRun:
+    """Sync bridge to the async engine (``il.run``)."""
+
+    def test_returns_result_from_sync_context(self):
+        async def add(a: int, b: int) -> int:
+            return a + b
+
+        assert run(add(1, 2)) == 3
+
+    def test_propagates_exceptions(self):
+        async def boom() -> None:
+            raise ValueError("nope")
+
+        with pytest.raises(ValueError, match="nope"):
+            run(boom())
+
+    def test_reuses_one_persistent_loop_across_calls(self):
+        # Loop-bound state (e.g. an AsyncRESTClient's pool) created by one
+        # call must remain valid for the next — the loop is process-lived.
+        async def current_loop() -> asyncio.AbstractEventLoop:
+            return asyncio.get_running_loop()
+
+        assert run(current_loop()) is run(current_loop())
+
+    def test_runs_off_the_calling_thread(self):
+        async def loop_thread() -> int:
+            return threading.get_ident()
+
+        assert run(loop_thread()) != threading.get_ident()
+
+    async def test_works_while_a_loop_is_running_in_the_calling_thread(self):
+        # The Jupyter scenario: the caller's thread already runs a loop
+        # (here: pytest-asyncio's), where asyncio.run would raise.
+        async def add(a: int, b: int) -> int:
+            return a + b
+
+        assert run(add(1, 2)) == 3
+
+    def test_calling_run_on_its_own_loop_raises(self):
+        async def nested() -> None:
+            async def noop() -> None:
+                pass
+
+            run(noop())  # sync call from the bridge's own loop thread
+
+        with pytest.raises(RuntimeError, match="use 'await'"):
+            run(nested())

--- a/packages/interloper-docker/src/interloper_docker/runner.py
+++ b/packages/interloper-docker/src/interloper_docker/runner.py
@@ -64,7 +64,7 @@ class DockerRunner(SyncRunner):
     runner satisfies the async-native ``run()`` contract::
 
         result = await DockerRunner(image="my-image", on_event=log_event).run(dag)
-        # or, from a sync edge: asyncio.run(DockerRunner(image=...).run(dag))
+        # or, from a sync edge: il.run(DockerRunner(image=...).run(dag))
     """
 
     image: str = "interloper:latest-worker"

--- a/packages/interloper-k8s/src/interloper_k8s/runner.py
+++ b/packages/interloper-k8s/src/interloper_k8s/runner.py
@@ -49,7 +49,7 @@ class KubernetesRunner(SyncRunner):
     satisfies the async-native ``run()`` contract::
 
         result = await KubernetesRunner(image="my-image", on_event=log_event).run(dag)
-        # or, from a sync edge: asyncio.run(KubernetesRunner(image=...).run(dag))
+        # or, from a sync edge: il.run(KubernetesRunner(image=...).run(dag))
     """
 
     image: str


### PR DESCRIPTION
## What

`asset.run()`, `asset.materialize()`, and `dag.materialize()` are now **plain synchronous calls** — the on-the-fly execution surface works in scripts, the REPL, and notebook cells with zero `asyncio`:

```python
dag = il.DAG(my_source(destination=il.FileDestination("./data")))
result = dag.materialize()

source.users.run()
source.users.materialize()
```

The async-native engine is untouched: the real implementations are the new coroutines `run_async()`, `materialize_async()`, and `DAG.materialize_async()`, which async code (and the runners) `await` directly.

Both are backed by **`il.run(coro)`** — a public sync bridge that executes any framework coroutine on a lazily-started, process-lived background event loop. It's also the tool for driving a configured runner from sync code: `il.run(il.AsyncRunner(max_workers=8).run(dag))`.

## Why

Manual runs required `asyncio.run(...)` around every call — noise in scripts, and it **fails outright in Jupyter** (`asyncio.run() cannot be called from a running event loop`), exactly where people poke at assets interactively.

## How

`il.run` submits the coroutine to a persistent daemon-thread event loop via `run_coroutine_threadsafe` and blocks on the result:

- **Works everywhere**: independent of the caller's loop state, so scripts and notebook cells behave identically. Two names, two clear contracts — sync returns the result, `*_async` returns a coroutine — no context-sensitive return types, no typing unions.
- **One persistent loop across calls**: loop-bound state created by one call — notably a connection's `cached_property` `AsyncRESTClient` pool — stays valid for the next. An `asyncio.run`-per-call bridge would orphan those pools ("Event loop is closed" on the second run of any async source).
- **Fails safe**: Ctrl-C cancels the in-flight coroutine before re-raising; calling `il.run` from code already on the bridge's own loop raises a clear `RuntimeError` pointing at `await`; an `atexit` hook stops the loop.

Docstrings, the docs site (tutorial, getting-started, FAQ, features), and `examples/source.py` are updated to the sync-first surface.

## Breaking change

`Asset.run`, `Asset.materialize`, and `DAG.materialize` are no longer coroutines. Async callers migrate to `run_async` / `materialize_async` / `materialize_async`. Internal call sites (AsyncRunner, MultiProcessRunner worker) are updated; `Runner.run` remains async-only.

## Reviewer notes

- The bridge lives in `interloper/utils/concurrency.py` next to `invoke`/`bounded_gather` (the existing sync↔async seam) and is exported as `il.run`.
- Engine/embedding paths (scheduler executor, CLI) deliberately keep calling the async API directly and own their loop lifecycle.
- Tests cover the bridge (result/exception propagation, loop persistence, off-thread execution, running-loop/Jupyter scenario, deadlock guard) and the sync entrypoints end to end for a bare asset, a destination write, and a DAG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)