### PR TITLE
feat: relation fields follow the kind vocabulary

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -64,7 +64,7 @@ Yes. You can run or materialize individual assets directly:
 
 ```py
 result = my_asset().run()
-my_asset(destination=il.FileDestination("./data")).materialize()
+my_asset(destinations=il.FileDestination("./data")).materialize()
 ```
 
 A DAG is only needed when you have multiple assets with dependencies.

--- a/docs/features/assets-sources.md
+++ b/docs/features/assets-sources.md
@@ -59,7 +59,7 @@ result = my_asset().run()
 `materialize()` executes the asset **and** writes the result to all configured destinations:
 
 ```py
-asset_instance = my_asset(destination=il.FileDestination("./data"))
+asset_instance = my_asset(destinations=il.FileDestination("./data"))
 asset_instance.materialize()
 ```
 
@@ -120,7 +120,7 @@ Call the source definition to create a runtime `Source`:
 
 ```py
 source = my_source()                                       # Default resources from env
-source = my_source(destination=il.FileDestination("./data"))
+source = my_source(destinations=il.FileDestination("./data"))
 source = my_source(resources={"conn": MyConnection(...)})  # With explicit resources
 ```
 
@@ -133,7 +133,7 @@ Assets are available as attributes on both the definition and the instance:
 my_source.asset_a
 
 # On the instance (returns the runtime Asset)
-source = my_source(destination=il.FileDestination("./data"))
+source = my_source(destinations=il.FileDestination("./data"))
 source.asset_a.run()
 source.asset_b.materialize()
 ```
@@ -144,7 +144,7 @@ Calling an existing source instance returns a reconfigured copy, leaving the ori
 untouched:
 
 ```py
-source = my_source(destination=il.FileDestination("./data"))
+source = my_source(destinations=il.FileDestination("./data"))
 
 # A copy whose assets won't be written during materialization
 read_only = source(materializable=False)
@@ -155,7 +155,7 @@ read_only = source(materializable=False)
 A `DAG` (Directed Acyclic Graph) orchestrates the execution of multiple assets, respecting their dependencies:
 
 ```py
-source = my_source(destination=il.FileDestination("./data"))
+source = my_source(destinations=il.FileDestination("./data"))
 dag = il.DAG(source)
 dag.materialize()
 ```

--- a/docs/features/backfilling.md
+++ b/docs/features/backfilling.md
@@ -22,7 +22,7 @@ def my_source():
 
     return [daily_data]
 
-source = my_source(destination=il.FileDestination("./data"))
+source = my_source(destinations=il.FileDestination("./data"))
 dag = il.DAG(source)
 
 window = il.TimePartitionWindow(

--- a/docs/features/destinations.md
+++ b/docs/features/destinations.md
@@ -15,19 +15,19 @@ logic.
 ### On a source
 
 ```py
-source = my_source(destination=il.FileDestination(base_path="./data"))
+source = my_source(destinations=il.FileDestination(base_path="./data"))
 ```
 
 ### On an individual asset
 
 ```py
-asset_instance = my_asset(destination=il.FileDestination(base_path="./data"))
+asset_instance = my_asset(destinations=il.FileDestination(base_path="./data"))
 ```
 
 ### Declaring destination types up front
 
 The `@asset`/`@source` decorators accept `destinations=[...]` to declare the destination
-**types** an asset supports. Instances are then supplied via the `destination=` argument at
+**types** an asset supports. Instances are then supplied via the `destinations=` argument at
 instantiation:
 
 ```py
@@ -43,7 +43,7 @@ its `id`:
 
 ```py
 asset_instance = my_asset(
-    destination=[
+    destinations=[
         il.FileDestination(id="file", base_path="./data"),
         il.CSVDestination(id="csv", base_path="./exports"),
     ],
@@ -61,7 +61,7 @@ one named by `default_destination_key` (matched against each destination's `id`)
 In-memory storage backed by a class-level dict. Useful for tests and quick experiments.
 
 ```py
-asset_instance = my_asset(destination=il.MemoryDestination())
+asset_instance = my_asset(destinations=il.MemoryDestination())
 asset_instance.materialize()
 ```
 
@@ -76,7 +76,7 @@ il.MemoryDestination.clear()
 Pickle-based storage on the local filesystem.
 
 ```py
-asset_instance = my_asset(destination=il.FileDestination(base_path="./data"))
+asset_instance = my_asset(destinations=il.FileDestination(base_path="./data"))
 asset_instance.materialize()
 # Writes to ./data/{dataset}/{asset_key}/data.pkl
 ```
@@ -94,7 +94,7 @@ instead of `data.pkl`). Because CSV is untyped, reads reconcile rows against the
 to restore declared types.
 
 ```py
-asset_instance = my_asset(destination=il.CSVDestination(base_path="./data"))
+asset_instance = my_asset(destinations=il.CSVDestination(base_path="./data"))
 ```
 
 ## IOContext
@@ -169,7 +169,7 @@ pip install interloper-google-cloud
 from interloper_google_cloud import BigQueryDestination, GoogleCloudConnection
 
 asset_instance = my_asset(
-    destination=BigQueryDestination(
+    destinations=BigQueryDestination(
         id="bq",
         connection=GoogleCloudConnection(...),
         project="my-gcp-project",

--- a/docs/features/partitioning.md
+++ b/docs/features/partitioning.md
@@ -24,7 +24,7 @@ def my_source():
 Run for a specific date:
 
 ```py
-source = my_source(destination=il.FileDestination("./data"))
+source = my_source(destinations=il.FileDestination("./data"))
 dag = il.DAG(source)
 dag.materialize(partition_or_window=il.TimePartition(dt.date(2025, 1, 15)))
 ```

--- a/docs/features/upstream-assets.md
+++ b/docs/features/upstream-assets.md
@@ -27,7 +27,7 @@ When the DAG executes, `users` runs first, its result is written to its destinat
 back and passed as the `users` argument to `user_count`.
 
 ```py
-source = my_source(destination=il.FileDestination("./data"))
+source = my_source(destinations=il.FileDestination("./data"))
 dag = il.DAG(source)
 dag.materialize()
 ```
@@ -80,7 +80,7 @@ dag.materialize()
 
 ## Runtime dependency overrides
 
-Each runtime asset carries a `deps` dict mapping a parameter name to an upstream asset's
+Each runtime asset carries a `dependencies` dict mapping a parameter name to an upstream asset's
 **instance id**. You can wire dependencies imperatively — useful for connecting a standalone
 asset to a source asset:
 
@@ -89,8 +89,8 @@ asset to a source asset:
 def extra():
     return "x"
 
-extra_asset = extra(destination=dest)
-source.report.deps["data"] = extra_asset.id
+extra_asset = extra(destinations=dest)
+source.report.dependencies["data"] = extra_asset.id
 
 dag = il.DAG(source, extra_asset)
 ```
@@ -99,7 +99,7 @@ dag = il.DAG(source, extra_asset)
 
 The DAG resolves each parameter in this order:
 
-1. **Explicit mapping** via `asset.deps` / `requires`
+1. **Explicit mapping** via `asset.dependencies` / `requires`
 2. **Same-source implicit** -- parameter name matches a sibling asset key
 3. **Renamed-asset alias** -- parameter name matches the original key of a renamed asset
 4. **Standalone implicit** -- parameter name matches a standalone asset key

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -56,7 +56,7 @@ print(result)
 Add a destination and materialize -- this runs the asset **and** writes the result:
 
 ```py
-greetings_asset = greetings(destination=il.FileDestination("./data"))
+greetings_asset = greetings(destinations=il.FileDestination("./data"))
 greetings_asset.materialize()
 # Data is written to ./data/greetings/data.pkl
 ```
@@ -83,7 +83,7 @@ def my_source():
 ### Build a DAG and materialize everything
 
 ```py
-source = my_source(destination=il.FileDestination("./data"))
+source = my_source(destinations=il.FileDestination("./data"))
 dag = il.DAG(source)
 dag.materialize()
 ```

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -84,7 +84,7 @@ Interloper ships with built-in destinations and additional ones via extension pa
 Let's materialize our asset using `FileDestination`, which pickles the data on the filesystem:
 
 ```py
-forecast_asset = forecast(destination=il.FileDestination("./data"))
+forecast_asset = forecast(destinations=il.FileDestination("./data"))
 forecast_asset.materialize()
 ```
 
@@ -132,7 +132,7 @@ def open_meteo():
 Instantiate the source and access individual assets by name:
 
 ```py
-source = open_meteo(destination=il.FileDestination("./data"))
+source = open_meteo(destinations=il.FileDestination("./data"))
 source.forecast.run()
 source.air_quality.materialize()
 ```
@@ -142,7 +142,7 @@ source.air_quality.materialize()
 When you want to materialize multiple assets together, respecting their dependencies, use a `DAG`:
 
 ```py
-source = open_meteo(destination=il.FileDestination("./data"))
+source = open_meteo(destinations=il.FileDestination("./data"))
 dag = il.DAG(source)
 dag.materialize()
 ```
@@ -226,7 +226,7 @@ def open_meteo():
 Materialize for a specific date:
 
 ```py
-source = open_meteo(destination=il.FileDestination("./data"))
+source = open_meteo(destinations=il.FileDestination("./data"))
 dag = il.DAG(source)
 dag.materialize(partition_or_window=il.TimePartition(dt.date.today()))
 ```

--- a/examples/assets/demo.py
+++ b/examples/assets/demo.py
@@ -10,7 +10,7 @@ load_dotenv()
 il.EventBus.subscribe(print)
 
 mem = il.MemoryDestination()
-demo = DemoSource(destination=mem)
+demo = DemoSource(destinations=[mem])
 
 
 @il.asset()
@@ -19,8 +19,8 @@ def XXX() -> str:
     return "x"
 
 
-x = XXX(id="xxx", destination=mem)
-demo.b.deps["x"] = x.id
+x = XXX(id="xxx", destinations=[mem])
+demo.b.dependencies["x"] = x.id
 
 dag = il.DAG(demo, x)
 partition = il.TimePartition(dt.date(2024, 1, 1))

--- a/examples/runner/async_.py
+++ b/examples/runner/async_.py
@@ -11,7 +11,7 @@ dotenv.load_dotenv()
 
 
 destination = il.FileDestination(base_path="/tmp/data")
-source = DemoSource(destination=destination)
+source = DemoSource(destinations=[destination])
 dag = il.DAG(source)
 partition = il.TimePartition(value=dt.date(2025, 1, 1))
 

--- a/examples/runner/docker_.py
+++ b/examples/runner/docker_.py
@@ -13,7 +13,7 @@ dotenv.load_dotenv()
 
 
 destination = il.FileDestination(base_path="/tmp/data")
-source = DemoSource(destination=destination)
+source = DemoSource(destinations=[destination])
 dag = il.DAG(source)
 partition = il.TimePartition(value=dt.date(2025, 1, 1))
 

--- a/examples/runner/k8s.py
+++ b/examples/runner/k8s.py
@@ -12,7 +12,7 @@ dotenv.load_dotenv()
 
 
 destination = il.FileDestination(base_path="/tmp/data")
-source = DemoSource(destination=destination)
+source = DemoSource(destinations=[destination])
 dag = il.DAG(source)
 partition = il.TimePartition(value=dt.date(2025, 1, 1))
 

--- a/examples/runner/multi_process.py
+++ b/examples/runner/multi_process.py
@@ -12,7 +12,7 @@ dotenv.load_dotenv()
 
 if __name__ == "__main__":
     destination = il.FileDestination(base_path="/tmp/data")
-    source = DemoSource(destination=destination)
+    source = DemoSource(destinations=[destination])
     dag = il.DAG(source)
     partition = il.TimePartition(value=dt.date(2025, 1, 1))
 

--- a/examples/runner/serial.py
+++ b/examples/runner/serial.py
@@ -11,7 +11,7 @@ dotenv.load_dotenv()
 
 
 destination = il.FileDestination(base_path="/tmp/data")
-source = DemoSource(destination=destination)
+source = DemoSource(destinations=[destination])
 dag = il.DAG(source)
 partition = il.TimePartition(value=dt.date(2025, 1, 1))
 

--- a/packages/interloper-core/src/interloper/asset/base.py
+++ b/packages/interloper-core/src/interloper/asset/base.py
@@ -8,7 +8,7 @@ import traceback
 import warnings
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from pydantic import Field, PrivateAttr
+from pydantic import Field, PrivateAttr, field_validator
 from typing_extensions import Self
 
 from interloper.asset.context import ExecutionContext
@@ -100,12 +100,12 @@ class Asset(Component):
     schema: ClassVar[type[Schema] | None] = None
     partitioning: ClassVar[PartitionConfig | None] = None
     relation_types: ClassVar[dict[str, RelationDefinition]] = {
-        "resource": RelationDefinition(kinds=["connection", "config", "resource"], slotted=True),
-        "destination": RelationDefinition(kinds=["destination"]),
-        "dependency": RelationDefinition(kinds=["asset"], slotted=True),
+        "resource": RelationDefinition(kinds=["connection", "config", "resource"], field="resources", slotted=True),
+        "destination": RelationDefinition(kinds=["destination"], field="destinations"),
+        "dependency": RelationDefinition(kinds=["asset"], field="dependencies", slotted=True, inline=False),
     }
     internal_fields: ClassVar[frozenset[str]] = frozenset(
-        {"destination", "normalizer", "materialization_strategy", "deps"}
+        {"destinations", "normalizer", "materialization_strategy", "dependencies"}
     )
     requires: ClassVar[dict[str, str]] = {}
     optional_requires: ClassVar[dict[str, str]] = {}
@@ -115,19 +115,31 @@ class Asset(Component):
     _source_type: ClassVar[type[Source] | None] = None
 
     # State
-    destination: Destination | list[Destination] | None = Field(default=None)
+    destinations: list[Destination] = Field(default_factory=list)
     dataset: str = Field(default="")
     default_destination_key: str = Field(default="")
     materializable: bool = Field(default=True)
     materialization_strategy: MaterializationStrategy = Field(default=MaterializationStrategy.AUTO)
     normalizer: Normalizer | None = Field(default=None)
-    deps: dict[str, str] = Field(default_factory=dict)
+    dependencies: dict[str, str] = Field(default_factory=dict)
 
     # Private
     _source: Source | None = PrivateAttr(default=None)
     # Effective schema of the last conform: the declared schema, or the one
     # inferred from the data. Carried to destinations via IOContext.schema.
     _effective_schema: type[Schema] | None = PrivateAttr(default=None)
+
+    @field_validator("destinations", mode="before")
+    @classmethod
+    def _coerce_destinations(cls, value: Any) -> Any:
+        """Accept a single destination or ``None`` where a list is expected.
+
+        Returns:
+            The value as a list.
+        """
+        if value is None:
+            return []
+        return value if isinstance(value, (list, tuple)) else [value]
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         """Infer ``resource_types`` from ``data()`` type annotations."""
@@ -282,13 +294,13 @@ class Asset(Component):
         *,
         id: str | None = None,
         resources: dict[str, Resource] | None = None,
-        destination: Destination | list[Destination] | None = None,
+        destinations: Destination | list[Destination] | None = None,
         dataset: str | None = None,
         default_destination_key: str | None = None,
         materializable: bool | None = None,
         materialization_strategy: MaterializationStrategy | None = None,
         normalizer: Normalizer | None = _UNSET,  # ty: ignore[invalid-parameter-default]
-        deps: dict[str, str] | None = None,
+        dependencies: dict[str, str] | None = None,
     ) -> Self:
         """Return a reconfigured copy of this asset."""
         overrides: dict[str, Any] = {}
@@ -296,8 +308,8 @@ class Asset(Component):
             overrides["id"] = id
         if resources is not None:
             overrides["resources"] = {**self.resources, **resources}
-        if destination is not None:
-            overrides["destination"] = destination
+        if destinations is not None:
+            overrides["destinations"] = destinations if isinstance(destinations, list) else [destinations]
         if dataset is not None:
             overrides["dataset"] = dataset
         if default_destination_key is not None:
@@ -308,8 +320,8 @@ class Asset(Component):
             overrides["materialization_strategy"] = materialization_strategy
         if normalizer is not _UNSET:
             overrides["normalizer"] = normalizer
-        if deps is not None:
-            overrides["deps"] = deps
+        if dependencies is not None:
+            overrides["dependencies"] = dependencies
         return self.model_copy(update=overrides)
 
     def run(
@@ -330,7 +342,7 @@ class Asset(Component):
 
         Args:
             partition_or_window: Partition or PartitionWindow for this run.
-            dag: DAG for dependency resolution (required if asset has deps).
+            dag: DAG for dependency resolution (required if asset has dependencies).
             metadata: Arbitrary metadata dict (e.g. run_id, backfill_id).
 
         Returns:
@@ -353,7 +365,7 @@ class Asset(Component):
 
         Args:
             partition_or_window: Partition or PartitionWindow for this run.
-            dag: DAG for dependency resolution (required if asset has deps).
+            dag: DAG for dependency resolution (required if asset has dependencies).
             metadata: Arbitrary metadata dict (e.g. run_id, backfill_id).
 
         Returns:
@@ -419,7 +431,7 @@ class Asset(Component):
 
         Args:
             partition_or_window: Partition or PartitionWindow for this run.
-            dag: DAG for dependency resolution (required if asset has deps).
+            dag: DAG for dependency resolution (required if asset has dependencies).
             metadata: Arbitrary metadata dict (e.g. run_id, backfill_id).
 
         Returns:
@@ -437,7 +449,7 @@ class Asset(Component):
 
         Args:
             partition_or_window: Partition or PartitionWindow for this run.
-            dag: DAG for dependency resolution (required if asset has deps).
+            dag: DAG for dependency resolution (required if asset has dependencies).
             metadata: Arbitrary metadata dict (e.g. run_id, backfill_id).
 
         Returns:
@@ -521,7 +533,7 @@ class Asset(Component):
             elif param_name in type(self).resource_types:
                 kwargs[param_name] = self._resolve_resource(param_name)
             else:
-                if param_name not in self.deps:
+                if param_name not in self.dependencies:
                     continue
                 if dag is None:
                     if param_name in optional_names:
@@ -532,7 +544,7 @@ class Asset(Component):
                         "Pass a DAG to run() or materialize() for dependency resolution."
                     )
 
-                upstream_id = self.deps[param_name]
+                upstream_id = self.dependencies[param_name]
                 upstream_asset = dag.asset_map[upstream_id]
                 if param_name in optional_names:
                     try:
@@ -838,19 +850,16 @@ class Asset(Component):
         """Resolve and validate the destination list for this asset.
 
         Resolution order:
-        1. Asset's own destination(s).
-        2. Source's destination(s) (if asset belongs to a source).
+        1. Asset's own destinations.
+        2. Source's destinations (if asset belongs to a source).
         3. Empty list.
 
         Returns:
             A list of validated destination instances (may be empty).
         """
-        raw = self.destination
-        if raw is None and self._source is not None:
-            raw = self._source.destination
-        if raw is None:
-            return []
-        dests = raw if isinstance(raw, list) else [raw]
+        dests = self.destinations
+        if not dests and self._source is not None:
+            dests = self._source.destinations
         for dest in dests:
             self._validate_destination(dest)
         return dests

--- a/packages/interloper-core/src/interloper/cli/manifest.py
+++ b/packages/interloper-core/src/interloper/cli/manifest.py
@@ -527,13 +527,13 @@ class RunManifest(_ManifestModel):
 
             kwargs = resolver.build_init(item.config)
             if item.destinations is not None:
-                if "destination" in kwargs:
+                if "destinations" in kwargs:
                     raise ManifestError(
-                        f"'{ref}' sets a destination in both 'config' and the 'destinations' field"
+                        f"'{ref}' sets destinations in both 'config' and the 'destinations' field"
                     )
-                kwargs["destination"] = [resolver.build_destination(d) for d in item.destinations]
-            elif "destination" not in kwargs and auto_destinations:
-                kwargs["destination"] = list(auto_destinations)
+                kwargs["destinations"] = [resolver.build_destination(d) for d in item.destinations]
+            elif "destinations" not in kwargs and auto_destinations:
+                kwargs["destinations"] = list(auto_destinations)
 
             if auto_resources:
                 _apply_auto_resources(cls, kwargs, auto_resources)

--- a/packages/interloper-core/src/interloper/component/base.py
+++ b/packages/interloper-core/src/interloper/component/base.py
@@ -64,10 +64,18 @@ class RelationDefinition(BaseModel):
     marks relations that carry a slot, and ``slots`` enumerates the slots a
     concrete class declares — together they fully describe the pickers a UI
     renders for the relation.
+
+    ``field`` names the instance field that carries relations of this type;
+    its shape follows the definition: slotted types are ``dict[slot, ...]``,
+    unslotted ones ``list[...]``. ``inline`` declares what the field carries:
+    embedded component instances (the default), or bare instance ids resolved
+    at execution time (``inline=False``, e.g. asset dependencies).
     """
 
     kinds: list[str]
+    field: str
     slotted: bool = False
+    inline: bool = True
     keys: list[str] = Field(default_factory=list)
     slots: dict[str, RelationSlot] = Field(default_factory=dict)
 

--- a/packages/interloper-core/src/interloper/component/registry.py
+++ b/packages/interloper-core/src/interloper/component/registry.py
@@ -48,10 +48,21 @@ class KindRegistry:
 
         Returns:
             The class, unchanged (usable as a decorator).
+
+        Raises:
+            ValueError: If a declared relation type's ``field`` does not
+                exist on the anchor — a misdeclared field would silently
+                drop persisted relations on reconstruction.
         """
         anchor = self._anchor_of(cls)
-        if anchor.kind:
-            self._anchors.setdefault(anchor.kind, anchor)
+        if anchor.kind and anchor.kind not in self._anchors:
+            for type_, definition in anchor.relation_types.items():
+                if definition.field not in anchor.model_fields:
+                    raise ValueError(
+                        f"Kind '{anchor.kind}' declares relation type '{type_}' with "
+                        f"field '{definition.field}', but {anchor.__name__} has no such field"
+                    )
+            self._anchors[anchor.kind] = anchor
         return cls
 
     def get(self, kind: str) -> type[Component] | None:

--- a/packages/interloper-core/src/interloper/dag/base.py
+++ b/packages/interloper-core/src/interloper/dag/base.py
@@ -15,7 +15,7 @@ from interloper.source.base import Source
 class DAG:
     """Directed acyclic graph of assets.
 
-    Dependencies are resolved from pre-computed ``deps`` on each asset
+    Dependencies are resolved from pre-computed ``dependencies`` on each asset
     (mapping parameter names to upstream asset ids).  The DAG validates
     the wiring and provides topological ordering for parallel execution.
     """
@@ -73,14 +73,14 @@ class DAG:
         for asset in self.assets:
             self.successors[asset.id] = []
 
-        # Build dependency graph from resolved deps
+        # Build dependency graph from resolved dependencies
         for asset in self.assets:
             if not asset.materializable:
                 continue
 
             self.predecessors[asset.id] = []
 
-            for param_name, upstream_id in asset.deps.items():
+            for param_name, upstream_id in asset.dependencies.items():
                 if upstream_id not in self.asset_map:
                     if param_name in type(asset).optional_requires:
                         continue
@@ -102,9 +102,9 @@ class DAG:
         self._check_partition_dependencies()
 
     def _check_requires(self) -> None:
-        """Validate that wired deps match the requires contract.
+        """Validate that wired dependencies match the requires contract.
 
-        For each ``(param_name, upstream_id)`` in ``asset.deps``, if
+        For each ``(param_name, upstream_id)`` in ``asset.dependencies``, if
         ``requires`` or ``optional_requires`` declares an expected key
         for that param, the upstream must match — either as a qualified
         key (``source_key.asset_key``) or a bare key.
@@ -118,9 +118,9 @@ class DAG:
             if not asset.materializable:
                 continue
             asset_cls = type(asset)
-            for param_name, upstream_id in asset.deps.items():
+            for param_name, upstream_id in asset.dependencies.items():
                 if upstream_id not in self.asset_map:
-                    continue  # Missing deps are caught in _build_graph
+                    continue  # Missing dependencies are caught in _build_graph
 
                 expected_key = asset_cls.requires.get(param_name) or asset_cls.optional_requires.get(param_name)
                 if not expected_key:

--- a/packages/interloper-core/src/interloper/destination/base.py
+++ b/packages/interloper-core/src/interloper/destination/base.py
@@ -46,7 +46,7 @@ class Destination(Component):
 
     tags: ClassVar[list[str]] = []
     relation_types: ClassVar[dict[str, RelationDefinition]] = {
-        "resource": RelationDefinition(kinds=["connection", "config", "resource"], slotted=True),
+        "resource": RelationDefinition(kinds=["connection", "config", "resource"], field="resources", slotted=True),
     }
 
     @classmethod

--- a/packages/interloper-core/src/interloper/job/base.py
+++ b/packages/interloper-core/src/interloper/job/base.py
@@ -27,7 +27,7 @@ class Job(Component):
     icon: ClassVar[str] = "carbon:event-schedule"
     runnable: ClassVar[bool] = True
     relation_types: ClassVar[dict[str, RelationDefinition]] = {
-        "target": RelationDefinition(kinds=["source", "asset"]),
+        "target": RelationDefinition(kinds=["source", "asset"], field="targets"),
     }
     internal_fields: ClassVar[frozenset[str]] = frozenset({"targets"})
 

--- a/packages/interloper-core/src/interloper/source/base.py
+++ b/packages/interloper-core/src/interloper/source/base.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import inspect
 from typing import Any, ClassVar
 
-from pydantic import Field, model_validator
+from pydantic import Field, field_validator, model_validator
 from typing_extensions import Self
 
 from interloper.asset import Asset
@@ -82,7 +82,7 @@ class Source(Component):
 
         class MySource(Source):
             resource_types = {"config": ProdConfig}
-            destination = PostgresDest(connection="...")
+            destinations = [PostgresDest(connection="...")]
             asset_types = [Users, Orders]
 
     Access assets by key via attribute access::
@@ -97,18 +97,30 @@ class Source(Component):
     tags: ClassVar[list[str]] = []
     runnable: ClassVar[bool] = True
     relation_types: ClassVar[dict[str, RelationDefinition]] = {
-        "resource": RelationDefinition(kinds=["connection", "config", "resource"], slotted=True),
-        "destination": RelationDefinition(kinds=["destination"]),
+        "resource": RelationDefinition(kinds=["connection", "config", "resource"], field="resources", slotted=True),
+        "destination": RelationDefinition(kinds=["destination"], field="destinations"),
     }
     internal_fields: ClassVar[frozenset[str]] = frozenset(
-        {"assets", "destination", "normalizer", "materialization_strategy"}
+        {"assets", "destinations", "normalizer", "materialization_strategy"}
     )
 
     # State
-    destination: Destination | list[Destination] | None = Field(default=None)
+    destinations: list[Destination] = Field(default_factory=list)
     normalizer: Normalizer | None = Field(default=None)
     materialization_strategy: MaterializationStrategy | None = Field(default=None)
     assets: list[Asset] = Field(default_factory=list)
+
+    @field_validator("destinations", mode="before")
+    @classmethod
+    def _coerce_destinations(cls, value: Any) -> Any:
+        """Accept a single destination or ``None`` where a list is expected.
+
+        Returns:
+            The value as a list.
+        """
+        if value is None:
+            return []
+        return value if isinstance(value, (list, tuple)) else [value]
 
     # Exposed fields
     dataset: str = InputField(default="", description="Defaults to the source key when left empty")
@@ -213,7 +225,7 @@ class Source(Component):
                     asset_spec = asset.to_spec()
                     asset_init = dict(asset_spec.init or {})
                     if asset_spec.id:
-                        # Preserve instance id so deps wire up after round-trip
+                        # Preserve instance id so dependencies wire up after round-trip
                         asset_init["id"] = asset_spec.id
                     overrides[type(asset).key] = asset_init
                 if overrides:
@@ -356,8 +368,8 @@ class Source(Component):
                 asset.dataset = self.dataset
             if not asset.default_destination_key and self.default_destination_key:
                 asset.default_destination_key = self.default_destination_key
-            if asset.destination is None and self.destination is not None:
-                asset.destination = self.destination
+            if not asset.destinations and self.destinations:
+                asset.destinations = list(self.destinations)
             if asset.normalizer is None and self.normalizer is not None:
                 asset.normalizer = self.normalizer
             if (
@@ -371,7 +383,7 @@ class Source(Component):
             self._resolve_deps(asset, siblings)
 
         # Trickle source resources down to destinations
-        for dest in self._resolve_own_destinations():
+        for dest in self.destinations:
             self.trickle_resources(dest)
 
     def __getattr__(self, name: str) -> Asset:
@@ -410,15 +422,15 @@ class Source(Component):
 
         Looks at ``requires`` and ``optional_requires`` entries whose
         qualified key belongs to this source.  If a sibling asset
-        matches, wires it into ``asset.deps``.
+        matches, wires it into ``asset.dependencies``.
 
-        Pre-existing ``deps`` entries (e.g. from the ``asset_dependencies``
-        table) are never overwritten.
+        Pre-existing ``dependencies`` entries (e.g. hydrated from persisted
+        relations) are never overwritten.
         """
         asset_cls = type(asset)
         for mapping in (asset_cls.requires, asset_cls.optional_requires):
             for param_name, required_qk in mapping.items():
-                if param_name in asset.deps:
+                if param_name in asset.dependencies:
                     continue
                 # Only wire intra-source: qualified key must belong to this source
                 if "." in required_qk:
@@ -429,18 +441,7 @@ class Source(Component):
                     asset_key = required_qk
                 sibling = siblings.get(asset_key)
                 if sibling is not None and sibling is not asset:
-                    asset.deps[param_name] = sibling.id
-
-    def _resolve_own_destinations(self) -> list[Destination]:
-        """Return the source's own destination list (without validation).
-
-        Unlike ``Asset._resolve_destinations`` this does not cascade — it only
-        returns destinations directly set on this source instance.
-        """
-        raw = self.destination
-        if raw is None:
-            return []
-        return raw if isinstance(raw, list) else [raw]
+                    asset.dependencies[param_name] = sibling.id
 
     @classmethod
     def definition(cls) -> SourceDefinition:
@@ -475,7 +476,7 @@ class Source(Component):
         self,
         *,
         resources: dict[str, Resource] | None = None,
-        destination: Destination | list[Destination] | None = None,
+        destinations: Destination | list[Destination] | None = None,
         dataset: str | None = None,
         default_destination_key: str | None = None,
         materializable: bool | None = None,
@@ -488,8 +489,8 @@ class Source(Component):
             a._source = copy
         if resources is not None:
             copy.resources = {**copy.resources, **resources}
-        if destination is not None:
-            copy.destination = destination
+        if destinations is not None:
+            copy.destinations = destinations if isinstance(destinations, list) else [destinations]
         if dataset is not None:
             copy.dataset = dataset
         if default_destination_key is not None:

--- a/packages/interloper-core/tests/asset/test_base.py
+++ b/packages/interloper-core/tests/asset/test_base.py
@@ -295,23 +295,23 @@ class TestResources:
 class TestDestinations:
     def test_resolve_asset_own_destination(self):
         dest = FakeDestination()
-        asset = FakeAsset(destination=dest)
+        asset = FakeAsset(destinations=[dest])
         assert asset._resolve_destinations() == [dest]
 
     def test_resolve_wraps_single_destination_in_list(self):
-        asset = FakeAsset(destination=FakeDestination())
+        asset = FakeAsset(destinations=[FakeDestination()])
         resolved = asset._resolve_destinations()
         assert isinstance(resolved, list)
         assert len(resolved) == 1
 
     def test_resolve_keeps_list_destination(self):
         dests = [FakeDestination(), FakeOtherDestination()]
-        asset = FakeAsset(destination=dests)  # ty: ignore[invalid-argument-type]
+        asset = FakeAsset(destinations=dests)  # ty: ignore[invalid-argument-type]
         assert asset._resolve_destinations() == dests
 
     def test_resolve_falls_back_to_source_destination(self):
         source_dest = FakeDestination()
-        source = FakeParentSource(destination=source_dest)
+        source = FakeParentSource(destinations=[source_dest])
         asset = FakeAsset()
         asset._source = source
         assert asset._resolve_destinations() == [source_dest]
@@ -403,12 +403,12 @@ class TestReconfiguration:
 
     def test_override_destination(self):
         new_dest = FakeOtherDestination()
-        reconfigured = FakeAsset(destination=FakeDestination())(destination=new_dest)
-        assert reconfigured.destination is new_dest
+        reconfigured = FakeAsset(destinations=[FakeDestination()])(destinations=new_dest)
+        assert reconfigured.destinations == [new_dest]
 
     def test_override_deps(self):
-        reconfigured = FakeAsset()(deps={"upstream": "abc"})
-        assert reconfigured.deps == {"upstream": "abc"}
+        reconfigured = FakeAsset()(dependencies={"upstream": "abc"})
+        assert reconfigured.dependencies == {"upstream": "abc"}
 
     def test_resources_are_merged_not_replaced(self):
         existing = FakeResource(value="existing")
@@ -443,17 +443,16 @@ class TestSerialization:
         assert restored.materializable is False
 
     def test_asset_with_destination_roundtrip(self):
-        asset = FakeAsset(destination=FakeDestination())
+        asset = FakeAsset(destinations=[FakeDestination()])
         restored = Component.from_spec(asset.to_spec())
         assert isinstance(restored, FakeAsset)
-        assert isinstance(restored.destination, FakeDestination)
+        assert isinstance(restored.destinations[0], FakeDestination)
 
     def test_asset_with_list_of_destinations_roundtrip(self):
-        asset = FakeAsset(destination=[FakeDestination(), FakeOtherDestination()])
+        asset = FakeAsset(destinations=[FakeDestination(), FakeOtherDestination()])
         restored = FakeAsset.from_spec(asset.to_spec())
-        assert isinstance(restored.destination, list)
-        assert isinstance(restored.destination[0], FakeDestination)
-        assert isinstance(restored.destination[1], FakeOtherDestination)
+        assert isinstance(restored.destinations[0], FakeDestination)
+        assert isinstance(restored.destinations[1], FakeOtherDestination)
 
     def test_asset_with_resources_roundtrip(self):
         asset = FakeAsset(resources={"config": FakeResource(value="abc")})
@@ -463,9 +462,9 @@ class TestSerialization:
         assert config.value == "abc"
 
     def test_asset_with_deps_roundtrip(self):
-        asset = FakeAsset(deps={"upstream": "asset-id-123"})
+        asset = FakeAsset(dependencies={"upstream": "asset-id-123"})
         restored = FakeAsset.from_spec(asset.to_spec())
-        assert restored.deps == {"upstream": "asset-id-123"}
+        assert restored.dependencies == {"upstream": "asset-id-123"}
 
     def test_asset_preserves_instance_id(self):
         asset = FakeAsset(id="fixed123")
@@ -485,7 +484,7 @@ class TestSerialization:
     def test_roundtrip_via_json_string(self):
         asset = FakeAsset(
             dataset="ds",
-            destination=[FakeDestination(), FakeOtherDestination()],
+            destinations=[FakeDestination(), FakeOtherDestination()],
             resources={"config": FakeResource(value="v")},
         )
         spec_json = asset.to_spec().model_dump_json()
@@ -493,7 +492,7 @@ class TestSerialization:
 
         assert isinstance(restored, FakeAsset)
         assert restored.dataset == "ds"
-        assert isinstance(restored.destination, list)
+        assert isinstance(restored.destinations, list)
         assert isinstance(restored.resources["config"], FakeResource)
 
 
@@ -526,7 +525,7 @@ class TestDestinationWrite:
         def empty() -> list[dict[str, Any]]:
             return []
 
-        asset = empty(id="empty", destination=mem)
+        asset = empty(id="empty", destinations=[mem])
         logs = await _capture_log_events(asset.materialize_async())
 
         # Nothing was written.
@@ -549,7 +548,7 @@ class TestDestinationWrite:
         def full() -> list[dict[str, Any]]:
             return [{"a": 1}]
 
-        asset = full(id="full", destination=mem)
+        asset = full(id="full", destinations=[mem])
         logs = await _capture_log_events(asset.materialize_async())
 
         # Data was written and no "no data" warning was emitted.
@@ -617,7 +616,7 @@ class TestAsyncAndSyncData:
         def users() -> list[dict[str, Any]]:
             return [{"id": 1}]
 
-        users(destination=CapturingDestination(id="sync-dest")).materialize()
+        users(destinations=[CapturingDestination(id="sync-dest")]).materialize()
         assert captured["data"] == [{"id": 1}]
 
     async def test_async_destination_write_is_awaited(self):
@@ -636,7 +635,7 @@ class TestAsyncAndSyncData:
         def users() -> list[dict[str, Any]]:
             return [{"id": 1}]
 
-        asset = users(destination=AsyncDestination(id="async-dest"))
+        asset = users(destinations=[AsyncDestination(id="async-dest")])
         await asset.materialize_async()
         assert captured["data"] == [{"id": 1}]
 
@@ -742,7 +741,7 @@ class TestConform:
         def users() -> list[dict[str, Any]]:
             return [{"user_id": 1, "name": "a"}]
 
-        asset = users(destination=CapturingDestination(id="cap"))
+        asset = users(destinations=[CapturingDestination(id="cap")])
         await asset.materialize_async()
         assert captured["schema"] is ConformSchema
 
@@ -760,7 +759,7 @@ class TestConform:
         def users() -> list[dict[str, Any]]:
             return [{"user_id": 1}]
 
-        asset = users(destination=CapturingDestination(id="cap"))
+        asset = users(destinations=[CapturingDestination(id="cap")])
         await asset.materialize_async()
         assert captured["schema"] is not None
         assert [s.name for s in captured["schema"].field_specs()] == ["user_id"]

--- a/packages/interloper-core/tests/cli/test_manifest.py
+++ b/packages/interloper-core/tests/cli/test_manifest.py
@@ -209,8 +209,7 @@ class TestCompile:
         for asset in plan.dag.assets:
             assert asset.source is not None
             assert asset.source.greeting == "hi"
-            assert isinstance(asset.destination, list)
-            assert isinstance(asset.destination[0], il.MemoryDestination)
+            assert isinstance(asset.destinations[0], il.MemoryDestination)
 
     def test_select_marks_unselected_non_materializable(self) -> None:
         plan = _manifest(
@@ -227,7 +226,7 @@ class TestCompile:
         generations = plan.dag.topological_generations()
         assert [[type(a).key for a in g] for g in generations] == [["beta"]]
         # The non-materializable parent stays wired as a dependency.
-        assert by_key["alpha"].id in by_key["beta"].deps.values()
+        assert by_key["alpha"].id in by_key["beta"].dependencies.values()
 
     def test_select_unknown_key_raises(self) -> None:
         with pytest.raises(ManifestError, match="has no asset"):
@@ -251,8 +250,7 @@ class TestCompile:
 
         assert len(plan.dag.assets) == 1
         assert type(plan.dag.assets[0]).key == "fake_standalone_asset"
-        assert isinstance(plan.dag.assets[0].destination, list)
-        assert isinstance(plan.dag.assets[0].destination[0], il.MemoryDestination)
+        assert isinstance(plan.dag.assets[0].destinations[0], il.MemoryDestination)
 
     def test_multiple_destinations_fan_out(self, tmp_path: Any) -> None:
         plan = _manifest(
@@ -270,8 +268,7 @@ class TestCompile:
         ).compile()
 
         for asset in plan.dag.assets:
-            assert isinstance(asset.destination, list)
-            types = {type(d) for d in asset.destination}
+            types = {type(d) for d in asset.destinations}
             assert types == {il.MemoryDestination, il.FileDestination}
 
     def test_ref_reuses_one_instance(self) -> None:
@@ -289,8 +286,7 @@ class TestCompile:
 
         instances = set()
         for a in plan.dag.assets:
-            assert isinstance(a.destination, list)
-            instances.add(id(a.destination[0]))
+            instances.add(id(a.destinations[0]))
         assert len(instances) == 1  # same instance across both items and all assets
 
     def test_ref_resolved_inside_config(self) -> None:
@@ -301,12 +297,12 @@ class TestCompile:
             assets:
               - source: {SOURCE_PATH}
                 config:
-                  destination: {{ref: mem}}
+                  destinations: [{{ref: mem}}]
             """
         ).compile()
 
         for asset in plan.dag.assets:
-            assert isinstance(asset.destination, il.MemoryDestination)
+            assert isinstance(asset.destinations[0], il.MemoryDestination)
 
     def test_unknown_ref_raises(self) -> None:
         with pytest.raises(ManifestError, match="Unknown reference 'nope'"):
@@ -358,8 +354,7 @@ class TestCompile:
         ).compile()
 
         for asset in plan.dag.assets:
-            assert isinstance(asset.destination, list)
-            assert isinstance(asset.destination[0], il.MemoryDestination)
+            assert isinstance(asset.destinations[0], il.MemoryDestination)
 
     def test_explicit_destinations_override_auto(self, tmp_path: Any) -> None:
         plan = _manifest(
@@ -378,8 +373,7 @@ class TestCompile:
         ).compile()
 
         for asset in plan.dag.assets:
-            assert isinstance(asset.destination, list)
-            assert {type(d) for d in asset.destination} == {il.FileDestination}  # auto 'mem' not applied
+            assert {type(d) for d in asset.destinations} == {il.FileDestination}  # auto 'mem' not applied
 
     def test_auto_resource_fills_empty_slot(self) -> None:
         plan = _manifest(
@@ -427,8 +421,8 @@ class TestCompile:
                 assets:
                   - source: {SOURCE_PATH}
                     config:
-                      destination:
-                        type: {MEMORY_DESTINATION_PATH}
+                      destinations:
+                        - type: {MEMORY_DESTINATION_PATH}
                     destinations:
                       - type: {MEMORY_DESTINATION_PATH}
                 """
@@ -440,15 +434,15 @@ class TestCompile:
             assets:
               - source: {SOURCE_PATH}
                 config:
-                  destination:
-                    type: {FILE_DESTINATION_PATH}
-                    config:
-                      base_path: {tmp_path}
+                  destinations:
+                    - type: {FILE_DESTINATION_PATH}
+                      config:
+                        base_path: {tmp_path}
             """
         ).compile()
 
         for asset in plan.dag.assets:
-            assert isinstance(asset.destination, il.FileDestination)
+            assert isinstance(asset.destinations[0], il.FileDestination)
 
     def test_partition_and_runner_carried_into_plan(self) -> None:
         plan = _manifest(

--- a/packages/interloper-core/tests/component/test_base.py
+++ b/packages/interloper-core/tests/component/test_base.py
@@ -145,7 +145,7 @@ class TestDefinition:
             """Component declaring a relation vocabulary."""
 
             relation_types: ClassVar[dict[str, RelationDefinition]] = {
-                "wires": RelationDefinition(kinds=["fake_component"], slotted=True)
+                "wires": RelationDefinition(kinds=["fake_component"], field="wires", slotted=True)
             }
 
         relations = FakeRelated.definition().relations

--- a/packages/interloper-core/tests/component/test_registry.py
+++ b/packages/interloper-core/tests/component/test_registry.py
@@ -2,24 +2,29 @@
 
 from __future__ import annotations
 
-from typing import ClassVar
+from typing import Any, ClassVar
+
+import pytest
+from pydantic import Field
 
 import interloper as il
 from interloper.component.base import Component, RelationDefinition
 from interloper.component.registry import KindRegistry
 
 
-class FakeSensor(Component):
+class FakeKind(Component):
     """A satellite-style kind with its own relation vocabulary."""
 
     sensitive: ClassVar[bool] = True
     relation_types: ClassVar[dict[str, RelationDefinition]] = {
-        "watches": RelationDefinition(kinds=["asset"], slotted=True),
+        "link": RelationDefinition(kinds=["asset"], field="links", slotted=True),
     }
 
+    links: dict[str, Any] = Field(default_factory=dict)
 
-class FakeNestSensor(FakeSensor):
-    """A concrete class of the fake kind (inherits kind ``fake_sensor``)."""
+
+class FakeConcreteKind(FakeKind):
+    """A concrete class of the fake kind (inherits kind ``fake_kind``)."""
 
 
 class TestBuiltins:
@@ -50,23 +55,33 @@ class TestRegistration:
 
     def test_registering_a_subclass_anchors_the_kind(self):
         registry = KindRegistry()
-        registry.register(FakeNestSensor)
-        assert registry.get("fake_sensor") is FakeSensor
+        registry.register(FakeConcreteKind)
+        assert registry.get("fake_kind") is FakeKind
 
     def test_first_anchor_wins(self):
         registry = KindRegistry()
-        registry.register(FakeSensor)
-        registry.register(FakeNestSensor)
-        assert registry.get("fake_sensor") is FakeSensor
+        registry.register(FakeKind)
+        registry.register(FakeConcreteKind)
+        assert registry.get("fake_kind") is FakeKind
+
+    def test_misdeclared_relation_field_is_rejected(self):
+        class Broken(Component):
+            relation_types: ClassVar[dict[str, RelationDefinition]] = {
+                "link": RelationDefinition(kinds=["asset"], field="linkss"),
+            }
+
+        registry = KindRegistry()
+        with pytest.raises(ValueError, match="no such field"):
+            registry.register(Broken)
 
     def test_kind_properties_flow_from_the_anchor(self):
         registry = KindRegistry()
-        registry.register(FakeNestSensor)
-        assert registry.sensitive("fake_sensor") is True
-        assert registry.relation_types("fake_sensor")["watches"].slotted is True
+        registry.register(FakeConcreteKind)
+        assert registry.sensitive("fake_kind") is True
+        assert registry.relation_types("fake_kind")["link"].slotted is True
 
     def test_unregistered_kind(self):
         registry = KindRegistry()
-        assert registry.get("fake_sensor") is None
-        assert "fake_sensor" not in registry
-        assert registry.sensitive("fake_sensor") is False
+        assert registry.get("fake_kind") is None
+        assert "fake_kind" not in registry
+        assert registry.sensitive("fake_kind") is False

--- a/packages/interloper-core/tests/dag/test_base.py
+++ b/packages/interloper-core/tests/dag/test_base.py
@@ -340,7 +340,7 @@ class TestGraph:
 
     def test_predecessors_wired_from_deps(self):
         upstream = FakeAsset()
-        downstream = FakeOtherAsset(deps={"upstream": upstream.id})
+        downstream = FakeOtherAsset(dependencies={"upstream": upstream.id})
         dag = DAG(upstream, downstream)
         assert dag.predecessors[downstream.id] == [upstream.id]
         assert dag.successors[upstream.id] == [downstream.id]
@@ -378,18 +378,18 @@ class TestGraph:
         # Non-materializable assets are parents, not roots — their predecessors
         # are not computed (they don't need to execute).
         upstream = FakeAsset(materializable=False)
-        downstream = FakeOtherAsset(deps={"upstream": upstream.id})
+        downstream = FakeOtherAsset(dependencies={"upstream": upstream.id})
         dag = DAG(upstream, downstream)
         assert upstream.id not in dag.predecessors
         assert dag.predecessors[downstream.id] == [upstream.id]
 
     def test_missing_required_dep_raises(self):
-        downstream = FakeAsset(deps={"upstream": "nonexistent-id"})
+        downstream = FakeAsset(dependencies={"upstream": "nonexistent-id"})
         with pytest.raises(DependencyNotFoundError):
             DAG(downstream)
 
     def test_missing_optional_dep_is_tolerated(self):
-        asset = FakeAssetOptionallyRequiringFake(deps={"upstream": "nonexistent-id"})
+        asset = FakeAssetOptionallyRequiringFake(dependencies={"upstream": "nonexistent-id"})
         dag = DAG(asset)
         assert asset.id in dag.asset_map
         assert dag.predecessors[asset.id] == []
@@ -403,26 +403,26 @@ class TestGraph:
 class TestValidation:
     def test_valid_requires_contract_passes(self):
         upstream = FakeAsset()
-        downstream = FakeAssetRequiringFake(deps={"upstream": upstream.id})
+        downstream = FakeAssetRequiringFake(dependencies={"upstream": upstream.id})
         DAG(upstream, downstream)  # no raise
 
     def test_requires_contract_mismatch_raises(self):
         upstream = FakeOtherAsset()
-        downstream = FakeAssetRequiringFake(deps={"upstream": upstream.id})
+        downstream = FakeAssetRequiringFake(dependencies={"upstream": upstream.id})
         with pytest.raises(DependencyContractError):
             DAG(upstream, downstream)
 
     def test_circular_dependency_raises(self):
         a = FakeAsset(id="aaaaaaaa")
         b = FakeOtherAsset(id="bbbbbbbb")
-        a.deps = {"b": b.id}
-        b.deps = {"a": a.id}
+        a.dependencies = {"b": b.id}
+        b.dependencies = {"a": a.id}
         with pytest.raises(CircularDependencyError):
             DAG(a, b)
 
     def test_non_partitioned_depending_on_partitioned_raises(self):
         upstream = FakePartitionedAsset()
-        downstream = FakeAsset(deps={"upstream": upstream.id})
+        downstream = FakeAsset(dependencies={"upstream": upstream.id})
         with pytest.raises(DAGError):
             DAG(upstream, downstream)
 
@@ -446,8 +446,8 @@ class TestTraversal:
 
     def test_topological_generations_linear_chain(self):
         a = FakeAsset()
-        b = FakeOtherAsset(deps={"a": a.id})
-        c = FakeThirdAsset(deps={"b": b.id})
+        b = FakeOtherAsset(dependencies={"a": a.id})
+        c = FakeThirdAsset(dependencies={"b": b.id})
         dag = DAG(a, b, c)
         levels = dag.topological_generations()
         assert len(levels) == 3
@@ -457,8 +457,8 @@ class TestTraversal:
 
     def test_topological_generations_parallel_branches(self):
         a = FakeAsset()
-        b = FakeOtherAsset(deps={"a": a.id})
-        c = FakeThirdAsset(deps={"a": a.id})
+        b = FakeOtherAsset(dependencies={"a": a.id})
+        c = FakeThirdAsset(dependencies={"a": a.id})
         dag = DAG(a, b, c)
         levels = dag.topological_generations()
         assert levels[0] == [a]
@@ -500,21 +500,21 @@ class TestTraversal:
         # Mini-DAG shape: a skipped parent upstream of a live target. The
         # parent's edge counts as satisfied, and only the target appears.
         a = FakeAsset()
-        b = FakeOtherAsset(deps={"a": a.id})
+        b = FakeOtherAsset(dependencies={"a": a.id})
         dag = DAG(a(materializable=False), b)
         levels = dag.topological_generations()
         assert [[asset.id for asset in level] for level in levels] == [[b.id]]
 
     def test_topological_generations_on_mini_dag(self):
         a = FakeAsset()
-        b = FakeOtherAsset(deps={"a": a.id})
+        b = FakeOtherAsset(dependencies={"a": a.id})
         mini = DAG(a, b).mini_dag(b.id)
         levels = mini.topological_generations()
         assert [[asset.id for asset in level] for level in levels] == [[b.id]]
 
     def test_get_predecessors_returns_upstream_ids(self):
         upstream = FakeAsset()
-        downstream = FakeOtherAsset(deps={"upstream": upstream.id})
+        downstream = FakeOtherAsset(dependencies={"upstream": upstream.id})
         dag = DAG(upstream, downstream)
         assert dag.get_predecessors(downstream.id) == [upstream.id]
 
@@ -525,7 +525,7 @@ class TestTraversal:
 
     def test_get_successors_returns_downstream_ids(self):
         upstream = FakeAsset()
-        downstream = FakeOtherAsset(deps={"upstream": upstream.id})
+        downstream = FakeOtherAsset(dependencies={"upstream": upstream.id})
         dag = DAG(upstream, downstream)
         assert dag.get_successors(upstream.id) == [downstream.id]
 
@@ -543,7 +543,7 @@ class TestTraversal:
 class TestMiniDag:
     def test_mini_dag_contains_target_and_parents(self):
         a = FakeAsset()
-        b = FakeOtherAsset(deps={"a": a.id})
+        b = FakeOtherAsset(dependencies={"a": a.id})
         dag = DAG(a, b)
         mini = dag.mini_dag(b.id)
 
@@ -553,7 +553,7 @@ class TestMiniDag:
 
     def test_mini_dag_marks_parents_non_materializable(self):
         a = FakeAsset()
-        b = FakeOtherAsset(deps={"a": a.id})
+        b = FakeOtherAsset(dependencies={"a": a.id})
         dag = DAG(a, b)
         mini = dag.mini_dag(b.id)
 
@@ -624,7 +624,7 @@ class TestSerialization:
 
     def test_roundtrip_preserves_predecessor_wiring(self):
         upstream = FakeAsset()
-        downstream = FakeOtherAsset(deps={"upstream": upstream.id})
+        downstream = FakeOtherAsset(dependencies={"upstream": upstream.id})
         dag = DAG(upstream, downstream)
         restored = DAG.from_spec(dag.to_spec())
 
@@ -646,7 +646,7 @@ class TestSerialization:
 
     def test_roundtrip_via_json_string(self):
         upstream = FakeAsset()
-        downstream = FakeOtherAsset(deps={"upstream": upstream.id})
+        downstream = FakeOtherAsset(dependencies={"upstream": upstream.id})
         dag = DAG(upstream, downstream)
 
         json_str = dag.to_spec().model_dump_json()
@@ -655,7 +655,7 @@ class TestSerialization:
         assert len(reloaded.assets) == 2
         downstream_restored = next(a for a in reloaded.assets if type(a).key == "fake_other_asset")
         upstream_restored = next(a for a in reloaded.assets if type(a).key == "fake_asset")
-        assert downstream_restored.deps["upstream"] == upstream_restored.id
+        assert downstream_restored.dependencies["upstream"] == upstream_restored.id
 
     def test_roundtrip_preserves_source_owned_assets(self):
         dag = DAG(FakeSource())
@@ -665,7 +665,7 @@ class TestSerialization:
 
     def test_roundtrip_preserves_mini_dag_shape(self):
         a = FakeAsset()
-        b = FakeOtherAsset(deps={"a": a.id})
+        b = FakeOtherAsset(dependencies={"a": a.id})
         dag = DAG(a, b)
         mini = dag.mini_dag(b.id)
 

--- a/packages/interloper-core/tests/runner/test_base.py
+++ b/packages/interloper-core/tests/runner/test_base.py
@@ -94,11 +94,11 @@ class TestOnEventScoping:
         events_two: list[Event] = []
         await asyncio.gather(
             AsyncRunner(on_event=events_one.append).run(
-                il.DAG(ping(id="ping", destination=il.MemoryDestination())),
+                il.DAG(ping(id="ping", destinations=[il.MemoryDestination()])),
                 metadata={"run_id": "run-one"},
             ),
             AsyncRunner(on_event=events_two.append).run(
-                il.DAG(pong(id="pong", destination=il.MemoryDestination())),
+                il.DAG(pong(id="pong", destinations=[il.MemoryDestination()])),
                 metadata={"run_id": "run-two"},
             ),
         )
@@ -114,7 +114,7 @@ class TestOnEventScoping:
             return [{"x": 1}]
 
         events: list[Event] = []
-        await AsyncRunner(on_event=events.append).run(il.DAG(solo(id="solo", destination=il.MemoryDestination())))
+        await AsyncRunner(on_event=events.append).run(il.DAG(solo(id="solo", destinations=[il.MemoryDestination()])))
 
         assert events
         run_ids = {e.metadata.get("run_id") for e in events}

--- a/packages/interloper-core/tests/source/test_base.py
+++ b/packages/interloper-core/tests/source/test_base.py
@@ -238,8 +238,8 @@ class TestResolution:
             class FakeChild(il.Asset):
                 pass
 
-        source = FakeTrickleSource(destination=source_dest)
-        assert source.assets[0].destination is source_dest
+        source = FakeTrickleSource(destinations=[source_dest])
+        assert source.assets[0].destinations == [source_dest]
 
     def test_trickles_normalizer_to_assets(self):
         normalizer = Normalizer()
@@ -300,7 +300,7 @@ class TestResolution:
         second = source.fake_second
         # ``_infer_all_requires`` populated ``second.requires``; ``_resolve_deps``
         # wires those into ``second.deps`` pointing at the sibling's instance id.
-        assert second.deps["fake_first"] == first.id
+        assert second.dependencies["fake_first"] == first.id
 
 
 # ---------------------------------------------------------------------------
@@ -320,8 +320,8 @@ class TestReconfiguration:
 
     def test_override_destination(self):
         new_dest = FakeDestination()
-        reconfigured = FakeSourceWithAssets()(destination=new_dest)
-        assert reconfigured.destination is new_dest
+        reconfigured = FakeSourceWithAssets()(destinations=new_dest)
+        assert reconfigured.destinations == [new_dest]
 
     def test_resources_are_merged_not_replaced(self):
         existing = FakeResource(value="existing")
@@ -347,10 +347,10 @@ class TestReconfiguration:
     def test_omitted_fields_preserved(self):
         source = FakeSourceWithAssets(
             dataset="original",
-            destination=FakeDestination(),
+            destinations=[FakeDestination()],
         )
         reconfigured = source(dataset="updated")
-        assert isinstance(reconfigured.destination, FakeDestination)
+        assert isinstance(reconfigured.destinations[0], FakeDestination)
 
     def test_override_default_destination_key(self):
         reconfigured = FakeSourceWithAssets()(default_destination_key="primary")
@@ -397,16 +397,15 @@ class TestSerialization:
         assert restored.assets[1].materializable is True
 
     def test_source_with_destination_roundtrip(self):
-        source = FakeSource(destination=FakeDestination())
+        source = FakeSource(destinations=[FakeDestination()])
         restored = FakeSource.from_spec(source.to_spec())
-        assert isinstance(restored.destination, FakeDestination)
+        assert isinstance(restored.destinations[0], FakeDestination)
 
     def test_source_with_list_of_destinations_roundtrip(self):
-        source = FakeSource(destination=[FakeDestination(), FakeOtherDestination()])
+        source = FakeSource(destinations=[FakeDestination(), FakeOtherDestination()])
         restored = FakeSource.from_spec(source.to_spec())
-        assert isinstance(restored.destination, list)
-        assert isinstance(restored.destination[0], FakeDestination)
-        assert isinstance(restored.destination[1], FakeOtherDestination)
+        assert isinstance(restored.destinations[0], FakeDestination)
+        assert isinstance(restored.destinations[1], FakeOtherDestination)
 
     def test_source_with_resources_roundtrip(self):
         source = FakeSource(resources={"config": FakeResource(value="abc")})
@@ -423,7 +422,7 @@ class TestSerialization:
     def test_roundtrip_via_json_string(self):
         source = FakeSourceWithAssets(
             dataset="ds",
-            destination=FakeDestination(),
+            destinations=[FakeDestination()],
             resources={"config": FakeResource(value="v")},
         )
         source.assets[0].materializable = False
@@ -433,6 +432,6 @@ class TestSerialization:
 
         assert isinstance(restored, FakeSourceWithAssets)
         assert restored.dataset == "ds"
-        assert isinstance(restored.destination, FakeDestination)
+        assert isinstance(restored.destinations[0], FakeDestination)
         assert isinstance(restored.resources["config"], FakeResource)
         assert restored.assets[0].materializable is False

--- a/packages/interloper-db/src/interloper_db/hydration.py
+++ b/packages/interloper-db/src/interloper_db/hydration.py
@@ -116,13 +116,13 @@ class Hydrator:
     def _build_init(self, session: Session, db_component: Component) -> dict[str, Any]:
         """Build the init payload for a component row.
 
-        Relation contributions map onto the framework's field conventions:
-        ``resource`` relations fill ``resources`` (by slot), ``destination``
-        relations fill ``destination``, ``dependency`` relations fill ``deps``
-        (slot → upstream instance id), ``target`` relations fill ``targets``.
-        Children are embedded as the ``assets`` override map — the parent
-        source is the unit of reconstruction, so each child contributes a
-        bare init dict under its key rather than a full spec.
+        Relations are mapped through the kind's own vocabulary: each type
+        fills its declared ``field``, shaped by its definition — slotted
+        types as ``{slot: value}``, unslotted ones as lists, carrying
+        nested specs (``inline``) or bare instance ids.
+        Children are the one non-relation contribution: they embed as the
+        ``assets`` override map, since the parent source is the unit of
+        reconstruction.
 
         Returns:
             A dict suitable for use as a ``ComponentSpec.init``.
@@ -132,23 +132,21 @@ class Hydrator:
         else:
             init = dict(db_component.config or {})
 
-        relations = self._relations_by_type(session, db_component.id)
-
-        if resources := {
-            rel.slot: self._dst_spec(session, rel).model_dump(mode="json") for rel in relations.get("resource", [])
-        }:
-            init["resources"] = resources
-
-        if destinations := [
-            self._dst_spec(session, rel).model_dump(mode="json") for rel in relations.get("destination", [])
-        ]:
-            init["destination"] = destinations if len(destinations) > 1 else destinations[0]
-
-        if deps := {rel.slot: str(rel.dst_id) for rel in relations.get("dependency", [])}:
-            init["deps"] = deps
-
-        if targets := [self._dst_spec(session, rel).model_dump(mode="json") for rel in relations.get("target", [])]:
-            init["targets"] = targets
+        vocabulary = KINDS.relation_types(db_component.kind)
+        for type_, rels in self._relations_by_type(session, db_component.id).items():
+            definition = vocabulary.get(type_)
+            if definition is None:
+                raise HydrationError(
+                    f"Component {db_component.id} ({db_component.kind}) has '{type_}' relations, "
+                    "which its kind's vocabulary does not declare"
+                )
+            if definition.inline:
+                values = [self._dst_spec(session, rel).model_dump(mode="json") for rel in rels]
+            else:
+                values = [str(rel.dst_id) for rel in rels]
+            init[definition.field] = (
+                {rel.slot: value for rel, value in zip(rels, values)} if definition.slotted else values
+            )
 
         children = session.exec(
             select(Component).where(Component.parent_id == db_component.id).order_by(Component.created_at)  # ty: ignore[invalid-argument-type]

--- a/packages/interloper-db/tests/test_hydration.py
+++ b/packages/interloper-db/tests/test_hydration.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from uuid import uuid4
 
 import interloper as il
+import pydantic
 import pytest
 from interloper_assets.demo.source import DemoSource, demo_asset
 from sqlalchemy import Engine
@@ -60,7 +61,7 @@ class TestSourceRoundTrip:
         rows_by_key = {child.key: str(child.id) for child in db_source.children}
         assets_by_key = {type(asset).key: asset for asset in source.assets}
         assert {key: asset.id for key, asset in assets_by_key.items()} == rows_by_key
-        assert assets_by_key["e"].deps == {
+        assert assets_by_key["e"].dependencies == {
             "b": rows_by_key["b"],
             "c": rows_by_key["c"],
             "d": rows_by_key["d"],
@@ -156,3 +157,30 @@ class TestJobRoundTrip:
         updated = store.update_component(db_job.id, name="Renamed", config={"cron": "0 7 * * *"})
         assert updated.name == "Renamed"
         assert updated.state == {"next_run_at": "2026-07-07T06:00:00+00:00"}
+
+
+class FakeLinker(il.Component):
+    """Test-only kind whose vocabulary the hydrator has never seen."""
+
+    relation_types = {"link": il.RelationDefinition(kinds=["source"], field="links")}
+    links: list[il.Component] = pydantic.Field(default_factory=list)
+
+
+il.KINDS.register(FakeLinker)
+
+
+class TestOpenVocabulary:
+    """A novel kind + relation type persists and hydrates with no per-type code."""
+
+    def test_custom_relation_type_round_trips(self, store: Store):
+        store._catalog.components["fake_linker"] = FakeLinker.definition()
+
+        db_source = store.create_component(_ORG, kind="source", key="demo_source", name="Demo")
+        db_linker = store.create_component(
+            _ORG, kind="fake_linker", key="fake_linker", name="L", relations={"link": [(db_source.id, "")]}
+        )
+
+        linker = store.load(db_linker.id)
+        assert isinstance(linker, FakeLinker)
+        assert [type(linked).key for linked in linker.links] == ["demo_source"]
+        assert linker.links[0].id == str(db_source.id)


### PR DESCRIPTION
Closes [ITLPR-83](https://digitlgroup.atlassian.net/browse/ITLPR-83) (epic [ITLPR-79](https://digitlgroup.atlassian.net/browse/ITLPR-79)). First of the 83+84 pair; the manifest ↔ ComponentSpec unification (ITLPR-84) follows on top of these shapes.

The DB stores every relation one way — `(type, slot, dst_id)` rows — while the framework exploded them into five bespoke in-memory shapes. This PR makes the in-memory model follow the rule the vocabulary already declares:

> **Each relation type declares the `field` that carries it: slotted types are `dict[slot, …]`, unslotted ones `list[…]`, holding instances (`inline`, the default) or bare ids (`inline=False`, dependencies).**

## Core

- `destination: Destination | list | None` → **`destinations: list[Destination]`** on Source and Asset. A `mode="before"` validator still accepts a scalar at dynamic call sites (manifest YAML, specs); the three scattered single-or-list unpackers are deleted. Typed surfaces say list; `__call__` keeps an explicitly-typed scalar-or-list param.
- `deps` → **`dependencies`** — still `dict[slot, upstream_id]`, deliberately: an id-carrying dict is exactly a `component_relations` row in memory, and it's what `DAG.asset_map` resolves against. Instance references would force sibling specs to embed each other on serialization.
- `RelationDefinition` gains **`field`** (explicit, required — no pluralization heuristics) and **`inline`**. `KINDS.register` validates that every declared field exists on the anchor, so a misdeclared field fails loudly at import time instead of silently dropping persisted relations on reconstruction.
- Ownership (`Source.assets`) is not a relation row (`parent_id`) and stays a plain list with its override-map serialization.

## DB

The hydrator's five-way fan-out (`_build_init`) collapses into **one loop over the kind's vocabulary**. Concrete payoff, pinned by the new `TestOpenVocabulary` round-trip test: a brand-new kind declaring a brand-new relation type persists, syncs, and hydrates with **zero interloper-db changes**. This is the contract the hook system (ITLPR-87) will build on.

No DB migration; rows, API wire format, and frontend are untouched (`field`/`inline` ride along additively in definition responses).

## Breaking (minor release per lockstep precedent)

Python callers using `destination=` / `deps` must rename (repo, examples, and docs updated here). Note pydantic ignores unknown init kwargs, so an external caller still passing `destination=` is **silently** dropped — `ty` caught three such sites in our own runner tests; the sibling manifests repo should be swept when it bumps.

## Verification

- 811 tests green (new: open-vocabulary round-trip, misdeclared-field rejection), ruff + ty clean.
- Live on the seeded dev instance: partitioned job run through `POST /runs` → hydration → DAG → destination writes, 5/5 assets succeeded; graph and sources pages render with zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)