### PR TITLE
feat: super-admins join organisations without an invitation

### DIFF
--- a/packages/interloper-api/src/interloper_api/routes/admin.py
+++ b/packages/interloper-api/src/interloper_api/routes/admin.py
@@ -67,6 +67,12 @@ class UpdateRoleRequest(BaseModel):
     role: str
 
 
+class JoinOrganisationRequest(BaseModel):
+    """Request body for a super-admin joining an organisation."""
+
+    role: str = "admin"
+
+
 class InviteRequest(BaseModel):
     """Request body for inviting a user."""
 
@@ -210,6 +216,27 @@ def list_members(
         )
         for profile, role in members
     ]
+
+
+@router.post("/organisations/{org_id}/members", status_code=201)
+def join_organisation(
+    org_id: UUID,
+    body: JoinOrganisationRequest,
+    user: Profile = Depends(require_super_admin),
+    store: Store = Depends(get_store),
+) -> MemberResponse:
+    """Add the calling super-admin to any organisation — no invitation needed."""
+    _require_org(store, org_id)
+    _validate_role(body.role)
+    if not store.add_org_member(org_id, user.id, body.role):
+        raise HTTPException(status_code=409, detail="Already a member of this organisation")
+    return MemberResponse(
+        id=user.id,
+        email=user.email,
+        name=user.name,
+        avatar_url=user.avatar_url,
+        role=body.role,
+    )
 
 
 @router.patch("/organisations/{org_id}/members/{user_id}")

--- a/packages/interloper-api/tests/test_admin.py
+++ b/packages/interloper-api/tests/test_admin.py
@@ -30,6 +30,8 @@ class FakeStore:
         self.role_updates: list[tuple[UUID, UUID, str]] = []
         self.removed: list[tuple[UUID, UUID]] = []
         self.created_invites: list[dict] = []
+        self.added_members: list[tuple[UUID, UUID, str]] = []
+        self.already_member = False
 
     # -- organisations --
     def list_all_organisations(self):
@@ -47,6 +49,12 @@ class FakeStore:
     # -- members --
     def list_org_members(self, org_id: UUID):
         return [(self.member, "admin")]
+
+    def add_org_member(self, org_id: UUID, user_id: UUID, role: str) -> bool:
+        if self.already_member:
+            return False
+        self.added_members.append((org_id, user_id, role))
+        return True
 
     def update_member_role(self, org_id: UUID, user_id: UUID, role: str) -> bool:
         self.role_updates.append((org_id, user_id, role))
@@ -161,6 +169,31 @@ def test_update_member_role(store: FakeStore) -> None:
 def test_update_member_role_rejects_invalid_role(store: FakeStore) -> None:
     resp = _client(store, is_super_admin=True).patch(
         f"/admin/organisations/{store.org.id}/members/{uuid4()}", json={"role": "root"}
+    )
+    assert resp.status_code == 400
+
+
+def test_join_organisation_without_invitation(store: FakeStore) -> None:
+    resp = _client(store, is_super_admin=True).post(
+        f"/admin/organisations/{store.org.id}/members", json={"role": "admin"}
+    )
+    assert resp.status_code == 201
+    assert resp.json()["role"] == "admin"
+    assert store.added_members[0][0] == store.org.id
+    assert store.created_invites == []
+
+
+def test_join_organisation_conflicts_when_already_member(store: FakeStore) -> None:
+    store.already_member = True
+    resp = _client(store, is_super_admin=True).post(
+        f"/admin/organisations/{store.org.id}/members", json={"role": "admin"}
+    )
+    assert resp.status_code == 409
+
+
+def test_join_organisation_rejects_invalid_role(store: FakeStore) -> None:
+    resp = _client(store, is_super_admin=True).post(
+        f"/admin/organisations/{store.org.id}/members", json={"role": "root"}
     )
     assert resp.status_code == 400
 

--- a/packages/interloper-app/app/app/pages/admin/organisations/[id].vue
+++ b/packages/interloper-app/app/app/pages/admin/organisations/[id].vue
@@ -8,12 +8,16 @@ const route = useRoute()
 const orgId = computed(() => route.params.id as string)
 
 const adminStore = useAdminStore()
+const userStore = useUserStore()
 const toast = useToast()
 
 const rows = ref<OrgMember[]>([])
 const orgName = ref<string | null>(null)
 const loading = ref(false)
 const inviteOpen = ref(false)
+
+const isMember = computed(() =>
+    rows.value.some(r => r.status === 'active' && r.id === userStore.user?.id))
 
 const inviteEndpoint = computed(() => `/admin/organisations/${orgId.value}/invitations`)
 
@@ -84,6 +88,17 @@ async function cancelInvite(member: OrgMember) {
     }
 }
 
+async function joinOrganisation() {
+    try {
+        await adminStore.joinOrganisation(orgId.value)
+        toast.add({ title: `Joined ${orgName.value ?? 'organisation'}`, color: 'success' })
+        await loadData()
+    }
+    catch (err: any) {
+        toast.add({ title: err?.data?.detail || 'Failed to join organisation', color: 'error' })
+    }
+}
+
 async function resendInvite(member: OrgMember) {
     try {
         await adminStore.cancelInvitation(orgId.value, member.id)
@@ -112,6 +127,11 @@ watch(orgId, loadData)
                                   @cancel-invite="cancelInvite"
                                   @resend-invite="resendInvite">
             <template #toolbar>
+                <UButton v-if="!loading && !isMember"
+                         icon="i-lucide-log-in"
+                         label="Join"
+                         variant="outline"
+                         @click="joinOrganisation" />
                 <UButton icon="i-lucide-user-plus"
                          label="Invite"
                          @click="inviteOpen = true" />

--- a/packages/interloper-app/app/app/stores/admin.ts
+++ b/packages/interloper-app/app/app/stores/admin.ts
@@ -42,6 +42,13 @@ export const useAdminStore = defineStore('admin', () => {
         return apiFetch<MemberResponse[]>(`/admin/organisations/${orgId}/members`)
     }
 
+    function joinOrganisation(orgId: string, role: string = 'admin') {
+        return apiFetch<MemberResponse>(`/admin/organisations/${orgId}/members`, {
+            method: 'POST',
+            body: { role },
+        })
+    }
+
     function updateMemberRole(orgId: string, userId: string, role: string) {
         return apiFetch(`/admin/organisations/${orgId}/members/${userId}`, {
             method: 'PATCH',
@@ -77,6 +84,7 @@ export const useAdminStore = defineStore('admin', () => {
         createOrganisation,
         renameOrganisation,
         listMembers,
+        joinOrganisation,
         updateMemberRole,
         removeMember,
         listInvitations,

--- a/packages/interloper-db/src/interloper_db/store/auth.py
+++ b/packages/interloper-db/src/interloper_db/store/auth.py
@@ -334,6 +334,34 @@ class AuthMixin:
                     results.append((db_profile, membership.role))
             return results
 
+    def add_org_member(self, org_id: UUID, user_id: UUID, role: str) -> bool:
+        """Add a user to an organisation directly, without an invitation.
+
+        Args:
+            org_id: Organisation UUID.
+            user_id: Profile UUID to add.
+            role: Role to assign.
+
+        Returns:
+            True if added, False if the user is already a member.
+        """
+        with Session(get_engine()) as session:
+            existing_membership = session.exec(
+                select(UserOrganisation).where(
+                    UserOrganisation.user_id == user_id,
+                    UserOrganisation.organisation_id == org_id,
+                )
+            ).first()
+            if existing_membership:
+                return False
+            session.add(UserOrganisation(
+                user_id=user_id,
+                organisation_id=org_id,
+                role=role,
+            ))
+            session.commit()
+            return True
+
     def update_member_role(self, org_id: UUID, user_id: UUID, role: str) -> bool:
         """Update a member's role within an organisation.
 


### PR DESCRIPTION
## What

Super-admins can now add themselves to any organisation directly, without going through the invite-by-email flow.

- **`interloper-db`**: new `Store.add_org_member(org_id, user_id, role)` — creates the membership directly, returns `False` if the user is already a member.
- **`interloper-api`**: new `POST /admin/organisations/{org_id}/members`, gated by `require_super_admin` like the rest of the admin surface. Adds the *calling* super-admin (default role `admin`, overridable in the body), returns the member as `201`, `409`s when already a member.
- **`interloper-app`**: the admin organisation page shows a **Join** button next to Invite, only when the super-admin is not already a member; it calls the new endpoint and reloads the members table.

## Why

A super-admin adding *themselves* to an org had to invite their own email and accept the invitation — pointless ceremony for an account that already has cross-org management rights. Invitations remain the path for adding anyone else.

## Notes for review

- The endpoint only ever adds the caller — there is no direct-add of arbitrary users; that still goes through invitations.
- Consistent with the admin surface's scope: membership management only, no org-data access.
- Tests cover the happy path (no invitation created), the already-a-member conflict, and invalid-role rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)