### PR TITLE
feat(app): redesign the UI to match the Claude Design system

### DIFF
--- a/packages/interloper-app/app/app/app.config.ts
+++ b/packages/interloper-app/app/app/app.config.ts
@@ -3,6 +3,10 @@ export default defineAppConfig({
     colors: {
       primary: 'blue',
       secondary: 'gray',
+      success: 'green',
+      warning: 'amber',
+      error: 'red',
+      info: 'blue',
     },
     badge: {
       defaultVariants: {
@@ -13,39 +17,68 @@ export default defineAppConfig({
     button: {
       defaultVariants: {
         size: 'lg',
-        variant: 'soft'
+        variant: 'solid'
       }
     },
     card: {
       defaultVariants: {
-        variant: 'soft'
+        variant: 'outline'
       }
     },
-    // navigationMenu: {
-    //   variants: {
-    //     orientation: {
-    //       vertical: {
-    //         // link: 'py-2.5',
-    //       },
-    //     },
-    //   },
-    // },
+    // Surface hierarchy from the Claude Design project: white header/cards,
+    // sidebar bg-muted (#F7F7F8).
+    dashboardSidebar: {
+      slots: {
+        root: 'bg-muted'
+      }
+    },
+    navigationMenu: {
+      // Design sidebar hierarchy: section labels lighter (#86868b) than
+      // menu entries (#3f3f44 text, #86868b icons).
+      slots: {
+        label: 'text-gray-700 dark:text-gray-800'
+      },
+      compoundVariants: [
+        // Sidebar active item: accent-tinted pill (a gray pill would be
+        // invisible on the gray sidebar).
+        {
+          orientation: 'vertical',
+          variant: 'pill',
+          active: true,
+          highlight: false,
+          class: {
+            link: 'before:bg-primary/10 text-primary',
+            linkLeadingIcon: 'text-primary group-data-[state=open]:text-primary'
+          }
+        },
+        {
+          orientation: 'vertical',
+          variant: 'pill',
+          active: false,
+          disabled: false,
+          class: {
+            link: 'text-toned',
+            linkLeadingIcon: 'text-gray-700'
+          }
+        }
+      ]
+    },
     input: {
       defaultVariants: {
         size: 'lg',
-        variant: 'soft'
+        variant: 'outline'
       }
     },
     textarea: {
       defaultVariants: {
         size: 'lg',
-        variant: 'soft'
+        variant: 'outline'
       }
     },
     inputTags: {
       defaultVariants: {
         size: 'lg',
-        variant: 'soft'
+        variant: 'outline'
       }
     },
     tag: {
@@ -57,18 +90,89 @@ export default defineAppConfig({
     select: {
       defaultVariants: {
         size: 'lg',
-        variant: 'soft'
+        variant: 'outline'
       }
     },
     selectMenu: {
       defaultVariants: {
         size: 'lg',
-        variant: 'soft'
+        variant: 'outline'
+      }
+    },
+    table: {
+      slots: {
+        // Design table treatment: bordered card, #FAFAFB header band,
+        // #86868b header text, #F2F3F5 row dividers (lighter than the
+        // card border).
+        root: 'border border-default rounded-xl bg-default',
+        thead: 'bg-(--ui-bg-band)',
+        th: 'text-gray-700',
+        tbody: 'divide-(--ui-border-muted)'
+      },
+      variants: {
+        sticky: {
+          true: {
+            // The sticky variant's own bg-default/75 wins the class merge
+            // over slots.thead, so restate the header band here (opaque).
+            thead: 'bg-(--ui-bg-band) backdrop-blur-none'
+          }
+        }
       }
     },
     alert: {
       defaultVariants: {
         variant: 'soft'
+      }
+    },
+    // Design wizard step indicator: 48px circles, accent glow + accent
+    // label on the active step, tinted check circle once completed.
+    stepper: {
+      slots: {
+        root: 'gap-7',
+        trigger: 'text-dimmed group-data-[state=active]:shadow-lg group-data-[state=active]:shadow-primary/30',
+        title: 'text-[13px] font-medium text-dimmed group-data-[state=active]:text-primary group-data-[state=active]:font-semibold group-data-[state=completed]:text-muted'
+      },
+      variants: {
+        size: {
+          md: {
+            trigger: 'size-12',
+            icon: 'size-[22px]'
+          }
+        },
+        color: {
+          primary: {
+            trigger: 'group-data-[state=completed]:bg-primary/15 group-data-[state=completed]:text-primary'
+          }
+        }
+      }
+    },
+    // Design mono section label on labeled separators.
+    separator: {
+      slots: {
+        label: 'eyebrow text-dimmed'
+      }
+    },
+    // Design segmented control: pill tabs get a white active pill with dark
+    // text on the grey track (theme default is a solid primary pill).
+    tabs: {
+      compoundVariants: [
+        {
+          color: 'primary',
+          variant: 'pill',
+          class: {
+            indicator: 'bg-default',
+            trigger: 'data-[state=active]:text-highlighted'
+          }
+        }
+      ]
+    },
+    // Design wizard drawer: 30px frame, 22px title, bordered header/footer.
+    drawer: {
+      slots: {
+        container: 'p-[30px] pt-[26px] gap-6',
+        header: 'border-b border-default -mx-[30px] px-[30px] pb-5',
+        title: 'text-[22px] font-bold tracking-[-0.01em]',
+        footer: 'border-t border-default -mx-[30px] -mb-[30px] px-[30px] py-4'
       }
     }
   }

--- a/packages/interloper-app/app/app/assets/css/main.css
+++ b/packages/interloper-app/app/app/assets/css/main.css
@@ -1,61 +1,122 @@
 @import "tailwindcss";
 @import "@nuxt/ui";
 
-/* Custom Colors */
+/* Custom Colors — palette from the Claude Design project ("Current" variant) */
 :root {
-    --color-blue-50: #f0f7ff;
-    --color-blue-100: #e0efff;
-    --color-blue-200: #b8d9ff;
-    --color-blue-300: #7ab9ff;
-    --color-blue-400: #3393ff;
-    --color-blue-500: #4CA0FF;
-    --color-blue-600: #006ce6;
-    --color-blue-700: #004da3;
-    --color-blue-800: #003775;
-    --color-blue-900: #00244d;
-    --color-blue-950: #001833;
-    --color-gray-50: #f5f5f6;
-    --color-gray-100: #eaeaec;
-    --color-gray-200: #d5d5d9;
-    --color-gray-300: #b0b0b8;
-    --color-gray-400: #85858f;
-    --color-gray-500: #6b6b75;
-    --color-gray-600: #565660;
-    --color-gray-700: #43434c;
-    --color-gray-800: #313139;
-    --color-gray-900: #232329;
-    --color-gray-950: #18181c;
+    /* accent #2D7DF6 */
+    --color-blue-50: #f0f6fe;
+    --color-blue-100: #e1edfe;
+    --color-blue-200: #c3dbfc;
+    --color-blue-300: #94bffa;
+    --color-blue-400: #5c9ef8;
+    --color-blue-500: #2d7df6;
+    --color-blue-600: #1e63d9;
+    --color-blue-700: #1a4fae;
+    --color-blue-800: #184189;
+    --color-blue-900: #173867;
+    --color-blue-950: #102344;
+    /* neutrals: 50 app bg · 100 sidebar · 200 controls/hover · 300 lines · 950 ink */
+    --color-gray-50: #fbfbfc;
+    --color-gray-100: #f7f7f8;
+    --color-gray-200: #f0f0f3;
+    --color-gray-300: #e8e8ec;
+    --color-gray-400: #d4d4d9;
+    --color-gray-500: #b0b0b6;
+    --color-gray-600: #9a9aa0;
+    --color-gray-700: #86868b;
+    --color-gray-800: #6b6b70;
+    --color-gray-900: #3f3f44;
+    --color-gray-950: #1d1d1f;
+    /* status: success #1FA463 · error #E5484D · warning #E69E2E (50 = design tints) */
+    --color-green-50: #edf9f2;
+    --color-green-100: #d8f2e4;
+    --color-green-200: #b2e5cb;
+    --color-green-300: #7ed3aa;
+    --color-green-400: #45bc84;
+    --color-green-500: #1fa463;
+    --color-green-600: #17854f;
+    --color-green-700: #146a41;
+    --color-green-800: #125435;
+    --color-green-900: #10452d;
+    --color-green-950: #08271a;
+    --color-red-50: #fceded;
+    --color-red-100: #fadbdc;
+    --color-red-200: #f5b8ba;
+    --color-red-300: #ef8d90;
+    --color-red-400: #ea686c;
+    --color-red-500: #e5484d;
+    --color-red-600: #c93338;
+    --color-red-700: #a6282d;
+    --color-red-800: #852125;
+    --color-red-900: #6b1d20;
+    --color-red-950: #3b0d0f;
+    --color-amber-50: #fbf1e1;
+    --color-amber-100: #f8e6c8;
+    --color-amber-200: #f2d096;
+    --color-amber-300: #edbb66;
+    --color-amber-400: #e9ac46;
+    --color-amber-500: #e69e2e;
+    --color-amber-600: #c98219;
+    --color-amber-700: #a66714;
+    --color-amber-800: #855112;
+    --color-amber-900: #6b4110;
+    --color-amber-950: #3d2407;
 }
 
 
 :root {
     --ui-font-sans: "Inter", sans-serif;
+    --font-mono: "JetBrains Mono", ui-monospace, monospace;
     --ui-header-height: 4rem;
 }
 
 :root {
-    --ui-text-dimmed: var(--color-gray-500);
-    --ui-text-muted: var(--color-gray-600);
-    --ui-text-toned: var(--color-gray-700);
-    --ui-text: var(--color-gray-800);
+    /* text: ink #1d1d1f · ink2 #6b6b70 · ink3 #9a9aa0 */
+    --ui-text-dimmed: var(--color-gray-600);
+    --ui-text-muted: var(--color-gray-800);
+    --ui-text-toned: var(--color-gray-900);
+    --ui-text: var(--color-gray-950);
     --ui-text-highlighted: var(--color-gray-950);
     --ui-text-inverted: #ffffff;
-    --ui-bg: var(--color-gray-50);
+    /* surfaces: white content/cards/header · sidebar (muted) #F7F7F8 */
+    --ui-bg: #ffffff;
+    /* contrasted band: table headers, info strips, chart rulers */
+    --ui-bg-band: #fafafb;
     --ui-bg-muted: var(--color-gray-100);
     --ui-bg-elevated: var(--color-gray-200);
     --ui-bg-accented: var(--color-gray-300);
-    --ui-bg-inverted: var(--color-gray-900);
-    --ui-border: var(--color-gray-200);
-    --ui-border-muted: var(--color-gray-300);
-    --ui-border-accented: var(--color-gray-400);
-    --ui-border-inverted: var(--color-gray-900);
+    --ui-bg-inverted: var(--color-gray-950);
+    /* borders: #E8E8EC lines/input rings · #F2F3F5 row dividers */
+    --ui-border: var(--color-gray-300);
+    --ui-border-muted: #f2f3f5;
+    --ui-border-accented: var(--color-gray-300);
+    --ui-border-inverted: var(--color-gray-950);
     --ui-radius: 0.4rem;
 }
 
+/* Design mono section label ("eyebrow"): pair with a text color utility. */
+.eyebrow {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+}
+
 /* Scrollbar */
+:root {
+    --scrollbar-thumb: var(--color-gray-400);
+    --scrollbar-thumb-hover: var(--color-gray-500);
+}
+
+.dark {
+    --scrollbar-thumb: var(--color-gray-900);
+    --scrollbar-thumb-hover: #4a4a50;
+}
+
 * {
     scrollbar-width: thin;
-    scrollbar-color: var(--ui-border-muted) transparent;
+    scrollbar-color: var(--scrollbar-thumb) transparent;
 }
 
 *::-webkit-scrollbar {
@@ -68,12 +129,12 @@
 }
 
 *::-webkit-scrollbar-thumb {
-    background-color: var(--ui-border-muted);
+    background-color: var(--scrollbar-thumb);
     border-radius: 3px;
 }
 
 *::-webkit-scrollbar-thumb:hover {
-    background-color: var(--ui-border-accented);
+    background-color: var(--scrollbar-thumb-hover);
 }
 
 @keyframes pulse-grow {
@@ -86,27 +147,30 @@
 }
 
 .dark {
-    --ui-text-dimmed: var(--color-gray-500);
-    --ui-text-muted: var(--color-gray-400);
-    --ui-text-toned: var(--color-gray-300);
-    --ui-text: var(--color-gray-200);
+    /* dark surfaces stay bespoke: the design's gray scale is light-oriented,
+       so these are ink-family (#1d1d1f) tones rather than scale slots */
+    --ui-text-dimmed: var(--color-gray-800);
+    --ui-text-muted: var(--color-gray-700);
+    --ui-text-toned: var(--color-gray-500);
+    --ui-text: var(--color-gray-400);
     --ui-text-highlighted: #ffffff;
-    --ui-text-inverted: var(--color-gray-900);
-    --ui-bg: var(--color-gray-950);
-    --ui-bg-muted: var(--color-gray-900);
-    --ui-bg-elevated: var(--color-gray-800);
-    --ui-bg-accented: var(--color-gray-700);
+    --ui-text-inverted: var(--color-gray-950);
+    --ui-bg: #18181b;
+    --ui-bg-band: #232326;
+    --ui-bg-muted: #232326;
+    --ui-bg-elevated: #2e2e32;
+    --ui-bg-accented: var(--color-gray-900);
     --ui-bg-inverted: #ffffff;
-    --ui-border: var(--color-gray-800);
-    --ui-border-muted: var(--color-gray-700);
-    --ui-border-accented: var(--color-gray-700);
+    --ui-border: #2e2e32;
+    --ui-border-muted: #29292c;
+    --ui-border-accented: var(--color-gray-900);
     --ui-border-inverted: #ffffff;
     --ui-radius: 0.4rem;
 
-    --vf-node-bg: var(--color-gray-800);
-    --vf-node-text: var(--color-gray-200);
-    --vf-connection-path: var(--color-gray-500);
-    --vf-handle: var(--color-gray-400);
+    --vf-node-bg: var(--ui-bg-elevated);
+    --vf-node-text: var(--color-gray-400);
+    --vf-connection-path: var(--color-gray-800);
+    --vf-handle: var(--color-gray-700);
 }
 
 /* Vue Flow dark mode overrides */
@@ -115,26 +179,26 @@
 }
 
 .dark .vue-flow__controls-button {
-    background: var(--color-gray-800);
-    border-bottom-color: var(--color-gray-700);
+    background: var(--ui-bg-elevated);
+    border-bottom-color: var(--color-gray-900);
 }
 
 .dark .vue-flow__controls-button svg {
-    fill: var(--color-gray-300);
+    fill: var(--color-gray-500);
 }
 
 .dark .vue-flow__controls-button:hover {
-    background: var(--color-gray-700);
+    background: var(--color-gray-900);
 }
 
 .dark .vue-flow__minimap {
-    background-color: var(--color-gray-900);
+    background-color: var(--ui-bg-muted);
 }
 
 .dark .vue-flow__edge-textbg {
-    fill: var(--color-gray-900);
+    fill: var(--ui-bg-muted);
 }
 
 .dark .vue-flow__handle {
-    border-color: var(--color-gray-800);
+    border-color: var(--ui-bg-elevated);
 }

--- a/packages/interloper-app/app/app/components/CatalogCard.vue
+++ b/packages/interloper-app/app/app/components/CatalogCard.vue
@@ -1,0 +1,103 @@
+<script setup lang="ts">
+/**
+ * Design catalog-grid card, used by the empty-state catalogs.
+ *
+ * Two variants, fully data-driven so every page renders the same structure:
+ * - `rich`: icon tile + title/caption header, description body, pinned
+ *   footer with info chips (left) and a "Set up →" action (right).
+ * - `compact`: single row — icon tile, title/caption, trailing "+".
+ */
+withDefaults(defineProps<{
+    icon: string
+    title: string
+    /** Mono uppercase caption under the title (e.g. tag or provider). */
+    caption?: string
+    /** Rich variant only: body text, clamped to two lines. */
+    description?: string
+    /** Rich variant only: bordered info chips in the footer. */
+    chips?: { icon?: string, label: string }[]
+    variant?: 'rich' | 'compact'
+    /** Set false for static usage (e.g. selected-type summary): no hover/cursor. */
+    interactive?: boolean
+}>(), { variant: 'rich', caption: undefined, description: undefined, chips: () => [], interactive: true })
+</script>
+
+<template>
+    <UCard v-if="variant === 'rich'"
+           class="cursor-pointer transition hover:ring-primary/40 hover:shadow-md hover:-translate-y-0.5"
+           :ui="{
+               root: 'rounded-[13px] shadow-xs divide-y-0 flex flex-col',
+               header: 'p-4 pb-0 sm:p-4 sm:pb-0',
+               body: 'p-4 py-3 sm:p-4 sm:py-3 flex-1',
+               footer: 'p-4 pt-0 sm:p-4 sm:pt-0',
+           }">
+        <template #header>
+            <div class="flex items-center gap-3">
+                <div class="size-[38px] shrink-0 rounded-[10px] border border-default flex items-center justify-center">
+                    <UIcon :name="icon"
+                           class="size-5" />
+                </div>
+                <div class="flex-1 min-w-0">
+                    <div class="text-[14.5px] font-semibold text-highlighted truncate">{{ title }}</div>
+                    <div v-if="caption"
+                         class="font-mono text-[11px] uppercase tracking-[0.04em] text-dimmed mt-0.5 truncate">
+                        {{ caption }}
+                    </div>
+                </div>
+            </div>
+        </template>
+
+        <p v-if="description"
+           class="text-[13px] text-muted leading-normal line-clamp-2">
+            {{ description }}
+        </p>
+
+        <template #footer>
+            <div class="flex items-center justify-between gap-2">
+                <div class="flex items-center gap-2 min-w-0">
+                    <span v-for="chip in chips"
+                          :key="chip.label"
+                          class="inline-flex items-center gap-1.5 border border-default rounded-md px-2 py-1 text-xs font-medium text-muted bg-(--ui-bg-band) truncate">
+                        <UIcon v-if="chip.icon"
+                               :name="chip.icon"
+                               class="size-3 shrink-0" />
+                        {{ chip.label }}
+                    </span>
+                </div>
+                <span class="flex items-center gap-1.5 text-primary text-[13px] font-semibold shrink-0">
+                    Set up
+                    <UIcon name="i-lucide-arrow-right"
+                           class="size-3" />
+                </span>
+            </div>
+        </template>
+    </UCard>
+
+    <UCard v-else
+           :class="interactive
+               ? 'cursor-pointer transition hover:ring-primary/40 hover:shadow-md hover:-translate-y-0.5'
+               : 'bg-(--ui-bg-band)'"
+           :ui="{
+               root: 'rounded-[13px] shadow-xs',
+               body: 'p-3.5 px-4 sm:p-3.5 sm:px-4',
+           }">
+        <div class="flex items-center gap-3">
+            <div class="size-10 shrink-0 rounded-[11px] border border-default bg-default flex items-center justify-center">
+                <UIcon :name="icon"
+                       class="size-6" />
+            </div>
+            <div class="flex-1 min-w-0">
+                <div class="text-[14.5px] font-semibold text-highlighted truncate">{{ title }}</div>
+                <div v-if="caption"
+                     class="font-mono text-[11px] uppercase tracking-[0.05em] text-dimmed mt-0.5 truncate">
+                    {{ caption }}
+                </div>
+            </div>
+            <slot name="trailing">
+                <UIcon v-if="interactive"
+                       name="i-lucide-plus"
+                       class="size-3.5 text-primary shrink-0" />
+            </slot>
+        </div>
+    </UCard>
+</template>

--- a/packages/interloper-app/app/app/components/DataTable.vue
+++ b/packages/interloper-app/app/app/components/DataTable.vue
@@ -117,12 +117,17 @@ function onRowContextMenu(e: Event, row: { original: TData }) {
     ctxMenuOpen.value = true
 }
 
-const totalPages = computed(() => Math.ceil(totalCount.value / PAGE_SIZE))
+
+// ── Empty state ──
+const slots = useSlots()
+/** With no data at all (not just filtered out), render the #empty slot instead of the table. */
+const showEmpty = computed(() => !props.loading && props.data.length === 0 && !!slots.empty)
 </script>
 
 <template>
     <div class="w-full flex flex-col gap-4">
-        <div class="flex items-center gap-2 px-4 pt-4">
+        <div v-if="!showEmpty"
+             class="flex items-center gap-3">
             <UInput v-model="globalFilter"
                     :placeholder="searchPlaceholder ?? 'Search...'"
                     icon="i-lucide-search"
@@ -158,7 +163,13 @@ const totalPages = computed(() => Math.ceil(totalCount.value / PAGE_SIZE))
             </div>
         </div>
 
-        <UTable ref="table"
+        <div v-if="showEmpty"
+             class="w-full max-w-[1040px] mx-auto">
+            <slot name="empty" />
+        </div>
+
+        <UTable v-if="!showEmpty"
+                ref="table"
                 v-model:pagination="pagination"
                 :data="data"
                 :columns="columnsWithActions"
@@ -209,20 +220,17 @@ const totalPages = computed(() => Math.ceil(totalCount.value / PAGE_SIZE))
             </template>
         </UModal>
 
-        <div class="flex items-center justify-between text-sm text-muted px-4 pb-4">
-            <span v-if="selectedCount > 0">
+        <TableFooter v-if="!showEmpty"
+                     :page="pagination.pageIndex + 1"
+                     :total="totalCount"
+                     :page-size="PAGE_SIZE"
+                     @update:page="(p: number) => pagination = { ...pagination, pageIndex: p - 1 }">
+            <template v-if="selectedCount > 0">
                 {{ selectedCount }} of {{ totalCount }} row(s) selected.
-            </span>
-            <span v-else>
+            </template>
+            <template v-else>
                 {{ totalCount }} row(s) total.
-            </span>
-            <UPagination v-if="totalPages > 1"
-                         :page="pagination.pageIndex + 1"
-                         :total="totalCount"
-                         :items-per-page="PAGE_SIZE"
-                         :sibling-count="1"
-                         show-edges
-                         @update:page="(p: number) => pagination = { ...pagination, pageIndex: p - 1 }" />
-        </div>
+            </template>
+        </TableFooter>
     </div>
 </template>

--- a/packages/interloper-app/app/app/components/EmptyState.vue
+++ b/packages/interloper-app/app/app/components/EmptyState.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+/** Design empty-state hero: gradient card with an accent icon tile. */
+defineProps<{
+    icon: string
+    title: string
+    description?: string
+}>()
+</script>
+
+<template>
+    <div class="w-full border border-default rounded-[18px] px-8 py-[42px] text-center bg-gradient-to-b from-[#FCFCFD] to-[#F6F7F9] dark:from-transparent dark:to-(--ui-bg-muted)">
+        <div class="size-[58px] mx-auto rounded-[16px] bg-primary/10 text-primary flex items-center justify-center">
+            <UIcon :name="icon"
+                   class="size-7" />
+        </div>
+        <h2 class="text-[22px] font-bold tracking-[-0.02em] text-highlighted mt-4">
+            {{ title }}
+        </h2>
+        <p v-if="description"
+           class="text-[15px] text-muted leading-relaxed max-w-[560px] mx-auto mt-3">
+            {{ description }}
+        </p>
+        <slot />
+    </div>
+</template>

--- a/packages/interloper-app/app/app/components/InlineEmptyState.vue
+++ b/packages/interloper-app/app/app/components/InlineEmptyState.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+/** Wizard placeholder when no resource exists yet: dashed card + create action. */
+defineProps<{
+    icon: string
+    message: string
+    actionLabel: string
+}>()
+
+const emit = defineEmits<{ action: [] }>()
+</script>
+
+<template>
+    <div class="flex flex-col items-center gap-3 rounded-[14px] border border-dashed border-accented bg-(--ui-bg-band) px-6 py-8">
+        <div class="size-10 rounded-[11px] border border-default bg-default flex items-center justify-center">
+            <UIcon :name="icon"
+                   class="size-6" />
+        </div>
+        <p class="text-sm text-muted">{{ message }}</p>
+        <UButton icon="i-lucide-plus"
+                 :label="actionLabel"
+                 size="md"
+                 @click="emit('action')" />
+    </div>
+</template>

--- a/packages/interloper-app/app/app/components/SelectionCard.vue
+++ b/packages/interloper-app/app/app/components/SelectionCard.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+/**
+ * Wizard "pick an option" card: bordered card that shows the accent
+ * border + tint when selected. Content comes from the default slot.
+ */
+withDefaults(defineProps<{
+    selected?: boolean
+    /** Root element — `button` for single-select rows, `div` when the card hosts interactive children. */
+    as?: 'button' | 'div'
+}>(), { selected: false, as: 'button' })
+
+const emit = defineEmits<{ select: [] }>()
+</script>
+
+<template>
+    <component :is="as"
+               :type="as === 'button' ? 'button' : undefined"
+               class="rounded-[13px] border-2 text-left cursor-pointer transition"
+               :class="selected
+                   ? 'border-primary bg-primary/5'
+                   : 'border-default bg-default hover:border-primary/40'"
+               @click="emit('select')">
+        <slot />
+    </component>
+</template>

--- a/packages/interloper-app/app/app/components/StatusPill.vue
+++ b/packages/interloper-app/app/app/components/StatusPill.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+/** Design status pill: tinted rounded-full chip with a currentColor dot. */
+const props = withDefaults(defineProps<{
+    label: string
+    color?: 'success' | 'warning' | 'error' | 'neutral' | 'primary'
+    /** Hide the leading dot (e.g. for counts). */
+    dot?: boolean
+}>(), { color: 'neutral', dot: true })
+
+const COLOR_CLASSES: Record<NonNullable<typeof props.color>, string> = {
+    success: 'bg-green-500/10 text-green-700 dark:bg-green-400/10 dark:text-green-400',
+    warning: 'bg-amber-500/15 text-amber-700 dark:bg-amber-400/10 dark:text-amber-400',
+    error: 'bg-red-500/10 text-red-700 dark:bg-red-400/10 dark:text-red-400',
+    neutral: 'bg-elevated text-muted',
+    primary: 'bg-primary/10 text-primary',
+}
+</script>
+
+<template>
+    <span class="inline-flex items-center gap-1.5 px-2.5 py-[3px] rounded-full text-[11px] font-semibold"
+          :class="COLOR_CLASSES[color]">
+        <span v-if="dot"
+              class="size-1.5 rounded-full bg-current" />
+        {{ label }}
+    </span>
+</template>

--- a/packages/interloper-app/app/app/components/StepperNav.vue
+++ b/packages/interloper-app/app/app/components/StepperNav.vue
@@ -11,12 +11,15 @@ withDefaults(defineProps<{
     submitting?: boolean
     submitLabel?: string
     backLabel?: string
+    /** On the last step the primary button drops its forward arrow. */
+    lastStep?: boolean
 }>(), {
     canProceed: false,
     hasPrev: false,
     submitting: false,
     submitLabel: 'Next',
     backLabel: 'Back',
+    lastStep: false,
 })
 
 const emit = defineEmits<{
@@ -35,6 +38,7 @@ const emit = defineEmits<{
         <UButton :disabled="!canProceed || submitting"
                  :loading="submitting"
                  :label="submitLabel"
+                 :trailing-icon="lastStep ? undefined : 'i-lucide-arrow-right'"
                  @click="emit('next')" />
     </div>
 </template>

--- a/packages/interloper-app/app/app/components/TableFooter.vue
+++ b/packages/interloper-app/app/app/components/TableFooter.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+/** Table caption + pagination bar (caption text via the default slot). */
+withDefaults(defineProps<{
+    page?: number
+    total?: number
+    pageSize?: number
+}>(), { page: 1, total: 0, pageSize: 20 })
+
+const emit = defineEmits<{ 'update:page': [page: number] }>()
+</script>
+
+<template>
+    <div class="flex items-center justify-between text-[13px] text-dimmed">
+        <span><slot /></span>
+        <UPagination v-if="total > pageSize"
+                     :page="page"
+                     :total="total"
+                     :items-per-page="pageSize"
+                     :sibling-count="1"
+                     show-edges
+                     @update:page="emit('update:page', $event)" />
+    </div>
+</template>

--- a/packages/interloper-app/app/app/components/TypeSelect.vue
+++ b/packages/interloper-app/app/app/components/TypeSelect.vue
@@ -52,6 +52,8 @@ const groups = computed(() => {
         <UInput v-model="search"
                 placeholder="Search..."
                 icon="i-lucide-search"
+                variant="subtle"
+                :ui="{ base: 'bg-muted' }"
                 class="w-full" />
 
         <div v-if="filtered.length === 0"
@@ -62,22 +64,21 @@ const groups = computed(() => {
         <template v-else>
             <div v-for="[tag, items] in groups"
                  :key="tag"
-                 class="flex flex-col gap-2">
+                 class="flex flex-col gap-3">
                 <span v-if="tag"
-                      class="text-sm font-medium text-muted capitalize tracking-wide">{{ tag }}</span>
-                <div class="grid grid-cols-3 auto-rows-[7rem] gap-2">
-                    <UCard v-for="defn in items"
-                           :key="defn.key"
-                           class="cursor-pointer text-center h-full"
-                           :class="[
-                               selectedKey === defn.key ? 'ring-primary ring-2' : '',
-                           ]"
-                           :ui="{ root: 'transition-colors hover:bg-elevated', body: 'flex flex-col items-center justify-center gap-4 p-3 sm:p-3 h-full' }"
-                           @click="selectedKey = defn.key">
-                        <UIcon :name="componentIcon(defn.key)"
-                               class="size-8 shrink-0" />
-                        <span class="text-sm font-medium leading-tight line-clamp-2">{{ defn.name }}</span>
-                    </UCard>
+                      class="eyebrow text-dimmed">{{ tag }}</span>
+                <div class="grid grid-cols-2 gap-3">
+                    <SelectionCard v-for="defn in items"
+                                   :key="defn.key"
+                                   :selected="selectedKey === defn.key"
+                                   class="flex flex-col items-center gap-2.5 px-3.5 py-[18px]"
+                                   @select="selectedKey = defn.key">
+                        <div class="size-11 shrink-0 rounded-xl border border-default bg-default flex items-center justify-center">
+                            <UIcon :name="componentIcon(defn.key)"
+                                   class="size-[26px]" />
+                        </div>
+                        <span class="text-[13.5px] font-semibold text-highlighted text-center leading-tight line-clamp-2">{{ defn.name }}</span>
+                    </SelectionCard>
                 </div>
             </div>
         </template>

--- a/packages/interloper-app/app/app/components/TypeSummaryCard.vue
+++ b/packages/interloper-app/app/app/components/TypeSummaryCard.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+/** Wizard summary of the selected type, with an optional "Change" action. */
+withDefaults(defineProps<{
+    icon: string
+    title: string
+    caption?: string
+    /** Show the "Change" action (create mode only — editing can't change type). */
+    changeable?: boolean
+}>(), { caption: undefined, changeable: false })
+
+const emit = defineEmits<{ change: [] }>()
+</script>
+
+<template>
+    <CatalogCard variant="compact"
+                 :interactive="false"
+                 :icon="icon"
+                 :title="title"
+                 :caption="caption">
+        <template v-if="changeable"
+                  #trailing>
+            <UButton label="Change"
+                     variant="link"
+                     size="sm"
+                     class="shrink-0"
+                     @click="emit('change')" />
+        </template>
+    </CatalogCard>
+</template>

--- a/packages/interloper-app/app/app/components/WizardDrawer.vue
+++ b/packages/interloper-app/app/app/components/WizardDrawer.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+/**
+ * Shared chrome for the create/edit wizards: right drawer at the design
+ * width, close button, and the StepperNav footer wired to the stepper
+ * exposed by the body slot (pages keep `ref="stepperRef"` on their stepper
+ * and pass it back via the `stepper` prop).
+ */
+interface StepperHandle {
+    title: string
+    canProceed: boolean
+    hasPrev: boolean
+    isLastStep: boolean
+    submitting: boolean
+    submitLabel: string
+    next: () => void
+    prev: () => void
+}
+
+const open = defineModel<boolean>('open', { required: true })
+
+withDefaults(defineProps<{
+    /** Fallback title while the stepper ref isn't mounted yet. */
+    defaultTitle: string
+    /** Accessible description (visually hidden). */
+    description: string
+    /** The stepper component instance exposed from the body slot. */
+    stepper?: StepperHandle | null
+}>(), { stepper: null })
+</script>
+
+<template>
+    <UDrawer v-model:open="open"
+             direction="right"
+             :handle="false"
+             :handle-only="true"
+             :title="stepper?.title ?? defaultTitle"
+             :ui="{ content: 'w-[35rem]', description: 'sr-only' }">
+        <template #description>
+            {{ description }}
+        </template>
+        <template #body>
+            <UButton icon="i-lucide-x"
+                     color="neutral"
+                     variant="soft"
+                     size="md"
+                     class="absolute top-[22px] right-[26px] rounded-[9px] text-muted"
+                     aria-label="Close"
+                     @click="open = false" />
+            <slot />
+        </template>
+        <template #footer>
+            <StepperNav v-if="stepper"
+                        :last-step="stepper.isLastStep"
+                        :can-proceed="stepper.canProceed"
+                        :has-prev="stepper.hasPrev"
+                        :submitting="stepper.submitting"
+                        :submit-label="stepper.submitLabel"
+                        @next="stepper.next()"
+                        @prev="stepper.prev()" />
+        </template>
+    </UDrawer>
+</template>

--- a/packages/interloper-app/app/app/components/WizardRecap.vue
+++ b/packages/interloper-app/app/app/components/WizardRecap.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+/** Design recap table: bordered card of icon | label | value rows. */
+defineProps<{
+    rows: { icon: string, label: string, value: string }[]
+}>()
+</script>
+
+<template>
+    <div class="border border-default rounded-[12px] px-3.5 py-1 bg-default">
+        <div v-for="(row, i) in rows"
+             :key="row.label"
+             class="flex items-center gap-2.5 py-2.5"
+             :class="i < rows.length - 1 ? 'border-b border-default' : ''">
+            <UIcon :name="row.icon"
+                   class="size-4 text-dimmed shrink-0" />
+            <span class="flex-1 text-[13px] text-muted">{{ row.label }}</span>
+            <span class="text-[13px] font-semibold text-highlighted text-right max-w-[60%] truncate">{{ row.value }}</span>
+        </div>
+    </div>
+</template>

--- a/packages/interloper-app/app/app/components/catalog/Table.vue
+++ b/packages/interloper-app/app/app/components/catalog/Table.vue
@@ -189,7 +189,6 @@ const uniqueSourceIds = computed(() => {
     return ids
 })
 
-const totalSourcePages = computed(() => Math.ceil(uniqueSourceIds.value.length / SOURCE_PAGE_SIZE))
 
 const paginatedData = computed(() => {
     const start = sourcePageIndex.value * SOURCE_PAGE_SIZE
@@ -225,7 +224,7 @@ function onRowClick(row: any) {
 
 <template>
     <div class="w-full flex flex-col gap-4">
-        <div class="flex items-center gap-2 px-4 pt-4">
+        <div class="flex items-center gap-3">
             <UInput v-model="globalFilter"
                     placeholder="Search catalog..."
                     icon="i-lucide-search"
@@ -560,17 +559,12 @@ function onRowClick(row: any) {
             <div class="hidden" />
         </UDropdownMenu>
 
-        <div class="flex items-center justify-between text-sm text-muted px-4 pb-4">
-            <span>{{ sources.length }} {{ sources.length === 1 ? 'source' : 'sources' }}, {{ assetCount }} {{
-                assetCount === 1
-                    ? 'asset' : 'assets' }}</span>
-            <UPagination v-if="totalSourcePages > 1"
-                         :page="sourcePageIndex + 1"
-                         :total="uniqueSourceIds.length"
-                         :items-per-page="SOURCE_PAGE_SIZE"
-                         :sibling-count="1"
-                         show-edges
-                         @update:page="(p: number) => sourcePageIndex = p - 1" />
-        </div>
+        <TableFooter :page="sourcePageIndex + 1"
+                     :total="uniqueSourceIds.length"
+                     :page-size="SOURCE_PAGE_SIZE"
+                     @update:page="(p: number) => sourcePageIndex = p - 1">
+            {{ sources.length }} {{ sources.length === 1 ? 'source' : 'sources' }},
+            {{ assetCount }} {{ assetCount === 1 ? 'asset' : 'assets' }}
+        </TableFooter>
     </div>
 </template>

--- a/packages/interloper-app/app/app/components/chart/ExecutionTimeline.vue
+++ b/packages/interloper-app/app/app/components/chart/ExecutionTimeline.vue
@@ -38,13 +38,8 @@ const colorMode = useColorMode()
 const isDark = computed(() => colorMode.value === 'dark')
 
 function getStatusColor(status: string) {
-    switch (status) {
-        case 'success': return isDark.value ? '#22c55e' : '#16a34a'
-        case 'failed': return isDark.value ? '#f87171' : '#dc2626'
-        case 'running': return isDark.value ? '#60a5fa' : '#2563eb'
-        case 'canceled': return isDark.value ? '#fbbf24' : '#d97706'
-        default: return isDark.value ? '#6b7280' : '#d1d5db'
-    }
+    const entry = CHART_STATUS_COLORS[status] ?? CHART_STATUS_COLORS.default!
+    return isDark.value ? entry.dark : entry.light
 }
 
 /**********************
@@ -431,7 +426,7 @@ watch(axisMax, () => {
          @click="onBlankClick"
          @dblclick="resetZoom">
         <!-- Time axis / ruler: sticky, and the drag-to-pan surface when zoomed. -->
-        <div class="sticky top-0 z-20 flex select-none border-b border-default bg-default"
+        <div class="sticky top-0 z-20 flex select-none border-b border-default bg-(--ui-bg-band)"
              :class="fitted ? '' : 'cursor-ew-resize'"
              :style="{ height: AXIS_HEIGHT + 'px' }"
              @pointerdown="onRulerPointerDown"

--- a/packages/interloper-app/app/app/components/chart/PartitionRowCounts.vue
+++ b/packages/interloper-app/app/app/components/chart/PartitionRowCounts.vue
@@ -30,8 +30,8 @@ const chartHeight = computed(() =>
 
 const option = computed(() => {
     const isDark = colorMode.value === 'dark'
-    const axisColor = isDark ? '#9ca3af' : '#6b7280'
-    const barColor = isDark ? '#60a5fa' : '#2563eb'
+    const axisColor = isDark ? CHART_AXIS_COLORS.axis.dark : CHART_AXIS_COLORS.axis.light
+    const barColor = isDark ? CHART_AXIS_COLORS.bar.dark : CHART_AXIS_COLORS.bar.light
 
     return {
         grid: {
@@ -70,7 +70,7 @@ const option = computed(() => {
                 formatter: formatNumber,
             },
             splitLine: {
-                lineStyle: { color: isDark ? '#374151' : '#e5e7eb' },
+                lineStyle: { color: isDark ? CHART_AXIS_COLORS.grid.dark : CHART_AXIS_COLORS.grid.light },
             },
         },
         series: [

--- a/packages/interloper-app/app/app/components/destinations/Stepper.vue
+++ b/packages/interloper-app/app/app/components/destinations/Stepper.vue
@@ -21,10 +21,13 @@ const props = withDefaults(defineProps<{
     compatibleKeys?: string[]
     /** When set, stepper opens in edit mode with values pre-filled. */
     destination?: Destination | null
+    /** Preselect this type and open directly on the next step (create mode). */
+    initialTypeKey?: string
 }>(), {
     mode: 'standalone',
     compatibleKeys: () => [],
     destination: null,
+    initialTypeKey: undefined,
 })
 
 const emit = defineEmits<{
@@ -105,7 +108,7 @@ const steps = computed<StepperItem[]>(() => {
         const kind = rs.slotName.charAt(0).toUpperCase() + rs.slotName.slice(1)
         items.push({
             title: kind,
-            icon: rs.slotName === 'connection' ? 'i-lucide-key-round' : 'i-lucide-settings',
+            icon: resourceSlotIcon(rs.slotName),
             slot: `resource-${rs.slotName}` as any,
         })
     }
@@ -121,6 +124,26 @@ const steps = computed<StepperItem[]>(() => {
 const totalSteps = computed(() => steps.value.length)
 const { activeStep, hasPrev, isLastStep, next: nextStep, prev: prevStep } = useStepperFlow(totalSteps)
 
+const displaySteps = useCheckedSteps(steps, activeStep)
+
+/** Selected-type summary card shown on every post-type step. */
+const summaryCard = computed(() => destDefn.value && {
+    icon: componentIcon(destDefn.value.key),
+    title: destDefn.value.name,
+    caption: destDefn.value.tags?.[0] ?? 'Destination',
+    changeable: !isEditMode.value,
+})
+
+/** Recap rows for the final step — the resources chosen along the way. */
+const recapRows = computed(() => resourceSlots.value.map((rs) => {
+    const id = resourceSelections.value[rs.slotName]
+    return {
+        icon: resourceSlotIcon(rs.slotName),
+        label: rs.slotName.charAt(0).toUpperCase() + rs.slotName.slice(1),
+        value: id ? (resourcesStore.findById(id)?.name ?? '—') : 'None',
+    }
+}))
+
 // ── Auto-advance on type selection ──────────────────────────────
 
 watch(selectedDestKey, (key) => {
@@ -129,6 +152,13 @@ watch(selectedDestKey, (key) => {
         resourceSelections.value = {}
         configData.value = {}
         nextStep()
+    }
+})
+
+onMounted(() => {
+    if (!isEditMode.value && props.initialTypeKey) {
+        // Triggers the selection watcher above, which advances past the type step.
+        selectedDestKey.value = props.initialTypeKey
     }
 })
 
@@ -248,7 +278,7 @@ defineExpose({ canProceed, hasPrev, isLastStep, submitting, submitLabel, title, 
 
 <template>
     <UStepper v-model="activeStep"
-              :items="steps"
+              :items="displaySteps"
               linear
               disabled
               class="w-full">
@@ -263,27 +293,40 @@ defineExpose({ canProceed, hasPrev, isLastStep, submitting, submitLabel, title, 
         <template v-for="rs in resourceSlots"
                   :key="rs.slotName"
                   #[`resource-${rs.slotName}`]>
-            <SourcesResourceStep v-if="rs.definition"
-                                 :ref="(el: any) => { if (el) resourceStepRefs[rs.slotName] = el }"
-                                 v-model="resourceSelections[rs.slotName]"
-                                 :slot-name="rs.slotName"
-                                 :definition="rs.definition"
-                                 :resource-context="resourceContext"
-                                 :silent="props.mode === 'collect'" />
+            <div class="flex flex-col gap-6">
+                <TypeSummaryCard v-if="summaryCard"
+                                 v-bind="summaryCard"
+                                 @change="activeStep = 0" />
+
+                <SourcesResourceStep v-if="rs.definition"
+                                     :ref="(el: any) => { if (el) resourceStepRefs[rs.slotName] = el }"
+                                     v-model="resourceSelections[rs.slotName]"
+                                     :slot-name="rs.slotName"
+                                     :definition="rs.definition"
+                                     :resource-context="resourceContext"
+                                     :silent="props.mode === 'collect'" />
+            </div>
         </template>
 
         <!-- Config step -->
         <template v-if="hasConfig"
                   #config>
-            <div class="flex flex-col gap-4">
-                <p class="text-sm text-muted">
-                    Configure <strong>{{ destDefn?.name }}</strong> settings.
-                </p>
-                <UFormField label="Name">
+            <div class="flex flex-col gap-6">
+                <TypeSummaryCard v-if="summaryCard"
+                                 v-bind="summaryCard"
+                                 @change="activeStep = 0" />
+
+                <UFormField label="Destination name">
                     <UInput v-model="destName"
                             placeholder="Destination name"
                             class="w-full" />
                 </UFormField>
+
+                <WizardRecap v-if="recapRows.length"
+                             :rows="recapRows" />
+
+                <USeparator label="Configuration" />
+
                 <SchemaForm v-if="destDefn?.config_schema"
                             v-model:data="configData"
                             v-model:is-valid="configValid"

--- a/packages/interloper-app/app/app/components/executions/BackfillsTable.vue
+++ b/packages/interloper-app/app/app/components/executions/BackfillsTable.vue
@@ -34,7 +34,6 @@ function jobName(backfill: Backfill): string {
 
 const pagination = ref({ pageIndex: 0, pageSize: PAGE_SIZE })
 const sorting = ref([{ id: 'started_at', desc: true }])
-const totalPages = computed(() => Math.ceil(backfills.value.length / PAGE_SIZE))
 
 const columns: TableColumn<Backfill>[] = withSortableHeaders([
     {
@@ -89,24 +88,35 @@ const columns: TableColumn<Backfill>[] = withSortableHeaders([
 
 <template>
     <div class="flex flex-col flex-1 min-h-0">
-        <UTable v-model:pagination="pagination"
-                v-model:sorting="sorting"
-                :data="backfills"
-                :columns="columns"
-                :loading="loading"
-                :pagination-options="{ getPaginationRowModel: getPaginationRowModel() }"
-                sticky
-                @select="(_e: Event, row: any) => navigateTo(`/executions/backfills/${row.original.id}`)" />
+        <div v-if="!loading && backfills.length === 0"
+             class="w-full max-w-[1040px] mx-auto">
+            <EmptyState icon="i-lucide-history"
+                        title="No backfills yet"
+                        description="Backfills re-run historical partitions to fill gaps or reprocess past data. Trigger one from a job and every partition it replays shows up here.">
+                <UButton icon="i-lucide-calendar-plus"
+                         label="Go to Jobs"
+                         class="mt-5"
+                         to="/jobs" />
+            </EmptyState>
+        </div>
 
-        <div class="flex items-center justify-between text-sm text-muted px-4 py-3">
-            <span>{{ backfills.length }} backfill(s) total.</span>
-            <UPagination v-if="totalPages > 1"
+        <template v-else>
+            <UTable v-model:pagination="pagination"
+                    v-model:sorting="sorting"
+                    :data="backfills"
+                    :columns="columns"
+                    :loading="loading"
+                    :pagination-options="{ getPaginationRowModel: getPaginationRowModel() }"
+                    sticky
+                    @select="(_e: Event, row: any) => navigateTo(`/executions/backfills/${row.original.id}`)" />
+
+            <TableFooter class="py-3"
                          :page="pagination.pageIndex + 1"
                          :total="backfills.length"
-                         :items-per-page="PAGE_SIZE"
-                         :sibling-count="1"
-                         show-edges
-                         @update:page="(p: number) => pagination = { ...pagination, pageIndex: p - 1 }" />
-        </div>
+                         :page-size="PAGE_SIZE"
+                         @update:page="(p: number) => pagination = { ...pagination, pageIndex: p - 1 }">
+                {{ backfills.length }} backfill(s) total.
+            </TableFooter>
+        </template>
     </div>
 </template>

--- a/packages/interloper-app/app/app/components/executions/EventsTable.vue
+++ b/packages/interloper-app/app/app/components/executions/EventsTable.vue
@@ -132,7 +132,7 @@ const columns: TableColumn<RunEvent>[] = [
             :columns="columns"
             :loading="loading"
             sticky
-            :ui="{ tr: 'h-10' }"
+            :ui="{ tr: 'h-10', root: 'border-0 rounded-none' }"
             class="h-full"
             :on-hover="onRowHover">
         <template #body-bottom>

--- a/packages/interloper-app/app/app/components/executions/RunsTable.vue
+++ b/packages/interloper-app/app/app/components/executions/RunsTable.vue
@@ -76,7 +76,6 @@ const columns: TableColumn<Run>[] = [
     },
 ]
 
-const totalPages = computed(() => Math.ceil(total.value / pageSize.value))
 
 function onPageChange(page: number) {
     runsStore.goToPage(page - 1)
@@ -85,22 +84,33 @@ function onPageChange(page: number) {
 
 <template>
     <div class="flex flex-col flex-1 min-h-0">
-        <UTable :data="runs"
-                :columns="columns"
-                :loading="loading"
-                :sorting="[{ id: 'created_at', desc: true }]"
-                sticky
-                @select="(_e: Event, row: any) => navigateTo(`/executions/runs/${row.original.id}`)" />
+        <div v-if="!loading && runs.length === 0"
+             class="w-full max-w-[1040px] mx-auto">
+            <EmptyState icon="i-lucide-activity"
+                        title="No executions yet"
+                        description="Executions are the run history of your pipelines. Every time a job runs — on schedule or triggered manually — each materialized partition appears here with its status and timing.">
+                <UButton icon="i-lucide-calendar-plus"
+                         label="Create a job"
+                         class="mt-5"
+                         to="/jobs" />
+            </EmptyState>
+        </div>
 
-        <div class="flex items-center justify-between text-sm text-muted px-4 py-3">
-            <span>{{ total }} run(s) total.</span>
-            <UPagination v-if="totalPages > 1"
+        <template v-else>
+            <UTable :data="runs"
+                    :columns="columns"
+                    :loading="loading"
+                    :sorting="[{ id: 'created_at', desc: true }]"
+                    sticky
+                    @select="(_e: Event, row: any) => navigateTo(`/executions/runs/${row.original.id}`)" />
+
+            <TableFooter class="py-3"
                          :page="pageIndex + 1"
                          :total="total"
-                         :items-per-page="pageSize"
-                         :sibling-count="1"
-                         show-edges
-                         @update:page="onPageChange" />
-        </div>
+                         :page-size="pageSize"
+                         @update:page="onPageChange">
+                {{ total }} run(s) total.
+            </TableFooter>
+        </template>
     </div>
 </template>

--- a/packages/interloper-app/app/app/components/graph/GraphCanvas.vue
+++ b/packages/interloper-app/app/app/components/graph/GraphCanvas.vue
@@ -610,11 +610,27 @@ function onEdgeContextMenu({ edge, event }: { edge: Edge; event: MouseEvent | To
             <Panel v-if="editable && sourceEntries.length === 0"
                    position="top-left"
                    class="!inset-0 !m-0 flex items-center justify-center pointer-events-none">
-                <UButton icon="i-lucide-plus"
-                         label="Add your first source"
-                         size="lg"
-                         class="pointer-events-auto"
-                         @click="emit('add-source')" />
+                <div class="pointer-events-auto w-[430px] max-w-[92%] bg-default border border-default rounded-[20px] shadow-2xl px-8 py-9 text-center">
+                    <div class="size-14 mx-auto rounded-[16px] bg-primary/10 text-primary flex items-center justify-center">
+                        <UIcon name="i-lucide-workflow"
+                               class="size-7" />
+                    </div>
+                    <div class="eyebrow text-primary mt-4">
+                        Asset graph
+                    </div>
+                    <h2 class="text-[22px] font-bold tracking-[-0.02em] text-highlighted mt-2">
+                        Your data, wired together
+                    </h2>
+                    <p class="text-[15px] text-muted leading-relaxed mt-2.5">
+                        The graph is a live map of every source, the assets they produce and
+                        the dependencies between them — Interloper wires it automatically as
+                        you build. Add your first source to watch it take shape.
+                    </p>
+                    <UButton icon="i-lucide-plus"
+                             label="Add your first source"
+                             class="mt-6"
+                             @click="emit('add-source')" />
+                </div>
             </Panel>
             <Panel v-else-if="editable && showNewSourceButton"
                    position="top-center"

--- a/packages/interloper-app/app/app/components/graph/Toolbar.vue
+++ b/packages/interloper-app/app/app/components/graph/Toolbar.vue
@@ -20,72 +20,51 @@ const FILTERS: Array<{ value: StatusFilter; label: string; dot?: GraphNodeState 
     { value: 'paused', label: 'Paused', dot: 'paused' },
 ]
 
-const EXPAND_OPTIONS: Array<{ value: ExpandMode; label: string; icon: string }> = [
+const EXPAND_OPTIONS = [
     { value: 'list', label: 'List', icon: 'i-lucide-list' },
     { value: 'graph', label: 'Graph', icon: 'i-lucide-git-fork' },
     { value: 'nodes', label: 'Nodes', icon: 'i-lucide-box' },
 ]
 
-const VIEW_OPTIONS: Array<{ value: ViewMode; label: string; icon: string }> = [
+const VIEW_OPTIONS = [
     { value: 'topology', label: 'Topology', icon: 'i-lucide-workflow' },
     { value: 'status', label: 'Status', icon: 'i-lucide-activity' },
 ]
 
 // Hide a filter pill when it has no members (except All), to avoid dead options.
-const visibleFilters = computed(() => FILTERS.filter(f => f.value === 'all' || props.counts[f.value] > 0))
+const filterItems = computed(() => FILTERS
+    .filter(f => f.value === 'all' || props.counts[f.value] > 0)
+    .map(f => ({ label: f.label, value: f.value, badge: props.counts[f.value], dot: f.dot })))
 </script>
 
 <template>
     <div class="flex shrink-0 items-center gap-2 border-b border-default px-4 py-2">
         <!-- Status filter -->
-        <div class="flex items-center gap-0.5 rounded-lg bg-elevated p-0.5">
-            <button v-for="f in visibleFilters"
-                    :key="f.value"
-                    type="button"
-                    class="flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors"
-                    :class="statusFilter === f.value
-                        ? 'bg-default text-highlighted shadow-sm'
-                        : 'text-muted hover:text-default'"
-                    @click="statusFilter = f.value">
-                <span v-if="f.dot"
+        <UTabs v-model="statusFilter"
+               :items="filterItems"
+               variant="pill"
+               size="xs"
+               :content="false">
+            <template #leading="{ item }">
+                <span v-if="(item as any).dot"
                       class="size-1.5 rounded-full"
-                      :class="statusDotClass(f.dot)" />
-                {{ f.label }}
-                <span class="text-dimmed">{{ counts[f.value] }}</span>
-            </button>
-        </div>
+                      :class="statusDotClass((item as any).dot)" />
+            </template>
+        </UTabs>
 
         <!-- Expand mode -->
-        <div class="flex items-center gap-0.5 rounded-lg bg-elevated p-0.5">
-            <button v-for="opt in EXPAND_OPTIONS"
-                    :key="opt.value"
-                    type="button"
-                    class="flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors"
-                    :class="expandMode === opt.value
-                        ? 'bg-default text-highlighted shadow-sm'
-                        : 'text-muted hover:text-default'"
-                    @click="expandMode = opt.value">
-                <UIcon :name="opt.icon"
-                       class="size-3.5" />
-                {{ opt.label }}
-            </button>
-        </div>
+        <UTabs v-model="expandMode"
+               :items="EXPAND_OPTIONS"
+               variant="pill"
+               size="xs"
+               :content="false" />
 
         <!-- View mode -->
-        <div class="flex items-center gap-0.5 rounded-lg bg-elevated p-0.5">
-            <button v-for="opt in VIEW_OPTIONS"
-                    :key="opt.value"
-                    type="button"
-                    class="flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors"
-                    :class="viewMode === opt.value
-                        ? 'bg-default text-highlighted shadow-sm'
-                        : 'text-muted hover:text-default'"
-                    @click="viewMode = opt.value">
-                <UIcon :name="opt.icon"
-                       class="size-3.5" />
-                {{ opt.label }}
-            </button>
-        </div>
+        <UTabs v-model="viewMode"
+               :items="VIEW_OPTIONS"
+               variant="pill"
+               size="xs"
+               :content="false" />
 
         <div class="ml-auto">
             <slot name="end" />

--- a/packages/interloper-app/app/app/components/jobs/SourceSelect.vue
+++ b/packages/interloper-app/app/app/components/jobs/SourceSelect.vue
@@ -47,25 +47,29 @@ function deselectAll() {
             </div>
         </div>
 
-        <div v-if="sources.length === 0"
-             class="flex flex-col items-center justify-center rounded-md p-6 gap-2">
-            <span class="text-sm text-muted">No sources configured yet.</span>
-        </div>
+        <InlineEmptyState v-if="sources.length === 0"
+                          icon="i-lucide-plug"
+                          message="No sources configured yet."
+                          action-label="Go to Sources"
+                          @action="navigateTo('/sources')" />
 
         <div v-else
-             class="flex flex-col gap-1">
-            <div v-for="source in sources"
-                 :key="source.id"
-                 class="flex items-center gap-3 px-3 py-2.5 rounded-md cursor-pointer bg-elevated/50 hover:bg-elevated transition-colors"
-                 @click="toggle(source.id)">
+             class="flex flex-col gap-2.5">
+            <SelectionCard v-for="source in sources"
+                           :key="source.id"
+                           :selected="selectedIds.includes(source.id)"
+                           class="flex items-center gap-3 px-4 py-3"
+                           @select="toggle(source.id)">
                 <UCheckbox :model-value="selectedIds.includes(source.id)"
                            @click.stop
                            @update:model-value="toggle(source.id)" />
-                <UIcon :name="sourceIcon(source)"
-                       class="size-5 shrink-0" />
+                <div class="size-10 shrink-0 rounded-[11px] border border-default bg-default flex items-center justify-center">
+                    <UIcon :name="sourceIcon(source)"
+                           class="size-6" />
+                </div>
                 <div class="flex flex-col min-w-0">
-                    <span class="text-sm font-medium">{{ source.name }}</span>
-                    <span class="text-xs text-muted truncate">{{ source.key }}</span>
+                    <span class="text-[14.5px] font-semibold text-highlighted truncate">{{ source.name }}</span>
+                    <span class="text-xs text-dimmed truncate">{{ source.key }}</span>
                 </div>
                 <UBadge color="neutral"
                         variant="subtle"
@@ -73,7 +77,7 @@ function deselectAll() {
                         class="ml-auto">
                     {{ source.assets.length }} asset{{ source.assets.length !== 1 ? 's' : '' }}
                 </UBadge>
-            </div>
+            </SelectionCard>
         </div>
     </div>
 </template>

--- a/packages/interloper-app/app/app/components/jobs/Stepper.vue
+++ b/packages/interloper-app/app/app/components/jobs/Stepper.vue
@@ -110,11 +110,26 @@ const steps = computed<StepperItem[]>(() => {
     if (props.mode !== 'collect') {
         items.push({ title: 'Sources', icon: 'i-lucide-plug', slot: 'sources' as const })
     }
-    items.push({ title: 'Details', icon: 'i-lucide-file-text', slot: 'details' as const })
+    items.push({ title: 'Details', icon: 'i-lucide-settings-2', slot: 'details' as const })
     return items
 })
 
 const { activeStep, hasPrev, hasNext, isLastStep, reset: resetStepper, next: nextStep, prev: prevStep } = useStepperFlow(computed(() => steps.value.length))
+
+const displaySteps = useCheckedSteps(steps, activeStep)
+
+/** Recap of the sources chosen on step 1 (standalone mode only). */
+const recapRows = computed(() => {
+    if (props.mode === 'collect') return []
+    const names = selectedSourceIds.value
+        .map(id => sourcesStore.findById(id)?.name)
+        .filter(Boolean)
+    return [{
+        icon: 'i-lucide-plug',
+        label: 'Sources',
+        value: names.length ? names.join(', ') : 'None',
+    }]
+})
 
 // ── Validation ──────────────────────────────────────────────────
 const detailsValid = computed(() =>
@@ -192,7 +207,7 @@ defineExpose({ canProceed, hasPrev, isLastStep, submitting, submitLabel, title, 
 
 <template>
     <UStepper v-model="activeStep"
-              :items="steps"
+              :items="displaySteps"
               :linear="steps.length > 1"
               :disabled="steps.length > 1"
               class="w-full">
@@ -204,8 +219,8 @@ defineExpose({ canProceed, hasPrev, isLastStep, submitting, submitLabel, title, 
 
         <!-- Details -->
         <template #details>
-            <div class="flex flex-col gap-4">
-                <UFormField label="Name"
+            <div class="flex flex-col gap-6">
+                <UFormField label="Job name"
                             required>
                     <UInput v-model="name"
                             placeholder="My job"
@@ -214,13 +229,16 @@ defineExpose({ canProceed, hasPrev, isLastStep, submitting, submitLabel, title, 
 
                 <UFormField label="Tags">
                     <UInputTags v-model="tags"
-                    placeholder="Add a tag..."
-                    class="w-full" />
+                                placeholder="Add a tag..."
+                                class="w-full" />
                 </UFormField>
 
-                <USeparator />
+                <WizardRecap v-if="recapRows.length"
+                             :rows="recapRows" />
 
-                <UFormField label="Schedule"
+                <USeparator label="Schedule" />
+
+                <UFormField label="Cron expression"
                             required
                             :description="cronDescription">
                     <UInput v-model="cron"
@@ -239,8 +257,6 @@ defineExpose({ canProceed, hasPrev, isLastStep, submitting, submitLabel, title, 
                 </div>
 
                 <template v-if="partitioned">
-                    <USeparator />
-
                     <div class="flex items-center gap-2 text-sm text-muted">
                         <UIcon name="i-lucide-calendar-days"
                                class="size-4 shrink-0" />
@@ -257,7 +273,8 @@ defineExpose({ canProceed, hasPrev, isLastStep, submitting, submitLabel, title, 
                                 class="w-full" />
                     </UFormField>
                 </template>
-                <USeparator />
+
+                <USeparator label="Options" />
 
                 <div class="flex items-center justify-between">
                     <div>

--- a/packages/interloper-app/app/app/components/organization/MembersTable.vue
+++ b/packages/interloper-app/app/app/components/organization/MembersTable.vue
@@ -4,9 +4,9 @@ import type { TableColumn, DropdownMenuItem } from '@nuxt/ui'
 import type { OrgMember } from '~/types/organisation'
 
 const UAvatar = resolveComponent('UAvatar')
-const UBadge = resolveComponent('UBadge')
 const UButton = resolveComponent('UButton')
 const UDropdownMenu = resolveComponent('UDropdownMenu')
+const StatusPill = resolveComponent('StatusPill')
 
 const props = defineProps<{
     members: OrgMember[]
@@ -20,6 +20,8 @@ const emit = defineEmits<{
     'resend-invite': [member: OrgMember]
 }>()
 
+const userStore = useUserStore()
+
 function getInitials(member: OrgMember): string {
     const name = member.name?.trim()
     if (name && name.length > 0) {
@@ -31,10 +33,14 @@ function getInitials(member: OrgMember): string {
     return member.email?.charAt(0).toUpperCase() ?? '?'
 }
 
-const roleColor: Record<string, 'primary' | 'success' | 'neutral'> = {
-    admin: 'primary',
-    editor: 'success',
-    viewer: 'neutral',
+/** Design avatar palette — deterministic per member so colors are stable. */
+const AVATAR_PALETTE = ['#10B6CB', '#6C5CE7', '#1FA463', '#E69E2E', '#2D7DF6', '#E5484D', '#C8511B']
+
+function avatarColor(member: OrgMember): string {
+    const key = member.email || member.id
+    let hash = 0
+    for (let i = 0; i < key.length; i++) hash = (hash * 31 + key.charCodeAt(i)) | 0
+    return AVATAR_PALETTE[Math.abs(hash) % AVATAR_PALETTE.length]!
 }
 
 function getRowMenuItems(member: OrgMember): DropdownMenuItem[][] {
@@ -72,22 +78,24 @@ function getRowMenuItems(member: OrgMember): DropdownMenuItem[][] {
 const columns = computed<TableColumn<OrgMember>[]>(() => {
     const base: TableColumn<OrgMember>[] = [
         {
-            id: 'avatar',
-            header: '',
-            cell: ({ row }) => h(UAvatar, {
-                src: row.original.avatar_url ?? undefined,
-                text: getInitials(row.original),
-                alt: row.original.name ?? row.original.email,
-                size: 'sm',
-            }),
-            size: 50,
-            enableSorting: false,
-            enableGlobalFilter: false,
-        },
-        {
             accessorKey: 'name',
             header: 'Name',
-            cell: ({ row }) => row.original.name ?? '—',
+            cell: ({ row }) => {
+                const member = row.original
+                const avatar = member.avatar_url
+                    ? h(UAvatar, { src: member.avatar_url, alt: member.name ?? member.email, size: 'sm' })
+                    : h('div', {
+                        class: 'size-8 shrink-0 rounded-full flex items-center justify-center text-white text-xs font-semibold',
+                        style: { background: avatarColor(member) },
+                    }, getInitials(member))
+                const name = member.name
+                    ? h('span', { class: 'font-semibold text-highlighted' }, member.name)
+                    : h('span', { class: 'text-dimmed' }, '—')
+                const you = member.id === userStore.user?.id
+                    ? h('span', { class: 'px-1.5 py-px rounded-[5px] bg-elevated text-[11px] font-semibold text-dimmed' }, 'You')
+                    : null
+                return h('div', { class: 'flex items-center gap-3' }, [avatar, name, you])
+            },
         },
         {
             accessorKey: 'email',
@@ -98,21 +106,20 @@ const columns = computed<TableColumn<OrgMember>[]>(() => {
             header: 'Role',
             cell: ({ row }) => {
                 const role = row.getValue<string>('role')
-                return h(UBadge, {
-                    color: roleColor[role] ?? 'neutral',
-                    variant: 'subtle',
-                }, () => role.charAt(0).toUpperCase() + role.slice(1))
+                return h('span', {
+                    class: `inline-block px-2.5 py-1 rounded-[7px] text-xs font-semibold ${ROLE_TINTS[role] ?? ROLE_TINTS.viewer}`,
+                }, role.charAt(0).toUpperCase() + role.slice(1))
             },
         },
         {
             accessorKey: 'status',
             header: 'Status',
             cell: ({ row }) => {
-                const status = row.getValue<string>('status')
-                return h(UBadge, {
-                    color: status === 'active' ? 'success' : 'warning',
-                    variant: 'subtle',
-                }, () => status === 'active' ? 'Active' : 'Invited')
+                const active = row.getValue<string>('status') === 'active'
+                return h(StatusPill, {
+                    color: active ? 'success' : 'warning',
+                    label: active ? 'Active' : 'Pending',
+                })
             },
         },
     ]

--- a/packages/interloper-app/app/app/components/resources/Stepper.vue
+++ b/packages/interloper-app/app/app/components/resources/Stepper.vue
@@ -19,6 +19,8 @@ const props = defineProps<{
     definitions: ComponentDefinition[]
     /** When set, opens in edit mode for this resource. */
     resource?: Resource | null
+    /** Preselect this type and open directly on the details step (create mode). */
+    initialTypeKey?: string
 }>()
 
 const emit = defineEmits<{
@@ -42,10 +44,14 @@ const loadingEdit = ref(false)
 /** Whether we're in edit mode. */
 const isEditing = computed(() => !!props.resource)
 
-const steps = computed<StepperItem[]>(() => [
+const steps: StepperItem[] = [
     { slot: 'type' as const, title: 'Type', icon: 'i-lucide-plug' },
-    { slot: 'details' as const, title: 'Details', icon: 'i-lucide-file-text' },
-])
+    { slot: 'details' as const, title: 'Details', icon: 'i-lucide-settings-2' },
+]
+const displaySteps = useCheckedSteps(steps, activeStep)
+
+/** Label for the schema section separator. */
+const schemaSectionLabel = computed(() => props.kind === 'connection' ? 'Credentials' : 'Configuration')
 
 /** The config_schema for the currently selected type. */
 const selectedSchema = computed(() => {
@@ -81,6 +87,10 @@ onMounted(() => {
     if (props.resource) {
         loadResourceData(props.resource)
     }
+    else if (props.initialTypeKey) {
+        // Triggers the selection watcher below, which advances to details.
+        selectedType.value = props.initialTypeKey
+    }
 })
 
 // When a type is selected (create mode only), reset form and advance
@@ -98,6 +108,12 @@ watch(selectedType, (newKey, oldKey) => {
 const selectedTypeName = computed(() => {
     if (!selectedType.value) return ''
     return props.definitions.find(d => d.key === selectedType.value)?.name ?? selectedType.value
+})
+
+/** First catalog tag of the selected type (summary-card caption). */
+const selectedTypeTag = computed(() => {
+    const defn = props.definitions.find(d => d.key === selectedType.value) as (ComponentDefinition & { tags?: string[] }) | undefined
+    return defn?.tags?.[0] ?? kindLabel.value
 })
 
 /** Can proceed to next step? */
@@ -171,7 +187,7 @@ defineExpose({ canProceed, hasPrev: computed(() => !isEditing.value && hasPrev.v
     <!-- Create mode: stepper -->
     <UStepper v-else-if="!isEditing"
               v-model="activeStep"
-              :items="steps"
+              :items="displaySteps"
               linear
               disabled
               class="w-full">
@@ -181,15 +197,21 @@ defineExpose({ canProceed, hasPrev: computed(() => !isEditing.value && hasPrev.v
         </template>
 
         <template #details>
-            <div class="flex flex-col gap-4">
-                <UFormField label="Name"
+            <div class="flex flex-col gap-6">
+                <TypeSummaryCard :icon="componentIcon(selectedType)"
+                                 :title="selectedTypeName"
+                                 :caption="selectedTypeTag"
+                                 changeable
+                                 @change="prevStep" />
+
+                <UFormField :label="`${kindLabel} name`"
                             required>
                     <UInput v-model="resourceName"
                             placeholder="Enter a name for this resource"
                             class="w-full" />
                 </UFormField>
 
-                <USeparator />
+                <USeparator :label="schemaSectionLabel" />
 
                 <div v-if="selectedSchema"
                      class="space-y-1">
@@ -207,21 +229,19 @@ defineExpose({ canProceed, hasPrev: computed(() => !isEditing.value && hasPrev.v
 
     <!-- Edit mode: details form only -->
     <div v-else
-         class="flex flex-col gap-4">
-        <div class="flex items-center gap-2 text-sm text-muted">
-            <UIcon :name="componentIcon(selectedType)"
-                   class="size-4" />
-            <span>{{ selectedTypeName }}</span>
-        </div>
+         class="flex flex-col gap-6">
+        <TypeSummaryCard :icon="componentIcon(selectedType)"
+                         :title="selectedTypeName"
+                         :caption="selectedTypeTag" />
 
-        <UFormField label="Name"
+        <UFormField :label="`${kindLabel} name`"
                     required>
             <UInput v-model="resourceName"
                     placeholder="Enter a name for this resource"
                     class="w-full" />
         </UFormField>
 
-        <USeparator />
+        <USeparator :label="schemaSectionLabel" />
 
         <div v-if="selectedSchema"
              class="space-y-1">

--- a/packages/interloper-app/app/app/components/sources/AssetSelect.vue
+++ b/packages/interloper-app/app/app/components/sources/AssetSelect.vue
@@ -164,12 +164,14 @@ function depSelectionKey(assetKey: string, paramName: string): string {
             </div>
         </div>
 
-        <div class="flex flex-col gap-1">
-            <div v-for="asset in sourceDefn.assets"
-                 :key="asset.key"
-                 class="flex flex-col rounded-md bg-elevated/50 hover:bg-elevated transition-colors">
+        <div class="flex flex-col gap-2.5">
+            <SelectionCard v-for="asset in sourceDefn.assets"
+                           :key="asset.key"
+                           as="div"
+                           :selected="selectedKeys.includes(asset.key)"
+                           class="flex flex-col">
                 <!-- Asset row -->
-                <div class="flex items-center gap-3 px-3 py-2.5 cursor-pointer"
+                <div class="flex items-center gap-3 px-4 py-3 cursor-pointer"
                      @click="toggle(asset.key)">
                     <UCheckbox :model-value="selectedKeys.includes(asset.key)"
                                @click.stop
@@ -236,7 +238,7 @@ function depSelectionKey(assetKey: string, paramName: string): string {
                         </UBadge>
                     </div>
                 </div>
-            </div>
+            </SelectionCard>
         </div>
     </div>
 </template>

--- a/packages/interloper-app/app/app/components/sources/DestinationStep.vue
+++ b/packages/interloper-app/app/app/components/sources/DestinationStep.vue
@@ -111,37 +111,29 @@ function destLabel(key: string) {
         <template v-else>
             <!-- Existing destinations -->
             <div v-if="availableDestinations.length > 0"
-                 class="flex flex-col gap-1">
-                <div v-for="dest in availableDestinations"
-                     :key="dest.id"
-                     class="flex items-center gap-3 px-3 py-2.5 rounded-md cursor-pointer bg-elevated/50 hover:bg-elevated transition-colors"
-                     :class="isSelected(dest.id) ? 'ring-primary ring-2' : ''"
-                     @click="toggle(dest.id)">
+                 class="flex flex-col gap-2.5">
+                <SelectionCard v-for="dest in availableDestinations"
+                               :key="dest.id"
+                               :selected="isSelected(dest.id)"
+                               class="flex items-center gap-3 px-4 py-3"
+                               @select="toggle(dest.id)">
                     <UCheckbox :model-value="isSelected(dest.id)"
                                @click.stop
                                @update:model-value="toggle(dest.id)" />
-                    <UIcon :name="destIcon(dest.key)"
-                           class="size-5 shrink-0" />
-                    <div class="flex flex-col min-w-0">
-                        <span class="text-sm font-medium">{{ dest.name || destLabel(dest.key) }}</span>
+                    <div class="size-10 shrink-0 rounded-[11px] border border-default bg-default flex items-center justify-center">
+                        <UIcon :name="destIcon(dest.key)"
+                               class="size-6" />
                     </div>
-                    <UIcon v-if="isSelected(dest.id)"
-                           name="i-lucide-check"
-                           class="size-4 ml-auto text-primary shrink-0" />
-                </div>
+                    <span class="text-[14.5px] font-semibold text-highlighted truncate">{{ dest.name || destLabel(dest.key) }}</span>
+                </SelectionCard>
             </div>
 
             <!-- Empty state -->
-            <div v-if="availableDestinations.length === 0"
-                 class="flex flex-col items-center gap-3 rounded-lg border border-dashed border-default py-6">
-                <UIcon name="i-lucide-hard-drive"
-                       class="size-8 text-muted" />
-                <p class="text-sm text-muted">No destinations available.</p>
-                <UButton icon="i-lucide-plus"
-                         label="Create Destination"
-                         variant="soft"
-                         @click="drawerOpen = true" />
-            </div>
+            <InlineEmptyState v-if="availableDestinations.length === 0"
+                              icon="i-lucide-hard-drive"
+                              message="No destinations yet."
+                              action-label="Create destination"
+                              @action="drawerOpen = true" />
         </template>
 
         <!-- Nested drawer for destination creation -->

--- a/packages/interloper-app/app/app/components/sources/EmptyState.vue
+++ b/packages/interloper-app/app/app/components/sources/EmptyState.vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+/**
+ * Placeholder for pages that need at least one source (sources, catalog):
+ * design hero + the connector catalog with tag filters.
+ */
+const emit = defineEmits<{
+    /** Open the source wizard on the type step. */
+    create: []
+    /** Open the source wizard with this connector preselected. */
+    createType: [key: string]
+}>()
+
+const catalogStore = useCatalogStore()
+
+/** Filter pills: the catalog's real tags (first tag per connector). */
+const connectorFilters = computed(() => {
+    const tags = new Set<string>()
+    for (const d of catalogStore.sourceDefinitions) tags.add(d.tags?.[0] ?? 'Other')
+    return ['All', ...tags].map(t => ({ label: t, value: t }))
+})
+const connectorFilter = ref('All')
+
+/** Card view-models, so chip arrays keep stable identities across renders. */
+const connectorCards = computed(() => catalogStore.sourceDefinitions
+    .filter(d => connectorFilter.value === 'All' || (d.tags?.[0] ?? 'Other') === connectorFilter.value)
+    .map(d => ({
+        key: d.key,
+        props: {
+            icon: componentIcon(d.key),
+            title: d.name,
+            caption: d.provider,
+            description: d.description,
+            chips: [
+                ...(d.tags ?? []).map(t => ({ label: t })),
+                { icon: 'i-lucide-layers', label: `${d.assets.length} assets` },
+            ],
+        },
+    })))
+</script>
+
+<template>
+    <div>
+        <EmptyState icon="i-lucide-plug"
+                    title="No sources yet"
+                    description="A source is a typed connector Interloper pulls from — authenticate once and it materializes its assets straight into your own warehouse. Pick one from the catalog below to add your first.">
+            <UButton icon="i-lucide-plus"
+                     label="New source"
+                     class="mt-5"
+                     @click="emit('create')" />
+        </EmptyState>
+
+        <div class="mt-9 mb-3.5">
+            <h2 class="text-lg font-bold tracking-[-0.015em] text-highlighted">
+                Connector catalog
+            </h2>
+            <p class="text-sm text-muted mt-1.5">
+                Every source Interloper can pull from — pick what you need, authenticate once,
+                and materialize into your own warehouse.
+            </p>
+        </div>
+
+        <div class="flex items-center gap-2 mb-4 flex-wrap">
+            <UTabs v-model="connectorFilter"
+                   :items="connectorFilters"
+                   variant="pill"
+                   size="xs"
+                   :content="false" />
+            <span class="ml-auto font-mono text-xs text-dimmed">
+                {{ connectorCards.length }} of {{ catalogStore.sourceDefinitions.length }} connectors
+            </span>
+        </div>
+
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+            <CatalogCard v-for="card in connectorCards"
+                         :key="card.key"
+                         variant="rich"
+                         v-bind="card.props"
+                         @click="emit('createType', card.key)" />
+        </div>
+    </div>
+</template>

--- a/packages/interloper-app/app/app/components/sources/ResourceStep.vue
+++ b/packages/interloper-app/app/app/components/sources/ResourceStep.vue
@@ -144,33 +144,29 @@ defineExpose({ formData })
         </div>
 
         <!-- Empty state -->
-        <div v-if="instances.length === 0"
-             class="flex flex-col items-center justify-center rounded-md p-6 gap-2">
-            <span class="text-sm text-muted">No {{ definition.name }} {{ definition.kind.toLowerCase() }} found.</span>
-            <UButton icon="i-lucide-plus"
-                     label="Create one"
-                     @click="openCreateDrawer" />
-        </div>
+        <InlineEmptyState v-if="instances.length === 0"
+                          :icon="componentIcon(definition.key)"
+                          :message="`No ${definition.name} ${definition.kind.toLowerCase()} yet.`"
+                          :action-label="`Create ${definition.kind.toLowerCase()}`"
+                          @action="openCreateDrawer" />
 
         <!-- Instance list -->
         <div v-else
-             class="flex flex-col gap-1">
-            <div v-for="inst in instances"
-                 :key="inst.id"
-                 class="flex items-center gap-3 px-3 py-2.5 rounded-md cursor-pointer bg-elevated/50 hover:bg-elevated transition-colors"
-                 :class="[
-                     selectedId === inst.id ? 'ring-primary ring-2' : '',
-                 ]"
-                 @click="selectedId = inst.id">
-                <UIcon :name="componentIcon(definition.key)"
-                       class="size-5 shrink-0" />
-                <div class="flex flex-col min-w-0">
-                    <span class="text-sm font-medium">{{ inst.name }}</span>
+             class="flex flex-col gap-2.5">
+            <SelectionCard v-for="inst in instances"
+                           :key="inst.id"
+                           :selected="selectedId === inst.id"
+                           class="flex items-center gap-3 px-4 py-3"
+                           @select="selectedId = inst.id">
+                <div class="size-10 shrink-0 rounded-[11px] border border-default bg-default flex items-center justify-center">
+                    <UIcon :name="componentIcon(definition.key)"
+                           class="size-6" />
                 </div>
+                <span class="text-[14.5px] font-semibold text-highlighted truncate">{{ inst.name }}</span>
                 <UIcon v-if="selectedId === inst.id"
                        name="i-lucide-check"
                        class="size-4 ml-auto text-primary shrink-0" />
-            </div>
+            </SelectionCard>
         </div>
 
         <!-- Create drawer (nested) -->
@@ -196,7 +192,7 @@ defineExpose({ formData })
                     <UFormField label="Name"
                                 required>
                         <UInput v-model="newName"
-                                :placeholder=definition.name
+                                :placeholder="definition.name"
                                 class="w-full" />
                     </UFormField>
 

--- a/packages/interloper-app/app/app/components/sources/Stepper.vue
+++ b/packages/interloper-app/app/app/components/sources/Stepper.vue
@@ -21,9 +21,12 @@ const props = withDefaults(defineProps<{
     mode?: 'standalone' | 'collect'
     /** When set, stepper opens in edit mode with values pre-filled. */
     source?: Source | null
+    /** Preselect this type and open directly on the next step (create mode). */
+    initialTypeKey?: string
 }>(), {
     mode: 'standalone',
     source: null,
+    initialTypeKey: undefined,
 })
 
 const emit = defineEmits<{
@@ -121,7 +124,7 @@ const steps = computed<StepperItem[]>(() => {
         const kind = rs.slotName.charAt(0).toUpperCase() + rs.slotName.slice(1)
         items.push({
             title: kind,
-            icon: rs.slotName === 'connection' ? 'i-lucide-key-round' : 'i-lucide-settings',
+            icon: resourceSlotIcon(rs.slotName),
             slot: `resource-${rs.slotName}` as any,
         })
     }
@@ -137,6 +140,42 @@ const steps = computed<StepperItem[]>(() => {
 
 const totalSteps = computed(() => steps.value.length)
 const { activeStep, hasPrev, isLastStep, reset: resetStepper, next: nextStep, prev: prevStep } = useStepperFlow(totalSteps)
+
+const displaySteps = useCheckedSteps(steps, activeStep)
+
+/** Selected-type summary card shown on every post-type step. */
+const summaryCard = computed(() => sourceDefn.value && {
+    icon: componentIcon(sourceDefn.value.key),
+    title: sourceDefn.value.name,
+    caption: sourceDefn.value.tags?.[0] ?? 'Source',
+    changeable: !isEditMode.value,
+})
+
+/** Recap rows for the final step — what was chosen along the way. */
+const recapRows = computed(() => {
+    const rows = [{
+        icon: 'i-lucide-layers',
+        label: 'Assets',
+        value: `${selectedAssetKeys.value.length} selected`,
+    }]
+    for (const rs of resourceSlots.value) {
+        const id = resourceSelections.value[rs.slotName]
+        rows.push({
+            icon: resourceSlotIcon(rs.slotName),
+            label: rs.slotName.charAt(0).toUpperCase() + rs.slotName.slice(1),
+            value: id ? (resourcesStore.findById(id)?.name ?? '—') : 'None',
+        })
+    }
+    const destNames = selectedDestinationIds.value
+        .map(id => destinationsStore.findById(id)?.name)
+        .filter(Boolean)
+    rows.push({
+        icon: 'i-lucide-hard-drive',
+        label: 'Destinations',
+        value: destNames.length ? destNames.join(', ') : 'None',
+    })
+    return rows
+})
 
 // ── Resource data caching (for x-fetch fields) ──────────────────
 
@@ -177,6 +216,13 @@ watch(selectedSourceKey, (key) => {
         resourceSelections.value = {}
         configData.value = {}
         nextStep()
+    }
+})
+
+onMounted(() => {
+    if (!isEditMode.value && props.initialTypeKey) {
+        // Triggers the selection watcher above, which advances past the type step.
+        selectedSourceKey.value = props.initialTypeKey
     }
 })
 
@@ -282,7 +328,7 @@ defineExpose({ canProceed, hasPrev, isLastStep, submitting, submitLabel, title, 
 
 <template>
     <UStepper v-model="activeStep"
-              :items="steps"
+              :items="displaySteps"
               linear
               disabled
               class="w-full">
@@ -295,34 +341,53 @@ defineExpose({ canProceed, hasPrev, isLastStep, submitting, submitLabel, title, 
 
         <!-- Step: Assets -->
         <template #assets>
-            <SourcesAssetSelect v-if="sourceDefn"
-                                v-model:selected-keys="selectedAssetKeys"
-                                v-model:resolved-deps="resolvedCrossDeps"
-                                :source-defn="sourceDefn"
-                                :all-sources="sourcesStore.sources" />
+            <div class="flex flex-col gap-6">
+                <TypeSummaryCard v-if="summaryCard"
+                                 v-bind="summaryCard"
+                                 @change="activeStep = 0" />
+                <SourcesAssetSelect v-if="sourceDefn"
+                                    v-model:selected-keys="selectedAssetKeys"
+                                    v-model:resolved-deps="resolvedCrossDeps"
+                                    :source-defn="sourceDefn"
+                                    :all-sources="sourcesStore.sources" />
+            </div>
         </template>
 
         <!-- Dynamic resource steps -->
         <template v-for="rs in resourceSlots"
                   :key="rs.slotName"
                   #[`resource-${rs.slotName}`]>
-            <SourcesResourceStep v-if="rs.definition"
-                                 :ref="(el: any) => { if (el) resourceStepRefs[rs.slotName] = el }"
-                                 v-model="resourceSelections[rs.slotName]"
-                                 :slot-name="rs.slotName"
-                                 :definition="rs.definition"
-                                 :resource-context="resourceContext"
-                                 :silent="props.mode === 'collect'" />
+            <div class="flex flex-col gap-6">
+                <TypeSummaryCard v-if="summaryCard"
+                                 v-bind="summaryCard"
+                                 @change="activeStep = 0" />
+                <SourcesResourceStep v-if="rs.definition"
+                                     :ref="(el: any) => { if (el) resourceStepRefs[rs.slotName] = el }"
+                                     v-model="resourceSelections[rs.slotName]"
+                                     :slot-name="rs.slotName"
+                                     :definition="rs.definition"
+                                     :resource-context="resourceContext"
+                                     :silent="props.mode === 'collect'" />
+            </div>
         </template>
 
         <!-- Step: Config -->
         <template #config>
-            <div class="flex flex-col gap-4">
-                <UFormField label="Name">
+            <div class="flex flex-col gap-6">
+                <TypeSummaryCard v-if="summaryCard"
+                                 v-bind="summaryCard"
+                                 @change="activeStep = 0" />
+
+                <UFormField label="Source name">
                     <UInput v-model="sourceName"
                             placeholder="Source name"
                             class="w-full" />
                 </UFormField>
+
+                <WizardRecap :rows="recapRows" />
+
+                <USeparator label="Configuration" />
+
                 <SchemaForm v-if="sourceDefn?.config_schema"
                             v-model:data="configData"
                             v-model:is-valid="configValid"
@@ -335,8 +400,13 @@ defineExpose({ canProceed, hasPrev, isLastStep, submitting, submitLabel, title, 
 
         <!-- Step: Destination -->
         <template #destination>
-            <SourcesDestinationStep v-model:selected-ids="selectedDestinationIds"
-                                    :compatible-keys="sourceDefn?.destinations ?? []" />
+            <div class="flex flex-col gap-6">
+                <TypeSummaryCard v-if="summaryCard"
+                                 v-bind="summaryCard"
+                                 @change="activeStep = 0" />
+                <SourcesDestinationStep v-model:selected-ids="selectedDestinationIds"
+                                        :compatible-keys="sourceDefn?.destinations ?? []" />
+            </div>
         </template>
     </UStepper>
 </template>

--- a/packages/interloper-app/app/app/composables/runStats.ts
+++ b/packages/interloper-app/app/app/composables/runStats.ts
@@ -16,8 +16,8 @@ const STATUS_META: StatusMeta[] = [
     { key: 'running', label: 'Running', statuses: ['running'], colorClass: 'bg-blue-500' },
     { key: 'failed', label: 'Failed', statuses: ['failed'], colorClass: 'bg-red-500' },
     { key: 'canceled', label: 'Canceled', statuses: ['canceled'], colorClass: 'bg-amber-500' },
-    { key: 'skipped', label: 'Skipped', statuses: ['skipped'], colorClass: 'bg-gray-400' },
-    { key: 'pending', label: 'Pending', statuses: ['pending', 'queued'], colorClass: 'bg-gray-600' },
+    { key: 'skipped', label: 'Skipped', statuses: ['skipped'], colorClass: 'bg-gray-500' },
+    { key: 'pending', label: 'Pending', statuses: ['pending', 'queued'], colorClass: 'bg-gray-800' },
 ]
 
 /** Always shown in the legend, even at zero. Pending only appears when present. */

--- a/packages/interloper-app/app/app/composables/stepperFlow.ts
+++ b/packages/interloper-app/app/app/composables/stepperFlow.ts
@@ -1,3 +1,18 @@
+import type { StepperItem } from '@nuxt/ui'
+
+/** Swap completed steps' icons for a check, based on the active index. */
+export function useCheckedSteps(steps: MaybeRefOrGetter<StepperItem[]>, activeStep: Ref<number>) {
+    return computed<StepperItem[]>(() => toValue(steps).map((item, i) => ({
+        ...item,
+        icon: activeStep.value > i ? 'i-lucide-check' : item.icon,
+    })))
+}
+
+/** Icon for a wizard resource-slot step or recap row. */
+export function resourceSlotIcon(slotName: string): string {
+    return slotName === 'connection' ? 'i-lucide-key-round' : 'i-lucide-settings'
+}
+
 export function useStepperFlow(stepsCount: MaybeRefOrGetter<number>) {
     const activeStep = ref(0)
 

--- a/packages/interloper-app/app/app/composables/wizardDrawer.ts
+++ b/packages/interloper-app/app/app/composables/wizardDrawer.ts
@@ -1,0 +1,34 @@
+/**
+ * State machine for the create/edit wizard drawers: open flag, the item
+ * being edited (null = create), and an optional preselected type key
+ * (from the empty-state catalogs) forwarded to the stepper.
+ */
+export function useWizardDrawer<T>() {
+    const open = ref(false)
+    const editing = ref<T | null>(null) as Ref<T | null>
+    const presetTypeKey = ref<string>()
+
+    function openCreate() {
+        editing.value = null
+        presetTypeKey.value = undefined
+        open.value = true
+    }
+
+    function openCreateWithType(key: string) {
+        editing.value = null
+        presetTypeKey.value = key
+        open.value = true
+    }
+
+    function openEdit(item: T) {
+        editing.value = item
+        presetTypeKey.value = undefined
+        open.value = true
+    }
+
+    function close() {
+        open.value = false
+    }
+
+    return { open, editing, presetTypeKey, openCreate, openCreateWithType, openEdit, close }
+}

--- a/packages/interloper-app/app/app/layouts/default.vue
+++ b/packages/interloper-app/app/app/layouts/default.vue
@@ -12,6 +12,14 @@ const modeItems = computed<NavigationMenuItem[]>(() => [
 const catalogStore = useCatalogStore()
 const { open: commandPaletteOpen, groups: commandPaletteGroups } = useCommandPalette()
 
+/** Design page header rendered by the layout, declared via definePageMeta({ pageHeader }). */
+interface PageHeaderMeta {
+    eyebrow?: string
+    title: string
+    description?: string
+}
+const pageHeader = computed(() => route.meta.pageHeader as PageHeaderMeta | undefined)
+
 /** Icons for resource kinds — fallback to generic box. */
 const RESOURCE_KIND_ICONS: Record<string, string> = {
     connection: 'i-lucide-key-round',
@@ -128,9 +136,10 @@ const items = computed<NavigationMenuItem[]>(() => {
                     <template #default="{ collapsed }">
                         <UButton :label="collapsed ? undefined : 'Search...'"
                                  icon="i-lucide-search"
-                                 color="secondary"
+                                 color="neutral"
+                                 variant="outline"
                                  block
-                                 class="mt-2"
+                                 class="mt-2 bg-default text-dimmed"
                                  :square="collapsed"
                                  @click="commandPaletteOpen = true">
                             <template v-if="!collapsed"
@@ -158,7 +167,30 @@ const items = computed<NavigationMenuItem[]>(() => {
                 <UDashboardPanel
                                  :ui="{ root: 'relative flex flex-col min-w-0 min-h-full lg:not-last:border-e lg:not-last:border-default shrink-0 flex-1', body: '!p-0 !gap-0 overflow-hidden [&>*]:flex-1 [&>*]:flex [&>*]:flex-col [&>*]:min-h-0' }">
                     <template #body>
-                        <slot />
+                        <!-- Full-bleed pages (canvas/split views) manage their own frame. -->
+                        <slot v-if="route.meta.fullBleed" />
+                        <div v-else
+                             class="flex-1 min-h-0 w-full overflow-y-auto">
+                            <div class="p-4 w-full"
+                                 :class="pageHeader && 'max-w-[1040px] mx-auto'">
+                                <div v-if="pageHeader"
+                                     class="mb-6">
+                                    <div v-if="pageHeader.eyebrow"
+                                         class="eyebrow text-primary">
+                                        {{ pageHeader.eyebrow }}
+                                    </div>
+                                    <h1 class="text-[28px] font-bold tracking-[-0.022em] leading-tight text-highlighted"
+                                        :class="pageHeader.eyebrow ? 'mt-2.5' : ''">
+                                        {{ pageHeader.title }}
+                                    </h1>
+                                    <p v-if="pageHeader.description"
+                                       class="text-[15px] text-muted leading-relaxed max-w-[660px] mt-2.5">
+                                        {{ pageHeader.description }}
+                                    </p>
+                                </div>
+                                <slot />
+                            </div>
+                        </div>
                     </template>
                 </UDashboardPanel>
                 <UModal v-model:open="commandPaletteOpen">

--- a/packages/interloper-app/app/app/pages/admin/index.vue
+++ b/packages/interloper-app/app/app/pages/admin/index.vue
@@ -130,7 +130,7 @@ onMounted(loadData)
 
 <template>
     <div class="flex flex-col flex-1 min-h-0">
-        <div class="px-4 pt-4 pb-2 shrink-0">
+        <div class="pb-4">
             <UBreadcrumb :items="breadcrumbs" />
         </div>
         <DataTable :columns="columns"

--- a/packages/interloper-app/app/app/pages/agent/chat/[id].vue
+++ b/packages/interloper-app/app/app/pages/agent/chat/[id].vue
@@ -51,8 +51,8 @@ onMounted(async () => {
                     </template>
 
                     <UChatMessage v-for="message in messages"
-                                  :key="message.id"
                                   :id="message.id"
+                                  :key="message.id"
                                   :role="message.role === 'user' ? 'user' : 'assistant'"
                                   :parts="[{ type: 'text', text: message.text }]"
                                   :variant="message.role === 'user' ? 'soft' : 'naked'"

--- a/packages/interloper-app/app/app/pages/analytics/campaigns.vue
+++ b/packages/interloper-app/app/app/pages/analytics/campaigns.vue
@@ -291,8 +291,7 @@ const kpis = [
 
             <!-- KPI row -->
             <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
-                <div
-                    v-for="kpi in kpis"
+                <div v-for="kpi in kpis"
                     :key="kpi.label"
                     class="rounded-xl border border-default bg-default/50 backdrop-blur px-4 py-3 space-y-1"
                 >

--- a/packages/interloper-app/app/app/pages/analytics/index.vue
+++ b/packages/interloper-app/app/app/pages/analytics/index.vue
@@ -61,8 +61,7 @@ const inactiveDashboards = [
         <div class="max-w-[1200px] mx-auto px-4 py-8 space-y-8">
             <!-- Dashboard cards -->
             <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <NuxtLink
-                    v-for="db in dashboards"
+                <NuxtLink v-for="db in dashboards"
                     :key="db.title"
                     :to="db.to"
                     class="group rounded-xl border border-default bg-elevated/40 backdrop-blur p-6 space-y-4 transition-all hover:border-primary hover:shadow-lg hover:shadow-primary/5"
@@ -83,8 +82,7 @@ const inactiveDashboards = [
 
                     <!-- Stats -->
                     <div class="grid grid-cols-3 gap-3">
-                        <div
-                            v-for="stat in db.stats"
+                        <div v-for="stat in db.stats"
                             :key="stat.label"
                             class="rounded-lg bg-elevated/50 px-3 py-2"
                         >
@@ -100,8 +98,7 @@ const inactiveDashboards = [
                 </NuxtLink>
 
                 <!-- Inactive cards -->
-                <div
-                    v-for="db in inactiveDashboards"
+                <div v-for="db in inactiveDashboards"
                     :key="db.title"
                     class="relative rounded-xl border border-dashed border-default bg-elevated/20 p-6 space-y-4 opacity-60"
                 >

--- a/packages/interloper-app/app/app/pages/analytics/mmm.vue
+++ b/packages/interloper-app/app/app/pages/analytics/mmm.vue
@@ -226,8 +226,7 @@ const kpis = [
 
             <!-- KPI row -->
             <div class="grid grid-cols-2 lg:grid-cols-4 gap-3">
-                <div
-                    v-for="kpi in kpis"
+                <div v-for="kpi in kpis"
                     :key="kpi.label"
                     class="rounded-xl border border-default bg-default/50 backdrop-blur px-4 py-3 space-y-1"
                 >

--- a/packages/interloper-app/app/app/pages/catalog.vue
+++ b/packages/interloper-app/app/app/pages/catalog.vue
@@ -3,15 +3,24 @@ import { SplitterGroup, SplitterPanel, SplitterResizeHandle } from 'reka-ui'
 import type { Source, SourceAsset } from '~/types/source'
 import type { AssetDefinition } from '~/types/catalog'
 
+definePageMeta({ title: 'Catalog' })
+
 const sourcesStore = useSourcesStore()
 const assetsStore = useAssetsStore()
 const catalogStore = useCatalogStore()
 const jobsStore = useJobsStore()
 const runsStore = useRunsStore()
 
-const drawerOpen = ref(false)
-const editingSource = ref<Source | null>(null)
 const sourceStepperRef = ref<any>(null)
+
+const {
+    open: drawerOpen,
+    editing: editingSource,
+    presetTypeKey,
+    openCreate: onCreateSource,
+    openCreateWithType: onCreateSourceFromCatalog,
+    openEdit: openEditSource,
+} = useWizardDrawer<Source>()
 
 // ── Asset panel ────────────────────────────────────────────────
 const panelOpen = ref(false)
@@ -53,15 +62,13 @@ function onCloseAnimationEnd() {
 
 // ── Data fetching ──────────────────────────────────────────────
 
-onMounted(async () => {
-    await Promise.all([
-        sourcesStore.fetch(),
-        assetsStore.fetch(),
-        jobsStore.fetch(),
-        runsStore.fetch(),
-        catalogStore.loaded ? Promise.resolve() : catalogStore.fetchCatalog(),
-    ])
-})
+// Fired in setup so `loading` flags are set before the first render
+// (gates the empty placeholder without a flash).
+sourcesStore.fetch()
+assetsStore.fetch()
+jobsStore.fetch()
+runsStore.fetch()
+if (!catalogStore.loaded) catalogStore.fetchCatalog()
 
 function handleSaved() {
     sourcesStore.fetch()
@@ -71,20 +78,25 @@ function handleSaved() {
 }
 
 function onEditSource(sourceId: string) {
-    editingSource.value = sourcesStore.findById(sourceId) ?? null
-    if (editingSource.value) drawerOpen.value = true
+    const source = sourcesStore.findById(sourceId)
+    if (source) openEditSource(source)
 }
 
-function onCreateSource() {
-    editingSource.value = null
-    drawerOpen.value = true
-}
+const showEmpty = computed(() => !sourcesStore.loading && sourcesStore.sources.length === 0)
 </script>
 
 <template>
     <div class="flex flex-col min-h-0 flex-1">
         <DriftBanner />
-        <SplitterGroup direction="horizontal"
+
+        <div v-if="showEmpty"
+             class="w-full max-w-[1040px] mx-auto">
+            <SourcesEmptyState @create="onCreateSource"
+                               @create-type="onCreateSourceFromCatalog" />
+        </div>
+
+        <SplitterGroup v-else
+                       direction="horizontal"
                        auto-save-id="catalog-panels"
                        class="flex-1 min-h-0">
             <SplitterPanel :default-size="panelVisible ? 70 : 100"
@@ -113,31 +125,18 @@ function onCreateSource() {
             </template>
         </SplitterGroup>
 
-        <UDrawer v-model:open="drawerOpen"
-                 direction="right"
-                 :handle="false"
-                 :handle-only="true"
-                 :title="sourceStepperRef?.title ?? 'New Source'"
-                 :ui="{ content: 'w-[40rem]', description: 'sr-only' }">
-            <template #description>Configure source</template>
-            <template #body>
-                <SourcesStepper v-if="drawerOpen"
-                                :key="editingSource?.id ?? 'new'"
-                                ref="sourceStepperRef"
-                                :source="editingSource"
-                                @created="handleSaved"
-                                @updated="handleSaved" />
-            </template>
-            <template #footer>
-                <StepperNav v-if="sourceStepperRef"
-                            :can-proceed="sourceStepperRef.canProceed"
-                            :has-prev="sourceStepperRef.hasPrev"
-                            :submitting="sourceStepperRef.submitting"
-                            :submit-label="sourceStepperRef.submitLabel"
-                            @next="sourceStepperRef.next()"
-                            @prev="sourceStepperRef.prev()" />
-            </template>
-        </UDrawer>
+        <WizardDrawer v-model:open="drawerOpen"
+                      default-title="New Source"
+                      description="Configure source"
+                      :stepper="sourceStepperRef">
+            <SourcesStepper v-if="drawerOpen"
+                            :key="editingSource?.id ?? 'new'"
+                            ref="sourceStepperRef"
+                            :source="editingSource"
+                            :initial-type-key="presetTypeKey"
+                            @created="handleSaved"
+                            @updated="handleSaved" />
+        </WizardDrawer>
     </div>
 </template>
 

--- a/packages/interloper-app/app/app/pages/destinations.vue
+++ b/packages/interloper-app/app/app/pages/destinations.vue
@@ -12,10 +12,17 @@ const catalogStore = useCatalogStore()
 const destinationsStore = useDestinationsStore()
 const resourcesStore = useResourcesStore()
 
-const drawerOpen = ref(false)
-const editingDestination = ref<Destination | null>(null)
 const stepperRef = ref<any>(null)
 const toast = useToast()
+
+const {
+    open: drawerOpen,
+    editing: editingDestination,
+    presetTypeKey,
+    openCreate: handleCreate,
+    openCreateWithType: handleCreateFromCatalog,
+    openEdit: handleEdit,
+} = useWizardDrawer<Destination>()
 
 destinationsStore.fetch()
 resourcesStore.fetch()
@@ -78,16 +85,6 @@ const columns: TableColumn<Destination>[] = [
     },
 ]
 
-function handleEdit(dest: Destination) {
-    editingDestination.value = dest
-    drawerOpen.value = true
-}
-
-function handleCreate() {
-    editingDestination.value = null
-    drawerOpen.value = true
-}
-
 async function handleDelete(ids: string[]) {
     try {
         await destinationsStore.remove(ids)
@@ -106,7 +103,7 @@ function handleSaved() {
 
 <template>
     <div>
-        <div class="flex flex-col h-full">
+        <div class="flex flex-col flex-1 min-h-0">
             <DataTable :columns="columns"
                        :data="destinationsStore.destinations"
                        :loading="destinationsStore.loading"
@@ -118,35 +115,51 @@ function handleSaved() {
                              label="New destination"
                              @click="handleCreate" />
                 </template>
+
+                <template #empty>
+                    <EmptyState icon="i-lucide-hard-drive"
+                                title="No destinations yet"
+                                description="A destination is wherever Interloper materializes your typed assets — a warehouse, a database, or plain files, all running on infrastructure you control. Pick one from the catalog below to start landing data.">
+                        <UButton icon="i-lucide-plus"
+                                 label="New destination"
+                                 class="mt-5"
+                                 @click="handleCreate" />
+                    </EmptyState>
+
+                    <div class="mt-9 mb-3.5">
+                        <h2 class="text-lg font-bold tracking-[-0.015em] text-highlighted">
+                            Destinations Catalog
+                        </h2>
+                        <p class="text-sm text-muted mt-1.5">
+                            Production-ready IO backends that ship with Interloper now.
+                        </p>
+                    </div>
+                    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+                        <CatalogCard v-for="def in catalogStore.destinationDefinitions"
+                                     :key="def.key"
+                                     variant="rich"
+                                     :icon="typeIcon(def.key)"
+                                     :title="def.name"
+                                     :caption="def.provider"
+                                     :description="def.description"
+                                     :chips="(def.tags ?? []).map(t => ({ label: t }))"
+                                     @click="handleCreateFromCatalog(def.key)" />
+                    </div>
+                </template>
             </DataTable>
         </div>
 
-        <UDrawer v-model:open="drawerOpen"
-                 direction="right"
-                 :handle="false"
-                 :handle-only="true"
-                 :title="stepperRef?.title ?? 'New Destination'"
-                 :ui="{ content: 'w-[40rem]', description: 'sr-only' }">
-            <template #description>
-                Configure destination
-            </template>
-            <template #body>
-                <DestinationsStepper v-if="drawerOpen"
-                                      :key="editingDestination?.id ?? 'new'"
-                                      ref="stepperRef"
-                                      :destination="editingDestination"
-                                      @created="handleSaved"
-                                      @updated="handleSaved" />
-            </template>
-            <template #footer>
-                <StepperNav v-if="stepperRef"
-                            :can-proceed="stepperRef.canProceed"
-                            :has-prev="stepperRef.hasPrev"
-                            :submitting="stepperRef.submitting"
-                            :submit-label="stepperRef.submitLabel"
-                            @next="stepperRef.next()"
-                            @prev="stepperRef.prev()" />
-            </template>
-        </UDrawer>
+        <WizardDrawer v-model:open="drawerOpen"
+                      default-title="New Destination"
+                      description="Configure destination"
+                      :stepper="stepperRef">
+            <DestinationsStepper v-if="drawerOpen"
+                                 :key="editingDestination?.id ?? 'new'"
+                                 ref="stepperRef"
+                                 :destination="editingDestination"
+                                 :initial-type-key="presetTypeKey"
+                                 @created="handleSaved"
+                                 @updated="handleSaved" />
+        </WizardDrawer>
     </div>
 </template>

--- a/packages/interloper-app/app/app/pages/executions/backfills/[backfill].vue
+++ b/packages/interloper-app/app/app/pages/executions/backfills/[backfill].vue
@@ -93,7 +93,7 @@ const columns: TableColumn<Run>[] = withSortableHeaders([
              back-to="/executions?tab=backfills"
              resource-label="backfill">
         <div>
-            <div class="flex items-center gap-3 mb-4 shrink-0 px-4 pt-4">
+            <div class="flex items-center gap-3 mb-4 shrink-0">
             <NuxtLink to="/executions?tab=backfills"
                       class="text-sm text-muted hover:text-default">
                 Backfills
@@ -108,7 +108,7 @@ const columns: TableColumn<Run>[] = withSortableHeaders([
         </div>
 
         <div v-if="backfill"
-             class="flex items-center gap-4 px-4 mb-4 text-sm text-muted">
+             class="flex items-center gap-4 mb-4 text-sm text-muted">
             <div class="flex items-center gap-1.5">
                 <UIcon name="i-lucide-briefcase"
                        class="size-4" />

--- a/packages/interloper-app/app/app/pages/executions/index.vue
+++ b/packages/interloper-app/app/app/pages/executions/index.vue
@@ -22,11 +22,11 @@ onMounted(() => {
 </script>
 
 <template>
+    <div class="flex flex-col flex-1 min-h-0">
         <UTabs :items="items"
                variant="link"
                :model-value="activeTab"
-               class="overflow-auto"
-               :ui="{ list: 'px-4 pt-4' }"
+               :ui="{ list: 'mb-4' }"
                @update:model-value="activeTab = $event as string">
             <template #runs>
                 <ExecutionsRunsTable />
@@ -35,4 +35,5 @@ onMounted(() => {
                 <ExecutionsBackfillsTable />
             </template>
         </UTabs>
+    </div>
 </template>

--- a/packages/interloper-app/app/app/pages/executions/runs/[run].vue
+++ b/packages/interloper-app/app/app/pages/executions/runs/[run].vue
@@ -7,7 +7,7 @@ import { SplitterGroup, SplitterPanel, SplitterResizeHandle } from 'reka-ui'
 
 // orgSwitchTarget: this page is bespoke to one org's run — switching org from
 // the nav lands on the runs list instead.
-definePageMeta({ title: 'Run', orgSwitchTarget: '/executions?tab=runs' })
+definePageMeta({ title: 'Run', orgSwitchTarget: '/executions?tab=runs', fullBleed: true })
 
 const route = useRoute()
 const runId = route.params.run!.toString()
@@ -58,19 +58,19 @@ watch(statusFilter, () => { selectedAsset.value = null })
 
 // Event category tab (All / Lifecycle / Errors / Logs), filtered server-side.
 const eventCategory = ref<EventCategory>('all')
-const eventTabs: { key: EventCategory; label: string; icon: string }[] = [
-    { key: 'all', label: 'All', icon: 'i-lucide-list' },
-    { key: 'lifecycle', label: 'Lifecycle', icon: 'i-lucide-activity' },
-    { key: 'errors', label: 'Errors', icon: 'i-lucide-circle-alert' },
-    { key: 'logs', label: 'Logs', icon: 'i-lucide-scroll-text' },
+const eventTabs = [
+    { value: 'all', label: 'All', icon: 'i-lucide-list' },
+    { value: 'lifecycle', label: 'Lifecycle', icon: 'i-lucide-activity' },
+    { value: 'errors', label: 'Errors', icon: 'i-lucide-circle-alert' },
+    { value: 'logs', label: 'Logs', icon: 'i-lucide-scroll-text' },
 ]
 watch(eventCategory, cat => eventsStore.filterByEventTypes(eventTypesForCategory(cat)))
 
 // Top-panel view: the Gantt timeline or the run dependency graph.
 const view = ref<'timeline' | 'graph'>('timeline')
-const viewTabs: { key: 'timeline' | 'graph'; label: string; icon: string }[] = [
-    { key: 'timeline', label: 'Timeline', icon: 'i-lucide-gantt-chart' },
-    { key: 'graph', label: 'Graph', icon: 'i-lucide-workflow' },
+const viewTabs = [
+    { value: 'timeline', label: 'Timeline', icon: 'i-lucide-gantt-chart' },
+    { value: 'graph', label: 'Graph', icon: 'i-lucide-workflow' },
 ]
 
 const markerTime = computed(() => eventInFocus.value?.timestamp ? new Date(eventInFocus.value.timestamp) : null)
@@ -165,28 +165,20 @@ onUnmounted(() => {
 
         <SplitterGroup direction="vertical"
                        auto-save-id="run-panels"
-                       class="flex-1 min-h-0 rounded-lg">
-            <!-- pr-0 so the timeline's scrollbar sits flush at the panel edge,
-                 aligned with the events table's scrollbar below. -->
+                       class="flex-1 min-h-0 rounded-lg px-4 pb-4">
             <SplitterPanel :default-size="40"
                            :min-size="15"
-                           class="flex flex-col overflow-hidden pt-4 pl-4">
-                <div class="mb-2 mr-4 flex items-center gap-0.5 self-start rounded-md bg-elevated p-0.5">
-                    <button v-for="tab in viewTabs"
-                            :key="tab.key"
-                            type="button"
-                            class="flex items-center gap-1.5 rounded px-2 py-1 text-xs transition-colors cursor-pointer"
-                            :class="view === tab.key
-                                ? 'bg-default text-default shadow-sm'
-                                : 'text-muted hover:text-default'"
-                            @click="view = tab.key">
-                        <UIcon :name="tab.icon"
-                               class="size-3.5" />
-                        {{ tab.label }}
-                    </button>
-                </div>
+                           class="flex flex-col overflow-hidden">
+                <div class="flex flex-col flex-1 min-h-0 border border-default rounded-xl bg-default overflow-hidden">
+                    <div class="flex items-center px-3.5 py-2 shrink-0 border-b border-default">
+                        <UTabs v-model="view"
+                               :items="viewTabs"
+                               variant="pill"
+                               size="xs"
+                               :content="false" />
+                    </div>
 
-                <div class="flex min-h-0 flex-1 flex-col">
+                    <div class="flex min-h-0 flex-1 flex-col">
                     <div v-if="run?.status === 'queued'"
                          class="flex h-full items-center justify-center text-muted">
                         <span class="text-sm">Run is currently queued...</span>
@@ -200,6 +192,7 @@ onUnmounted(() => {
                     <ExecutionsRunGraph v-else
                                         v-model:selected-asset="selectedAsset"
                                         :run-id="runId" />
+                    </div>
                 </div>
             </SplitterPanel>
 
@@ -214,36 +207,29 @@ onUnmounted(() => {
             <SplitterPanel :default-size="60"
                            :min-size="20"
                            class="flex flex-col min-h-0">
-                <div class="flex items-center gap-2 px-4 py-2 shrink-0">
-                    <div class="flex items-center gap-0.5 rounded-md bg-elevated p-0.5">
-                        <button v-for="tab in eventTabs"
-                                :key="tab.key"
-                                type="button"
-                                class="flex items-center gap-1.5 rounded px-2 py-1 text-xs transition-colors cursor-pointer"
-                                :class="eventCategory === tab.key
-                                    ? 'bg-default text-default shadow-sm'
-                                    : 'text-muted hover:text-default'"
-                                @click="eventCategory = tab.key">
-                            <UIcon :name="tab.icon"
-                                   class="size-3.5" />
-                            {{ tab.label }}
-                        </button>
+                <div class="flex flex-col flex-1 min-h-0 border border-default rounded-xl bg-default overflow-hidden">
+                    <div class="flex items-center gap-2 px-3.5 py-2 shrink-0 border-b border-default">
+                        <UTabs v-model="eventCategory"
+                               :items="eventTabs"
+                               variant="pill"
+                               size="xs"
+                               :content="false" />
+                        <span class="ml-auto text-xs font-medium uppercase tracking-wide text-muted">Events</span>
+                        <UBadge v-if="!eventsStore.loading"
+                                color="neutral"
+                                variant="subtle"
+                                size="sm">
+                            {{ eventsStore.hasMore ? `${eventsStore.events.length} / ${eventsStore.total}` : eventsStore.events.length }}
+                        </UBadge>
                     </div>
-                    <span class="ml-auto text-xs font-medium uppercase tracking-wide text-muted">Events</span>
-                    <UBadge v-if="!eventsStore.loading"
-                            color="neutral"
-                            variant="subtle"
-                            size="sm">
-                        {{ eventsStore.hasMore ? `${eventsStore.events.length} / ${eventsStore.total}` : eventsStore.events.length }}
-                    </UBadge>
-                </div>
-                <div class="flex-1 min-h-0">
-                    <ExecutionsEventsTable v-model:event-in-focus="eventInFocus"
-                                           :events="eventsStore.events"
-                                           :loading="eventsStore.loading"
-                                           :loading-more="eventsStore.loadingMore"
-                                           :has-more="eventsStore.hasMore"
-                                           :load-more="eventsStore.loadMore" />
+                    <div class="flex-1 min-h-0">
+                        <ExecutionsEventsTable v-model:event-in-focus="eventInFocus"
+                                               :events="eventsStore.events"
+                                               :loading="eventsStore.loading"
+                                               :loading-more="eventsStore.loadingMore"
+                                               :has-more="eventsStore.hasMore"
+                                               :load-more="eventsStore.loadMore" />
+                    </div>
                 </div>
             </SplitterPanel>
         </SplitterGroup>

--- a/packages/interloper-app/app/app/pages/graph.vue
+++ b/packages/interloper-app/app/app/pages/graph.vue
@@ -2,11 +2,16 @@
 import { SplitterGroup, SplitterPanel, SplitterResizeHandle } from 'reka-ui'
 import type { Source } from '~/types/source'
 
-definePageMeta({ title: 'Graph' })
+definePageMeta({ title: 'Graph', fullBleed: true })
 
-const sourceDrawerOpen = ref(false)
-const editingSource = ref<Source | null>(null)
 const sourceStepperRef = ref<any>(null)
+
+const {
+    open: sourceDrawerOpen,
+    editing: editingSource,
+    openCreate: onCreateSource,
+    openEdit: openEditSource,
+} = useWizardDrawer<Source>()
 const sourcesStore = useSourcesStore()
 const assetsStore = useAssetsStore()
 const jobsStore = useJobsStore()
@@ -38,13 +43,8 @@ onMounted(() => {
 })
 
 function onEditSource(sourceId: string) {
-    editingSource.value = sourcesStore.findById(sourceId) ?? null
-    if (editingSource.value) sourceDrawerOpen.value = true
-}
-
-function onCreateSource() {
-    editingSource.value = null
-    sourceDrawerOpen.value = true
+    const source = sourcesStore.findById(sourceId)
+    if (source) openEditSource(source)
 }
 
 function handleSaved() {
@@ -164,31 +164,17 @@ async function onDeleteDependency(payload: { upstreamAssetId: string; downstream
             </template>
         </SplitterGroup>
 
-        <UDrawer v-model:open="sourceDrawerOpen"
-                 direction="right"
-                 :handle="false"
-                 :handle-only="true"
-                 :title="sourceStepperRef?.title ?? 'New Source'"
-                 :ui="{ content: 'w-[40rem]', description: 'sr-only' }">
-            <template #description>Configure source</template>
-            <template #body>
-                <SourcesStepper v-if="sourceDrawerOpen"
-                                :key="editingSource?.id ?? 'new'"
-                                ref="sourceStepperRef"
-                                :source="editingSource"
-                                @created="handleSaved"
-                                @updated="handleSaved" />
-            </template>
-            <template #footer>
-                <StepperNav v-if="sourceStepperRef"
-                            :can-proceed="sourceStepperRef.canProceed"
-                            :has-prev="sourceStepperRef.hasPrev"
-                            :submitting="sourceStepperRef.submitting"
-                            :submit-label="sourceStepperRef.submitLabel"
-                            @next="sourceStepperRef.next()"
-                            @prev="sourceStepperRef.prev()" />
-            </template>
-        </UDrawer>
+        <WizardDrawer v-model:open="sourceDrawerOpen"
+                      default-title="New Source"
+                      description="Configure source"
+                      :stepper="sourceStepperRef">
+            <SourcesStepper v-if="sourceDrawerOpen"
+                            :key="editingSource?.id ?? 'new'"
+                            ref="sourceStepperRef"
+                            :source="editingSource"
+                            @created="handleSaved"
+                            @updated="handleSaved" />
+        </WizardDrawer>
     </div>
 </template>
 

--- a/packages/interloper-app/app/app/pages/invite/[token].vue
+++ b/packages/interloper-app/app/app/pages/invite/[token].vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-definePageMeta({ title: 'Accept Invitation' })
+definePageMeta({ title: 'Accept Invitation', fullBleed: true })
 
 const route = useRoute()
 const { apiFetch } = useApi()

--- a/packages/interloper-app/app/app/pages/jobs.vue
+++ b/packages/interloper-app/app/app/pages/jobs.vue
@@ -12,9 +12,14 @@ const jobsStore = useJobsStore()
 const sourcesStore = useSourcesStore()
 const toast = useToast()
 
-const drawerOpen = ref(false)
 const stepperRef = ref<any>(null)
-const editingJob = ref<Job | null>(null)
+
+const {
+    open: drawerOpen,
+    editing: editingJob,
+    openCreate: handleCreate,
+    openEdit: handleEdit,
+} = useWizardDrawer<Job>()
 const runModalOpen = ref(false)
 const runModalJob = ref<Job | null>(null)
 
@@ -30,20 +35,16 @@ function cronLabel(cron: string): string {
     }
 }
 
-function handleCreate() {
-    editingJob.value = null
-    drawerOpen.value = true
-}
-
-function handleEdit(job: Job) {
-    editingJob.value = job
-    drawerOpen.value = true
-}
-
 function openRun(job: Job) {
     runModalJob.value = job
     runModalOpen.value = true
 }
+
+/** Onboarding cards shown in the empty state. */
+const SETUP_STEPS = [
+    { to: '/sources', icon: 'i-lucide-plug', title: 'Step 1 · Connect a source', sub: 'Pull from Google Ads, Meta, Bing & more', link: 'Go to Sources' },
+    { to: '/destinations', icon: 'i-lucide-database', title: 'Step 2 · Add a destination', sub: 'Choose where assets are materialized', link: 'Go to Destinations' },
+]
 
 const columns: TableColumn<Job>[] = [
     { accessorKey: 'select' as any, header: '' },
@@ -116,7 +117,7 @@ async function handleDelete(ids: string[]) {
 
 <template>
     <div>
-        <div class="flex flex-col h-full">
+        <div class="flex flex-col flex-1 min-h-0">
             <DataTable :columns="columns"
                        :data="jobsStore.jobs"
                        :loading="jobsStore.loading"
@@ -129,36 +130,76 @@ async function handleDelete(ids: string[]) {
                              label="New job"
                              @click="handleCreate" />
                 </template>
+
+                <template #empty>
+                    <EmptyState icon="i-lucide-calendar-clock"
+                                title="No jobs yet"
+                                description="A job is a scheduled pipeline. It runs your sources on a cron schedule and materializes the results into your destination — automatically, with no manual triggering. Every run is recorded under Executions." />
+
+                    <div class="mt-9">
+                        <div class="eyebrow text-primary">
+                            Before your first job
+                        </div>
+                        <h2 class="text-[19px] font-bold tracking-[-0.015em] text-highlighted mt-2">
+                            A job needs something to run
+                        </h2>
+                        <p class="text-[14.5px] text-muted leading-relaxed max-w-[640px] mt-2">
+                            Set up at least one source to pull from and one destination to write to.
+                            Once both exist, you can wire them into a scheduled job.
+                        </p>
+                    </div>
+
+                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-3.5 mt-5">
+                        <NuxtLink v-for="step in SETUP_STEPS"
+                                  :key="step.to"
+                                  :to="step.to"
+                                  class="block border border-default rounded-[14px] p-5 bg-default shadow-xs transition hover:border-primary/40 hover:shadow-md hover:-translate-y-0.5">
+                            <div class="flex items-center gap-3">
+                                <div class="size-[42px] rounded-[11px] bg-primary/10 text-primary flex items-center justify-center">
+                                    <UIcon :name="step.icon"
+                                           class="size-[21px]" />
+                                </div>
+                                <div>
+                                    <div class="text-[15.5px] font-semibold text-highlighted">{{ step.title }}</div>
+                                    <div class="text-[12.5px] text-dimmed mt-0.5">{{ step.sub }}</div>
+                                </div>
+                            </div>
+                            <div class="flex items-center gap-1.5 mt-3.5 text-primary text-[13.5px] font-semibold">
+                                {{ step.link }}
+                                <UIcon name="i-lucide-arrow-right"
+                                       class="size-3" />
+                            </div>
+                        </NuxtLink>
+                    </div>
+
+                    <div class="flex items-center gap-3 border border-default rounded-[14px] px-5 py-4 bg-(--ui-bg-band) mt-4">
+                        <div class="size-[30px] shrink-0 rounded-full bg-elevated flex items-center justify-center font-mono text-[13px] font-semibold text-muted">
+                            3
+                        </div>
+                        <div class="flex-1 text-sm text-toned">
+                            With a source and destination ready, create a job to run them on a schedule.
+                        </div>
+                        <UButton icon="i-lucide-plus"
+                                 label="New job"
+                                 size="md"
+                                 @click="handleCreate" />
+                    </div>
+
+                </template>
             </DataTable>
         </div>
 
-        <UDrawer v-model:open="drawerOpen"
-                 direction="right"
-                 :handle="false"
-                 :handle-only="true"
-                 :title="stepperRef?.title ?? 'New Job'"
-                 :ui="{ content: 'w-[36rem]', description: 'sr-only' }">
-            <template #description>
-                {{ editingJob ? 'Edit job configuration' : 'Configure a new job' }}
-            </template>
-            <template #body>
-                <JobsStepper v-if="drawerOpen"
-                             :key="editingJob?.id ?? 'new'"
-                             ref="stepperRef"
-                             :job="editingJob"
-                             @created="handleSaved"
-                             @updated="handleSaved" />
-            </template>
-            <template #footer>
-                <StepperNav v-if="stepperRef"
-                            :can-proceed="stepperRef.canProceed"
-                            :has-prev="stepperRef.hasPrev"
-                            :submitting="stepperRef.submitting"
-                            :submit-label="stepperRef.submitLabel"
-                            @next="stepperRef.next()"
-                            @prev="stepperRef.prev()" />
-            </template>
-        </UDrawer>
+        <WizardDrawer v-model:open="drawerOpen"
+                      :default-title="editingJob ? 'Edit Job' : 'New Job'"
+                      description="Configure job"
+                      :stepper="stepperRef">
+            <JobsStepper v-if="drawerOpen"
+                         :key="editingJob?.id ?? 'new'"
+                         ref="stepperRef"
+                         :job="editingJob"
+                         @created="handleSaved"
+                         @updated="handleSaved" />
+        </WizardDrawer>
 
         <JobsRunModal v-if="runModalJob"
                        v-model:open="runModalOpen"

--- a/packages/interloper-app/app/app/pages/organization.vue
+++ b/packages/interloper-app/app/app/pages/organization.vue
@@ -1,7 +1,15 @@
 <script setup lang="ts">
 import type { OrgMember } from '~/types/organisation'
 
-definePageMeta({ title: 'Organization' })
+definePageMeta({
+    title: 'Organization',
+    pageHeader: {
+        eyebrow: 'Workspace',
+        title: 'Members',
+        description: 'Invite your team to your workspace and give everyone the right level of access. '
+            + 'Roles control who can build pipelines, who can only read data, and who can manage the workspace.',
+    },
+})
 
 interface Invitation {
     id: string
@@ -101,6 +109,28 @@ const organisationStore = useOrganisationStore()
 
 onMounted(loadData)
 watch(() => organisationStore.organisation, loadData)
+
+/** Access-level explainer cards — matches the app's real role vocabulary. */
+const ROLE_CARDS = [
+    {
+        name: 'Admin',
+        icon: 'i-lucide-shield-check',
+        tile: ROLE_TINTS.admin!,
+        desc: 'Full control — manage members, invitations, connections and every pipeline.',
+    },
+    {
+        name: 'Editor',
+        icon: 'i-lucide-wrench',
+        tile: ROLE_TINTS.editor!,
+        desc: 'Build and run the data layer: create sources, destinations, connections and jobs, and trigger runs.',
+    },
+    {
+        name: 'Viewer',
+        icon: 'i-lucide-eye',
+        tile: ROLE_TINTS.viewer!,
+        desc: 'Read-only access to the catalog, graph and run history. Cannot change anything.',
+    },
+]
 </script>
 
 <template>
@@ -117,6 +147,30 @@ watch(() => organisationStore.organisation, loadData)
                          @click="inviteOpen = true" />
             </template>
         </OrganizationMembersTable>
+
+        <div class="mt-11 mb-3.5">
+            <div class="eyebrow text-primary">
+                Access levels
+            </div>
+            <h2 class="text-[19px] font-bold tracking-[-0.015em] text-highlighted mt-2">
+                What each role can do
+            </h2>
+        </div>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div v-for="role in ROLE_CARDS"
+                 :key="role.name"
+                 class="border border-default rounded-xl p-[18px] bg-default">
+                <div class="flex items-center gap-2.5">
+                    <div class="size-[34px] rounded-lg flex items-center justify-center"
+                         :class="role.tile">
+                        <UIcon :name="role.icon"
+                               class="size-[18px]" />
+                    </div>
+                    <div class="text-[15px] font-bold text-highlighted">{{ role.name }}</div>
+                </div>
+                <p class="text-[13px] text-muted leading-normal mt-2.5">{{ role.desc }}</p>
+            </div>
+        </div>
 
         <OrganizationInviteModal v-model:open="inviteOpen"
                                  @invited="loadData" />

--- a/packages/interloper-app/app/app/pages/resources/[kind].vue
+++ b/packages/interloper-app/app/app/pages/resources/[kind].vue
@@ -28,13 +28,16 @@ function typeName(key: string): string {
     return catalogStore.catalog[key]?.name ?? key
 }
 
-function typeIcon(key: string): string {
-    return componentIcon(key)
-}
-
-const drawerOpen = ref(false)
 const stepperRef = ref<any>(null)
-const editingResource = ref<Resource | null>(null)
+
+const {
+    open: drawerOpen,
+    editing: editingResource,
+    presetTypeKey,
+    openCreate: handleCreate,
+    openCreateWithType: handleCreateFromCatalog,
+    openEdit: handleEdit,
+} = useWizardDrawer<Resource>()
 
 // Re-fetch when kind changes
 watch(kind, () => resourcesStore.fetch(kind.value), { immediate: true })
@@ -49,7 +52,7 @@ const columns: TableColumn<Resource>[] = [
             color: 'neutral',
             variant: 'subtle',
         }, () => h('span', { class: 'flex items-center gap-1.5' }, [
-            h(UIcon, { name: typeIcon(row.original.key), class: 'size-4 shrink-0' }),
+            h(UIcon, { name: componentIcon(row.original.key), class: 'size-4 shrink-0' }),
             typeName(row.original.key),
         ])),
     },
@@ -73,25 +76,38 @@ async function handleDelete(ids: string[]) {
     }
 }
 
-function handleEdit(item: Resource) {
-    editingResource.value = item
-    drawerOpen.value = true
-}
-
-function handleCreate() {
-    editingResource.value = null
-    drawerOpen.value = true
-}
-
 function handleSaved() {
     resourcesStore.fetch(kind.value)
     drawerOpen.value = false
 }
+
+// ── Empty state ──
+
+const KIND_ICONS: Record<string, string> = {
+    connection: 'i-lucide-key-round',
+    config: 'i-lucide-settings',
+}
+
+const EMPTY_COPY: Record<string, { hero: string, catalogTitle: string, catalogDesc: string }> = {
+    connection: {
+        hero: 'A connection is a securely-stored credential — an OAuth token, API key or service account — that '
+            + 'Interloper uses to authenticate with a platform. Create one, and every source from that provider '
+            + 'can reuse it. Credentials are encrypted at rest and never leave your cloud.',
+        catalogTitle: 'Connections Catalog',
+        catalogDesc: 'Pick a platform to store a reusable credential — every source from that provider can share it.',
+    },
+}
+
+const emptyCopy = computed(() => EMPTY_COPY[kind.value] ?? {
+    hero: `Create your first ${kind.value} to get started.`,
+    catalogTitle: 'Available types',
+    catalogDesc: `Pick a type to create a new ${kind.value}.`,
+})
 </script>
 
 <template>
     <div>
-        <div class="flex flex-col h-full">
+        <div class="flex flex-col flex-1 min-h-0">
             <DataTable :columns="columns"
                        :data="resources"
                        :loading="resourcesStore.loading"
@@ -103,38 +119,62 @@ function handleSaved() {
                              :label="`New ${kind}`"
                              @click="handleCreate" />
                 </template>
+
+                <template #empty>
+                    <EmptyState :icon="KIND_ICONS[kind] ?? 'i-lucide-box'"
+                                :title="`No ${pageTitle.toLowerCase()} yet`"
+                                :description="emptyCopy.hero">
+                        <UButton icon="i-lucide-plus"
+                                 :label="`New ${kind}`"
+                                 class="mt-5"
+                                 @click="handleCreate" />
+                    </EmptyState>
+
+                    <div class="mt-9 mb-3.5">
+                        <h2 class="text-lg font-bold tracking-[-0.015em] text-highlighted">
+                            {{ emptyCopy.catalogTitle }}
+                        </h2>
+                        <p class="text-sm text-muted mt-1.5">{{ emptyCopy.catalogDesc }}</p>
+                    </div>
+                    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+                        <CatalogCard v-for="def in definitions"
+                                     :key="def.key"
+                                     variant="compact"
+                                     :icon="componentIcon(def.key)"
+                                     :title="def.name"
+                                     :caption="def.provider"
+                                     @click="handleCreateFromCatalog(def.key)" />
+                    </div>
+
+                    <div v-if="kind === 'connection'"
+                         class="flex items-center gap-3 border border-default rounded-[14px] px-5 py-4 bg-(--ui-bg-band) mt-6">
+                        <UIcon name="i-lucide-info"
+                               class="size-5 text-primary shrink-0" />
+                        <div class="flex-1 text-[13.5px] text-toned leading-normal">
+                            You can also create a connection inline while adding a source — whichever you reach first.
+                            Ready to connect data?
+                            <NuxtLink to="/sources"
+                                      class="text-primary font-semibold">Browse sources →</NuxtLink>
+                        </div>
+                    </div>
+                </template>
             </DataTable>
         </div>
 
-        <UDrawer v-model:open="drawerOpen"
-                 direction="right"
-                 modal
-                 :handle="false"
-                 :handle-only="true"
-                 :title="stepperRef?.title ?? `New ${kind}`"
-                 :ui="{ content: 'w-[40rem]', description: 'sr-only' }">
-            <template #description>
-                {{ editingResource ? 'Edit' : 'Configure a new' }} {{ kind }}
-            </template>
-            <template #body>
-                <ResourcesStepper v-if="drawerOpen"
-                                  :key="editingResource?.id ?? 'new'"
-                                  ref="stepperRef"
-                                  :kind="kind"
-                                  :definitions="definitions"
-                                  :resource="editingResource"
-                                  @created="handleSaved"
-                                  @updated="handleSaved" />
-            </template>
-            <template #footer>
-                <StepperNav v-if="stepperRef"
-                            :can-proceed="stepperRef.canProceed"
-                            :has-prev="stepperRef.hasPrev"
-                            :submitting="stepperRef.submitting"
-                            :submit-label="stepperRef.submitLabel"
-                            @next="stepperRef.next()"
-                            @prev="stepperRef.prev()" />
-            </template>
-        </UDrawer>
+        <WizardDrawer v-model:open="drawerOpen"
+                      modal
+                      :default-title="`New ${kind}`"
+                      :description="`${editingResource ? 'Edit' : 'Configure a new'} ${kind}`"
+                      :stepper="stepperRef">
+            <ResourcesStepper v-if="drawerOpen"
+                              :key="editingResource?.id ?? 'new'"
+                              ref="stepperRef"
+                              :kind="kind"
+                              :initial-type-key="presetTypeKey"
+                              :definitions="definitions"
+                              :resource="editingResource"
+                              @created="handleSaved"
+                              @updated="handleSaved" />
+        </WizardDrawer>
     </div>
 </template>

--- a/packages/interloper-app/app/app/pages/sources.vue
+++ b/packages/interloper-app/app/app/pages/sources.vue
@@ -13,28 +13,21 @@ const sourcesStore = useSourcesStore()
 const destinationsStore = useDestinationsStore()
 const { statusBadge, sourceDrift } = useDrift()
 
-function typeIcon(key: string): string {
-    return componentIcon(key)
-}
-
 function typeName(key: string): string {
     return catalogStore.catalog[key]?.name ?? key
 }
 
-const drawerOpen = ref(false)
-const editingSource = ref<Source | null>(null)
 const stepperRef = ref<any>(null)
 const toast = useToast()
 
-function handleEdit(source: Source) {
-    editingSource.value = source
-    drawerOpen.value = true
-}
-
-function handleCreate() {
-    editingSource.value = null
-    drawerOpen.value = true
-}
+const {
+    open: drawerOpen,
+    editing: editingSource,
+    presetTypeKey,
+    openCreate: handleCreate,
+    openCreateWithType: handleCreateFromCatalog,
+    openEdit: handleEdit,
+} = useWizardDrawer<Source>()
 
 sourcesStore.fetch()
 
@@ -45,7 +38,7 @@ const columns: TableColumn<Source>[] = [
         header: 'Source',
         cell: ({ row }) => {
             const children: any[] = [
-                h(UIcon, { name: typeIcon(row.original.key), class: 'size-4 shrink-0' }),
+                h(UIcon, { name: componentIcon(row.original.key), class: 'size-4 shrink-0' }),
                 row.original.name,
             ]
             const badge = statusBadge(sourceDrift(row.original))
@@ -70,7 +63,7 @@ const columns: TableColumn<Source>[] = [
             color: 'neutral',
             variant: 'subtle',
         }, () => h('span', { class: 'flex items-center gap-1.5' }, [
-            h(UIcon, { name: typeIcon(row.original.key), class: 'size-4 shrink-0' }),
+            h(UIcon, { name: componentIcon(row.original.key), class: 'size-4 shrink-0' }),
             typeName(row.original.key),
         ])),
     },
@@ -129,7 +122,7 @@ async function handleDelete(ids: string[]) {
     <div>
         <DriftBanner />
 
-        <div class="flex flex-col h-full">
+        <div class="flex flex-col flex-1 min-h-0">
             <DataTable :columns="columns"
                        :data="sourcesStore.sources"
                        :loading="sourcesStore.loading"
@@ -141,35 +134,25 @@ async function handleDelete(ids: string[]) {
                              label="New source"
                              @click="handleCreate" />
                 </template>
+
+                <template #empty>
+                    <SourcesEmptyState @create="handleCreate"
+                                       @create-type="handleCreateFromCatalog" />
+                </template>
             </DataTable>
         </div>
 
-        <UDrawer v-model:open="drawerOpen"
-                 direction="right"
-                 :handle="false"
-                 :handle-only="true"
-                 :title="stepperRef?.title ?? 'New Source'"
-                 :ui="{ content: 'w-[40rem]', description: 'sr-only' }">
-            <template #description>
-                Configure a new source
-            </template>
-            <template #body>
-                <SourcesStepper v-if="drawerOpen"
-                                :key="editingSource?.id ?? 'new'"
-                                ref="stepperRef"
-                                :source="editingSource"
-                                @created="handleSaved"
-                                @updated="handleSaved" />
-            </template>
-            <template #footer>
-                <StepperNav v-if="stepperRef"
-                            :can-proceed="stepperRef.canProceed"
-                            :has-prev="stepperRef.hasPrev"
-                            :submitting="stepperRef.submitting"
-                            :submit-label="stepperRef.submitLabel"
-                            @next="stepperRef.next()"
-                            @prev="stepperRef.prev()" />
-            </template>
-        </UDrawer>
+        <WizardDrawer v-model:open="drawerOpen"
+                      default-title="New Source"
+                      description="Configure a new source"
+                      :stepper="stepperRef">
+            <SourcesStepper v-if="drawerOpen"
+                            :key="editingSource?.id ?? 'new'"
+                            ref="stepperRef"
+                            :source="editingSource"
+                            :initial-type-key="presetTypeKey"
+                            @created="handleSaved"
+                            @updated="handleSaved" />
+        </WizardDrawer>
     </div>
 </template>

--- a/packages/interloper-app/app/app/utils/chartColors.ts
+++ b/packages/interloper-app/app/app/utils/chartColors.ts
@@ -1,0 +1,17 @@
+/**
+ * Design palette values for canvas/ECharts contexts that can't use CSS
+ * variables. Mirrors the scales in assets/css/main.css — keep in sync.
+ */
+export const CHART_STATUS_COLORS: Record<string, { light: string, dark: string }> = {
+    success: { light: '#1fa463', dark: '#45bc84' }, // green-500 / green-400
+    failed: { light: '#e5484d', dark: '#ea686c' }, // red-500 / red-400
+    running: { light: '#2d7df6', dark: '#5c9ef8' }, // blue-500 / blue-400
+    canceled: { light: '#e69e2e', dark: '#e9ac46' }, // amber-500 / amber-400
+    default: { light: '#d4d4d9', dark: '#6b6b70' }, // gray-400 / gray-800
+}
+
+export const CHART_AXIS_COLORS = {
+    axis: { light: '#6b6b70', dark: '#9a9aa0' }, // gray-800 / gray-600
+    grid: { light: '#e8e8ec', dark: '#3f3f44' }, // gray-300 / gray-900
+    bar: { light: '#2d7df6', dark: '#5c9ef8' }, // blue-500 / blue-400
+}

--- a/packages/interloper-app/app/app/utils/roles.ts
+++ b/packages/interloper-app/app/app/utils/roles.ts
@@ -1,0 +1,6 @@
+/** Design role tints (Members page ROLE_META) — chips and role-card tiles. */
+export const ROLE_TINTS: Record<string, string> = {
+    admin: 'bg-[#E7EFFD] text-[#2461C4] dark:bg-blue-400/15 dark:text-blue-300',
+    editor: 'bg-[#EEEAFB] text-[#5B45C9] dark:bg-violet-400/15 dark:text-violet-300',
+    viewer: 'bg-elevated text-muted',
+}

--- a/packages/interloper-app/app/nuxt.config.ts
+++ b/packages/interloper-app/app/nuxt.config.ts
@@ -15,7 +15,10 @@ export default defineNuxtConfig({
             Inter: {
                 wght: [100, 200, 300, 400, 500, 600, 700, 800, 900],
                 ital: [100, 200, 300, 400, 500, 600, 700, 800, 900],
-            }
+            },
+            'JetBrains Mono': {
+                wght: [400, 500, 600],
+            },
         },
         display: 'swap',
         prefetch: true,


### PR DESCRIPTION
## What

Full visual redesign of the Nuxt SPA to match the **Interloper App** claude.ai/design project ("Current" blue variant), with dark mode adapted. Every value was pulled from the design pages themselves (`theme.js` + page markup), not eyeballed.

### Theme
- Palettes rebuilt from the design: blue centered on `#2D7DF6`, gray scale = the design neutrals (`#FBFBFC`…`#1D1D1F`), status scales on `#1FA463`/`#E5484D`/`#E69E2E` with the design tints as the 50 shades. **Note: gray slot semantics shifted** (borders are slot 300 now, not 200) — direct `gray-N` utilities were audited and updated.
- Surface hierarchy: white content/header, `#F7F7F8` sidebar, `--ui-bg-band` token (`#FAFAFB`) for table headers / info strips / chart rulers.
- Component defaults via `app.config.ts`: solid buttons, outlined inputs, outline cards, design table treatment (bordered card, band header, light row dividers), segmented pill tabs (white active pill), themed stepper (48px circles, tinted check when completed), wizard drawer chrome, labeled separators, JetBrains Mono, `.eyebrow` utility.

### Layout
- The default layout owns the content frame (`p-4` scroll region). Pages opt out with `definePageMeta({ fullBleed: true })` (graph canvas, run detail split view).
- Page headers render from `definePageMeta({ pageHeader })` and switch the page to the fixed 1040px column; data tables get full width.

### Pages
- Design **empty states with real catalog data** on sources, destinations, connections, jobs, executions, and catalog (shared with sources), plus a floating card over the empty graph canvas. Clicking a catalog card preselects the type and opens the wizard on step 2.
- All four **wizards** share one visual language: `WizardDrawer` chrome, `TypeSelect` tiles, `SelectionCard` option rows, type summary card with *Change*, final-step recap table, dashed inline placeholders.
- **Members** page rebuilt to the design (role chips/cards, status pills); **run detail** gets framed timeline/events cards with `UTabs` switchers and the contrasted time band.

### Shared building blocks
`EmptyState`, `CatalogCard`, `SelectionCard`, `TypeSummaryCard`, `WizardRecap`, `InlineEmptyState`, `StatusPill`, `TableFooter`, `WizardDrawer` + `useWizardDrawer()`, `useCheckedSteps`, `ROLE_TINTS`, chart color maps mirroring the CSS palette.

## Why

First implementation phase of the app redesign tracked in the Claude Design project (`fa3b2c24-1141-4650-9ea0-9a3aea9609c6`).

## Reviewer notes

- Only real data is surfaced: catalog tags, asset counts, and role vocabulary come from the backend — no mocked "Available/Beta" badges or invented roles from the mock.
- A 4-agent simplify pass ran over the diff before this PR (reuse/simplification/efficiency/altitude); the shared components above are the result. Half-pixel font sizes and radius literals are intentional design-fidelity values.
- Verified end-to-end with a headless-Chrome pipeline against a seeded dev instance (all wizards walked step-by-step, empty states via stubbed APIs, light + dark) — zero page errors.
- `nuxt typecheck` is broken on `main` (pre-existing `@vue/language-core` packaging error); `pnpm run lint` is clean except one pre-existing `v-html` warning.
- Not in scope yet: the dashboard page (`index.vue` is still a stub), invite modal restyle, analytics chart palette.

🤖 Generated with [Claude Code](https://claude.com/claude-code)