### PR TITLE
fix(api): warn when an invitation email is skipped because SMTP is unconfigured

### DIFF
--- a/packages/interloper-api/src/interloper_api/routes/admin.py
+++ b/packages/interloper-api/src/interloper_api/routes/admin.py
@@ -113,6 +113,7 @@ def _send_invitation_email(
 
     smtp_config = get_smtp_config()
     if not smtp_config or not smtp_config.enabled:
+        logger.warning("SMTP not configured; invitation email to %s not sent", invitation.email)
         return
 
     token = invitation.token

--- a/packages/interloper-api/src/interloper_api/routes/organisations.py
+++ b/packages/interloper-api/src/interloper_api/routes/organisations.py
@@ -222,6 +222,8 @@ def invite_member(
         org_name = org.name if org else "Unknown"
         inviter_name = user.name or user.email
         _send_invitation_email(request, smtp_config, invitation, org_name, inviter_name)
+    else:
+        logger.warning("SMTP not configured; invitation email to %s not sent", invitation.email)
 
     return InvitationResponse(
         id=invitation.id,
@@ -278,5 +280,7 @@ def resend_invitation(
         org_name = org.name if org else "Unknown"
         inviter_name = user.name or user.email
         _send_invitation_email(request, smtp_config, new_invitation, org_name, inviter_name)
+    else:
+        logger.warning("SMTP not configured; invitation email to %s not sent", new_invitation.email)
 
     return {"status": "ok"}


### PR DESCRIPTION
## Why

Invitation emails were silently not being sent in prod: the invite endpoints gate sending on `SmtpSettings.enabled` and, when SMTP isn't configured, skip the send with **no log line at all** — the request still returns 201 and the UI shows the invitation. This made a missing `smtp` config (prod had `smtp: {}` and only `INTERLOPER_SMTP_PASSWORD` set, no host/user) undiagnosable from the logs.

## What

Log a warning (`SMTP not configured; invitation email to <email> not sent`) on every skipped send:

- `routes/admin.py` — `_send_invitation_email` early return
- `routes/organisations.py` — `invite_member` and `resend_invitation` else-branches

No behavioural change otherwise; the prod config itself is fixed separately in the Flux repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)