### PR TITLE
fix(core): tear down the full dev process tree on shutdown

### DIFF
--- a/packages/interloper-core/src/interloper/cli/commands/app.py
+++ b/packages/interloper-core/src/interloper/cli/commands/app.py
@@ -3,8 +3,9 @@
 Starts any combination of the API server, cron controller, and queue
 worker depending on which packages are installed and which flags are set.
 
-Services run concurrently in threads. ``SIGINT`` / ``SIGTERM`` trigger a
-graceful shutdown.
+Services run concurrently in threads. ``SIGINT`` / ``SIGTERM`` / ``SIGHUP``
+trigger a graceful shutdown; in dev mode, losing the parent process or the
+Nuxt dev server does too.
 
 Available when ``interloper-api`` and/or ``interloper-scheduler`` are installed.
 """

--- a/packages/interloper-core/src/interloper/cli/services.py
+++ b/packages/interloper-core/src/interloper/cli/services.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import atexit
 import logging
+import os
 import signal
+import socket
+import subprocess
 import threading
 from typing import TYPE_CHECKING, Any
 
@@ -44,6 +48,9 @@ def run_services(
         run_reaper: Whether to start the reaper (timed-out run cleanup).
         dev_mode: Whether to run Nuxt in development mode.
         api_port: Effective API port to bind.
+
+    Raises:
+        SystemExit: In dev mode, when the server port is already in use.
     """
     stop_event = threading.Event()
 
@@ -51,7 +58,7 @@ def run_services(
     cron_controller = None
     queue_controller = None
     reaper = None
-    nuxt_process = None
+    nuxt_process: subprocess.Popen[bytes] | None = None
 
     # -- API server -----------------------------------------------------------
     if run_api:
@@ -133,12 +140,39 @@ def run_services(
                 poll_interval=settings.reaper.poll_interval,
             )
 
+    # -- Shutdown -------------------------------------------------------------
+    def signal_nuxt(sig: int) -> None:
+        if nuxt_process is not None:
+            _kill_process_group(nuxt_process, sig)
+
+    def shutdown_all(reason: str) -> None:
+        if stop_event.is_set():
+            return
+        logger.info("Shutting down (%s)...", reason)
+        stop_event.set()
+        signal_nuxt(signal.SIGTERM)
+        if cron_controller:
+            cron_controller.stop()
+        if queue_controller:
+            queue_controller.stop()
+        if reaper:
+            reaper.stop()
+        if api_server:
+            api_server.should_exit = True
+
     # -- Nuxt dev server (dev mode only) ----------------------------------------
     if dev_mode:
-        import os
-        import subprocess
-
         from interloper_app import source_dir
+
+        # Fail fast if the port is taken: Nuxt would silently fall back to
+        # :3001, stacking a half-broken instance (OAuth and CORS are pinned to
+        # settings.server.port) on top of the one already running.
+        if _port_in_use(settings.server.port):
+            raise SystemExit(
+                f"Port {settings.server.port} is already in use — a previous dev instance is likely still "
+                f"running (check `lsof -nP -iTCP:{settings.server.port} -sTCP:LISTEN`). "
+                "Stop it, or set INTERLOPER_SERVER_PORT to a free port."
+            )
 
         nuxt_env = {
             **os.environ,
@@ -148,32 +182,40 @@ def run_services(
 
         def run_nuxt_dev() -> None:
             nonlocal nuxt_process
+            if stop_event.is_set():
+                return
+            # New session: the whole pnpm → nuxt → dev-worker tree lands in one
+            # process group that shutdown can kill atomically; terminate()-ing
+            # just pnpm leaves the rest of the tree orphaned on the port.
             nuxt_process = subprocess.Popen(
                 ["pnpm", "dev"],
                 cwd=source_dir(),
                 env=nuxt_env,
+                stdin=subprocess.DEVNULL,
+                start_new_session=True,
             )
-            nuxt_process.wait()
+            if stop_event.is_set():
+                # Shutdown ran between the check above and Popen returning.
+                signal_nuxt(signal.SIGTERM)
+            returncode = nuxt_process.wait()
+            if not stop_event.is_set():
+                logger.error("Nuxt dev server exited unexpectedly (code %s).", returncode)
+                shutdown_all("nuxt dev server died")
 
+        # Last resort if run_services unwinds via an unhandled exception.
+        atexit.register(signal_nuxt, signal.SIGKILL)
         logger.info("Starting Nuxt dev server from %s", source_dir())
 
     # -- Signal handling ------------------------------------------------------
-    def shutdown(sig: int, frame: object) -> None:
-        logger.info("Shutting down (signal %s)...", sig)
-        if nuxt_process:
-            nuxt_process.terminate()
-        if cron_controller:
-            cron_controller.stop()
-        if queue_controller:
-            queue_controller.stop()
-        if reaper:
-            reaper.stop()
-        if api_server:
-            api_server.should_exit = True
-        stop_event.set()
+    def on_signal(sig: int, frame: object) -> None:
+        shutdown_all(f"signal {signal.Signals(sig).name}")
 
-    signal.signal(signal.SIGINT, shutdown)
-    signal.signal(signal.SIGTERM, shutdown)
+    signal.signal(signal.SIGINT, on_signal)
+    signal.signal(signal.SIGTERM, on_signal)
+    if hasattr(signal, "SIGHUP"):
+        # Terminal/session closed — without this the default handler kills us
+        # before shutdown runs and the Nuxt tree is orphaned.
+        signal.signal(signal.SIGHUP, on_signal)
 
     # -- Start threads --------------------------------------------------------
     threads: list[threading.Thread] = []
@@ -188,6 +230,19 @@ def run_services(
     if dev_mode:
         threads.append(threading.Thread(target=run_nuxt_dev, name="nuxt-dev", daemon=True))
 
+        parent_pid = os.getppid()
+
+        def watch_parent() -> None:
+            # `make dev-up` runs us under make/uv. If that chain dies without
+            # signaling us (terminal killed, agent session reaped), we get
+            # reparented — shut down instead of running on as an orphan.
+            while not stop_event.wait(1.0):
+                if os.getppid() != parent_pid:
+                    shutdown_all("parent process died")
+                    return
+
+        threads.append(threading.Thread(target=watch_parent, name="parent-watchdog", daemon=True))
+
     for t in threads:
         t.start()
 
@@ -201,7 +256,38 @@ def run_services(
     for t in threads:
         t.join(timeout=5)
 
+    # Nuxt got SIGTERM when shutdown started; if its group survived the grace
+    # period, kill it so nothing outlives this process.
+    if nuxt_process is not None and nuxt_process.poll() is None:
+        logger.warning("Nuxt dev server still running after grace period; killing its process group.")
+        signal_nuxt(signal.SIGKILL)
+
     logger.info("Shutdown complete.")
+
+
+def _kill_process_group(process: subprocess.Popen[bytes], sig: int) -> None:
+    """Send a signal to a child's entire process group.
+
+    The child must have been started with ``start_new_session=True`` so its
+    pid is also its process-group id.
+    """
+    if process.poll() is not None:
+        return
+    try:
+        os.killpg(process.pid, sig)
+    except ProcessLookupError:
+        pass
+
+
+def _port_in_use(port: int) -> bool:
+    """Check whether something is already listening on localhost:``port``.
+
+    Returns:
+        True if a connection to the port succeeds.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(0.5)
+        return sock.connect_ex(("127.0.0.1", port)) == 0
 
 
 def _mount_spa(app: Any, directory: Any) -> None:

--- a/packages/interloper-core/tests/cli/test_services.py
+++ b/packages/interloper-core/tests/cli/test_services.py
@@ -1,0 +1,61 @@
+"""Tests for interloper.cli.services."""
+
+import os
+import signal
+import socket
+import subprocess
+import time
+
+from interloper.cli.services import _kill_process_group, _port_in_use
+
+
+def test_port_in_use_detects_listener() -> None:
+    """A live listener on the port is detected."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server:
+        server.bind(("127.0.0.1", 0))
+        server.listen(1)
+        port = server.getsockname()[1]
+        assert _port_in_use(port) is True
+
+
+def test_port_in_use_free_port() -> None:
+    """A free port reports not in use."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+    assert _port_in_use(port) is False
+
+
+def test_kill_process_group_kills_children() -> None:
+    """The group kill reaches grandchildren that terminate() would orphan.
+
+    Raises:
+        AssertionError: If the grandchild survives the group kill.
+    """
+    # Mimics pnpm → nuxt: a shell whose child would survive a plain terminate().
+    proc = subprocess.Popen(
+        ["/bin/sh", "-c", "sleep 30 & echo $!; wait"],
+        stdout=subprocess.PIPE,
+        start_new_session=True,
+    )
+    assert proc.stdout is not None
+    child_pid = int(proc.stdout.readline())
+
+    _kill_process_group(proc, signal.SIGKILL)
+    proc.wait(timeout=5)
+
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        try:
+            os.kill(child_pid, 0)
+        except ProcessLookupError:
+            return
+        time.sleep(0.05)
+    raise AssertionError(f"grandchild {child_pid} still alive after killpg")
+
+
+def test_kill_process_group_ignores_exited_process() -> None:
+    """Killing an already-exited process is a no-op."""
+    proc = subprocess.Popen(["/bin/sh", "-c", "exit 0"], start_new_session=True)
+    proc.wait(timeout=5)
+    _kill_process_group(proc, signal.SIGTERM)


### PR DESCRIPTION
## Problem

`interloper app --dev` (what `make dev-up` runs) routinely orphaned its process tree. One day of dev sessions left nine stale `interloper app` stacks and four `nuxt dev` instances holding ports 3000–3002 and running nine concurrent cron/worker/reaper loops against the shared dev DB. A nuxt master whose worker had died kept holding :3000, making the app unusable ("worker exited with code 0").

Three root causes in `services.py`:

1. **Shutdown only `terminate()`'d the pnpm wrapper.** `pnpm dev` → `node nuxt dev` → Vite/Nitro workers is a tree; SIGTERM to pnpm alone often doesn't propagate, and since all service threads are daemons with a 5s join timeout, python exited anyway and left the nuxt tree on the port.
2. **Only SIGINT/SIGTERM were handled.** SIGHUP killed python without cleanup, and when the `make → sh → uv` chain above python died without signaling it (typical for reaped agent sessions with no controlling tty), python never noticed at all — that's the stale cron/worker/reaper stacks.
3. **No duplicate detection.** With the port taken, nuxt silently fell back to :3001/:3002, so each new `dev-up` "worked" while the pile grew — and the fallback instance was broken anyway (CORS/OAuth are pinned to the configured port).

## Fix

- Spawn nuxt with `start_new_session=True` and kill its whole process group on shutdown (`os.killpg`), escalating SIGTERM → SIGKILL after the grace period, with an `atexit` fallback. `stdin=DEVNULL` keeps the detached session off the tty.
- Handle SIGHUP like SIGINT/SIGTERM.
- Dev mode: a parent watchdog polls `os.getppid()`; reparenting (parent chain died) triggers a full shutdown within ~1s.
- Dev mode: an unexpected nuxt exit shuts the whole instance down instead of lingering half-dead on the port.
- Dev mode: fail fast with a clear error when the configured server port is already in use (points at `lsof` and `INTERLOPER_SERVER_PORT`).

## Verification

- New tests in `tests/cli/test_services.py`, including a real killpg-reaches-grandchildren subprocess test.
- Live-verified on a running instance (`INTERLOPER_SERVER_PORT=3150 make dev-up`):
  - SIGTERM to python → nuxt group gone in ~2s, port freed, clean exit.
  - SIGKILL of make/sh/uv (python untouched) → python logs "Shutting down (parent process died)" and exits within ~3s, taking nuxt with it.
  - Second instance against an occupied port → immediate `SystemExit` with the new message.
- Full suite green: ruff, ty, 809 tests.

Reviewer note: the port guard is a small behavior change — `dev-up` against an occupied port now fails fast instead of letting nuxt bind the next port. Agent sessions already must pick a non-3000 port per AGENTS.md, so this only surfaces genuinely stale instances.

By Digitl