### PR TITLE
feat(core): kind registry as the single authority on component kinds

### DIFF
--- a/packages/interloper-api/src/interloper_api/routes/catalog.py
+++ b/packages/interloper-api/src/interloper_api/routes/catalog.py
@@ -22,12 +22,19 @@ def list_catalog(catalog: Catalog = Depends(get_catalog)) -> dict[str, Any]:
 def list_resource_kinds(catalog: Catalog = Depends(get_catalog)) -> list[str]:
     """Return distinct resource kinds from the catalog.
 
-    Resource kinds are all component kinds except the top-level categories
-    (source, asset, destination, job). Currently this yields kinds like
-    ``connection`` and ``config``.
+    A resource kind is any registered kind anchored under ``Resource``
+    (currently ``connection`` and ``config``) — the kinds usable as
+    slot bindings on other components.
     """
-    top_level = {"source", "asset", "destination", "job"}
-    return sorted({defn.kind for defn in catalog.components.values() if defn.kind and defn.kind not in top_level})
+    import interloper as il
+
+    return sorted(
+        {
+            defn.kind
+            for defn in catalog.components.values()
+            if (anchor := il.KINDS.get(defn.kind)) is not None and issubclass(anchor, il.Resource)
+        }
+    )
 
 
 @router.get("/{key}")

--- a/packages/interloper-api/src/interloper_api/routes/components.py
+++ b/packages/interloper-api/src/interloper_api/routes/components.py
@@ -13,6 +13,7 @@ from typing import Annotated, Any
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from interloper.component import KINDS
 from interloper.errors import CatalogKeyError, ComponentDriftError, ConfigError, DataNotFoundError, NotFoundError
 from interloper_db import Component, ComponentStatus, Profile, Store
 from pydantic import BaseModel
@@ -27,10 +28,6 @@ from interloper_api.dependencies import (
 )
 
 router = APIRouter()
-
-# Kinds whose config payload is stored encrypted and only decoded on detail
-# responses (mirrors the store's SECRET_KINDS).
-_SECRET_KINDS = {"connection", "config", "resource"}
 
 
 # -- Request/Response models --------------------------------------------------
@@ -158,7 +155,7 @@ def _to_response(
         status = store.source_status(row.key)
 
     config: dict[str, Any] | None = row.config
-    if row.kind in _SECRET_KINDS:
+    if KINDS.sensitive(row.kind):
         config = store.decode_config(row) if include_config else None
 
     return ComponentResponse(

--- a/packages/interloper-core/pyproject.toml
+++ b/packages/interloper-core/pyproject.toml
@@ -30,6 +30,15 @@ async = "interloper.runner.async_runner:AsyncRunner"
 serial = "interloper.runner.serial:SerialRunner"
 multi_process = "interloper.runner.multi_process:MultiProcessRunner"
 
+[project.entry-points."interloper.kinds"]
+source = "interloper.source.base:Source"
+asset = "interloper.asset.base:Asset"
+destination = "interloper.destination.base:Destination"
+resource = "interloper.resource.base:Resource"
+connection = "interloper.connection.base:Connection"
+config = "interloper.config.base:Config"
+job = "interloper.job.base:Job"
+
 [project.entry-points."interloper.oauth_providers"]
 amazon = "interloper.oauth.builtin:AMAZON"
 criteo = "interloper.oauth.builtin:CRITEO"

--- a/packages/interloper-core/src/interloper/__init__.py
+++ b/packages/interloper-core/src/interloper/__init__.py
@@ -1,7 +1,7 @@
 from interloper.asset import Asset, AssetDefinition, ExecutionContext, asset
 from interloper.catalog import Catalog
 from interloper.cli.manifest import RunManifest, RunPlan
-from interloper.component import Component, ComponentDefinition, ComponentSpec, RelationDefinition
+from interloper.component import KINDS, Component, ComponentDefinition, ComponentSpec, KindRegistry, RelationDefinition
 from interloper.config import Config, config
 from interloper.connection import Connection, OAuthConnection, RefreshTokenOAuthConnection, connection
 from interloper.dag import DAG
@@ -61,6 +61,7 @@ from interloper.utils import bounded_gather, run
 
 __all__ = [
     "DAG",
+    "KINDS",
     "Asset",
     "AssetDefinition",
     "AsyncRESTClient",
@@ -89,6 +90,7 @@ __all__ = [
     "JSONLinkPaginator",
     "Job",
     "JsonField",
+    "KindRegistry",
     "MaterializationStrategy",
     "MemoryDestination",
     "MultiProcessRunner",

--- a/packages/interloper-core/src/interloper/catalog/base.py
+++ b/packages/interloper-core/src/interloper/catalog/base.py
@@ -34,16 +34,13 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 from interloper.asset.base import Asset
-from interloper.component import Component, ComponentDefinition
+from interloper.component import KINDS, Component, ComponentDefinition
 from interloper.destination.base import Destination
 from interloper.job.base import Job
-from interloper.resource.base import Resource
 from interloper.settings import AppSettings
 from interloper.source.base import Source
 
 logger = logging.getLogger(__name__)
-
-COMPONENT_TYPES = (Source, Destination, Asset, Resource, Job)
 
 BUILTIN_COMPONENTS: tuple[type[Component], ...] = (Job,)
 
@@ -80,9 +77,9 @@ def _discovered_paths() -> tuple[str, ...]:
         if isinstance(loaded, ModuleType):
             for attr in dir(loaded):
                 obj = getattr(loaded, attr)
-                if isinstance(obj, type) and any(issubclass(obj, t) for t in COMPONENT_TYPES):
+                if isinstance(obj, type) and issubclass(obj, Component) and obj.kind in KINDS:
                     paths.append(get_object_path(obj))
-        elif isinstance(loaded, type) and any(issubclass(loaded, t) for t in COMPONENT_TYPES):
+        elif isinstance(loaded, type) and issubclass(loaded, Component) and loaded.kind in KINDS:
             paths.append(get_object_path(loaded))
     return tuple(paths)
 
@@ -142,9 +139,10 @@ class Catalog(BaseModel):
                 obj = import_from_path(path)
                 if not isinstance(obj, type):
                     continue
-                if not any(issubclass(obj, t) for t in COMPONENT_TYPES):
+                if not (issubclass(obj, Component) and obj.kind in KINDS):
                     continue
 
+                KINDS.register(obj)
                 components[obj.key] = obj.definition()
 
                 # Auto-discover resources and destinations reachable from

--- a/packages/interloper-core/src/interloper/component/__init__.py
+++ b/packages/interloper-core/src/interloper/component/__init__.py
@@ -6,12 +6,15 @@ from interloper.component.base import (
     RelationDefinition,
 )
 from interloper.component.build import build_component_class
+from interloper.component.registry import KINDS, KindRegistry
 
 __all__ = [
+    "KINDS",
     "Component",
     "ComponentDefinition",
     "ComponentDescriptor",
     "ComponentSpec",
+    "KindRegistry",
     "RelationDefinition",
     "build_component_class",
 ]

--- a/packages/interloper-core/src/interloper/component/base.py
+++ b/packages/interloper-core/src/interloper/component/base.py
@@ -127,6 +127,9 @@ class Component(BaseModel):
     icon: ClassVar[str] = ""
     resource_types: ClassVar[dict[str, type[Resource]]] = {}
     relation_types: ClassVar[dict[str, RelationDefinition]] = {}
+    # Kinds whose instance payload carries credentials/secrets; the store
+    # encrypts their config at rest and the API only decodes it on detail.
+    sensitive: ClassVar[bool] = False
     # Class-declared config fields that are framework plumbing, stripped from
     # the definition's config_schema on top of the always-internal set.
     internal_fields: ClassVar[frozenset[str]] = frozenset()

--- a/packages/interloper-core/src/interloper/component/registry.py
+++ b/packages/interloper-core/src/interloper/component/registry.py
@@ -1,0 +1,130 @@
+"""Kind registry: the single authority on component kinds.
+
+A *kind* is a category of component (``source``, ``asset``, ``connection``,
+``job``, …), anchored by the class that declares it. The registry maps each
+kind to its anchor so every kind-level question — which class anchors it,
+whether its payload is sensitive, which relation types it may declare — has
+one answer, shared by the catalog, the store, and the API.
+
+Population — one mechanism, three feeders:
+
+- every kind, built-ins included, is declared through the
+  ``interloper.kinds`` entry-point group (each entry names a ``Component``
+  subclass; core declares its own seven in its own ``pyproject.toml``),
+  loaded lazily on first lookup;
+- catalog discovery auto-registers the anchor of every component class it
+  imports, so a package shipping concrete components under
+  ``interloper.components`` never *needs* the kinds group — declare it
+  anyway when the kind's metadata must resolve without catalog discovery
+  (the store and API ask ``sensitive``/``relation_types`` in paths that
+  never build a catalog, and the kinds group loads one class where
+  discovery imports every connector module);
+- ``KINDS.register`` accepts any component class and resolves it to its
+  anchor, so registering ``FacebookAdsConnection`` registers ``connection``.
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import entry_points
+
+from interloper.component.base import Component, RelationDefinition
+
+_ENTRY_POINT_GROUP = "interloper.kinds"
+
+
+class KindRegistry:
+    """Registry of component kinds, keyed by ``Component.kind``."""
+
+    def __init__(self) -> None:
+        """Initialize an empty registry."""
+        self._anchors: dict[str, type[Component]] = {}
+        self._discovered = False
+
+    def register(self, cls: type[Component]) -> type[Component]:
+        """Register a component class's kind (idempotent).
+
+        The kind is anchored to the base-most class in the MRO that
+        declares it, so registering any subclass registers the kind itself.
+
+        Returns:
+            The class, unchanged (usable as a decorator).
+        """
+        anchor = self._anchor_of(cls)
+        if anchor.kind:
+            self._anchors.setdefault(anchor.kind, anchor)
+        return cls
+
+    def get(self, kind: str) -> type[Component] | None:
+        """Look up the anchoring class for a kind.
+
+        Returns:
+            The anchor class, or ``None`` if the kind is unregistered.
+        """
+        self._load_entry_points()
+        return self._anchors.get(kind)
+
+    def __contains__(self, kind: str) -> bool:
+        """Check whether a kind is registered.
+
+        Returns:
+            True when the kind has a registered anchor.
+        """
+        return self.get(kind) is not None
+
+    def kinds(self) -> tuple[str, ...]:
+        """All registered kinds.
+
+        Returns:
+            The kind names, sorted.
+        """
+        self._load_entry_points()
+        return tuple(sorted(self._anchors))
+
+    def sensitive(self, kind: str) -> bool:
+        """Whether the kind's instance payload is sensitive (encrypted at rest).
+
+        Returns:
+            The anchor class's ``sensitive`` declaration (False if unregistered).
+        """
+        cls = self.get(kind)
+        return bool(cls and cls.sensitive)
+
+    def relation_types(self, kind: str) -> dict[str, RelationDefinition]:
+        """The relation vocabulary the kind declares.
+
+        Returns:
+            The anchor class's ``relation_types`` (empty for unknown kinds).
+        """
+        cls = self.get(kind)
+        return dict(cls.relation_types) if cls else {}
+
+    @staticmethod
+    def _anchor_of(component_cls: type[Component]) -> type[Component]:
+        """The base-most class in the MRO declaring *component_cls*'s kind.
+
+        Returns:
+            The anchoring class.
+        """
+        anchor = component_cls
+        for base in component_cls.__mro__:
+            if (
+                base is not Component
+                and isinstance(base, type)
+                and issubclass(base, Component)
+                and getattr(base, "kind", "") == component_cls.kind
+            ):
+                anchor = base
+        return anchor
+
+    def _load_entry_points(self) -> None:
+        """Register kinds declared via the ``interloper.kinds`` group (once)."""
+        if self._discovered:
+            return
+        self._discovered = True
+        for entry_point in entry_points(group=_ENTRY_POINT_GROUP):
+            loaded = entry_point.load()
+            if isinstance(loaded, type) and issubclass(loaded, Component):
+                self.register(loaded)
+
+
+KINDS = KindRegistry()

--- a/packages/interloper-core/src/interloper/resource/base.py
+++ b/packages/interloper-core/src/interloper/resource/base.py
@@ -39,6 +39,7 @@ class Resource(Component):
     """
 
     kind: ClassVar[str] = "resource"
+    sensitive: ClassVar[bool] = True
 
     @classmethod
     def definition(cls) -> ResourceDefinition:

--- a/packages/interloper-core/tests/component/test_registry.py
+++ b/packages/interloper-core/tests/component/test_registry.py
@@ -1,0 +1,68 @@
+"""Tests for ``interloper.component.registry``."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+import interloper as il
+from interloper.component.base import Component, RelationDefinition
+from interloper.component.registry import KindRegistry
+
+
+class FakeSensor(Component):
+    """A satellite-style kind with its own relation vocabulary."""
+
+    sensitive: ClassVar[bool] = True
+    relation_types: ClassVar[dict[str, RelationDefinition]] = {
+        "watches": RelationDefinition(kinds=["asset"], slotted=True),
+    }
+
+
+class FakeNestSensor(FakeSensor):
+    """A concrete class of the fake kind (inherits kind ``fake_sensor``)."""
+
+
+class TestBuiltins:
+    """The framework's kinds are registered on package import."""
+
+    def test_builtin_kinds_present(self):
+        for kind in ("source", "asset", "destination", "resource", "connection", "config", "job"):
+            assert kind in il.KINDS
+
+    def test_sensitive_follows_the_resource_subtree(self):
+        assert il.KINDS.sensitive("connection") is True
+        assert il.KINDS.sensitive("config") is True
+        assert il.KINDS.sensitive("source") is False
+        assert il.KINDS.sensitive("job") is False
+
+    def test_relation_vocabulary_from_anchors(self):
+        assert set(il.KINDS.relation_types("asset")) == {"resource", "destination", "dependency"}
+        assert il.KINDS.relation_types("job")["target"].kinds == ["source", "asset"]
+        assert il.KINDS.relation_types("nope") == {}
+
+
+class TestRegistration:
+    """Anchor resolution and idempotency."""
+
+    def test_registering_a_subclass_anchors_the_kind(self):
+        registry = KindRegistry()
+        registry.register(FakeNestSensor)
+        assert registry.get("fake_sensor") is FakeSensor
+
+    def test_first_anchor_wins(self):
+        registry = KindRegistry()
+        registry.register(FakeSensor)
+        registry.register(FakeNestSensor)
+        assert registry.get("fake_sensor") is FakeSensor
+
+    def test_kind_properties_flow_from_the_anchor(self):
+        registry = KindRegistry()
+        registry.register(FakeNestSensor)
+        assert registry.sensitive("fake_sensor") is True
+        assert registry.relation_types("fake_sensor")["watches"].slotted is True
+
+    def test_unregistered_kind(self):
+        registry = KindRegistry()
+        assert registry.get("fake_sensor") is None
+        assert "fake_sensor" not in registry
+        assert registry.sensitive("fake_sensor") is False

--- a/packages/interloper-db/src/interloper_db/hydration.py
+++ b/packages/interloper-db/src/interloper_db/hydration.py
@@ -30,15 +30,12 @@ from typing import Any
 from uuid import UUID
 
 from interloper.catalog.base import Catalog
+from interloper.component import KINDS
 from interloper.component.base import ComponentSpec
 from interloper.errors import CatalogKeyError, HydrationError
 from sqlmodel import Session, select
 
 from interloper_db.models import Component, ComponentRelation
-
-# Kinds whose instance payload lives in the (optionally encrypted) ``data``
-# column rather than ``config``.
-SECRET_KINDS = ("connection", "config", "resource")
 
 
 class Hydrator:
@@ -130,7 +127,7 @@ class Hydrator:
         Returns:
             A dict suitable for use as a ``ComponentSpec.init``.
         """
-        if db_component.kind in SECRET_KINDS:
+        if KINDS.sensitive(db_component.kind):
             init = self.decode_data(db_component)
         else:
             init = dict(db_component.config or {})

--- a/packages/interloper-db/src/interloper_db/models.py
+++ b/packages/interloper-db/src/interloper_db/models.py
@@ -145,6 +145,8 @@ class Component(SQLModel, table=True):
         UniqueConstraint("id", "org_id", "kind", name="uq_components_id_org_kind"),
         Index("ix_components_org_id_kind", "org_id", "kind"),
         CheckConstraint("parent_id IS NULL OR kind = 'asset'", name="ck_components_parent_kind"),
+        # Snapshot of the sensitive kinds (see interloper.KINDS) — a new
+        # sensitive kind needs this CHECK widened in a migration.
         CheckConstraint(
             "data IS NULL OR kind IN ('connection', 'config', 'resource')",
             name="ck_components_data_kind",

--- a/packages/interloper-db/src/interloper_db/store/components.py
+++ b/packages/interloper-db/src/interloper_db/store/components.py
@@ -36,7 +36,7 @@ from sqlmodel import Session, col, select
 
 from interloper_db.drift import ComponentStatus, asset_status, resolve_source_cls, source_status
 from interloper_db.engine import get_engine
-from interloper_db.hydration import SECRET_KINDS, Hydrator
+from interloper_db.hydration import Hydrator
 from interloper_db.models import Component, ComponentRelation
 
 # One relation binding: (destination component id, slot). Slot is "" for
@@ -55,29 +55,6 @@ COMPONENT_LOAD_OPTIONS = [
     .selectinload(Component.out_relations)  # ty: ignore[invalid-argument-type]
     .selectinload(ComponentRelation.dst),  # ty: ignore[invalid-argument-type]
 ]
-
-# Kind → framework base class, for kind-level metadata lookups (relation
-# vocabulary). Satellite-registered kinds will extend this via the catalog.
-_KIND_CLASSES: dict[str, type[il.Component]] = {
-    "source": il.Source,
-    "asset": il.Asset,
-    "destination": il.Destination,
-    "resource": il.Resource,
-    "connection": il.Connection,
-    "config": il.Config,
-    "job": il.Job,
-}
-
-
-def relation_vocabulary(kind: str) -> dict[str, il.RelationDefinition]:
-    """The relation types a component kind may declare.
-
-    Returns:
-        The kind's class-declared vocabulary (empty for unknown kinds).
-    """
-    cls = _KIND_CLASSES.get(kind)
-    return dict(cls.relation_types) if cls else {}
-
 
 class ComponentMixin:
     """Store methods for component CRUD, relations, and hydration."""
@@ -344,7 +321,7 @@ class ComponentMixin:
         Returns:
             The decoded configuration dict.
         """
-        if db_component.kind in SECRET_KINDS:
+        if il.KINDS.sensitive(db_component.kind):
             return self._hydrator.decode_data(db_component)
         return dict(db_component.config or {})
 
@@ -354,7 +331,7 @@ class ComponentMixin:
 
     def _apply_config(self, db_component: Component, config: dict[str, Any] | None, encrypted: bool | None) -> None:
         """Write the config payload onto the row, encrypting secret kinds."""
-        if db_component.kind in SECRET_KINDS:
+        if il.KINDS.sensitive(db_component.kind):
             db_component.data, db_component.encrypted = self._encode_data(config or {}, encrypted)
             db_component.config = None
         else:
@@ -473,7 +450,7 @@ class ComponentMixin:
     @staticmethod
     def _check_vocabulary(kind: str, type_: str) -> None:
         """Reject relation types the kind's class vocabulary doesn't declare."""
-        vocabulary = relation_vocabulary(kind)
+        vocabulary = il.KINDS.relation_types(kind)
         if type_ not in vocabulary:
             raise ConfigError(
                 f"Components of kind '{kind}' declare no '{type_}' relations "


### PR DESCRIPTION
Implements [ITLPR-80](https://digitlgroup.atlassian.net/browse/ITLPR-80) (epic ITLPR-79, component-model consistency).

## What

One `KindRegistry` (`interloper.KINDS`) maps each component kind to the class that anchors it:

- **populated** through the new `interloper.kinds` entry-point group (each entry names a `Component` subclass) — core declares its own seven built-ins in its own `pyproject.toml`, the same dogfooding pattern as `interloper.runners`,
- **auto-fed** by catalog discovery, which registers the anchor of every component class it imports — so packages shipping concrete components need no extra declaration; the dedicated group matters when kind metadata must resolve without triggering the full discovery scan,
- **anchor-resolving**: registering any subclass registers its kind's base-most declaring class, so `KINDS.register(FacebookAdsConnection)` anchors `connection` → `Connection`.

It replaces the four parallel enumerations of the same fact:

| Before | Now |
|---|---|
| `COMPONENT_TYPES` (catalog eligibility) | `issubclass(obj, Component) and obj.kind in KINDS` |
| `_KIND_CLASSES` + `relation_vocabulary()` (store) | `KINDS.relation_types(kind)` |
| `SECRET_KINDS` (hydration) | `KINDS.sensitive(kind)` |
| `_SECRET_KINDS` (API router) + the resource-kinds exclusion set | `KINDS.sensitive(kind)` / positive `issubclass(anchor, Resource)` check |

Sensitivity is now a **class declaration** — `Component.sensitive: ClassVar[bool]`, `True` on the `Resource` subtree — not a hardcoded kind list. The `ck_components_data_kind` DDL CHECK stays as a documented snapshot (a new sensitive kind needs it widened in a migration; noted in the model).

## Why

This is the satellite-extension mechanism in concrete form: a package ships `class Sensor(Component)` with a `relation_types` vocabulary + one entry point, and gets catalog eligibility, store vocabulary validation, and encryption behavior with zero core changes — exactly the path `Job` already takes as a built-in.

## Verification

796 tests green (new `tests/component/test_registry.py`: builtin seeding, anchor resolution through subclasses, first-anchor-wins idempotency, sensitivity/vocabulary flow, unknown kinds). No API or schema behavior change — `catalog/resource-kinds` returns the same kinds via the positive check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
