### PR TITLE
feat: runs target any runnable component (ad-hoc materialization)

### DIFF
--- a/packages/interloper-agent/src/interloper_agent/tools/actions.py
+++ b/packages/interloper-agent/src/interloper_agent/tools/actions.py
@@ -12,21 +12,21 @@ from interloper_agent.context import get_org_id, get_store, serialize
 
 
 def trigger_run(
-    job_id: str,
+    component_id: str,
     partition_date: str | None = None,
     tool_context: ToolContext | None = None,
 ) -> dict[str, Any]:
     """Queue a single run for a job.
 
     Args:
-        job_id: UUID of the job to run.
+        component_id: UUID of the job to run.
         partition_date: Optional partition date in ISO format (YYYY-MM-DD).
     """
     try:
         org_id = get_org_id(tool_context)
         store = get_store()
         pd = datetime.date.fromisoformat(partition_date) if partition_date else None
-        run = store.create_run(org_id, job_id=UUID(job_id), partition_date=pd)
+        run = store.create_run(org_id, component_id=UUID(component_id), partition_date=pd)
         return {
             "status": "success",
             "message": "Run queued successfully",
@@ -37,7 +37,7 @@ def trigger_run(
 
 
 def trigger_backfill(
-    job_id: str,
+    component_id: str,
     start_date: str,
     end_date: str,
     concurrency: int = 1,
@@ -47,7 +47,7 @@ def trigger_backfill(
     """Start a backfill for a job over a date range.
 
     Args:
-        job_id: UUID of the job.
+        component_id: UUID of the job.
         start_date: Start date in ISO format (YYYY-MM-DD).
         end_date: End date in ISO format (YYYY-MM-DD), inclusive.
         concurrency: Max number of runs in-flight at once (default 1).
@@ -58,7 +58,7 @@ def trigger_backfill(
         store = get_store()
         backfill = store.create_backfill(
             org_id,
-            job_id=UUID(job_id),
+            component_id=UUID(component_id),
             start_date=datetime.date.fromisoformat(start_date),
             end_date=datetime.date.fromisoformat(end_date),
             concurrency=concurrency,
@@ -74,19 +74,19 @@ def trigger_backfill(
 
 
 def toggle_job(
-    job_id: str,
+    component_id: str,
     enabled: bool,
     tool_context: ToolContext | None = None,
 ) -> dict[str, Any]:
     """Enable or disable a scheduled job.
 
     Args:
-        job_id: UUID of the job.
+        component_id: UUID of the job.
         enabled: True to enable, false to disable.
     """
     try:
         store = get_store()
-        jid = UUID(job_id)
+        jid = UUID(component_id)
         job = store.get_component(jid, kind="job")
         updated = store.update_component(jid, config={**(job.config or {}), "enabled": enabled})
         action = "enabled" if enabled else "disabled"

--- a/packages/interloper-agent/src/interloper_agent/tools/analytics.py
+++ b/packages/interloper-agent/src/interloper_agent/tools/analytics.py
@@ -12,14 +12,14 @@ from interloper_agent.context import get_org_id, get_store, serialize
 
 
 def run_history_summary(
-    job_id: str | None = None,
+    component_id: str | None = None,
     days: int = 7,
     tool_context: ToolContext | None = None,
 ) -> dict[str, Any]:
     """Summarize run statistics over a period.
 
     Args:
-        job_id: Filter to a specific job UUID (optional, all jobs if omitted).
+        component_id: Filter to a specific job UUID (optional, all jobs if omitted).
         days: Number of days to look back (default 7).
 
     Returns aggregate counts (total, success, failed, canceled),
@@ -30,7 +30,7 @@ def run_history_summary(
         store = get_store()
         runs = store.list_runs(
             org_id,
-            job_id=UUID(job_id) if job_id else None,
+            component_id=UUID(component_id) if component_id else None,
             limit=500,
         )
 
@@ -49,7 +49,7 @@ def run_history_summary(
         return {
             "status": "success",
             "period_days": days,
-            "job_id": job_id,
+            "component_id": component_id,
             "total_runs": total,
             "by_status": by_status,
             "success_rate": round(success / total, 2) if total > 0 else None,
@@ -60,7 +60,7 @@ def run_history_summary(
 
 
 def partition_coverage(
-    job_id: str,
+    component_id: str,
     start_date: str,
     end_date: str,
     tool_context: ToolContext | None = None,
@@ -68,7 +68,7 @@ def partition_coverage(
     """Check partition coverage for a job over a date range.
 
     Args:
-        job_id: UUID of the job.
+        component_id: UUID of the job.
         start_date: Start date in ISO format (YYYY-MM-DD).
         end_date: End date in ISO format (YYYY-MM-DD), inclusive.
 
@@ -77,8 +77,8 @@ def partition_coverage(
     try:
         org_id = get_org_id(tool_context)
         store = get_store()
-        jid = UUID(job_id)
-        runs = store.list_runs(org_id, job_id=jid, limit=1000)
+        jid = UUID(component_id)
+        runs = store.list_runs(org_id, component_id=jid, limit=1000)
 
         start = datetime.date.fromisoformat(start_date)
         end = datetime.date.fromisoformat(end_date)
@@ -102,7 +102,7 @@ def partition_coverage(
 
         return {
             "status": "success",
-            "job_id": job_id,
+            "component_id": component_id,
             "start_date": start_date,
             "end_date": end_date,
             "total_days": len(expected),
@@ -131,8 +131,8 @@ def freshness_check(tool_context: ToolContext) -> dict[str, Any]:
         for job in jobs:
             if not (job.config or {}).get("enabled", True):
                 continue
-            job_id = job.id
-            runs = store.list_runs(org_id, job_id=job_id, status="success", limit=1)
+            component_id = job.id
+            runs = store.list_runs(org_id, component_id=component_id, status="success", limit=1)
             last_success = runs[0] if runs else None
 
             hours_since = None

--- a/packages/interloper-agent/src/interloper_agent/tools/operations.py
+++ b/packages/interloper-agent/src/interloper_agent/tools/operations.py
@@ -11,7 +11,7 @@ from interloper_agent.context import get_org_id, get_store, serialize
 
 
 def list_recent_runs(
-    job_id: str | None = None,
+    component_id: str | None = None,
     status: str | None = None,
     limit: int = 20,
     tool_context: ToolContext | None = None,
@@ -19,7 +19,7 @@ def list_recent_runs(
     """List recent runs with optional filters.
 
     Args:
-        job_id: Filter by job UUID (optional).
+        component_id: Filter by job UUID (optional).
         status: Filter by status: 'queued', 'running', 'success', 'failed', 'canceled' (optional).
         limit: Maximum number of runs to return (default 20).
     """
@@ -28,7 +28,7 @@ def list_recent_runs(
         store = get_store()
         runs = store.list_runs(
             org_id,
-            job_id=UUID(job_id) if job_id else None,
+            component_id=UUID(component_id) if component_id else None,
             status=status,
             limit=limit,
         )
@@ -94,20 +94,20 @@ def list_failures(limit: int = 20, tool_context: ToolContext | None = None) -> d
         return {"status": "error", "error": str(e)}
 
 
-def get_job_health(job_id: str, tool_context: ToolContext) -> dict[str, Any]:
+def get_job_health(component_id: str, tool_context: ToolContext) -> dict[str, Any]:
     """Get health summary for a job: metadata, recent success/failure rate.
 
     Args:
-        job_id: UUID of the job to inspect.
+        component_id: UUID of the job to inspect.
 
     Returns job metadata plus success rate computed from the last 20 runs.
     """
     try:
         org_id = get_org_id(tool_context)
         store = get_store()
-        jid = UUID(job_id)
+        jid = UUID(component_id)
         job = store.get_component(jid, kind="job")
-        runs = store.list_runs(org_id, job_id=jid, limit=20)
+        runs = store.list_runs(org_id, component_id=jid, limit=20)
 
         total = len(runs)
         success = sum(1 for r in runs if r.status == "success")

--- a/packages/interloper-api/src/interloper_api/routes/backfills.py
+++ b/packages/interloper-api/src/interloper_api/routes/backfills.py
@@ -26,7 +26,7 @@ router = APIRouter()
 class BackfillCreateRequest(BaseModel):
     """Request body for queuing a backfill."""
 
-    job_id: UUID
+    component_id: UUID
     start_date: dt.date
     end_date: dt.date
     concurrency: int = 1
@@ -38,7 +38,7 @@ class BackfillResponse(BaseModel):
 
     id: UUID
     org_id: UUID
-    job_id: UUID | None
+    component_id: UUID | None
     status: str
     start_date: dt.date
     end_date: dt.date
@@ -62,7 +62,7 @@ def _backfill_to_response(backfill: Backfill) -> BackfillResponse:
     return BackfillResponse(
         id=backfill.id,
         org_id=backfill.org_id,
-        job_id=backfill.job_id,
+        component_id=backfill.component_id,
         status=backfill.status,
         start_date=backfill.start_date,
         end_date=backfill.end_date,
@@ -97,10 +97,12 @@ def create_backfill(
     store: Store = Depends(get_store),
 ) -> BackfillResponse:
     """Queue a backfill for a job over a date range."""
-    job = load_authorized(store.get_component, body.job_id, user, store, label="Job", minimum="editor")
+    job = load_authorized(
+        lambda i: store.get_component(i, kind="job"), body.component_id, user, store, label="Job", minimum="editor"
+    )
     backfill = store.create_backfill(
         job.org_id,
-        job_id=body.job_id,
+        component_id=body.component_id,
         start_date=body.start_date,
         end_date=body.end_date,
         concurrency=body.concurrency,

--- a/packages/interloper-api/src/interloper_api/routes/runs.py
+++ b/packages/interloper-api/src/interloper_api/routes/runs.py
@@ -7,6 +7,7 @@ from typing import Annotated, Literal
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from interloper.component import KINDS
 from interloper.errors import NotFoundError
 from interloper_db import Profile, Store
 from interloper_db.models import Event, Run
@@ -34,7 +35,7 @@ class RunResponse(BaseModel):
 
     id: UUID
     org_id: UUID
-    job_id: UUID | None
+    component_id: UUID | None
     backfill_id: UUID | None
     partition_date: dt.date | None
     status: str
@@ -47,9 +48,9 @@ class RunResponse(BaseModel):
 
 
 class RunCreateRequest(BaseModel):
-    """Request body for queuing a run for a job."""
+    """Request body for queuing a run targeting a runnable component."""
 
-    job_id: UUID
+    component_id: UUID
     partition_date: dt.date | None = None
 
 
@@ -101,7 +102,7 @@ def _run_to_response(run: Run) -> RunResponse:
     return RunResponse(
         id=run.id,
         org_id=run.org_id,
-        job_id=run.job_id,
+        component_id=run.component_id,
         backfill_id=run.backfill_id,
         partition_date=run.partition_date,
         status=run.status,
@@ -166,7 +167,7 @@ def _event_to_response(event: Event) -> EventResponse:
 @router.get("/")
 def list_runs(
     response: Response,
-    job_id: UUID | None = None,
+    component_id: UUID | None = None,
     backfill_id: UUID | None = None,
     status: str | None = None,
     limit: int = 50,
@@ -180,11 +181,11 @@ def list_runs(
     The total number of matching runs (ignoring ``limit``/``offset``) is
     returned in the ``X-Total-Count`` response header so clients can paginate.
     """
-    total = store.count_runs(org_id, job_id=job_id, backfill_id=backfill_id, status=status)
+    total = store.count_runs(org_id, component_id=component_id, backfill_id=backfill_id, status=status)
     response.headers["X-Total-Count"] = str(total)
     runs = store.list_runs(
         org_id,
-        job_id=job_id,
+        component_id=component_id,
         backfill_id=backfill_id,
         status=status,
         limit=limit,
@@ -199,9 +200,11 @@ def create_run(
     user: Profile = Depends(get_current_user),
     store: Store = Depends(get_store),
 ) -> RunResponse:
-    """Queue a single run for a job."""
-    job = load_authorized(store.get_component, body.job_id, user, store, label="Job", minimum="editor")
-    run = store.create_run(job.org_id, job_id=body.job_id, partition_date=body.partition_date)
+    """Queue a single run targeting a runnable component (job, source, or asset)."""
+    target = load_authorized(store.get_component, body.component_id, user, store, label="Component", minimum="editor")
+    if not KINDS.runnable(target.kind):
+        raise HTTPException(status_code=400, detail=f"Components of kind '{target.kind}' cannot be run")
+    run = store.create_run(target.org_id, component_id=body.component_id, partition_date=body.partition_date)
     return _run_to_response(run)
 
 

--- a/packages/interloper-api/tests/test_runs.py
+++ b/packages/interloper-api/tests/test_runs.py
@@ -24,7 +24,7 @@ def _fake_run(run_id: UUID, org_id: UUID = _ORG_ID) -> SimpleNamespace:
     return SimpleNamespace(
         id=run_id,
         org_id=org_id,
-        job_id=None,
+        component_id=None,
         backfill_id=None,
         partition_date=None,
         status="failed",

--- a/packages/interloper-app/app/app/components/RunModal.vue
+++ b/packages/interloper-app/app/app/components/RunModal.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 /**
- * Modal for triggering a job run or backfill.
+ * Modal for triggering a run of a runnable component (job, source, or asset).
  *
- * Same date → single run, date range → backfill.
+ * Jobs: same date → single run, date range → backfill.
+ * Sources/assets: single partition date → run (backfills are job-only).
  * Mirrors the MaterializeModal layout from the old app.
  */
 import { today, getLocalTimeZone } from '@internationalized/date'
@@ -13,12 +14,17 @@ import { jobPartitioned } from '~/types/component'
 const open = defineModel<boolean>('open', { default: false })
 
 const props = defineProps<{
-    job: ComponentRecord
+    target: ComponentRecord
+    /** Whether the target takes a partition date. Defaults to the job's config for jobs. */
+    partitioned?: boolean
 }>()
 
 const runsStore = useRunsStore()
 const backfillsStore = useBackfillsStore()
 const toast = useToast()
+
+const isJob = computed(() => props.target.kind === 'job')
+const partitioned = computed(() => props.partitioned ?? (isJob.value && jobPartitioned(props.target)))
 
 const submitting = ref(false)
 const failFast = ref(false)
@@ -26,6 +32,12 @@ const failFast = ref(false)
 const now = today(getLocalTimeZone())
 
 const dateRange = shallowRef<DateRange>({ start: now, end: now })
+
+/** Single-date proxy for non-job targets (no backfills, so no range picking). */
+const singleDate = computed({
+    get: () => dateRange.value.start,
+    set: (d) => { dateRange.value = { start: d, end: d } },
+})
 
 const startISO = computed(() => dateRange.value.start?.toString())
 const endISO = computed(() => dateRange.value.end?.toString())
@@ -90,6 +102,16 @@ const presets: Preset[] = [
     },
 ]
 
+/** Non-job targets can't backfill — hide multi-day presets. */
+const visiblePresets = computed(() =>
+    isJob.value
+        ? presets
+        : presets.filter((p) => {
+            const r = p.range()
+            return r.start?.toString() === r.end?.toString()
+        }),
+)
+
 const activePreset = computed(() =>
     presets.find((p) => {
         const r = p.range()
@@ -113,7 +135,7 @@ async function onSubmit() {
     try {
         if (isRange.value) {
             const backfillId = await backfillsStore.createBackfill({
-                jobId: props.job.id,
+                componentId: props.target.id,
                 startDate: startISO.value,
                 endDate: endISO.value,
                 failFast: failFast.value,
@@ -122,8 +144,8 @@ async function onSubmit() {
         }
         else {
             const runId = await runsStore.createRun(
-                props.job.id,
-                jobPartitioned(props.job) ? startISO.value : undefined,
+                props.target.id,
+                partitioned.value ? startISO.value : undefined,
             )
             toast.add({ title: `Run queued (${runId.slice(0, 8)})`, color: 'success' })
         }
@@ -146,7 +168,7 @@ async function onSubmit() {
             <UBadge color="neutral"
                     variant="subtle"
                     class="ml-1.5">
-                {{ props.job.name }}
+                {{ props.target.name ?? props.target.key }}
             </UBadge>
         </template>
 
@@ -154,7 +176,7 @@ async function onSubmit() {
             <div class="flex">
                 <!-- Presets -->
                 <div class="flex flex-col gap-1 border-r border-default pr-4">
-                    <UButton v-for="preset in presets"
+                    <UButton v-for="preset in visiblePresets"
                              :key="preset.label"
                              :icon="preset.icon"
                              :label="preset.label"
@@ -167,8 +189,11 @@ async function onSubmit() {
 
                 <!-- Calendar -->
                 <div class="flex flex-col w-full pl-4">
-                    <UCalendar v-model="dateRange"
+                    <UCalendar v-if="isJob"
+                               v-model="dateRange"
                                range />
+                    <UCalendar v-else
+                               v-model="singleDate" />
                     <p class="text-xs text-muted mt-3">
                         <template v-if="isRange">
                             This will create a <strong>backfill</strong> with daily runs from {{ startISO }} to {{ endISO }}.

--- a/packages/interloper-app/app/app/components/executions/BackfillsTable.vue
+++ b/packages/interloper-app/app/app/components/executions/BackfillsTable.vue
@@ -29,7 +29,7 @@ onMounted(async () => {
 })
 
 function jobName(backfill: Backfill): string {
-    return backfill.job?.name ?? jobNameMap.value.get(backfill.job_id ?? '') ?? 'Deleted'
+    return jobNameMap.value.get(backfill.component_id ?? '') ?? 'Deleted'
 }
 
 const pagination = ref({ pageIndex: 0, pageSize: PAGE_SIZE })
@@ -42,8 +42,8 @@ const columns: TableColumn<Backfill>[] = withSortableHeaders([
         cell: ({ row }) => h('span', { class: 'font-mono text-xs' }, row.getValue<string>('id').substring(0, 8)),
     },
     {
-        id: 'job',
-        header: 'Job',
+        id: 'target',
+        header: 'Target',
         cell: ({ row }) => {
             const backfill = row.original as Backfill
             return h(UBadge, { color: 'neutral', variant: 'subtle' }, () => jobName(backfill))

--- a/packages/interloper-app/app/app/components/executions/RunSummary.vue
+++ b/packages/interloper-app/app/app/components/executions/RunSummary.vue
@@ -13,6 +13,15 @@ const statusFilter = defineModel<string | null>('statusFilter', { default: null 
 
 const stats = useRunStats(toRef(props, 'run'), toRef(props, 'assetExecutions'))
 
+const componentsStore = useComponentsStore()
+
+/** Run target (job, source, or asset), resolved from the components store. */
+const targetName = computed(() => {
+    if (!props.run.component_id) return 'Deleted'
+    const target = componentsStore.byId(props.run.component_id)
+    return target ? (target.name ?? target.key) : 'Deleted'
+})
+
 /** Toggle a status filter; empty buckets aren't selectable (nothing to show). */
 function toggleStatus(bucket: RunStatusBucket) {
     if (bucket.count === 0) return
@@ -41,7 +50,7 @@ function clockTime(value: string | null): string {
 const metaItems = computed(() => [
     { label: 'Duration', icon: 'i-lucide-timer', value: stats.value.duration ?? '—' },
     { label: 'Started', icon: 'i-lucide-play', value: clockTime(props.run.started_at) },
-    { label: 'Job', icon: 'i-lucide-calendar-clock', value: props.run.job?.name ?? 'Manual' },
+    { label: 'Target', icon: 'i-lucide-calendar-clock', value: targetName.value },
     { label: 'Attempt', icon: 'i-lucide-rotate-ccw', value: String(props.run.attempt) },
 ])
 </script>

--- a/packages/interloper-app/app/app/components/executions/RunsTable.vue
+++ b/packages/interloper-app/app/app/components/executions/RunsTable.vue
@@ -9,11 +9,12 @@ const runsStore = useRunsStore()
 const componentsStore = useComponentsStore()
 const { runs, loading, total, pageIndex, pageSize } = storeToRefs(runsStore)
 
-/** Reactive map so cell render functions pick up changes. */
-const jobNameMap = computed(() => {
+/** Reactive map so cell render functions pick up changes. Targets can be jobs, sources, or assets. */
+const targetNameMap = computed(() => {
     const map = new Map<string, string>()
-    for (const job of componentsStore.byKind('job')) {
-        map.set(job.id, job.name ?? job.key)
+    for (const component of componentsStore.components) {
+        map.set(component.id, component.name ?? component.key)
+        for (const child of component.children) map.set(child.id, child.name ?? child.key)
     }
     return map
 })
@@ -21,12 +22,12 @@ const jobNameMap = computed(() => {
 onMounted(async () => {
     await Promise.all([
         !loading.value ? runsStore.fetch() : Promise.resolve(),
-        componentsStore.fetchAll(['job']),
+        componentsStore.fetchAll(['job', 'source', 'asset']),
     ])
 })
 
-function jobName(run: Run): string {
-    return run.job?.name ?? jobNameMap.value.get(run.job_id ?? '') ?? 'Deleted'
+function targetName(run: Run): string {
+    return targetNameMap.value.get(run.component_id ?? '') ?? 'Deleted'
 }
 
 const columns: TableColumn<Run>[] = [
@@ -36,11 +37,11 @@ const columns: TableColumn<Run>[] = [
         cell: ({ row }) => h('span', { class: 'font-mono text-xs' }, row.getValue<string>('id').substring(0, 8)),
     },
     {
-        id: 'job',
-        header: 'Job',
+        id: 'target',
+        header: 'Target',
         cell: ({ row }) => {
             const run = row.original as Run
-            return h(UBadge, { color: 'neutral', variant: 'subtle' }, () => jobName(run))
+            return h(UBadge, { color: 'neutral', variant: 'subtle' }, () => targetName(run))
         },
     },
     {

--- a/packages/interloper-app/app/app/components/graph/AssetPanel.vue
+++ b/packages/interloper-app/app/app/components/graph/AssetPanel.vue
@@ -187,7 +187,7 @@ async function fetchRecentRuns() {
         return
     }
     try {
-        recentRuns.value = await apiFetch<Run[]>(`/runs?job_id=${job.id}&limit=7`)
+        recentRuns.value = await apiFetch<Run[]>(`/runs?component_id=${job.id}&limit=7`)
     }
     catch {
         recentRuns.value = []
@@ -216,8 +216,8 @@ const materialization = computed(() => {
     }
 })
 
-/** Job that materialises this asset (from the latest run, else the source's first job). */
-const jobName = computed(() => latestRun.value?.job?.name ?? jobsForSource(props.source)[0]?.name ?? null)
+/** Job that materialises this asset (the source's first job — recent runs are fetched for it). */
+const jobName = computed(() => jobsForSource(props.source)[0]?.name ?? null)
 
 const materializationMeta = computed(() => {
     const head = lastRunText.value ? `Last run ${lastRunText.value}` : 'Not yet materialized'
@@ -233,6 +233,31 @@ function heatColor(status: string): string {
 function historyTooltip(run: Run): string {
     const elapsed = formatElapsed(run.started_at, run.completed_at)
     return `${statusLabel(run.status)}${elapsed ? ` · ${elapsed}` : ''} · ${formatDate(run.started_at)}`
+}
+
+// ── Run now ─────────────────────────────────────────────────────
+
+const runsStore = useRunsStore()
+const runModalOpen = ref(false)
+const runSubmitting = ref(false)
+
+/** Partitioned assets prompt for a partition date; the rest run immediately. */
+async function runNow() {
+    if (isPartitioned.value) {
+        runModalOpen.value = true
+        return
+    }
+    runSubmitting.value = true
+    try {
+        const runId = await runsStore.createRun(props.asset.id)
+        toast.add({ title: `Run queued (${runId.slice(0, 8)})`, color: 'success' })
+    }
+    catch {
+        toast.add({ title: 'Failed to queue run', color: 'error' })
+    }
+    finally {
+        runSubmitting.value = false
+    }
 }
 
 /** Upstream dependencies as display rows (param → resolved upstream asset). */
@@ -269,6 +294,14 @@ const dependencyRows = computed(() => {
                     </p>
                 </div>
                 <UButton class="shrink-0 ml-auto"
+                         icon="i-lucide-play"
+                         label="Run now"
+                         color="neutral"
+                         variant="outline"
+                         size="xs"
+                         :loading="runSubmitting"
+                         @click="runNow" />
+                <UButton class="shrink-0"
                          icon="i-lucide-x"
                          color="neutral"
                          variant="ghost"
@@ -573,5 +606,9 @@ const dependencyRows = computed(() => {
                 </template>
             </UCollapsible>
         </div>
+
+        <RunModal v-model:open="runModalOpen"
+                  :target="asset"
+                  :partitioned="isPartitioned" />
     </div>
 </template>

--- a/packages/interloper-app/app/app/composables/catalog.ts
+++ b/packages/interloper-app/app/app/composables/catalog.ts
@@ -101,24 +101,30 @@ export function useCatalogRows(options: UseCatalogRowsOptions) {
         return map
     })
 
-    /** Latest run per job. */
-    const lastRunByJobId = computed(() => {
+    /** Latest run per target component (job, source, or asset). */
+    const lastRunByTargetId = computed(() => {
         const map = new Map<string, Run>()
         for (const run of options.runs.value) {
-            if (!run.job_id) continue
-            const existing = map.get(run.job_id)
+            if (!run.component_id) continue
+            const existing = map.get(run.component_id)
             if (!existing || (run.started_at && (!existing.started_at || run.started_at > existing.started_at))) {
-                map.set(run.job_id, run)
+                map.set(run.component_id, run)
             }
         }
         return map
     })
 
     function getLastRunForSource(sourceId: string): { status: string | null; at: string | null } {
-        const sourceJobs = jobsBySourceId.value.get(sourceId) ?? []
+        // Runs targeting the source itself or its assets count, alongside its jobs' runs.
+        const source = options.sources.value.find(s => s.id === sourceId)
+        const targetIds = [
+            sourceId,
+            ...(source?.children.map(a => a.id) ?? []),
+            ...(jobsBySourceId.value.get(sourceId) ?? []).map(j => j.id),
+        ]
         let latest: Run | undefined
-        for (const job of sourceJobs) {
-            const run = lastRunByJobId.value.get(job.id)
+        for (const id of targetIds) {
+            const run = lastRunByTargetId.value.get(id)
             if (!run) continue
             if (!latest || (run.started_at && (!latest.started_at || run.started_at > latest.started_at))) {
                 latest = run

--- a/packages/interloper-app/app/app/pages/executions/backfills/[backfill].vue
+++ b/packages/interloper-app/app/app/pages/executions/backfills/[backfill].vue
@@ -22,9 +22,10 @@ const backfillRuns = ref<Run[]>([])
 const runsLoading = ref(false)
 const sorting = ref([{ id: 'partition_date', desc: false }])
 
-const backfillJobName = computed(() =>
-    backfill.value?.job?.name ?? componentsStore.byId(backfill.value?.job_id ?? '')?.name ?? 'Deleted job',
-)
+const backfillTargetName = computed(() => {
+    const target = componentsStore.byId(backfill.value?.component_id ?? '')
+    return target ? (target.name ?? target.key) : 'Deleted job'
+})
 
 const fetchError = ref<unknown>(null)
 
@@ -112,7 +113,7 @@ const columns: TableColumn<Run>[] = withSortableHeaders([
             <div class="flex items-center gap-1.5">
                 <UIcon name="i-lucide-briefcase"
                        class="size-4" />
-                <span>{{ backfillJobName }}</span>
+                <span>{{ backfillTargetName }}</span>
             </div>
             <div class="flex items-center gap-1.5">
                 <UIcon name="i-lucide-calendar-range"

--- a/packages/interloper-app/app/app/pages/executions/runs/[run].vue
+++ b/packages/interloper-app/app/app/pages/executions/runs/[run].vue
@@ -100,7 +100,10 @@ onMounted(async () => {
             runsStore.fetchOne(runId),
             eventsStore.fetchForRun(runId),
             assetExecutionsStore.fetchForRun(runId),
-            componentsStore.byKind('source').length === 0 ? componentsStore.fetchAll(['source', 'asset']) : Promise.resolve(),
+            // Sources/assets back the Graph view; jobs resolve the run's target in the summary.
+            componentsStore.byKind('source').length === 0 || componentsStore.byKind('job').length === 0
+                ? componentsStore.fetchAll(['source', 'asset', 'job'])
+                : Promise.resolve(),
             // Asset dependency relations back the Graph view's edges.
             componentsStore.dependencies.length === 0 ? componentsStore.fetchRelations('dependency') : Promise.resolve(),
             catalogStore.loaded ? Promise.resolve() : catalogStore.fetchCatalog(),

--- a/packages/interloper-app/app/app/pages/jobs.vue
+++ b/packages/interloper-app/app/app/pages/jobs.vue
@@ -205,8 +205,8 @@ async function handleDelete(ids: string[]) {
                          @updated="handleSaved" />
         </WizardDrawer>
 
-        <JobsRunModal v-if="runModalJob"
-                       v-model:open="runModalOpen"
-                       :job="runModalJob" />
+        <RunModal v-if="runModalJob"
+                  v-model:open="runModalOpen"
+                  :target="runModalJob" />
     </div>
 </template>

--- a/packages/interloper-app/app/app/pages/sources.vue
+++ b/packages/interloper-app/app/app/pages/sources.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { h, resolveComponent } from 'vue'
-import type { TableColumn } from '@nuxt/ui'
+import type { TableColumn, DropdownMenuItem } from '@nuxt/ui'
 import type { ComponentRecord } from '~/types/component'
 import { relationIds } from '~/types/component'
 
@@ -32,6 +32,43 @@ const {
 } = useWizardDrawer<ComponentRecord>()
 
 componentsStore.fetchAll(['source', 'destination'])
+
+// ── Run now ─────────────────────────────────────────────────────
+
+const runsStore = useRunsStore()
+const runModalOpen = ref(false)
+const runModalSource = ref<ComponentRecord | null>(null)
+
+/** Whether any of the source's assets is partitioned (then a partition date is prompted). */
+function sourcePartitioned(source: ComponentRecord): boolean {
+    const defn = catalogStore.getSourceDefinition(source.key)
+    return defn?.assets?.some(a => a.partitioning) ?? false
+}
+
+async function runNow(source: ComponentRecord) {
+    if (sourcePartitioned(source)) {
+        runModalSource.value = source
+        runModalOpen.value = true
+        return
+    }
+    try {
+        const runId = await runsStore.createRun(source.id)
+        toast.add({ title: `Run queued (${runId.slice(0, 8)})`, color: 'success' })
+    }
+    catch {
+        toast.add({ title: 'Failed to queue run', color: 'error' })
+    }
+}
+
+function rowActions(source: ComponentRecord): DropdownMenuItem[][] {
+    return [[
+        {
+            label: 'Run now',
+            icon: 'i-lucide-play',
+            onSelect: () => runNow(source),
+        },
+    ]]
+}
 
 const columns: TableColumn<ComponentRecord>[] = [
     { accessorKey: 'select' as any, header: '' },
@@ -130,6 +167,7 @@ async function handleDelete(ids: string[]) {
             <DataTable :columns="columns"
                        :data="sources"
                        :loading="componentsStore.loading"
+                       :row-actions="rowActions"
                        search-placeholder="Search sources..."
                        @delete="handleDelete"
                        @edit="handleEdit">
@@ -158,5 +196,10 @@ async function handleDelete(ids: string[]) {
                             @created="handleSaved"
                             @updated="handleSaved" />
         </WizardDrawer>
+
+        <RunModal v-if="runModalSource"
+                  v-model:open="runModalOpen"
+                  :target="runModalSource"
+                  partitioned />
     </div>
 </template>

--- a/packages/interloper-app/app/app/stores/backfills.ts
+++ b/packages/interloper-app/app/app/stores/backfills.ts
@@ -57,9 +57,9 @@ export const useBackfillsStore = defineStore('backfills', () => {
         return apiFetch<Backfill>(`/backfills/${id}`)
     }
 
-    /** Queue a backfill for a job. Returns the created backfill's id. */
+    /** Queue a backfill for a job (backfills are job-only). Returns the created backfill's id. */
     async function createBackfill(input: {
-        jobId: string
+        componentId: string
         startDate: string
         endDate: string
         concurrency?: number
@@ -68,7 +68,7 @@ export const useBackfillsStore = defineStore('backfills', () => {
         const backfill = await apiFetch<Backfill>('/backfills', {
             method: 'POST',
             body: {
-                job_id: input.jobId,
+                component_id: input.componentId,
                 start_date: input.startDate,
                 end_date: input.endDate,
                 concurrency: input.concurrency ?? 1,

--- a/packages/interloper-app/app/app/stores/runs.ts
+++ b/packages/interloper-app/app/app/stores/runs.ts
@@ -56,14 +56,14 @@ export const useRunsStore = defineStore('runs', () => {
     /**********************
      * Actions
      **********************/
-    async function fetch(filters?: { jobId?: string; backfillId?: string; status?: string }) {
+    async function fetch(filters?: { componentId?: string; backfillId?: string; status?: string }) {
         loading.value = true
         error.value = null
         try {
             const params = new URLSearchParams()
             params.set('limit', String(pageSize.value))
             params.set('offset', String(pageIndex.value * pageSize.value))
-            if (filters?.jobId) params.set('job_id', filters.jobId)
+            if (filters?.componentId) params.set('component_id', filters.componentId)
             if (filters?.backfillId) params.set('backfill_id', filters.backfillId)
             if (filters?.status) params.set('status', filters.status)
             const res = await apiFetchRaw<Run[]>(`/runs?${params}`)
@@ -82,11 +82,11 @@ export const useRunsStore = defineStore('runs', () => {
         return apiFetch<Run>(`/runs/${id}`)
     }
 
-    /** Queue a manual run for a job. Returns the created run's id. */
-    async function createRun(jobId: string, partitionDate?: string): Promise<string> {
+    /** Queue a manual run for a runnable component (job, source, or asset). Returns the created run's id. */
+    async function createRun(componentId: string, partitionDate?: string): Promise<string> {
         const run = await apiFetch<Run>('/runs', {
             method: 'POST',
-            body: { job_id: jobId, partition_date: partitionDate },
+            body: { component_id: componentId, partition_date: partitionDate },
         })
         return run.id
     }

--- a/packages/interloper-app/app/app/types/backfill.ts
+++ b/packages/interloper-app/app/app/types/backfill.ts
@@ -1,7 +1,8 @@
 export interface Backfill {
     id: string
     org_id: string
-    job_id: string | null
+    /** Target component (backfills are job-only); null if the job was deleted. */
+    component_id: string | null
     status: string
     start_date: string
     end_date: string
@@ -11,5 +12,4 @@ export interface Backfill {
     started_at: string | null
     completed_at: string | null
     created_at: string | null
-    job: { id: string; name: string } | null
 }

--- a/packages/interloper-app/app/app/types/run.ts
+++ b/packages/interloper-app/app/app/types/run.ts
@@ -1,7 +1,8 @@
 export interface Run {
     id: string
     org_id: string
-    job_id: string | null
+    /** Target component (job, source, or asset); null if the target was deleted. */
+    component_id: string | null
     backfill_id: string | null
     partition_date: string | null
     status: string
@@ -11,5 +12,4 @@ export interface Run {
     started_at: string | null
     completed_at: string | null
     created_at: string | null
-    job: { id: string; name: string } | null
 }

--- a/packages/interloper-core/src/interloper/asset/base.py
+++ b/packages/interloper-core/src/interloper/asset/base.py
@@ -110,6 +110,7 @@ class Asset(Component):
     requires: ClassVar[dict[str, str]] = {}
     optional_requires: ClassVar[dict[str, str]] = {}
     tags: ClassVar[list[str]] = []
+    runnable: ClassVar[bool] = True
 
     _source_type: ClassVar[type[Source] | None] = None
 

--- a/packages/interloper-core/src/interloper/component/base.py
+++ b/packages/interloper-core/src/interloper/component/base.py
@@ -146,6 +146,8 @@ class Component(BaseModel):
     # Kinds whose instance payload carries credentials/secrets; the store
     # encrypts their config at rest and the API only decodes it on detail.
     sensitive: ClassVar[bool] = False
+    # Kinds a run can target directly (they resolve to a materializable DAG).
+    runnable: ClassVar[bool] = False
     # Class-declared config fields that are framework plumbing, stripped from
     # the definition's config_schema on top of the always-internal set.
     internal_fields: ClassVar[frozenset[str]] = frozenset()

--- a/packages/interloper-core/src/interloper/component/registry.py
+++ b/packages/interloper-core/src/interloper/component/registry.py
@@ -89,6 +89,15 @@ class KindRegistry:
         cls = self.get(kind)
         return bool(cls and cls.sensitive)
 
+    def runnable(self, kind: str) -> bool:
+        """Whether a run can target the kind directly.
+
+        Returns:
+            The anchor class's ``runnable`` declaration (False if unregistered).
+        """
+        cls = self.get(kind)
+        return bool(cls and cls.runnable)
+
     def relation_types(self, kind: str) -> dict[str, RelationDefinition]:
         """The relation vocabulary the kind declares.
 

--- a/packages/interloper-core/src/interloper/job/base.py
+++ b/packages/interloper-core/src/interloper/job/base.py
@@ -25,6 +25,7 @@ class Job(Component):
     """
 
     icon: ClassVar[str] = "carbon:event-schedule"
+    runnable: ClassVar[bool] = True
     relation_types: ClassVar[dict[str, RelationDefinition]] = {
         "target": RelationDefinition(kinds=["source", "asset"]),
     }

--- a/packages/interloper-core/src/interloper/source/base.py
+++ b/packages/interloper-core/src/interloper/source/base.py
@@ -95,6 +95,7 @@ class Source(Component):
     destination_types: ClassVar[list[type[Destination]]] = []
     asset_types: ClassVar[list[type[Asset]]] = []
     tags: ClassVar[list[str]] = []
+    runnable: ClassVar[bool] = True
     relation_types: ClassVar[dict[str, RelationDefinition]] = {
         "resource": RelationDefinition(kinds=["connection", "config", "resource"], slotted=True),
         "destination": RelationDefinition(kinds=["destination"]),

--- a/packages/interloper-core/tests/component/test_registry.py
+++ b/packages/interloper-core/tests/component/test_registry.py
@@ -29,6 +29,10 @@ class TestBuiltins:
         for kind in ("source", "asset", "destination", "resource", "connection", "config", "job"):
             assert kind in il.KINDS
 
+    def test_runnable_kinds(self):
+        for kind, expected in (("job", True), ("source", True), ("asset", True), ("connection", False)):
+            assert il.KINDS.runnable(kind) is expected
+
     def test_sensitive_follows_the_resource_subtree(self):
         assert il.KINDS.sensitive("connection") is True
         assert il.KINDS.sensitive("config") is True

--- a/packages/interloper-db/src/interloper_db/migrations/versions/004_run_component_target.py
+++ b/packages/interloper-db/src/interloper_db/migrations/versions/004_run_component_target.py
@@ -1,0 +1,69 @@
+"""Runs and backfills target any component: rename job_id → component_id.
+
+A run's target generalizes from "a job" to "any runnable component" (job,
+source, or asset — ad-hoc materialization without a throwaway job). This is
+an in-place rename: run and backfill history is preserved, and the FK still
+points at ``components(id) ON DELETE SET NULL``.
+
+Guarded so it is a no-op on freshly provisioned databases, where
+``create_all()`` already produced the new column names.
+
+Revision ID: 004
+Revises: 003
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "004"
+down_revision: str | None = "003"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+_RENAMES = [
+    # (table, old constraint fkey, old index)
+    ("runs", "runs_job_id_fkey", "ix_runs_job_id"),
+    ("backfills", "backfills_job_id_fkey", "ix_backfills_job_id"),
+]
+
+
+def upgrade() -> None:
+    """Rename the target column, its FK constraint, and its index."""
+    for table, fkey, index in _RENAMES:
+        op.execute(
+            f"""
+            DO $$
+            BEGIN
+                IF EXISTS (
+                    SELECT 1 FROM information_schema.columns
+                    WHERE table_name = '{table}' AND column_name = 'job_id'
+                ) THEN
+                    ALTER TABLE {table} RENAME COLUMN job_id TO component_id;
+                    ALTER TABLE {table} RENAME CONSTRAINT {fkey} TO {table}_component_id_fkey;
+                    ALTER INDEX {index} RENAME TO ix_{table}_component_id;
+                END IF;
+            END $$
+            """
+        )
+
+
+def downgrade() -> None:
+    """Rename back to job_id."""
+    for table, _fkey, _index in _RENAMES:
+        op.execute(
+            f"""
+            DO $$
+            BEGIN
+                IF EXISTS (
+                    SELECT 1 FROM information_schema.columns
+                    WHERE table_name = '{table}' AND column_name = 'component_id'
+                ) THEN
+                    ALTER TABLE {table} RENAME COLUMN component_id TO job_id;
+                    ALTER TABLE {table} RENAME CONSTRAINT {table}_component_id_fkey TO {table}_job_id_fkey;
+                    ALTER INDEX ix_{table}_component_id RENAME TO {"ix_" + table + "_job_id"};
+                END IF;
+            END $$
+            """
+        )

--- a/packages/interloper-db/src/interloper_db/models.py
+++ b/packages/interloper-db/src/interloper_db/models.py
@@ -280,7 +280,7 @@ class Backfill(SQLModel, table=True):
         primary_key=True,
         sa_column_kwargs={"server_default": text("gen_random_uuid()")},
     )
-    job_id: UUID | None = SQLField(
+    component_id: UUID | None = SQLField(
         default=None,
         sa_column=Column(ForeignKey("components.id", ondelete="SET NULL"), index=True),
     )
@@ -315,7 +315,7 @@ class Run(SQLModel, table=True):
         primary_key=True,
         sa_column_kwargs={"server_default": text("gen_random_uuid()")},
     )
-    job_id: UUID | None = SQLField(
+    component_id: UUID | None = SQLField(
         default=None,
         sa_column=Column(ForeignKey("components.id", ondelete="SET NULL"), index=True),
     )

--- a/packages/interloper-db/src/interloper_db/store/runs.py
+++ b/packages/interloper-db/src/interloper_db/store/runs.py
@@ -191,14 +191,14 @@ class RunMixin:
         self,
         org_id: UUID,
         *,
-        job_id: UUID | None = None,
+        component_id: UUID | None = None,
         partition_date: dt.date | None = None,
     ) -> Run:
         """Create a single queued run.
 
         Args:
             org_id: Organisation UUID.
-            job_id: Optional job UUID.
+            component_id: Optional job UUID.
             partition_date: Optional partition date.
 
         Returns:
@@ -207,7 +207,7 @@ class RunMixin:
         with Session(get_engine()) as session:
             db_run = Run(
                 org_id=org_id,
-                job_id=job_id,
+                component_id=component_id,
                 partition_date=partition_date,
                 status="queued",
             )
@@ -238,7 +238,7 @@ class RunMixin:
         self,
         org_id: UUID,
         *,
-        job_id: UUID | None = None,
+        component_id: UUID | None = None,
         backfill_id: UUID | None = None,
         status: str | None = None,
         limit: int = 50,
@@ -248,7 +248,7 @@ class RunMixin:
 
         Args:
             org_id: Organisation UUID.
-            job_id: Optional job filter.
+            component_id: Optional job filter.
             backfill_id: Optional backfill filter.
             status: Optional status filter.
             limit: Max results (default 50).
@@ -259,8 +259,8 @@ class RunMixin:
         """
         with Session(get_engine()) as session:
             statement = select(Run).where(Run.org_id == org_id)
-            if job_id:
-                statement = statement.where(Run.job_id == job_id)
+            if component_id:
+                statement = statement.where(Run.component_id == component_id)
             if backfill_id:
                 statement = statement.where(Run.backfill_id == backfill_id)
             if status:
@@ -272,7 +272,7 @@ class RunMixin:
         self,
         org_id: UUID,
         *,
-        job_id: UUID | None = None,
+        component_id: UUID | None = None,
         backfill_id: UUID | None = None,
         status: str | None = None,
     ) -> int:
@@ -280,7 +280,7 @@ class RunMixin:
 
         Args:
             org_id: Organisation UUID.
-            job_id: Optional job filter.
+            component_id: Optional job filter.
             backfill_id: Optional backfill filter.
             status: Optional status filter.
 
@@ -289,8 +289,8 @@ class RunMixin:
         """
         with Session(get_engine()) as session:
             statement = select(func.count()).select_from(Run).where(Run.org_id == org_id)
-            if job_id:
-                statement = statement.where(Run.job_id == job_id)
+            if component_id:
+                statement = statement.where(Run.component_id == component_id)
             if backfill_id:
                 statement = statement.where(Run.backfill_id == backfill_id)
             if status:
@@ -323,8 +323,8 @@ class RunMixin:
             db_run.completed_at = datetime.now(timezone.utc)
             session.add(db_run)
 
-            if db_run.job_id:
-                db_job = session.get(Component, db_run.job_id)
+            if db_run.component_id:
+                db_job = session.get(Component, db_run.component_id)
                 if db_job:
                     db_job.state = {**(db_job.state or {}), "last_run_at": db_run.completed_at.isoformat()}
                     session.add(db_job)
@@ -367,7 +367,7 @@ class RunMixin:
 
             db_run = Run(
                 org_id=src.org_id,
-                job_id=src.job_id,
+                component_id=src.component_id,
                 partition_date=src.partition_date,
                 status="queued",
                 retry_of=run_id,
@@ -385,7 +385,7 @@ class RunMixin:
         self,
         org_id: UUID,
         *,
-        job_id: UUID | None = None,
+        component_id: UUID | None = None,
         start_date: dt.date,
         end_date: dt.date,
         concurrency: int = 1,
@@ -398,7 +398,7 @@ class RunMixin:
 
         Args:
             org_id: Organisation UUID.
-            job_id: Optional job UUID.
+            component_id: Optional job UUID.
             start_date: First partition date.
             end_date: Last partition date (inclusive).
             concurrency: Max runs in-flight at once.
@@ -410,7 +410,7 @@ class RunMixin:
         with Session(get_engine()) as session:
             db_backfill = Backfill(
                 org_id=org_id,
-                job_id=job_id,
+                component_id=component_id,
                 start_date=start_date,
                 end_date=end_date,
                 concurrency=concurrency,
@@ -428,7 +428,7 @@ class RunMixin:
                 run_status = "queued" if launched < concurrency else "pending"
                 db_run = Run(
                     org_id=org_id,
-                    job_id=job_id,
+                    component_id=component_id,
                     backfill_id=db_backfill.id,
                     partition_date=current_date,
                     status=run_status,

--- a/packages/interloper-db/tests/test_run_events.py
+++ b/packages/interloper-db/tests/test_run_events.py
@@ -224,17 +224,17 @@ def test_complete_run_stamps_the_jobs_last_run_at(run_store: RunMixin) -> None:
         job = Component(org_id=org, kind="job", key="job", name="J")
         session.add(job)
         session.flush()
-        run = Run(id=uuid4(), org_id=org, job_id=job.id, status="running")
+        run = Run(id=uuid4(), org_id=org, component_id=job.id, status="running")
         session.add(run)
         session.commit()
-        job_id, run_id = job.id, run.id
+        component_id, run_id = job.id, run.id
 
     completed = run_store.complete_run(run_id, success=True)
     assert completed.status == "success"
     assert completed.completed_at is not None
 
     with Session(engine_module.get_engine()) as session:
-        stamped = session.get(Component, job_id)
+        stamped = session.get(Component, component_id)
         assert stamped is not None and stamped.state is not None
         # SQLite round-trips the column naive; the stamped ISO string is aware UTC.
         stamped_at = datetime.fromisoformat(stamped.state["last_run_at"])

--- a/packages/interloper-scheduler/src/interloper_scheduler/cron.py
+++ b/packages/interloper-scheduler/src/interloper_scheduler/cron.py
@@ -151,7 +151,7 @@ class CronController:
                     start_date = end_date - dt.timedelta(days=config["backfill_days"] - 1)
                     backfill = Backfill(
                         org_id=job.org_id,
-                        job_id=job.id,
+                        component_id=job.id,
                         start_date=start_date,
                         end_date=end_date,
                         status="running",
@@ -164,7 +164,7 @@ class CronController:
                     current = start_date
                     while current <= end_date:
                         run = Run(
-                            job_id=job.id,
+                            component_id=job.id,
                             org_id=job.org_id,
                             backfill_id=backfill.id,
                             status="queued",
@@ -177,7 +177,7 @@ class CronController:
                     session.add(backfill)
                 else:
                     run = Run(
-                        job_id=job.id,
+                        component_id=job.id,
                         org_id=job.org_id,
                         status="queued",
                     )

--- a/packages/interloper-scheduler/src/interloper_scheduler/executor.py
+++ b/packages/interloper-scheduler/src/interloper_scheduler/executor.py
@@ -58,11 +58,11 @@ class RunExecutor:
 
             with Session(get_engine()) as session:
                 db_run = session.get(Run, run_id)
-                if not db_run or not db_run.job_id:
+                if not db_run or not db_run.component_id:
                     logger.info("Run %s not found, skipping", run_id)
                     return False
 
-                job_id = db_run.job_id
+                component_id = db_run.component_id
                 org_id = db_run.org_id
                 backfill_id = str(db_run.backfill_id) if db_run.backfill_id else None
                 partition_date = db_run.partition_date
@@ -70,8 +70,8 @@ class RunExecutor:
 
                 self._mark_running(session, db_run)
 
-            job = cast(il.Job, self._store.load(job_id))
-            assets = _job_assets(job)
+            target = self._store.load(component_id)
+            assets = _target_assets(target)
             if not assets:
                 logger.info("No sources or assets for run %s, marking success", run_id)
                 self._store.complete_run(run_id, success=True)
@@ -195,12 +195,19 @@ class RunExecutor:
         )
 
 
-def _job_assets(job: il.Job) -> list[il.Asset]:
-    """Flatten a hydrated job's targets into the asset list to materialize."""
-    assets: list[il.Asset] = []
-    for target in job.targets:
-        if isinstance(target, il.Source):
-            assets.extend(target.assets)
-        else:
-            assets.append(target)
-    return assets
+def _target_assets(component: il.Component) -> list[il.Asset]:
+    """Flatten a run's hydrated target component into the assets to materialize.
+
+    A job contributes its targets' assets, a source its own assets, and an
+    asset itself — any runnable component resolves to a DAG-able list.
+    """
+    if isinstance(component, il.Job):
+        assets: list[il.Asset] = []
+        for target in component.targets:
+            assets.extend(target.assets if isinstance(target, il.Source) else [target])
+        return assets
+    if isinstance(component, il.Source):
+        return list(component.assets)
+    if isinstance(component, il.Asset):
+        return [component]
+    raise ValueError(f"Component kind '{type(component).kind}' is not runnable")


### PR DESCRIPTION
Implements [ITLPR-82](https://digitlgroup.atlassian.net/browse/ITLPR-82) (epic ITLPR-79, component-model consistency).

## What

"Run this asset / this source **now**" — without creating a throwaway job.

- **`runs.component_id`** (renamed in place from `job_id`, same for `backfills`): a run targets any *runnable* component. Migration `004` renames column + FK constraint + index and **preserves run/backfill history** (guarded no-op on fresh databases). Verified in place against a live DB with existing runs.
- **Runnability is a kind declaration**: `Component.runnable` (`True` on `Source`/`Asset`/`Job`), surfaced through the registry (`KINDS.runnable`) and enforced at `POST /runs` — targeting a destination returns `400 "Components of kind 'destination' cannot be run"`. Satellite kinds opt in by declaring it.
- **Executor generalizes**: any target resolves to its asset list — a job flattens its targets, a source contributes its assets, an asset is itself; upstream-dependency resolution and retry semantics unchanged. `complete_run` stamps `last_run_at` on whatever component the run targeted.
- **Backfills stay job-only** (server-enforced): date-range semantics follow a cron's partitioning.
- **Frontend**: executions "Job" column becomes **Target**, resolving job/source/asset names via the components store; the jobs run modal generalizes into a shared `RunModal` (single-date picker for non-job targets); new **Run now** affordances on the asset side panel and the sources row menu.

## Verification

- 798 tests + ruff/ty green, frontend lint clean.
- Live: migration renamed the column in place with 2 historical runs preserved; an **asset-targeted run and a source-targeted run both executed to success** through the queue; the runnable gate rejected a destination; browser-verified executions Target column showing all three target types by name and the Run now affordance on the asset panel (screenshots in session).

## Noticed while verifying (pre-existing, filed separately)

Two runs executing concurrently under the **in-process launcher** cross-attribute events (the global `EventBus` delivers every run's events to every in-process subscriber, each tagging with its own run_id). Both runs complete correctly; only dev-harness event streams interleave. Prod launchers (per-process) unaffected. Flagged as a follow-up task, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)