### PR TITLE
refactor: dedupe entity authorization and shared API response plumbing

### DIFF
--- a/packages/interloper-api/src/interloper_api/components.py
+++ b/packages/interloper-api/src/interloper_api/components.py
@@ -7,9 +7,40 @@ the database again.
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any
+from uuid import UUID
 
 from interloper_db import Component
+from pydantic import BaseModel
+
+
+class DestinationResponse(BaseModel):
+    """Response body for a destination, standalone or nested."""
+
+    id: UUID
+    key: str
+    name: str | None = None
+    config: dict[str, Any] | None = None
+    resources: dict[str, str] = {}
+    created_at: str | None = None
+
+
+def destination_response(dest: Component) -> DestinationResponse:
+    """Convert a destination component row to its response model."""
+    return DestinationResponse(
+        id=dest.id,
+        key=dest.key,
+        name=dest.name,
+        config=dest.config,
+        resources=resource_map(dest),
+        created_at=timestamp(dest.created_at),
+    )
+
+
+def timestamp(value: datetime | None) -> str | None:
+    """Render an optional timestamp the way every response does."""
+    return str(value) if value else None
 
 
 def resource_map(component: Component) -> dict[str, str]:

--- a/packages/interloper-api/src/interloper_api/dependencies.py
+++ b/packages/interloper-api/src/interloper_api/dependencies.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
 from uuid import UUID
 
 from fastapi import Cookie, Depends, HTTPException
 from interloper.catalog.base import Catalog
+from interloper.errors import NotFoundError
 from interloper_db import Organisation, Profile, Store
 from interloper_db.models import Session as SessionModel
 
@@ -271,6 +273,45 @@ def authorize_org_member(
         raise HTTPException(status_code=404, detail=detail)
     if _ROLE_RANK.get(role, -1) < _ROLE_RANK[minimum]:
         raise HTTPException(status_code=403, detail=f"Requires {minimum} role or higher")
+
+
+def load_authorized(
+    fetch: Callable[[UUID], Any],
+    entity_id: UUID,
+    user: Profile,
+    store: Store,
+    *,
+    label: str,
+    minimum: str = "viewer",
+) -> Any:
+    """Fetch an org-owned entity and authorize the user by membership in its org.
+
+    The one ID-addressed authorization pattern shared by every entity route:
+    a missing entity and a non-member get the same 404 (IDs don't act as an
+    existence oracle); a member with an insufficient role gets a 403.
+
+    Args:
+        fetch: Store getter taking the entity id (e.g. ``store.get_asset``).
+        entity_id: The entity UUID.
+        user: The authenticated user.
+        store: The Store instance.
+        label: Entity label for the 404 detail (e.g. ``"Asset"``).
+        minimum: Minimum role required in the owning organisation.
+
+    Returns:
+        Whatever *fetch* returned.
+
+    Raises:
+        HTTPException: 404 if missing or the user is not a member of the
+            owning org, 403 if the role is insufficient.
+    """
+    detail = f"{label} {entity_id} not found"
+    try:
+        entity = fetch(entity_id)
+    except NotFoundError:
+        raise HTTPException(status_code=404, detail=detail)
+    authorize_org_member(user, entity.org_id, store, minimum=minimum, detail=detail)
+    return entity
 
 
 def _check_role(

--- a/packages/interloper-api/src/interloper_api/routes/assets.py
+++ b/packages/interloper-api/src/interloper_api/routes/assets.py
@@ -10,12 +10,20 @@ from interloper.errors import DataNotFoundError, NotFoundError
 from interloper_db import Component, ComponentStatus, Profile, Store
 from pydantic import BaseModel
 
-from interloper_api.components import destination_rows, materializable, resource_map, user_config
+from interloper_api.components import (
+    DestinationResponse,
+    destination_response,
+    destination_rows,
+    materializable,
+    resource_map,
+    timestamp,
+    user_config,
+)
 from interloper_api.dependencies import (
-    authorize_org_member,
     get_current_user,
     get_org_id,
     get_store,
+    load_authorized,
     require_editor,
     require_viewer,
 )
@@ -42,17 +50,6 @@ class AssetUpdateRequest(BaseModel):
     config: dict[str, Any] | None = None
     resources: dict[str, str] | None = None
     destination_ids: list[str] | None = None
-
-
-class DestinationResponse(BaseModel):
-    """Nested destination in asset response."""
-
-    id: UUID
-    key: str
-    name: str | None = None
-    config: dict[str, Any] | None = None
-    resources: dict[str, str] = {}
-    created_at: str | None = None
 
 
 class AssetResponse(BaseModel):
@@ -102,41 +99,6 @@ class PartitionRowCountsResponse(BaseModel):
 # -- Helpers ------------------------------------------------------------------
 
 
-def _dest_to_response(dest: Component) -> DestinationResponse:
-    return DestinationResponse(
-        id=dest.id,
-        key=dest.key,
-        name=dest.name,
-        config=dest.config,
-        resources=resource_map(dest),
-        created_at=str(dest.created_at) if dest.created_at else None,
-    )
-
-
-def _load_authorized_asset(asset_id: UUID, user: Profile, store: Store, *, minimum: str = "viewer") -> Component:
-    """Load an asset and authorize the user by membership in its org.
-
-    Args:
-        asset_id: The asset UUID.
-        user: The authenticated user.
-        store: The Store instance.
-        minimum: Minimum role required in the asset's organisation.
-
-    Returns:
-        The asset's component row.
-
-    Raises:
-        HTTPException: 404 if missing or the user is not a member of the
-            owning org, 403 if the role is insufficient.
-    """
-    try:
-        asset = store.get_asset(asset_id)
-    except NotFoundError:
-        raise HTTPException(status_code=404, detail=f"Asset {asset_id} not found")
-    authorize_org_member(user, asset.org_id, store, minimum=minimum, detail=f"Asset {asset_id} not found")
-    return asset
-
-
 def _asset_to_response(asset: Component, store: Store) -> AssetResponse:
     """Convert an asset component row to an AssetResponse.
 
@@ -154,8 +116,8 @@ def _asset_to_response(asset: Component, store: Store) -> AssetResponse:
         status=store.asset_status(asset.key, source_key=source_key),
         config=user_config(asset),
         resources=resource_map(asset),
-        destinations=[_dest_to_response(d) for d in destination_rows(asset)],
-        created_at=str(asset.created_at) if asset.created_at else None,
+        destinations=[destination_response(d) for d in destination_rows(asset)],
+        created_at=timestamp(asset.created_at),
     )
 
 
@@ -215,7 +177,7 @@ def get_asset(
     store: Store = Depends(get_store),
 ) -> AssetResponse:
     """Get a single asset by ID. Authorized by membership in the asset's org."""
-    asset = _load_authorized_asset(asset_id, user, store)
+    asset = load_authorized(store.get_asset, asset_id, user, store, label="Asset")
     return _asset_to_response(asset, store)
 
 
@@ -227,7 +189,7 @@ def update_asset(
     store: Store = Depends(get_store),
 ) -> AssetResponse:
     """Update an asset's configuration, resources, or destinations."""
-    _load_authorized_asset(asset_id, user, store, minimum="editor")
+    load_authorized(store.get_asset, asset_id, user, store, label="Asset", minimum="editor")
     try:
         asset = store.update_asset(
             asset_id,
@@ -248,7 +210,7 @@ def delete_asset(
     store: Store = Depends(get_store),
 ) -> dict[str, str]:
     """Delete a standalone asset."""
-    _load_authorized_asset(asset_id, user, store, minimum="editor")
+    load_authorized(store.get_asset, asset_id, user, store, label="Asset", minimum="editor")
     try:
         store.delete_asset(asset_id)
     except NotFoundError:
@@ -269,8 +231,8 @@ def add_dependency(
     store: Store = Depends(get_store),
 ) -> DependencyResponse:
     """Add a dependency between two assets. Both must belong to the same org."""
-    asset = _load_authorized_asset(asset_id, user, store, minimum="editor")
-    upstream = _load_authorized_asset(body.upstream_asset_id, user, store, minimum="editor")
+    asset = load_authorized(store.get_asset, asset_id, user, store, label="Asset", minimum="editor")
+    upstream = load_authorized(store.get_asset, body.upstream_asset_id, user, store, label="Asset", minimum="editor")
     if upstream.org_id != asset.org_id:
         raise HTTPException(status_code=404, detail=f"Asset {body.upstream_asset_id} not found")
     try:
@@ -291,7 +253,7 @@ def remove_dependency(
     store: Store = Depends(get_store),
 ) -> None:
     """Remove an asset dependency."""
-    _load_authorized_asset(asset_id, user, store, minimum="editor")
+    load_authorized(store.get_asset, asset_id, user, store, label="Asset", minimum="editor")
     try:
         store.remove_dependency(asset_id, upstream_asset_id)
     except NotFoundError as e:
@@ -308,7 +270,7 @@ def get_partition_row_counts(
     store: Store = Depends(get_store),
 ) -> PartitionRowCountsResponse:
     """Get row counts grouped by partition for an asset."""
-    _load_authorized_asset(asset_id, user, store)
+    load_authorized(store.get_asset, asset_id, user, store, label="Asset")
     try:
         il_asset = store.load_asset(asset_id)
     except NotFoundError as e:

--- a/packages/interloper-api/src/interloper_api/routes/destinations.py
+++ b/packages/interloper-api/src/interloper_api/routes/destinations.py
@@ -7,15 +7,15 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
 from interloper.errors import NotFoundError
-from interloper_db import Component, Profile, Store
+from interloper_db import Profile, Store
 from pydantic import BaseModel
 
-from interloper_api.components import resource_map
+from interloper_api.components import DestinationResponse, destination_response
 from interloper_api.dependencies import (
-    authorize_org_member,
     get_current_user,
     get_org_id,
     get_store,
+    load_authorized,
     require_editor,
     require_viewer,
 )
@@ -32,28 +32,6 @@ class DestinationCreateRequest(BaseModel):
     resources: dict[str, str] | None = None
 
 
-class DestinationResponse(BaseModel):
-    """Response body for a destination."""
-
-    id: UUID
-    key: str
-    name: str | None = None
-    config: dict[str, Any] | None = None
-    resources: dict[str, str] = {}
-    created_at: str | None = None
-
-
-def _to_response(dest: Component) -> DestinationResponse:
-    return DestinationResponse(
-        id=dest.id,
-        key=dest.key,
-        name=dest.name,
-        config=dest.config,
-        resources=resource_map(dest),
-        created_at=str(dest.created_at) if dest.created_at else None,
-    )
-
-
 @router.get("/")
 def list_destinations(
     user: object = Depends(require_viewer),
@@ -62,7 +40,7 @@ def list_destinations(
 ) -> list[DestinationResponse]:
     """List all destinations for the current organisation."""
     destinations = store.list_destinations(org_id)
-    return [_to_response(d) for d in destinations]
+    return [destination_response(d) for d in destinations]
 
 
 @router.post("/")
@@ -80,21 +58,7 @@ def create_destination(
         config=body.config,
         resources=body.resources,
     )
-    return _to_response(dest)
-
-
-def _authorize_destination(destination_id: UUID, user: Profile, store: Store, *, minimum: str = "viewer") -> None:
-    """Authorize the user by membership in the destination's org.
-
-    Raises:
-        HTTPException: 404 if missing or the user is not a member of the
-            owning org, 403 if the role is insufficient.
-    """
-    try:
-        dest = store.get_destination(destination_id)
-    except NotFoundError:
-        raise HTTPException(status_code=404, detail=f"Destination {destination_id} not found")
-    authorize_org_member(user, dest.org_id, store, minimum=minimum, detail=f"Destination {destination_id} not found")
+    return destination_response(dest)
 
 
 @router.put("/{destination_id}")
@@ -105,7 +69,7 @@ def update_destination(
     store: Store = Depends(get_store),
 ) -> DestinationResponse:
     """Update a destination."""
-    _authorize_destination(destination_id, user, store, minimum="editor")
+    load_authorized(store.get_destination, destination_id, user, store, label="Destination", minimum="editor")
     try:
         dest = store.update_destination(
             destination_id,
@@ -115,7 +79,7 @@ def update_destination(
         )
     except NotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
-    return _to_response(dest)
+    return destination_response(dest)
 
 
 @router.delete("/{destination_id}")
@@ -125,6 +89,6 @@ def delete_destination(
     store: Store = Depends(get_store),
 ) -> dict[str, str]:
     """Delete a destination."""
-    _authorize_destination(destination_id, user, store, minimum="editor")
+    load_authorized(store.get_destination, destination_id, user, store, label="Destination", minimum="editor")
     store.delete_destination(destination_id)
     return {"status": "deleted"}

--- a/packages/interloper-api/src/interloper_api/routes/jobs.py
+++ b/packages/interloper-api/src/interloper_api/routes/jobs.py
@@ -10,11 +10,12 @@ from interloper.errors import NotFoundError
 from interloper_db import JobRecord, Profile, Store
 from pydantic import BaseModel
 
+from interloper_api.components import timestamp
 from interloper_api.dependencies import (
-    authorize_org_member,
     get_current_user,
     get_org_id,
     get_store,
+    load_authorized,
     require_editor,
     require_viewer,
 )
@@ -68,30 +69,6 @@ class BackfillRequest(BaseModel):
     fail_fast: bool = False
 
 
-def _load_authorized_job(job_id: UUID, user: Profile, store: Store, *, minimum: str = "viewer") -> JobRecord:
-    """Load a job and authorize the user by membership in its org.
-
-    Args:
-        job_id: The job UUID.
-        user: The authenticated user.
-        store: The Store instance.
-        minimum: Minimum role required in the job's organisation.
-
-    Returns:
-        The job record.
-
-    Raises:
-        HTTPException: 404 if missing or the user is not a member of the
-            owning org, 403 if the role is insufficient.
-    """
-    try:
-        job = store.get_job(job_id)
-    except NotFoundError:
-        raise HTTPException(status_code=404, detail=f"Job {job_id} not found")
-    authorize_org_member(user, job.org_id, store, minimum=minimum, detail=f"Job {job_id} not found")
-    return job
-
-
 def _job_to_response(job: JobRecord) -> JobResponse:
     """Convert a JobRecord to a JobResponse."""
     return JobResponse(
@@ -105,9 +82,9 @@ def _job_to_response(job: JobRecord) -> JobResponse:
         backfill_days=job.backfill_days,
         source_ids=job.source_ids,
         asset_ids=job.asset_ids,
-        last_run_at=str(job.last_run_at) if job.last_run_at else None,
-        next_run_at=str(job.next_run_at) if job.next_run_at else None,
-        created_at=str(job.created_at) if job.created_at else None,
+        last_run_at=timestamp(job.last_run_at),
+        next_run_at=timestamp(job.next_run_at),
+        created_at=timestamp(job.created_at),
     )
 
 
@@ -129,7 +106,7 @@ def get_job(
     store: Store = Depends(get_store),
 ) -> JobResponse:
     """Get a single job by ID. Authorized by membership in the job's org."""
-    job = _load_authorized_job(job_id, user, store)
+    job = load_authorized(store.get_job, job_id, user, store, label="Job")
     return _job_to_response(job)
 
 
@@ -163,7 +140,7 @@ def update_job(
     store: Store = Depends(get_store),
 ) -> JobResponse:
     """Update an existing job."""
-    _load_authorized_job(job_id, user, store, minimum="editor")
+    load_authorized(store.get_job, job_id, user, store, label="Job", minimum="editor")
     try:
         job = store.update_job(
             job_id,
@@ -188,7 +165,7 @@ def delete_job(
     store: Store = Depends(get_store),
 ) -> dict[str, str]:
     """Delete a job."""
-    _load_authorized_job(job_id, user, store, minimum="editor")
+    load_authorized(store.get_job, job_id, user, store, label="Job", minimum="editor")
     store.delete_job(job_id)
     return {"status": "deleted"}
 
@@ -201,7 +178,7 @@ def queue_run(
     store: Store = Depends(get_store),
 ) -> dict[str, str]:
     """Queue a single run for a job."""
-    job = _load_authorized_job(job_id, user, store, minimum="editor")
+    job = load_authorized(store.get_job, job_id, user, store, label="Job", minimum="editor")
 
     run = store.create_run(
         job.org_id,
@@ -219,7 +196,7 @@ def queue_backfill(
     store: Store = Depends(get_store),
 ) -> dict[str, str]:
     """Queue a backfill for a job."""
-    job = _load_authorized_job(job_id, user, store, minimum="editor")
+    job = load_authorized(store.get_job, job_id, user, store, label="Job", minimum="editor")
 
     backfill = store.create_backfill(
         job.org_id,

--- a/packages/interloper-api/src/interloper_api/routes/resources.py
+++ b/packages/interloper-api/src/interloper_api/routes/resources.py
@@ -8,15 +8,16 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException
 from interloper.catalog.base import Catalog
 from interloper.errors import NotFoundError
-from interloper_db import Component, Profile, Store
+from interloper_db import Profile, Store
 from pydantic import BaseModel
 
+from interloper_api.components import timestamp
 from interloper_api.dependencies import (
-    authorize_org_member,
     get_catalog,
     get_current_user,
     get_org_id,
     get_store,
+    load_authorized,
     require_editor,
     require_viewer,
 )
@@ -58,30 +59,6 @@ class ResourceDetailResponse(ResourceResponse):
     data: dict[str, Any] = {}
 
 
-def _load_authorized_resource(resource_id: UUID, user: Profile, store: Store, *, minimum: str = "viewer") -> Component:
-    """Load a resource and authorize the user by membership in its org.
-
-    Args:
-        resource_id: The resource UUID.
-        user: The authenticated user.
-        store: The Store instance.
-        minimum: Minimum role required in the resource's organisation.
-
-    Returns:
-        The Resource row.
-
-    Raises:
-        HTTPException: 404 if missing or the user is not a member of the
-            owning org, 403 if the role is insufficient.
-    """
-    try:
-        resource = store.load_resource(resource_id)
-    except NotFoundError:
-        raise HTTPException(status_code=404, detail=f"Resource {resource_id} not found")
-    authorize_org_member(user, resource.org_id, store, minimum=minimum, detail=f"Resource {resource_id} not found")
-    return resource
-
-
 @router.get("/kinds")
 def list_resource_kinds(
     catalog: Catalog = Depends(get_catalog),
@@ -113,8 +90,8 @@ def list_resources(
             key=r.key,
             name=r.name or "",
             encrypted=r.encrypted,
-            created_at=str(r.created_at) if r.created_at else None,
-            updated_at=str(r.updated_at) if r.updated_at else None,
+            created_at=timestamp(r.created_at),
+            updated_at=timestamp(r.updated_at),
         )
         for r in resources
     ]
@@ -130,7 +107,7 @@ def get_resource(
 
     Authorized by membership in the resource's org.
     """
-    r = _load_authorized_resource(resource_id, user, store)
+    r = load_authorized(store.load_resource, resource_id, user, store, label="Resource")
 
     return ResourceDetailResponse(
         id=r.id,
@@ -140,8 +117,8 @@ def get_resource(
         name=r.name or "",
         encrypted=r.encrypted,
         data=store.decode_resource_data(r),
-        created_at=str(r.created_at) if r.created_at else None,
-        updated_at=str(r.updated_at) if r.updated_at else None,
+        created_at=timestamp(r.created_at),
+        updated_at=timestamp(r.updated_at),
     )
 
 
@@ -168,8 +145,8 @@ def create_resource(
         key=resource.key,
         name=resource.name or "",
         encrypted=resource.encrypted,
-        created_at=str(resource.created_at) if resource.created_at else None,
-        updated_at=str(resource.updated_at) if resource.updated_at else None,
+        created_at=timestamp(resource.created_at),
+        updated_at=timestamp(resource.updated_at),
     )
 
 
@@ -181,7 +158,7 @@ def update_resource(
     store: Store = Depends(get_store),
 ) -> ResourceResponse:
     """Update an existing resource."""
-    _load_authorized_resource(resource_id, user, store, minimum="editor")
+    load_authorized(store.load_resource, resource_id, user, store, label="Resource", minimum="editor")
     try:
         resource = store.update_resource(
             resource_id,
@@ -200,8 +177,8 @@ def update_resource(
         key=resource.key,
         name=resource.name or "",
         encrypted=resource.encrypted,
-        created_at=str(resource.created_at) if resource.created_at else None,
-        updated_at=str(resource.updated_at) if resource.updated_at else None,
+        created_at=timestamp(resource.created_at),
+        updated_at=timestamp(resource.updated_at),
     )
 
 
@@ -212,6 +189,6 @@ def delete_resource(
     store: Store = Depends(get_store),
 ) -> dict[str, str]:
     """Delete a resource."""
-    _load_authorized_resource(resource_id, user, store, minimum="editor")
+    load_authorized(store.load_resource, resource_id, user, store, label="Resource", minimum="editor")
     store.delete_resource(resource_id)
     return {"status": "deleted"}

--- a/packages/interloper-api/src/interloper_api/routes/sources.py
+++ b/packages/interloper-api/src/interloper_api/routes/sources.py
@@ -10,12 +10,19 @@ from interloper.errors import NotFoundError
 from interloper_db import Component, ComponentStatus, Profile, Store
 from pydantic import BaseModel
 
-from interloper_api.components import destination_rows, materializable, resource_map
+from interloper_api.components import (
+    DestinationResponse,
+    destination_response,
+    destination_rows,
+    materializable,
+    resource_map,
+    timestamp,
+)
 from interloper_api.dependencies import (
-    authorize_org_member,
     get_current_user,
     get_org_id,
     get_store,
+    load_authorized,
     require_editor,
     require_viewer,
 )
@@ -42,17 +49,6 @@ class AssetResponse(BaseModel):
     key: str
     materializable: bool
     status: ComponentStatus
-
-
-class DestinationResponse(BaseModel):
-    """Nested destination in source response."""
-
-    id: UUID
-    key: str
-    name: str | None = None
-    config: dict[str, Any] | None = None
-    resources: dict[str, str] = {}
-    created_at: str | None = None
 
 
 class SourceResponse(BaseModel):
@@ -85,17 +81,7 @@ def _build_source_response(source: Component, store: Store) -> SourceResponse:
         config=source.config,
         status=store.source_status(source.key),
         resources=resource_map(source),
-        destinations=[
-            DestinationResponse(
-                id=destination.id,
-                key=destination.key,
-                name=destination.name,
-                config=destination.config,
-                resources=resource_map(destination),
-                created_at=str(destination.created_at) if destination.created_at else None,
-            )
-            for destination in destination_rows(source)
-        ],
+        destinations=[destination_response(destination) for destination in destination_rows(source)],
         assets=[
             AssetResponse(
                 id=child.id,
@@ -105,7 +91,7 @@ def _build_source_response(source: Component, store: Store) -> SourceResponse:
             )
             for child in source.children
         ],
-        created_at=str(source.created_at) if source.created_at else None,
+        created_at=timestamp(source.created_at),
     )
 
 
@@ -140,20 +126,6 @@ def create_source(
     return _build_source_response(source, store)
 
 
-def _authorize_source(source_id: UUID, user: Profile, store: Store, *, minimum: str = "viewer") -> None:
-    """Authorize the user by membership in the source's org.
-
-    Raises:
-        HTTPException: 404 if missing or the user is not a member of the
-            owning org, 403 if the role is insufficient.
-    """
-    try:
-        source = store.get_source(source_id)
-    except NotFoundError:
-        raise HTTPException(status_code=404, detail=f"Source {source_id} not found")
-    authorize_org_member(user, source.org_id, store, minimum=minimum, detail=f"Source {source_id} not found")
-
-
 @router.put("/{source_id}")
 def update_source(
     source_id: UUID,
@@ -162,7 +134,7 @@ def update_source(
     store: Store = Depends(get_store),
 ) -> SourceResponse:
     """Update a source."""
-    _authorize_source(source_id, user, store, minimum="editor")
+    load_authorized(store.get_source, source_id, user, store, label="Source", minimum="editor")
     try:
         source = store.update_source(
             source_id,
@@ -185,6 +157,6 @@ def delete_source(
     store: Store = Depends(get_store),
 ) -> dict[str, str]:
     """Delete a source. Assets cascade via FK."""
-    _authorize_source(source_id, user, store, minimum="editor")
+    load_authorized(store.get_source, source_id, user, store, label="Source", minimum="editor")
     store.delete_source(source_id)
     return {"status": "deleted"}

--- a/packages/interloper-api/tests/test_runs.py
+++ b/packages/interloper-api/tests/test_runs.py
@@ -12,7 +12,7 @@ from uuid import UUID, uuid4
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from interloper.errors import RunNotFoundError
+from interloper.errors import NotFoundError
 
 from interloper_api.dependencies import get_current_user, get_store
 from interloper_api.routes import runs as runs_module
@@ -51,7 +51,7 @@ class FakeStore:
 
     def get_run(self, run_id: UUID):
         if self.raise_not_found:
-            raise RunNotFoundError(f"Run {run_id} not found")
+            raise NotFoundError(f"Run {run_id} not found")
         return _fake_run(run_id, self.run_org_id)
 
     def get_user_role(self, user_id: UUID, org_id: UUID) -> str | None:

--- a/packages/interloper-core/src/interloper/errors.py
+++ b/packages/interloper-core/src/interloper/errors.py
@@ -151,25 +151,8 @@ class AuthenticationError(InterloperError, ValueError):
 class NotFoundError(InterloperError, KeyError):
     """A database record was not found.
 
-    Base class for entity-specific not-found errors used by the store
-    layer.  API routes catch these and return HTTP 404.
+    Raised by the store layer; API routes catch it and return HTTP 404.
     """
-
-
-class SourceNotFoundError(NotFoundError):
-    """A source record was not found."""
-
-
-class JobNotFoundError(NotFoundError):
-    """A job record was not found."""
-
-
-class RunNotFoundError(NotFoundError):
-    """A run record was not found."""
-
-
-class ResourceNotFoundError(NotFoundError):
-    """A resource record was not found."""
 
 
 # ---------------------------------------------------------------------------

--- a/packages/interloper-db/src/interloper_db/store/jobs.py
+++ b/packages/interloper-db/src/interloper_db/store/jobs.py
@@ -18,7 +18,7 @@ from typing import Any, cast
 from uuid import UUID
 
 import interloper as il
-from interloper.errors import ComponentDriftError, HydrationError, JobNotFoundError
+from interloper.errors import ComponentDriftError, HydrationError, NotFoundError
 from sqlmodel import Session, select
 
 from interloper_db.drift import ComponentStatus, asset_status, source_status
@@ -161,12 +161,12 @@ class JobMixin:
             The updated job record.
 
         Raises:
-            JobNotFoundError: If the job is not found.
+            NotFoundError: If the job is not found.
         """
         with Session(get_engine()) as session:
             db_job = session.get(Component, job_id)
             if not db_job or db_job.kind != "job":
-                raise JobNotFoundError(f"Job {job_id} not found")
+                raise NotFoundError(f"Job {job_id} not found")
             db_job.name = name
             db_job.config = _job_config(cron, tags, enabled, partitioned, backfill_days)
             sync_relations(session, db_job, "target", [*(source_ids or []), *(asset_ids or [])])
@@ -183,12 +183,12 @@ class JobMixin:
             The job record.
 
         Raises:
-            JobNotFoundError: If the job is not found.
+            NotFoundError: If the job is not found.
         """
         with Session(get_engine()) as session:
             db_job = session.get(Component, job_id)
             if not db_job or db_job.kind != "job":
-                raise JobNotFoundError(f"Job {job_id} not found")
+                raise NotFoundError(f"Job {job_id} not found")
             return _job_record(db_job, _target_relations(session, db_job.id))
 
     def list_jobs(self, org_id: UUID) -> list[JobRecord]:
@@ -234,14 +234,14 @@ class JobMixin:
             The hydrated framework Job, targets included.
 
         Raises:
-            JobNotFoundError: If the job is not found.
+            NotFoundError: If the job is not found.
             ComponentDriftError: If any target's catalog key does not resolve.
             HydrationError: If reconstruction fails.
         """
         with Session(get_engine()) as session:
             db_job = session.get(Component, job_id)
             if not db_job or db_job.kind != "job":
-                raise JobNotFoundError(f"Job {job_id} not found")
+                raise NotFoundError(f"Job {job_id} not found")
 
             for rel in _target_relations(session, db_job.id):
                 target = session.get(Component, rel.dst_id)

--- a/packages/interloper-db/src/interloper_db/store/resources.py
+++ b/packages/interloper-db/src/interloper_db/store/resources.py
@@ -12,7 +12,7 @@ from typing import Any, cast
 from uuid import UUID
 
 import interloper as il
-from interloper.errors import ConfigError, HydrationError, ResourceNotFoundError
+from interloper.errors import ConfigError, HydrationError, NotFoundError
 from sqlmodel import Session, col, select
 
 from interloper_db.engine import get_engine
@@ -121,14 +121,14 @@ class ResourceMixin:
             The updated component row.
 
         Raises:
-            ResourceNotFoundError: If the resource is not found.
+            NotFoundError: If the resource is not found.
         """
         raw, encrypted = self._encode_data(data, encrypted)
 
         with Session(get_engine()) as session:
             db_resource = session.get(Component, resource_id)
             if not db_resource or db_resource.kind not in SECRET_KINDS:
-                raise ResourceNotFoundError(f"Resource {resource_id} not found")
+                raise NotFoundError(f"Resource {resource_id} not found")
             db_resource.kind = kind
             db_resource.key = key
             db_resource.name = name
@@ -148,12 +148,12 @@ class ResourceMixin:
             The component row.
 
         Raises:
-            ResourceNotFoundError: If the resource is not found.
+            NotFoundError: If the resource is not found.
         """
         with Session(get_engine()) as session:
             db_resource = session.get(Component, resource_id)
             if not db_resource or db_resource.kind not in SECRET_KINDS:
-                raise ResourceNotFoundError(f"Resource {resource_id} not found")
+                raise NotFoundError(f"Resource {resource_id} not found")
             return db_resource
 
     def list_resources(self, org_id: UUID, kind: str | None = None) -> list[Component]:

--- a/packages/interloper-db/src/interloper_db/store/runs.py
+++ b/packages/interloper-db/src/interloper_db/store/runs.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta, timezone
 from uuid import UUID, uuid4
 
 import interloper as il
-from interloper.errors import NotFoundError, RunNotFoundError
+from interloper.errors import NotFoundError
 from sqlalchemy import func, text
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlmodel import Session, col, select
@@ -231,7 +231,7 @@ class RunMixin:
         with Session(get_engine()) as session:
             db_run = session.get(Run, run_id)
             if not db_run:
-                raise RunNotFoundError(f"Run {run_id} not found")
+                raise NotFoundError(f"Run {run_id} not found")
             return db_run
 
     def list_runs(
@@ -313,7 +313,7 @@ class RunMixin:
         with Session(get_engine()) as session:
             db_run = session.get(Run, run_id)
             if not db_run:
-                raise RunNotFoundError(f"Run {run_id} not found")
+                raise NotFoundError(f"Run {run_id} not found")
 
             db_run.status = "success" if success else "failed"
             db_run.completed_at = datetime.now(timezone.utc)
@@ -342,7 +342,7 @@ class RunMixin:
             The newly created, queued Run row.
 
         Raises:
-            RunNotFoundError: If the run is not found.
+            NotFoundError: If the run is not found.
             ValueError: If the run is not in a failed state or ``scope`` is invalid.
         """
         if scope not in ("all", "failed"):
@@ -351,7 +351,7 @@ class RunMixin:
         with Session(get_engine()) as session:
             src = session.get(Run, run_id)
             if not src:
-                raise RunNotFoundError(f"Run {run_id} not found")
+                raise NotFoundError(f"Run {run_id} not found")
             if src.status != "failed":
                 raise ValueError(f"Run {run_id} is not failed (status={src.status!r}); only failed runs can be retried")
 

--- a/packages/interloper-db/src/interloper_db/store/sources.py
+++ b/packages/interloper-db/src/interloper_db/store/sources.py
@@ -11,7 +11,7 @@ from typing import Any, cast
 from uuid import UUID
 
 import interloper as il
-from interloper.errors import CatalogKeyError, ComponentDriftError, HydrationError, NotFoundError, SourceNotFoundError
+from interloper.errors import CatalogKeyError, ComponentDriftError, HydrationError, NotFoundError
 from sqlmodel import Session, select
 
 from interloper_db.drift import ComponentStatus, resolve_source_cls, source_status
@@ -75,7 +75,7 @@ class SourceMixin:
         with Session(get_engine()) as session:
             db_source = session.get(Component, source_id)
             if not db_source or db_source.kind != "source":
-                raise SourceNotFoundError(f"Source {source_id} not found")
+                raise NotFoundError(f"Source {source_id} not found")
             if name is not None:
                 db_source.name = name
             if config is not None:
@@ -100,13 +100,10 @@ class SourceMixin:
             The component row.
 
         Raises:
-            SourceNotFoundError: If the source is not found.
+            NotFoundError: If the source is not found.
         """
         with Session(get_engine()) as session:
-            try:
-                return load_component(session, source_id, kind="source")
-            except NotFoundError:
-                raise SourceNotFoundError(f"Source {source_id} not found") from None
+            return load_component(session, source_id, kind="source")
 
     def list_sources(self, org_id: UUID) -> list[Component]:
         """List all sources with children and relations loaded."""
@@ -118,9 +115,9 @@ class SourceMixin:
         with Session(get_engine()) as session:
             db_asset = session.get(Component, asset_id)
             if not db_asset or db_asset.kind != "asset":
-                raise SourceNotFoundError(f"Asset {asset_id} not found")
+                raise NotFoundError(f"Asset {asset_id} not found")
             if not db_asset.parent_id:
-                raise SourceNotFoundError(f"Asset {asset_id} is standalone (no source)")
+                raise NotFoundError(f"Asset {asset_id} is standalone (no source)")
             return self.load_source(db_asset.parent_id)
 
     def delete_source(self, source_id: UUID) -> None:
@@ -277,7 +274,7 @@ class SourceMixin:
         with Session(get_engine()) as session:
             db_source = session.get(Component, source_id)
             if not db_source or db_source.kind != "source":
-                raise SourceNotFoundError(f"Source {source_id} not found")
+                raise NotFoundError(f"Source {source_id} not found")
 
             status = source_status(self._catalog, db_source.key)
             if status is not ComponentStatus.OK:


### PR DESCRIPTION
## What

Tier-1 dedupe pass over the API and store layers, agreed as follow-up to #113. No contract change: same URLs, same response bytes, frontend untouched.

- **One `load_authorized` dependency** replaces the five per-router fetch → 404 → org-membership helpers (`_load_authorized_asset`, `_authorize_source`, `_authorize_destination`, `_load_authorized_resource`, `_load_authorized_job`), which were structurally identical.
- **`DestinationResponse` is defined once** (it existed three times, field-identical, in the sources, assets, and destinations routers), with a single shared builder.
- **Timestamp rendering** (`str(x) if x else None`, repeated in every response builder) becomes one helper.
- **The per-kind `NotFoundError` subclasses collapse** into the base class: routes always caught the base, so `SourceNotFoundError`/`JobNotFoundError`/`RunNotFoundError`/`ResourceNotFoundError` carried no information. The store raises `NotFoundError` with the entity-specific message directly.

Net: −96 lines, five copies of two patterns → one each.

## Deliberately not done

The generic `/components` API (one router over all kinds) is deferred to the satellite-extension phase, where open-ended kinds make per-kind routers stop scaling by definition — and where its frontend rework is justified. Doing it now would break the response-shape contract with no driver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)