### PR TITLE
fix(core): scope runner on_event delivery to its own run

### DIFF
--- a/packages/interloper-core/src/interloper/runner/base.py
+++ b/packages/interloper-core/src/interloper/runner/base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import uuid
 from abc import abstractmethod
 from collections.abc import Callable
 from functools import cache
@@ -114,6 +115,13 @@ class Runner(Component):
         run, delegates to :meth:`_run`, then flushes pending events and
         unsubscribes — so every emitted event is delivered before returning.
 
+        The subscription is scoped to this run: the EventBus is a
+        process-wide singleton, so when several runs execute concurrently
+        (e.g. the in-process launcher) every handler would otherwise
+        receive every run's events. The run's ``run_id`` is assigned here
+        (before any event is emitted) and only events carrying it in their
+        metadata are delivered to ``on_event``.
+
         Args:
             dag: The DAG to execute.
             partition_or_window: Partition or window to scope the run.
@@ -122,14 +130,25 @@ class Runner(Component):
         Returns:
             A RunResult summarizing the execution outcome.
         """
+        metadata = dict(metadata or {})
+        metadata.setdefault("run_id", str(uuid.uuid4()))
+        run_id = metadata["run_id"]
+
+        handler: Callable[[Event], None] | None = None
         if self.on_event is not None:
-            EventBus.subscribe(self.on_event)
+            on_event = self.on_event
+
+            def handler(event: Event) -> None:
+                if event.metadata.get("run_id") == run_id:
+                    on_event(event)
+
+            EventBus.subscribe(handler)
         try:
             return await self._run(dag, partition_or_window, metadata)
         finally:
-            if self.on_event is not None:
+            if handler is not None:
                 await asyncio.to_thread(EventBus.flush, 5.0)
-                EventBus.unsubscribe(self.on_event)
+                EventBus.unsubscribe(handler)
 
     @abstractmethod
     async def _run(

--- a/packages/interloper-core/tests/runner/test_base.py
+++ b/packages/interloper-core/tests/runner/test_base.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
+from typing import Any
+
 import pytest
 
+import interloper as il
 from interloper.errors import ConfigError
+from interloper.events import Event
 from interloper.runner import build_runner
 from interloper.runner.async_runner import AsyncRunner
 from interloper.runner.base import runners
@@ -54,3 +59,64 @@ class TestBuildRunner:
     def test_unknown_type_raises_actionable_error(self):
         with pytest.raises(ConfigError, match=r"Unknown runner: 'ray'.*available.*async.*serial"):
             build_runner("ray")
+
+
+class TestOnEventScoping:
+    """``on_event`` only receives its own run's events.
+
+    The EventBus is a process-wide singleton, so when two runs execute
+    concurrently in one process (the in-process launcher) an unscoped
+    subscription would deliver each run's events to *both* handlers — and
+    the scheduler's handler persists whatever it receives under its own
+    run_id, cross-attributing events between runs.
+    """
+
+    async def test_concurrent_runs_do_not_cross_deliver(self):
+        il.MemoryDestination.clear()
+
+        # Each asset waits for the other run's asset to start, forcing the
+        # two runs (and their bus subscriptions) to overlap in time.
+        started = {"one": asyncio.Event(), "two": asyncio.Event()}
+
+        @il.asset()
+        async def ping() -> list[dict[str, Any]]:
+            started["one"].set()
+            await asyncio.wait_for(started["two"].wait(), timeout=5)
+            return [{"x": 1}]
+
+        @il.asset()
+        async def pong() -> list[dict[str, Any]]:
+            started["two"].set()
+            await asyncio.wait_for(started["one"].wait(), timeout=5)
+            return [{"x": 2}]
+
+        events_one: list[Event] = []
+        events_two: list[Event] = []
+        await asyncio.gather(
+            AsyncRunner(on_event=events_one.append).run(
+                il.DAG(ping(id="ping", destination=il.MemoryDestination())),
+                metadata={"run_id": "run-one"},
+            ),
+            AsyncRunner(on_event=events_two.append).run(
+                il.DAG(pong(id="pong", destination=il.MemoryDestination())),
+                metadata={"run_id": "run-two"},
+            ),
+        )
+
+        assert events_one and all(e.metadata.get("run_id") == "run-one" for e in events_one)
+        assert events_two and all(e.metadata.get("run_id") == "run-two" for e in events_two)
+
+    async def test_run_id_is_generated_and_events_still_delivered(self):
+        il.MemoryDestination.clear()
+
+        @il.asset()
+        def solo() -> list[dict[str, Any]]:
+            return [{"x": 1}]
+
+        events: list[Event] = []
+        await AsyncRunner(on_event=events.append).run(il.DAG(solo(id="solo", destination=il.MemoryDestination())))
+
+        assert events
+        run_ids = {e.metadata.get("run_id") for e in events}
+        assert len(run_ids) == 1
+        assert None not in run_ids


### PR DESCRIPTION
## Problem

When two runs execute concurrently under the in-process launcher, their events cross-attribute: each `RunExecutor`'s `on_event` handler receives the **other** run's events and persists them under its own `run_id` (observed as a 1-asset run's event stream containing a sibling 5-asset run's `run_started`/`asset_queued` rows; both runs otherwise complete correctly).

Root cause: the `EventBus` is a process-wide singleton, and `Runner.run` subscribed the raw `on_event` callable to it — so every handler received every run's bus traffic, and the scheduler's handler stamps whatever it receives with its own `run_id` on persistence.

## Fix

Scoped in core, so every `on_event` consumer (scheduler, CLI) is fixed at once. Every emission path already tags events with the run's `run_id` in metadata (`RunState` spreads its metadata, assets go through `_event_metadata`, `EventLogger` spreads run metadata). `Runner.run` now:

1. assigns the run's `run_id` up front, before any event is emitted (previously generated later inside `RunState`), and
2. subscribes a wrapper that only forwards events whose `metadata["run_id"]` matches this run.

## Reviewer notes

- Cross-process runners (docker/k8s) are unaffected: child containers run with the host's `--run-id`, so their re-emitted events carry the matching `run_id` and pass the filter. Per-process launchers never hit the bug in the first place.
- Global (non-runner) subscribers such as the container-mode `StderrEventHandler` are untouched — only the runner's own `on_event` subscription is scoped.
- The regression test forces the two runs to overlap in time (each asset waits for the other to start) and was verified to fail against the pre-fix code with exactly the observed cross-delivery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)