### PR TITLE
feat: bootstrap super-admins from INTERLOPER_AUTH_SUPER_ADMIN_EMAILS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,9 @@ INTERLOPER_AUTH_GOOGLE_CLIENT_SECRET=
 # Defaults below suit local http; override only if you change the app port.
 # INTERLOPER_AUTH_GOOGLE_REDIRECT_URI=http://localhost:3000/api/auth/google/callback
 # INTERLOPER_AUTH_COOKIE_SECURE=false
+# Comma-separated emails promoted to super-admin on login (promote-only).
+# The seed above already covers dev; this is the production bootstrap path.
+# INTERLOPER_AUTH_SUPER_ADMIN_EMAILS=
 
 
 # ── Connector OAuth (connecting data sources from the UI) ────────────────────

--- a/chart/interloper/values.yaml
+++ b/chart/interloper/values.yaml
@@ -186,10 +186,14 @@ config:
   #   port: 465
   #   user: "no-reply@example.com"
 
-  # Auth config (OAuth client ID)
+  # Auth config (OAuth client ID). super_admin_emails bootstraps the first
+  # platform super-admin(s): listed users are promoted when they log in
+  # (promote-only — removing an email never demotes).
   auth: {}
   # auth:
   #   google_client_id: "..."
+  #   super_admin_emails:
+  #     - you@example.com
 
 # =============================================================================
 # Secrets

--- a/dev/seed.py
+++ b/dev/seed.py
@@ -70,16 +70,6 @@ def _is_synthetic(profile: Profile) -> bool:
     return (profile.google_id or "").startswith(SYNTHETIC_GOOGLE_ID_PREFIX)
 
 
-def _set_super_admin(profile_id: UUID) -> None:
-    """Force the super-admin flag on (no Store method exposes it)."""
-    with Session(get_engine()) as session:
-        db_profile = session.get(Profile, profile_id)
-        if db_profile and not db_profile.is_super_admin:
-            db_profile.is_super_admin = True
-            session.add(db_profile)
-            session.commit()
-
-
 def _upsert_by_google_id(google_id: str, email: str) -> Profile:
     """Create or promote the profile keyed by ``google_id``.
 
@@ -155,7 +145,7 @@ def _ensure_super_admin(store: Store) -> tuple[Profile, str]:
 
     if chosen is not None:
         assert chosen.id is not None
-        _set_super_admin(chosen.id)
+        store.set_super_admin(chosen.id)
         return chosen, "matched"
 
     # No profile with this email yet — create a synthetic placeholder. A real
@@ -168,7 +158,7 @@ def _ensure_super_admin(store: Store) -> tuple[Profile, str]:
         name=name,
     )
     assert profile.id is not None
-    _set_super_admin(profile.id)
+    store.set_super_admin(profile.id)
     return profile, "synthetic"
 
 

--- a/packages/interloper-api/src/interloper_api/routes/auth.py
+++ b/packages/interloper-api/src/interloper_api/routes/auth.py
@@ -131,6 +131,11 @@ def google_callback(
         avatar_url=avatar_url,
     )
 
+    # Bootstrap super-admins from settings. Promote-only: removing an email from
+    # the list never demotes an existing super-admin.
+    if not profile.is_super_admin and email.lower() in auth_config.super_admin_emails:
+        profile = store.set_super_admin(profile.id) or profile
+
     # Create session (no org context — frontend resolves org after login)
     token = store.create_session(user_id=profile.id)
 

--- a/packages/interloper-api/tests/test_auth.py
+++ b/packages/interloper-api/tests/test_auth.py
@@ -1,0 +1,96 @@
+"""Tests for ``interloper_api.routes.auth`` — super-admin bootstrap on login.
+
+The Google OAuth exchange is faked at the httpx layer; a lightweight fake store
+records the promotion calls. The property under test: a user whose email is in
+``auth_config.super_admin_emails`` is promoted on login, everyone else is not,
+and the promotion is promote-only (an existing super-admin is left alone).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from interloper_api.dependencies import get_auth_config, get_store
+from interloper_api.routes import auth as auth_module
+
+
+class FakeStore:
+    """In-memory stand-in implementing only the methods the callback calls."""
+
+    def __init__(self, *, is_super_admin: bool = False) -> None:
+        self.profile = SimpleNamespace(id=uuid4(), is_super_admin=is_super_admin)
+        self.promoted: list[UUID] = []
+
+    def upsert_profile(self, **kwargs) -> SimpleNamespace:
+        return self.profile
+
+    def set_super_admin(self, user_id: UUID) -> SimpleNamespace:
+        self.promoted.append(user_id)
+        self.profile.is_super_admin = True
+        return self.profile
+
+    def create_session(self, user_id: UUID) -> str:
+        return "token"
+
+
+def _auth_config(super_admin_emails: list[str]) -> SimpleNamespace:
+    return SimpleNamespace(
+        google_client_id="client-id",
+        google_client_secret="client-secret",
+        google_redirect_uri="http://localhost/api/auth/google/callback",
+        cookie_secure=False,
+        session_expiry_days=1,
+        super_admin_emails=super_admin_emails,
+    )
+
+
+def _client(store: FakeStore, super_admin_emails: list[str]) -> TestClient:
+    app = FastAPI()
+    app.include_router(auth_module.router)
+    app.dependency_overrides[get_store] = lambda: store
+    app.dependency_overrides[get_auth_config] = lambda: _auth_config(super_admin_emails)
+    return TestClient(app, follow_redirects=False)
+
+
+@pytest.fixture(autouse=True)
+def fake_google(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fake the token exchange and userinfo fetch."""
+    monkeypatch.setattr(
+        auth_module.httpx,
+        "post",
+        lambda *a, **k: SimpleNamespace(status_code=200, json=lambda: {"access_token": "at"}),
+    )
+    monkeypatch.setattr(
+        auth_module.httpx,
+        "get",
+        lambda *a, **k: SimpleNamespace(
+            status_code=200,
+            json=lambda: {"id": "google-1", "email": "Boss@Example.com", "name": "Boss"},
+        ),
+    )
+
+
+def test_listed_email_is_promoted_case_insensitively() -> None:
+    store = FakeStore()
+    resp = _client(store, ["boss@example.com"]).get("/auth/google/callback", params={"code": "c"})
+    assert resp.status_code == 302
+    assert store.promoted == [store.profile.id]
+
+
+def test_unlisted_email_is_not_promoted() -> None:
+    store = FakeStore()
+    resp = _client(store, ["someone-else@example.com"]).get("/auth/google/callback", params={"code": "c"})
+    assert resp.status_code == 302
+    assert store.promoted == []
+
+
+def test_existing_super_admin_is_not_touched() -> None:
+    store = FakeStore(is_super_admin=True)
+    resp = _client(store, ["boss@example.com"]).get("/auth/google/callback", params={"code": "c"})
+    assert resp.status_code == 302
+    assert store.promoted == []

--- a/packages/interloper-core/src/interloper/settings.py
+++ b/packages/interloper-core/src/interloper/settings.py
@@ -12,10 +12,16 @@ are unambiguous.
 
 from __future__ import annotations
 
-from typing import Any, ClassVar
+from typing import Annotated, Any, ClassVar
 
-from pydantic import Field
-from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict, YamlConfigSettingsSource
+from pydantic import Field, field_validator
+from pydantic_settings import (
+    BaseSettings,
+    NoDecode,
+    PydanticBaseSettingsSource,
+    SettingsConfigDict,
+    YamlConfigSettingsSource,
+)
 
 PREFIX = "INTERLOPER_"
 
@@ -38,7 +44,13 @@ class PostgresSettings(BaseSettings):
 
 
 class AuthSettings(BaseSettings):
-    """Authentication settings (Google OAuth, cookies)."""
+    """Authentication settings (Google OAuth, cookies).
+
+    ``super_admin_emails`` bootstraps platform-wide super-admins: a user whose
+    Google email is listed gets ``is_super_admin`` set on login. Promotion only —
+    removing an email never demotes an existing super-admin. The env var takes a
+    comma-separated list (``INTERLOPER_AUTH_SUPER_ADMIN_EMAILS=a@x.com,b@x.com``).
+    """
 
     model_config = SettingsConfigDict(env_prefix=f"{PREFIX}AUTH_")
 
@@ -47,6 +59,19 @@ class AuthSettings(BaseSettings):
     google_redirect_uri: str = ""
     cookie_secure: bool = True
     session_expiry_days: int = 30
+    super_admin_emails: Annotated[list[str], NoDecode] = Field(default_factory=list)
+
+    @field_validator("super_admin_emails", mode="before")
+    @classmethod
+    def _parse_super_admin_emails(cls, value: Any) -> list[str]:
+        """Accept a comma-separated string (env) or a list (YAML).
+
+        Returns:
+            Trimmed, lowercased email list with empty entries dropped.
+        """
+        if isinstance(value, str):
+            value = value.split(",")
+        return [email.strip().lower() for email in value if email and email.strip()]
 
 
 class SecretsSettings(BaseSettings):

--- a/packages/interloper-core/tests/test_settings.py
+++ b/packages/interloper-core/tests/test_settings.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from interloper.settings import AgentSettings, AppSettings
+from interloper.settings import AgentSettings, AppSettings, AuthSettings
 
 
 def test_agent_settings_defaults():
@@ -22,3 +22,26 @@ def test_agent_settings_env_override(monkeypatch: pytest.MonkeyPatch):
 
     assert settings.agent.enabled is False
     assert settings.agent.model == "anthropic/claude-sonnet-4-5"
+
+
+def test_auth_settings_super_admin_emails_default():
+    """No super-admin emails unless configured."""
+    settings = AuthSettings()
+
+    assert settings.super_admin_emails == []
+
+
+def test_auth_settings_super_admin_emails_env(monkeypatch: pytest.MonkeyPatch):
+    """The env var takes a comma-separated list; entries are trimmed and lowercased."""
+    monkeypatch.setenv("INTERLOPER_AUTH_SUPER_ADMIN_EMAILS", " Admin@Example.com ,second@example.com,")
+
+    settings = AppSettings()
+
+    assert settings.auth.super_admin_emails == ["admin@example.com", "second@example.com"]
+
+
+def test_auth_settings_super_admin_emails_list():
+    """A YAML/init list passes through, normalised to lowercase."""
+    settings = AuthSettings(super_admin_emails=["Admin@Example.com"])
+
+    assert settings.super_admin_emails == ["admin@example.com"]

--- a/packages/interloper-db/src/interloper_db/migrations/versions/005_super_admin.py
+++ b/packages/interloper-db/src/interloper_db/migrations/versions/005_super_admin.py
@@ -1,7 +1,8 @@
 """Add is_super_admin flag to profiles.
 
 Grants a profile platform-wide super-admin privileges (cross-org management).
-The first super-admin is bootstrapped manually, e.g.::
+The first super-admin is bootstrapped via ``INTERLOPER_AUTH_SUPER_ADMIN_EMAILS``
+(promoted on login), or manually::
 
     UPDATE profiles SET is_super_admin = true WHERE email = '<you>';
 

--- a/packages/interloper-db/src/interloper_db/store/auth.py
+++ b/packages/interloper-db/src/interloper_db/store/auth.py
@@ -65,6 +65,27 @@ class AuthMixin:
             session.refresh(db_profile)
             return db_profile
 
+    def set_super_admin(self, user_id: UUID, is_super_admin: bool = True) -> Profile | None:
+        """Set the platform-wide super-admin flag on a profile.
+
+        Args:
+            user_id: Profile UUID.
+            is_super_admin: Flag value to set.
+
+        Returns:
+            The updated Profile, or None if not found.
+        """
+        with Session(get_engine()) as session:
+            db_profile = session.get(Profile, user_id)
+            if not db_profile:
+                return None
+            db_profile.is_super_admin = is_super_admin
+            session.add(db_profile)
+            session.commit()
+            session.refresh(db_profile)
+            session.expunge(db_profile)
+            return db_profile
+
     def get_profile(self, user_id: UUID) -> Profile | None:
         """Get a profile by ID.
 


### PR DESCRIPTION
## Summary

The first platform super-admin previously required manual SQL (`UPDATE profiles SET is_super_admin = true …`). This makes it provisionable:

- **`auth.super_admin_emails` on `AuthSettings`** — comma-separated env var (`INTERLOPER_AUTH_SUPER_ADMIN_EMAILS=a@x.com,b@x.com`) or YAML list, trimmed + lowercased.
- **Promotion on login** — after `upsert_profile` in the Google callback, a listed email gets `is_super_admin` set via the new `Store.set_super_admin`. **Promote-only**: removing an email never demotes an existing super-admin, so there's no accidental-lockout / demotion story tied to env churn.
- **`Store.set_super_admin`** — first Store method exposing the flag; the dev seed now uses it instead of raw row writes.
- **Chart**: no template changes needed — `config.auth.super_admin_emails` flows through the existing `config.auth` block into the rendered `interloper.yaml` (values example added).
- Docs touched: `.env.example`, migration 005 docstring.

## Security note

Login matches profiles by `google_id` and the email comes from Google's userinfo, so this trusts Google-asserted emails — fine for workspace-domain accounts, worth knowing if the OAuth client is ever opened up.

## Test plan

- `tests/test_settings.py`: env comma-list parsing (trim/lowercase), default empty, YAML/init list passthrough.
- New `interloper-api/tests/test_auth.py`: listed email promoted (case-insensitive), unlisted not promoted, existing super-admin untouched.
- Full suite: 756 passed; ruff + ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)