### PR TITLE
fix(app): oauth popup flow reports cancel and failure to the opener

### DIFF
--- a/packages/interloper-app/app/app/components/OAuthSignIn.vue
+++ b/packages/interloper-app/app/app/components/OAuthSignIn.vue
@@ -41,8 +41,11 @@ async function handleSignIn() {
         emit('success', tokens)
         toast.add({ title: `Connected to ${providerInfo.value?.label ?? props.provider}`, color: 'success' })
     }
-    catch {
-        toast.add({ title: 'Sign-in failed', color: 'error' })
+    catch (error) {
+        // Closing the popup is a deliberate cancel, not a failure.
+        if (!(error instanceof OAuthCancelledError)) {
+            toast.add({ title: 'Sign-in failed', color: 'error' })
+        }
     }
     finally {
         loading.value = false

--- a/packages/interloper-app/app/app/composables/oauth.ts
+++ b/packages/interloper-app/app/app/composables/oauth.ts
@@ -5,9 +5,21 @@
  * - Building provider-specific authorization URLs
  * - Opening a popup window for the OAuth consent screen
  * - Exchanging the authorization code for tokens via the backend
- * - Communicating tokens back from the popup to the opener
+ * - Communicating the outcome back from the popup to the opener
+ *
+ * Opener and popup talk over a BroadcastChannel (same-origin by construction)
+ * rather than `window.opener.postMessage`: providers that respond with
+ * `Cross-Origin-Opener-Policy: same-origin` sever the opener link, which would
+ * silently drop the result and leave the opener waiting forever.
  */
 
+/** Rejection raised when the popup is closed before the flow completes. */
+export class OAuthCancelledError extends Error {}
+
+const OAUTH_CHANNEL = 'interloper-oauth'
+const POPUP_POLL_INTERVAL_MS = 500
+/** Delay between the popup closing and rejecting, so an in-flight result message wins the race. */
+const POPUP_CLOSE_GRACE_MS = 1_000
 
 /**
  * Extract a human-readable detail from a failed token-exchange request.
@@ -23,17 +35,6 @@ export function oauthErrorDetail(error: unknown): string {
     return e?.message || 'Unknown error'
 }
 
-/** Wait for a single DOM event, returned as a promise. */
-function promiseFromEvent<T extends Event>(target: EventTarget, event: string): Promise<T> {
-    return new Promise((resolve) => {
-        const handler = (e: Event) => {
-            target.removeEventListener(event, handler)
-            resolve(e as T)
-        }
-        target.addEventListener(event, handler)
-    })
-}
-
 /**
  * Composable for the OAuth2 popup sign-in flow.
  */
@@ -41,8 +42,11 @@ export function useOAuthPopup() {
     const { apiFetch } = useApi()
 
     /**
-     * Open a popup to the given authorization URL and wait for
-     * the callback page to post tokens back via `postMessage`.
+     * Open a popup to the given authorization URL and wait for the callback
+     * page to report the outcome over the OAuth channel.
+     *
+     * Rejects with `OAuthCancelledError` when the popup is closed before the
+     * flow completes, and with a regular `Error` when the flow itself fails.
      */
     async function signIn(url: string): Promise<Record<string, unknown>> {
         const width = 500
@@ -50,64 +54,80 @@ export function useOAuthPopup() {
         const left = window.screen.width / 2 - width / 2
         const top = window.screen.height / 2 - height / 2
 
+        // Correlates this flow instance with its popup: providers echo `state`
+        // back to the callback page, which includes it in the result message.
+        const state = crypto.randomUUID()
+        const popupUrl = new URL(url)
+        popupUrl.searchParams.set('state', state)
+
         const popup = window.open(
-            url,
+            popupUrl.toString(),
             'oauth2popup',
             `width=${width},height=${height},left=${left},top=${top}`,
         )
         if (!popup) throw new Error('Failed to open popup window')
 
-        // Wait for the popup to post a message with our status type
-        let event: MessageEvent
-        do {
-            event = await promiseFromEvent<MessageEvent>(window, 'message')
-        } while (
-            !event.data?.type
-            || !Object.values(OAuthPopupStatus).includes(event.data.type)
-        )
+        return new Promise((resolve, reject) => {
+            const channel = new BroadcastChannel(OAUTH_CHANNEL)
+            let settled = false
 
-        if (event.data.type !== OAuthPopupStatus.Success) {
-            throw new Error(event.data.error || 'OAuth sign-in failed')
-        }
+            function settle(complete: () => void) {
+                if (settled) return
+                settled = true
+                clearInterval(poll)
+                channel.close()
+                complete()
+            }
 
-        popup.close()
-        return event.data.tokens as Record<string, unknown>
+            // There is no close event for a (cross-origin) popup, so poll.
+            const poll = setInterval(() => {
+                if (!popup.closed) return
+                clearInterval(poll)
+                setTimeout(
+                    () => settle(() => reject(new OAuthCancelledError('Sign-in window was closed'))),
+                    POPUP_CLOSE_GRACE_MS,
+                )
+            }, POPUP_POLL_INTERVAL_MS)
+
+            channel.onmessage = (event: MessageEvent<OAuthPopupMessage>) => {
+                const message = event.data
+                if (message?.type !== OAuthPopupStatus.Success && message?.type !== OAuthPopupStatus.Failure) return
+                // A mismatched state belongs to another flow instance. A missing
+                // one means the provider dropped the param — accept rather than hang.
+                if (message.state && message.state !== state) return
+
+                if (message.type === OAuthPopupStatus.Success) {
+                    popup.close()
+                    settle(() => resolve(message.tokens))
+                }
+                else {
+                    // Leave the popup open — it displays the failure details.
+                    settle(() => reject(new Error(message.error || 'OAuth sign-in failed')))
+                }
+            }
+        })
     }
 
     /**
      * Exchange an authorization code for tokens (called from the callback page).
-     * Posts the result back to the opener window.
      */
-    async function exchangeCode(provider: string, code: string) {
-        try {
-            const tokens = await apiFetch<Record<string, unknown>>(`/oauth/${provider}`, {
-                method: 'POST',
-                body: { code },
-            })
-
-            if (window.opener) {
-                window.opener.postMessage({
-                    type: OAuthPopupStatus.Success,
-                    tokens,
-                }, '*')
-            }
-
-            return tokens
-        }
-        catch (error) {
-            // Notify the opener of the failure so its `signIn` promise rejects
-            // instead of hanging, forwarding the detail for display.
-            if (window.opener) {
-                window.opener.postMessage({
-                    type: OAuthPopupStatus.Failure,
-                    error: oauthErrorDetail(error),
-                }, '*')
-            }
-            throw error
-        }
+    async function exchangeCode(provider: string, code: string): Promise<Record<string, unknown>> {
+        return await apiFetch<Record<string, unknown>>(`/oauth/${provider}`, {
+            method: 'POST',
+            body: { code },
+        })
     }
 
-    return { signIn, exchangeCode }
+    /**
+     * Report the flow outcome to the opener (called from the callback page).
+     */
+    function reportResult(message: OAuthPopupMessage) {
+        const channel = new BroadcastChannel(OAUTH_CHANNEL)
+        channel.postMessage(message)
+        channel.close()
+    }
+
+    return { signIn, exchangeCode, reportResult }
 }
 
 /**

--- a/packages/interloper-app/app/app/pages/auth/[provider].vue
+++ b/packages/interloper-app/app/app/pages/auth/[provider].vue
@@ -6,7 +6,7 @@ definePageMeta({
 })
 
 const route = useRoute()
-const { exchangeCode } = useOAuthPopup()
+const { exchangeCode, reportResult } = useOAuthPopup()
 
 const provider = route.params.provider?.toString()
 if (!provider) {
@@ -17,20 +17,37 @@ if (!provider) {
 }
 
 const code = route.query.code as string | undefined
-const status = ref<OAuthPopupStatus>(
-    code ? OAuthPopupStatus.Loading : OAuthPopupStatus.MissingCode,
-)
+const providerError = route.query.error as string | undefined
+const state = route.query.state as string | undefined
+
+const status = ref<OAuthPopupStatus>(OAuthPopupStatus.Loading)
 const errorDetail = ref('')
 
+function fail(error: string, failureStatus = OAuthPopupStatus.Failure) {
+    errorDetail.value = error
+    status.value = failureStatus
+    reportResult({ type: OAuthPopupStatus.Failure, state, error })
+}
+
+// Every terminal state reports back to the opener, so its pending sign-in
+// settles instead of spinning forever.
 onMounted(async () => {
-    if (code) {
+    if (providerError) {
+        // Provider redirected back with an error (e.g. the user denied consent).
+        const description = route.query.error_description as string | undefined
+        fail(description ? `${providerError}: ${description}` : providerError)
+    }
+    else if (!code) {
+        fail('Authorization code is missing', OAuthPopupStatus.MissingCode)
+    }
+    else {
         try {
-            await exchangeCode(provider, code)
+            const tokens = await exchangeCode(provider, code)
             status.value = OAuthPopupStatus.Success
+            reportResult({ type: OAuthPopupStatus.Success, state, tokens })
         }
         catch (error) {
-            errorDetail.value = oauthErrorDetail(error)
-            status.value = OAuthPopupStatus.Failure
+            fail(oauthErrorDetail(error))
         }
     }
 })

--- a/packages/interloper-app/app/app/types/oauth.ts
+++ b/packages/interloper-app/app/app/types/oauth.ts
@@ -7,6 +7,21 @@ export enum OAuthPopupStatus {
     MissingCode = 'OAUTH_POPUP_MISSING_CODE',
 }
 
+/**
+ * Flow outcome sent by the popup callback page to the opener over the OAuth
+ * BroadcastChannel. `state` echoes the OAuth `state` nonce so the opener can
+ * ignore results from another flow instance (e.g. a popup opened by another tab).
+ */
+export type OAuthPopupMessage = {
+    type: OAuthPopupStatus.Success
+    state?: string
+    tokens: Record<string, unknown>
+} | {
+    type: OAuthPopupStatus.Failure
+    state?: string
+    error: string
+}
+
 /** Public provider info returned by the API (no secrets). */
 export interface OAuthProviderInfo {
     key: string


### PR DESCRIPTION
## Problem

When the OAuth popup was closed by the user, or the provider redirected back with an error (e.g. denied consent), the opener never learned about it — `signIn()` only settled on a `postMessage` from the token exchange, so the "Sign in with X" button kept spinning forever.

## What changed

- **Transport**: opener and popup now communicate over a `BroadcastChannel('interloper-oauth')` instead of `window.opener.postMessage(..., '*')`. Same-origin by construction (the old wildcard target could deliver tokens cross-origin), and it keeps working when a provider severs the opener link via `Cross-Origin-Opener-Policy` — which silently dropped results before.
- **Close detection**: `signIn()` polls `popup.closed` (there is no cross-origin close event) and rejects with a new `OAuthCancelledError` after a 1s grace period, so an in-flight success message wins the race. `OAuthSignIn.vue` treats the cancel silently — the button just resets, no "Sign-in failed" toast.
- **All terminal states report back**: the callback page now posts a result for provider `?error=` redirects (with `error_description` in the details), missing code, exchange failure, and success — previously only the exchange itself posted. The popup still stays open on failure so the Details collapse stays readable.
- **Flow correlation**: `signIn()` appends a `state` nonce to the auth URL; the callback echoes it in the result. A mismatched state is ignored (another tab's flow), a missing one is accepted so a provider that drops the param can't re-introduce the hang.

## Reviewer notes

- The `success` emit contract of `OAuthSignIn.vue` (token payload shape) is unchanged; `SchemaForm` consumers are unaffected.
- The channel naming follows the existing `'interloper-org'` precedent in the org store.
- Worth confirming on the next live pass with real creds that TikTok's non-standard flow tolerates the extra `state` param — standard OAuth2 providers echo it per spec, and the lenient match means even dropping it is harmless.
- Verified with `pnpm run lint` (0 errors; 7 pre-existing warnings in unrelated files) and `pnpm exec nuxt typecheck` (clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)