### PR TITLE
fix(chart): move agent values from api.agent to the root

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ Both run against [dev/interloper.yaml](dev/interloper.yaml), which carries **onl
 Built from a single multi-target [dockerfile](dockerfile). The image catalog is defined in the [Makefile](Makefile): one image per role (`interloper-<role>`), with **flavors** (extra-bearing variants) riding the **tag** as a `-<flavor>` suffix — not a separate image name.
 
 - `ROLES` (`api`, `frontend`, `worker`, `scheduler`) → image `interloper-<role>:<version>` (base, no flavor extras).
-- `FLAVORS_<role>` defines the per-role flavors and `EXTRAS_ARG_<role>` the build arg that carries them: `scheduler` → `k8s`, `docker` (via `SCHEDULER_EXTRAS`); `api` → `agent` (via `API_EXTRAS`). These build `interloper-scheduler:<version>-k8s`, `interloper-api:<version>-agent`, etc. (plus matching `latest-<flavor>` tags). The Helm chart picks the scheduler tag suffix from `config.launcher.type` and the api `-agent` tag from `api.agent.enabled`.
+- `FLAVORS_<role>` defines the per-role flavors and `EXTRAS_ARG_<role>` the build arg that carries them: `scheduler` → `k8s`, `docker` (via `SCHEDULER_EXTRAS`); `api` → `agent` (via `API_EXTRAS`). These build `interloper-scheduler:<version>-k8s`, `interloper-api:<version>-agent`, etc. (plus matching `latest-<flavor>` tags). The Helm chart picks the scheduler tag suffix from `config.launcher.type` and the api `-agent` tag from `agent.enabled`.
 - Build one target: `make docker-build-<role>` (base) or `make docker-build-<role>-<flavor>` (e.g. `docker-build-scheduler-k8s`, `docker-build-api-agent`).
 - Build everything: `make docker-build` (host arch) or `make docker-build-linux` (linux/amd64 for the registry).
 - Push: `make docker-push`, or `make docker-build-push` to build linux + push in one step.

--- a/chart/interloper/README.md
+++ b/chart/interloper/README.md
@@ -31,7 +31,7 @@ ghcr.io/digitl-cloud/interloper-worker:<version>             # kubernetes runner
 ```
 
 The chart picks the scheduler tag suffix from `config.launcher.type`
-automatically, and the api `-agent` tag when `api.agent.enabled=true` — no
+automatically, and the api `-agent` tag when `agent.enabled=true` — no
 manual mapping. Override `image.registry` (and `image.pullSecrets` for a
 private registry) to pull from elsewhere.
 

--- a/chart/interloper/templates/_helpers.tpl
+++ b/chart/interloper/templates/_helpers.tpl
@@ -80,7 +80,7 @@ Flavor token for the api image. The "agent" flavor
 mount; the base image omits it (those routes 404).
 */}}
 {{- define "interloper.apiFlavor" -}}
-{{- if .Values.api.agent.enabled -}}agent{{- end -}}
+{{- if .Values.agent.enabled -}}agent{{- end -}}
 {{- end -}}
 
 {{/*

--- a/chart/interloper/templates/configmap.yaml
+++ b/chart/interloper/templates/configmap.yaml
@@ -1,12 +1,13 @@
 {{/*
 Generated interloper.yaml mounted into every pod at /etc/interloper/interloper.yaml.
 The launcher, runner, and agent sections get auto-filled from chart values
-(cluster-aware defaults, api.agent) when the user hasn't set them explicitly.
+(cluster-aware defaults, the root agent block) when the user hasn't set
+them explicitly.
 */}}
 {{- $cfg := deepCopy .Values.config -}}
 {{- if not (hasKey $cfg "agent") -}}
-  {{- $_ := set $cfg "agent" (dict "enabled" .Values.api.agent.enabled) -}}
-  {{- with .Values.api.agent.model -}}
+  {{- $_ := set $cfg "agent" (dict "enabled" .Values.agent.enabled) -}}
+  {{- with .Values.agent.model -}}
     {{- $_ := set $cfg.agent "model" . -}}
   {{- end -}}
 {{- end -}}

--- a/chart/interloper/values.yaml
+++ b/chart/interloper/values.yaml
@@ -8,7 +8,7 @@
 # convention "<registry>/interloper-<component>:<tag>" — e.g.
 # ghcr.io/digitl-cloud/interloper-api:0.3.1. Flavored variants ride the TAG as
 # a "-<flavor>" suffix on the same image: the scheduler gets "-k8s"/"-docker"
-# from config.launcher.type, and the api gets "-agent" when api.agent.enabled.
+# from config.launcher.type, and the api gets "-agent" when agent.enabled.
 image:
   registry: ghcr.io/digitl-cloud
   tag: ""  # defaults to Chart.appVersion
@@ -58,22 +58,6 @@ worker:
 api:
   enabled: true
   replicaCount: 1
-  # Agent (ADK chat) support. When true, the chart deploys the
-  # `interloper-api:<tag>-agent` image, which bundles interloper-agent, and
-  # enables the /agent routes via the generated interloper.yaml (the API
-  # reports availability to the app, which shows/hides the Agent UI).
-  #
-  # `model` takes a bare name for native Gemini models (default
-  # "gemini-2.5-flash") or a LiteLLM `provider/model` reference such as
-  # "anthropic/claude-sonnet-4-5" or "openai/gpt-5". Credentials come from the
-  # provider's standard env vars supplied via api.extraEnv / api.extraEnvFrom
-  # (e.g. GOOGLE_API_KEY, ANTHROPIC_API_KEY, OPENAI_API_KEY). For Gemini on
-  # GKE, Vertex AI needs no key at all: set GOOGLE_GENAI_USE_VERTEXAI=TRUE,
-  # GOOGLE_CLOUD_PROJECT, and GOOGLE_CLOUD_LOCATION and grant the pod's
-  # service account Vertex access via workload identity.
-  agent:
-    enabled: false
-    model: ""  # defaults to gemini-2.5-flash
   image:
     repository: ""  # defaults to {image.registry}/interloper-api
     tag: ""
@@ -137,6 +121,23 @@ dbInit:
 # =============================================================================
 # Configuration
 # =============================================================================
+
+# Agent (ADK chat) support. When enabled, the chart deploys the
+# `interloper-api:<tag>-agent` image, which bundles interloper-agent, and
+# enables the /agent routes via the generated interloper.yaml (the API
+# reports availability to the app, which shows/hides the Agent UI).
+#
+# `model` takes a bare name for native Gemini models (default
+# "gemini-2.5-flash") or a LiteLLM `provider/model` reference such as
+# "anthropic/claude-sonnet-4-5" or "openai/gpt-5". Credentials come from the
+# provider's standard env vars supplied via api.extraEnv / api.extraEnvFrom
+# (e.g. GOOGLE_API_KEY, ANTHROPIC_API_KEY, OPENAI_API_KEY). For Gemini on
+# GKE, Vertex AI needs no key at all: set GOOGLE_GENAI_USE_VERTEXAI=TRUE,
+# GOOGLE_CLOUD_PROJECT, and GOOGLE_CLOUD_LOCATION and grant the pod's
+# service account Vertex access via workload identity.
+agent:
+  enabled: false
+  model: ""  # defaults to gemini-2.5-flash
 
 # The chart generates an interloper.yaml ConfigMap from this block.
 # Any value set here becomes part of the config file mounted into the pods.


### PR DESCRIPTION
Follow-up to #110 (merged before this restructure landed): the agent block is a platform feature — a runtime flag and model that feed the generated `interloper.yaml` — not an api deployment knob, so it moves from `api.agent.*` to root-level `agent.enabled` / `agent.model`. It still drives the api image's `-agent` tag.

No release has shipped a chart with `api.agent.model` in use, and `api.agent.enabled` existed only as the image-flavor toggle; deployments setting it need the one-line rename.

Verified with `helm lint` and `helm template` in both modes (agent block + `-agent` tag rendered from the root values).

🤖 Generated with [Claude Code](https://claude.com/claude-code)