### PR TITLE
feat: realtime updates for components

### DIFF
--- a/packages/interloper-app/app/app/stores/components.ts
+++ b/packages/interloper-app/app/app/stores/components.ts
@@ -160,6 +160,49 @@ export const useComponentsStore = defineStore('components', () => {
         await Promise.all([fetchAll(), fetchRelations()])
     }, $reset)
 
+    /**********************
+     * Realtime
+     **********************/
+    const orgStore = useOrganisationStore()
+
+    // Component notifications are slim ({id, kind, parent_id}) — the payload
+    // channel never carries configs — so changes refetch through the API.
+    // A parent refetch keeps sources' embedded children fresh.
+    function _refetchChanged(record: Record<string, any>) {
+        fetchOne(record.id).catch(() => {})
+        if (record.parent_id) fetchOne(record.parent_id).catch(() => {})
+    }
+
+    useRealtimeSubscription({
+        table: 'components',
+        scope: () => orgStore.organisation?.id,
+        onInsert: _refetchChanged,
+        onUpdate: _refetchChanged,
+        onDelete: (record: Record<string, any>) => {
+            _remove(record.id)
+            relations.value = relations.value.filter(r => r.src_id !== record.id && r.dst_id !== record.id)
+            if (record.parent_id) fetchOne(record.parent_id).catch(() => {})
+        },
+    })
+
+    // Relation rows are small and arrive whole — mirror them locally.
+    useRealtimeSubscription({
+        table: 'component_relations',
+        scope: () => orgStore.organisation?.id,
+        onInsert: (record: Record<string, any>) => {
+            const key = (r: Relation) => `${r.src_id}|${r.type}|${r.slot}|${r.dst_id}`
+            const incoming = record as Relation
+            if (!relations.value.some(r => key(r) === key(incoming))) relations.value.push(incoming)
+        },
+        onUpdate: () => {},
+        onDelete: (record: Record<string, any>) => {
+            relations.value = relations.value.filter(
+                r => !(r.src_id === record.src_id && r.type === record.type
+                    && r.slot === record.slot && r.dst_id === record.dst_id),
+            )
+        },
+    })
+
     return {
         components,
         relations,

--- a/packages/interloper-db/src/interloper_db/migrations/versions/005_realtime_components.py
+++ b/packages/interloper-db/src/interloper_db/migrations/versions/005_realtime_components.py
@@ -1,0 +1,69 @@
+"""Realtime notifications for components and their relations.
+
+Extends the ``table_changes`` fan-out (003) to the component domain so the
+UI stops polling for component edits.
+
+Component rows carry unbounded payloads (JSONB config, encrypted blobs)
+while ``pg_notify`` caps payloads at ~8KB — so ``components`` notifies with
+a slim record (``id``/``kind``/``parent_id``; subscribers refetch through
+the API, which also keeps secret payloads off the notification channel).
+Relation rows are small and bounded, so they reuse the generic full-record
+function.
+
+Revision ID: 005
+Revises: 004
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "005"
+down_revision: str | None = "004"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+_SLIM_FUNCTION = """
+CREATE OR REPLACE FUNCTION notify_component_change()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    payload jsonb;
+    rec RECORD;
+BEGIN
+    rec := COALESCE(NEW, OLD);
+    payload := jsonb_build_object(
+        'table', TG_TABLE_NAME,
+        'op', TG_OP,
+        'org_id', rec.org_id,
+        'record', jsonb_build_object('id', rec.id, 'kind', rec.kind, 'parent_id', rec.parent_id)
+    );
+    PERFORM pg_notify('table_changes', payload::text);
+    RETURN rec;
+END;
+$$
+"""
+
+
+def upgrade() -> None:
+    """Create the slim notify function and the component-domain triggers."""
+    op.execute(_SLIM_FUNCTION)
+    op.execute(
+        "CREATE OR REPLACE TRIGGER trg_components_notify "
+        "AFTER INSERT OR UPDATE OR DELETE ON components "
+        "FOR EACH ROW EXECUTE FUNCTION notify_component_change()"
+    )
+    op.execute(
+        "CREATE OR REPLACE TRIGGER trg_component_relations_notify "
+        "AFTER INSERT OR UPDATE OR DELETE ON component_relations "
+        "FOR EACH ROW EXECUTE FUNCTION notify_table_change()"
+    )
+
+
+def downgrade() -> None:
+    """Drop the component-domain triggers and the slim function."""
+    op.execute("DROP TRIGGER IF EXISTS trg_components_notify ON components")
+    op.execute("DROP TRIGGER IF EXISTS trg_component_relations_notify ON component_relations")
+    op.execute("DROP FUNCTION IF EXISTS notify_component_change()")


### PR DESCRIPTION
Closes [ITLPR-85](https://digitlgroup.atlassian.net/browse/ITLPR-85) (epic [ITLPR-79](https://digitlgroup.atlassian.net/browse/ITLPR-79)).

Extends the `table_changes` pg_notify fan-out (003) to the component domain, so the UI reflects component and relation changes live — no reloads.

## Backend (migration 005)

- **`components`** notifies with a dedicated slim function: the record carries only `id` / `kind` / `parent_id`. Two reasons, documented in the migration: `pg_notify` caps payloads at ~8KB while component configs are unbounded JSONB, and this keeps encrypted payloads off the notification channel entirely. Subscribers refetch through the API, which enforces the usual auth/decode rules.
- **`component_relations`** rows are small and bounded, so they reuse the generic full-record `notify_table_change()` from 003.

The API's existing generic LISTEN → org-scoped websocket forwarding (`ws.py`) needed no changes.

## Frontend

`useComponentsStore` gains two `useRealtimeSubscription` blocks (same pattern as the runs store):

- `components`: insert/update refetch the record via `fetchOne` (plus its parent when set, keeping sources' embedded children fresh); delete drops it and prunes dangling relations locally.
- `component_relations`: mirrored directly into `relations` from the full payload (dedup on `src|type|slot|dst`).

## Verification (live, seeded dev instance)

- `UPDATE components SET name = 'Demo LIVE' …` in psql → open `/sources` tab renames without reload; revert flows back too.
- Deleting a `dependency` relation row → the B–E edge disappears from the open graph view **and** asset E flips to "Attention" (drift detection re-evaluates live); re-inserting restores the edge and "Healthy".
- `ruff` / `ty` / 798 pytest green; app lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)