### PR TITLE
feat(core): hook component kind

### DIFF
--- a/packages/interloper-core/pyproject.toml
+++ b/packages/interloper-core/pyproject.toml
@@ -38,6 +38,7 @@ resource = "interloper.resource.base:Resource"
 connection = "interloper.connection.base:Connection"
 config = "interloper.config.base:Config"
 job = "interloper.job.base:Job"
+hook = "interloper.hook.base:Hook"
 
 [project.entry-points."interloper.oauth_providers"]
 amazon = "interloper.oauth.builtin:AMAZON"

--- a/packages/interloper-core/src/interloper/__init__.py
+++ b/packages/interloper-core/src/interloper/__init__.py
@@ -23,7 +23,8 @@ from interloper.destination import (
     destination,
 )
 from interloper.events import Event, EventBus, EventType
-from interloper.job import Job
+from interloper.hook import HOOK_EVENT_TYPES, Hook, HookContext, HookState, TriggerHook, WebhookHook
+from interloper.job import Job, JobState
 from interloper.normalizer import MaterializationStrategy, Normalizer
 from interloper.oauth import OAuthConfig, OAuthProvider
 from interloper.partitioning import (
@@ -68,6 +69,7 @@ from interloper.utils import bounded_gather, run
 
 __all__ = [
     "DAG",
+    "HOOK_EVENT_TYPES",
     "KINDS",
     "Asset",
     "AssetDefinition",
@@ -91,11 +93,15 @@ __all__ = [
     "FileDestination",
     "HTTPBearerAuth",
     "HeaderLinkPaginator",
+    "Hook",
+    "HookContext",
+    "HookState",
     "IOContext",
     "InputField",
     "JSONCursorPaginator",
     "JSONLinkPaginator",
     "Job",
+    "JobState",
     "JsonField",
     "KindRegistry",
     "MaterializationStrategy",
@@ -135,6 +141,8 @@ __all__ = [
     "TimePartition",
     "TimePartitionConfig",
     "TimePartitionWindow",
+    "TriggerHook",
+    "WebhookHook",
     "asset",
     "bounded_gather",
     "config",

--- a/packages/interloper-core/src/interloper/catalog/base.py
+++ b/packages/interloper-core/src/interloper/catalog/base.py
@@ -36,13 +36,14 @@ from pydantic import BaseModel, Field
 from interloper.asset.base import Asset
 from interloper.component import KINDS, Component, ComponentDefinition
 from interloper.destination.base import Destination
+from interloper.hook import TriggerHook, WebhookHook
 from interloper.job.base import Job
 from interloper.settings import AppSettings
 from interloper.source.base import Source
 
 logger = logging.getLogger(__name__)
 
-BUILTIN_COMPONENTS: tuple[type[Component], ...] = (Job,)
+BUILTIN_COMPONENTS: tuple[type[Component], ...] = (Job, TriggerHook, WebhookHook)
 
 _ENTRY_POINT_GROUP = "interloper.components"
 

--- a/packages/interloper-core/src/interloper/component/base.py
+++ b/packages/interloper-core/src/interloper/component/base.py
@@ -255,6 +255,9 @@ class Component(BaseModel):
     # Class-declared config fields that are framework plumbing, stripped from
     # the definition's config_schema on top of the always-internal set.
     internal_fields: ClassVar[frozenset[str]] = frozenset()
+    # Model of the kind's machine-owned persisted state (None = stateless).
+    # The store validates state payloads against it at the write boundary.
+    state_model: ClassVar[type[BaseModel] | None] = None
 
     id: str = Field(default="")
     resources: dict[str, Any] = Field(default_factory=dict)

--- a/packages/interloper-core/src/interloper/component/registry.py
+++ b/packages/interloper-core/src/interloper/component/registry.py
@@ -27,6 +27,8 @@ from __future__ import annotations
 
 from importlib.metadata import entry_points
 
+from pydantic import BaseModel
+
 from interloper.component.base import Component, RelationDefinition
 
 _ENTRY_POINT_GROUP = "interloper.kinds"
@@ -108,6 +110,16 @@ class KindRegistry:
         """
         cls = self.get(kind)
         return bool(cls and cls.runnable)
+
+    def state_model(self, kind: str) -> type[BaseModel] | None:
+        """The kind's machine-owned state model, if it declares one.
+
+        Returns:
+            The anchor class's ``state_model`` (``None`` for stateless or
+            unknown kinds).
+        """
+        cls = self.get(kind)
+        return cls.state_model if cls else None
 
     def relation_types(self, kind: str) -> dict[str, RelationDefinition]:
         """The relation vocabulary the kind declares.

--- a/packages/interloper-core/src/interloper/hook/__init__.py
+++ b/packages/interloper-core/src/interloper/hook/__init__.py
@@ -1,0 +1,12 @@
+from interloper.hook.base import HOOK_EVENT_TYPES, Hook, HookContext, HookState
+from interloper.hook.trigger import TriggerHook
+from interloper.hook.webhook import WebhookHook
+
+__all__ = [
+    "HOOK_EVENT_TYPES",
+    "Hook",
+    "HookContext",
+    "HookState",
+    "TriggerHook",
+    "WebhookHook",
+]

--- a/packages/interloper-core/src/interloper/hook/base.py
+++ b/packages/interloper-core/src/interloper/hook/base.py
@@ -1,0 +1,88 @@
+"""Hook: a component that reacts to what other components do."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, ClassVar
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from interloper.asset.base import Asset
+from interloper.component.base import Component, RelationDefinition
+from interloper.job.base import Job
+from interloper.source.base import Source
+
+#: Event types a hook may subscribe to (v1: run-terminal outcomes).
+HOOK_EVENT_TYPES: tuple[str, ...] = ("run_completed", "run_failed")
+
+
+class HookContext(BaseModel):
+    """What a firing hook knows about the event that triggered it.
+
+    Carries the event's identity and metadata, plus the capabilities the
+    operator injects: ``trigger`` creates a run for a component id, so
+    trigger-style hooks stay free of any persistence dependency.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    event_type: str
+    component_id: str
+    run_id: str | None = None
+    partition_date: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    trigger: Callable[[str], None] | None = Field(default=None, exclude=True)
+
+
+class HookState(BaseModel):
+    """Machine-owned hook state (see ``Component.state_model``)."""
+
+    last_fired_at: str | None = None
+    last_run_id: str | None = None
+
+
+class Hook(Component):
+    """A reaction to events on watched components.
+
+    A hook declares *what to observe* (``watches``), *which outcomes matter*
+    (``events``), and — like an asset's partitioning or a job's cron — the
+    declaration is inert intent: the framework carries it, and an operator
+    (the scheduler) evaluates events and calls :meth:`fire`. Concrete hook
+    classes own the side effect::
+
+        class SlackHook(Hook):
+            channel: str = InputField(description="Channel to notify")
+
+            def fire(self, context: HookContext) -> None:
+                post_message(self.channel, context.metadata)
+
+    Trigger-style hooks act on their ``targets`` through the operator-injected
+    ``context.trigger`` capability.
+    """
+
+    icon: ClassVar[str] = "carbon:lightning"
+    relation_types: ClassVar[dict[str, RelationDefinition]] = {
+        "watch": RelationDefinition(kinds=["source", "asset", "job"], field="watches"),
+        "target": RelationDefinition(kinds=["source", "asset", "job"], field="targets"),
+        "resource": RelationDefinition(kinds=["connection", "config", "resource"], field="resources", slotted=True),
+    }
+    internal_fields: ClassVar[frozenset[str]] = frozenset({"watches", "targets"})
+    state_model: ClassVar[type[BaseModel] | None] = HookState
+
+    watches: list[Source | Asset | Job] = Field(default_factory=list)
+    targets: list[Source | Asset | Job] = Field(default_factory=list)
+    events: list[str] = Field(
+        default_factory=lambda: ["run_failed"],
+        description="Run outcomes this hook reacts to (run_completed, run_failed)",
+    )
+    enabled: bool = Field(default=True)
+
+    def fire(self, context: HookContext) -> None:
+        """Execute this hook's reaction to an event.
+
+        Subclasses must override this method.
+
+        Raises:
+            NotImplementedError: If the subclass does not implement ``fire()``.
+        """
+        raise NotImplementedError(f"{type(self).__name__} does not implement fire()")

--- a/packages/interloper-core/src/interloper/hook/trigger.py
+++ b/packages/interloper-core/src/interloper/hook/trigger.py
@@ -1,0 +1,27 @@
+"""Trigger hook: run components in reaction to watched outcomes."""
+
+from __future__ import annotations
+
+from interloper.errors import ConfigError
+from interloper.hook.base import Hook, HookContext
+
+
+class TriggerHook(Hook):
+    """Triggers a run of each target when a watched event matches.
+
+    The cascading-pipelines primitive: watch an upstream source or job,
+    target the downstream workload. Execution goes through the operator's
+    injected ``context.trigger`` capability, so the hook itself carries no
+    persistence dependency.
+    """
+
+    def fire(self, context: HookContext) -> None:
+        """Trigger a run for every target.
+
+        Raises:
+            ConfigError: If the operator provided no trigger capability.
+        """
+        if context.trigger is None:
+            raise ConfigError(f"TriggerHook '{self.id}' fired without a trigger capability in its context")
+        for target in self.targets:
+            context.trigger(target.id)

--- a/packages/interloper-core/src/interloper/hook/webhook.py
+++ b/packages/interloper-core/src/interloper/hook/webhook.py
@@ -1,0 +1,44 @@
+"""Webhook hook: POST event metadata to a URL."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from interloper.hook.base import Hook, HookContext
+from interloper.resource.fields import InputField
+
+
+class WebhookHook(Hook):
+    """POSTs a JSON document describing the event to a URL.
+
+    The payload is a fixed metadata document — the event type, the watched
+    component, the run — so receivers integrate against one stable shape.
+    """
+
+    url: str = InputField(description="URL that receives the event POST")
+    timeout: float = InputField(default=10.0, description="Request timeout in seconds")
+
+    def fire(self, context: HookContext) -> None:
+        """POST the event payload to the configured URL.
+
+        An error status from the receiver raises ``httpx.HTTPStatusError``.
+        """
+        import httpx
+
+        response = httpx.post(self.url, json=self._payload(context), timeout=self.timeout)
+        response.raise_for_status()
+
+    def _payload(self, context: HookContext) -> dict[str, Any]:
+        """Build the fixed event document.
+
+        Returns:
+            The JSON-able payload.
+        """
+        return {
+            "event_type": context.event_type,
+            "component_id": context.component_id,
+            "run_id": context.run_id,
+            "partition_date": context.partition_date,
+            "hook_id": self.id,
+            "metadata": context.metadata,
+        }

--- a/packages/interloper-core/src/interloper/job/__init__.py
+++ b/packages/interloper-core/src/interloper/job/__init__.py
@@ -1,5 +1,5 @@
 """Job: a named, schedulable materialization workload."""
 
-from interloper.job.base import Job
+from interloper.job.base import Job, JobState
 
-__all__ = ["Job"]
+__all__ = ["Job", "JobState"]

--- a/packages/interloper-core/src/interloper/job/base.py
+++ b/packages/interloper-core/src/interloper/job/base.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from pydantic import Field, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 from interloper.asset.base import Asset
 from interloper.component.base import Component, RelationDefinition
@@ -13,6 +13,18 @@ from interloper.source.base import Source
 
 if TYPE_CHECKING:
     from interloper.dag.base import DAG
+
+
+class JobState(BaseModel):
+    """Machine-owned job state (see ``Component.state_model``).
+
+    Timestamps are canonical timezone-aware ISO-8601 strings — the scheduler
+    compares them lexicographically in SQL, so they are validated here but
+    never rewritten.
+    """
+
+    next_run_at: str | None = None
+    last_run_at: str | None = None
 
 
 class Job(Component):
@@ -38,6 +50,7 @@ class Job(Component):
         "resource": RelationDefinition(kinds=["connection", "config", "resource"], field="resources", slotted=True),
     }
     internal_fields: ClassVar[frozenset[str]] = frozenset({"targets", "destinations"})
+    state_model: ClassVar[type[BaseModel] | None] = JobState
 
     targets: list[Source | Asset] = Field(default_factory=list)
     destinations: list[Destination] = Field(default_factory=list)

--- a/packages/interloper-core/tests/hook/test_base.py
+++ b/packages/interloper-core/tests/hook/test_base.py
@@ -1,0 +1,91 @@
+"""Tests for ``interloper.hook.base``."""
+
+from typing import Any, ClassVar
+
+import pytest
+
+import interloper as il
+
+
+class FakeNotifyHook(il.Hook):
+    """Concrete hook capturing its firings."""
+
+    fired: ClassVar[list[il.HookContext]] = []
+
+    def fire(self, context: il.HookContext) -> None:
+        type(self).fired.append(context)
+
+
+class FakeSource(il.Source):
+    """Source fixture to watch."""
+
+    class One(il.Asset):
+        """Single asset."""
+
+        def data(self) -> Any:  # pragma: no cover
+            return [{"x": 1}]
+
+
+class TestDefinition:
+    """The hook kind self-describes like every other kind."""
+
+    def test_kind_and_registration(self):
+        assert il.Hook.kind == "hook"
+        assert "hook" in il.KINDS
+        assert il.KINDS.get("hook") is il.Hook
+        assert il.KINDS.runnable("hook") is False
+        assert il.KINDS.sensitive("hook") is False
+
+    def test_vocabulary(self):
+        relations = il.KINDS.relation_types("hook")
+        assert relations["watch"].field == "watches"
+        assert relations["watch"].kinds == ["source", "asset", "job"]
+        assert relations["target"].field == "targets"
+        assert relations["resource"].slotted is True
+
+    def test_state_model(self):
+        assert il.KINDS.state_model("hook") is il.HookState
+        assert il.KINDS.state_model("job") is il.JobState
+        assert il.KINDS.state_model("source") is None
+
+    def test_config_schema_hides_relation_fields(self):
+        schema = il.Hook.config_schema()
+        assert "events" in schema["properties"]
+        assert "enabled" in schema["properties"]
+        assert "watches" not in schema["properties"]
+        assert "targets" not in schema["properties"]
+
+    def test_builtins_always_in_catalog(self):
+        from interloper.catalog.base import _with_builtins
+
+        components = _with_builtins({})
+        assert "trigger_hook" in components
+        assert "webhook_hook" in components
+
+
+class TestFire:
+    """The fire contract."""
+
+    def test_base_fire_is_abstract(self):
+        with pytest.raises(NotImplementedError):
+            il.Hook().fire(il.HookContext(event_type="run_failed", component_id="c1"))
+
+    def test_concrete_hook_receives_context(self):
+        FakeNotifyHook.fired.clear()
+        hook = FakeNotifyHook(watches=[FakeSource()], events=["run_failed"])
+        context = il.HookContext(event_type="run_failed", component_id="c1", run_id="r1")
+        hook.fire(context)
+        assert FakeNotifyHook.fired == [context]
+
+    def test_default_events(self):
+        assert il.Hook().events == ["run_failed"]
+
+
+class TestSpecRoundTrip:
+    """Hooks serialize like every other component."""
+
+    def test_round_trip_preserves_watches(self):
+        hook = FakeNotifyHook(watches=[FakeSource()], events=["run_completed"])
+        restored = FakeNotifyHook.from_spec(hook.to_spec())
+        assert restored.events == ["run_completed"]
+        assert [type(w).key for w in restored.watches] == ["fake_source"]

--- a/packages/interloper-core/tests/hook/test_trigger.py
+++ b/packages/interloper-core/tests/hook/test_trigger.py
@@ -1,0 +1,30 @@
+"""Tests for ``interloper.hook.trigger``."""
+
+from typing import Any
+
+import pytest
+
+import interloper as il
+from interloper.errors import ConfigError
+
+
+class FakeTargetAsset(il.Asset):
+    """Asset fixture used as a trigger target."""
+
+    def data(self) -> Any:  # pragma: no cover
+        return [{"x": 1}]
+
+
+class TestTriggerHook:
+    def test_fires_trigger_capability_per_target(self):
+        a, b = FakeTargetAsset(), FakeTargetAsset()
+        triggered: list[str] = []
+        hook = il.TriggerHook(targets=[a, b])
+        hook.fire(il.HookContext(event_type="run_completed", component_id="c1", trigger=triggered.append))
+        assert triggered == [a.id, b.id]
+
+    def test_missing_capability_raises(self):
+        with pytest.raises(ConfigError, match="without a trigger capability"):
+            il.TriggerHook(targets=[FakeTargetAsset()]).fire(
+                il.HookContext(event_type="run_completed", component_id="c1")
+            )

--- a/packages/interloper-core/tests/hook/test_webhook.py
+++ b/packages/interloper-core/tests/hook/test_webhook.py
@@ -1,0 +1,46 @@
+"""Tests for ``interloper.hook.webhook``."""
+
+from typing import Any
+
+import httpx
+import pytest
+
+import interloper as il
+
+
+class TestWebhookHook:
+    def test_posts_fixed_payload(self, monkeypatch: pytest.MonkeyPatch):
+        calls: list[tuple[str, dict[str, Any]]] = []
+
+        def fake_post(url: str, *, json: dict[str, Any], timeout: float) -> httpx.Response:
+            calls.append((url, json))
+            return httpx.Response(200, request=httpx.Request("POST", url))
+
+        monkeypatch.setattr(httpx, "post", fake_post)
+        hook = il.WebhookHook(id="h1", url="https://example.test/hook")
+        hook.fire(
+            il.HookContext(
+                event_type="run_failed", component_id="c1", run_id="r1", metadata={"error": "boom"}
+            )
+        )
+
+        url, payload = calls[0]
+        assert url == "https://example.test/hook"
+        assert payload == {
+            "event_type": "run_failed",
+            "component_id": "c1",
+            "run_id": "r1",
+            "partition_date": None,
+            "hook_id": "h1",
+            "metadata": {"error": "boom"},
+        }
+
+    def test_error_status_raises(self, monkeypatch: pytest.MonkeyPatch):
+        def fake_post(url: str, *, json: dict[str, Any], timeout: float) -> httpx.Response:
+            return httpx.Response(500, request=httpx.Request("POST", url))
+
+        monkeypatch.setattr(httpx, "post", fake_post)
+        with pytest.raises(httpx.HTTPStatusError):
+            il.WebhookHook(url="https://example.test/hook").fire(
+                il.HookContext(event_type="run_failed", component_id="c1")
+            )

--- a/packages/interloper-db/src/interloper_db/store/runs.py
+++ b/packages/interloper-db/src/interloper_db/store/runs.py
@@ -326,7 +326,9 @@ class RunMixin:
             if db_run.component_id:
                 db_job = session.get(Component, db_run.component_id)
                 if db_job:
-                    db_job.state = {**(db_job.state or {}), "last_run_at": db_run.completed_at.isoformat()}
+                    db_job.state = _checked_state(
+                        db_job.kind, {**(db_job.state or {}), "last_run_at": db_run.completed_at.isoformat()}
+                    )
                     session.add(db_job)
 
             if db_run.backfill_id:
@@ -547,3 +549,17 @@ def _advance_backfill(session: Session, backfill_id: UUID, *, failed: bool) -> N
     for pending_run in pending_runs[:available_slots]:
         pending_run.status = "queued"
         session.add(pending_run)
+
+
+def _checked_state(kind: str, state: dict) -> dict:
+    """Validate a state payload against the kind's declared model (non-normalizing).
+
+    Returns:
+        The original payload, unchanged — validation only checks shape, so the
+        stored string format (lexicographically comparable ISO timestamps)
+        never drifts.
+    """
+    model = il.KINDS.state_model(kind)
+    if model is not None:
+        model.model_validate(state)
+    return state

--- a/packages/interloper-scheduler/src/interloper_scheduler/cron.py
+++ b/packages/interloper-scheduler/src/interloper_scheduler/cron.py
@@ -204,8 +204,18 @@ class CronController:
 
     @staticmethod
     def _set_state(session: Session, job: Component, **timestamps: datetime) -> None:
-        """Merge timestamps into the job's machine-owned state (spec untouched)."""
-        job.state = {**(job.state or {}), **{key: value.isoformat() for key, value in timestamps.items()}}
+        """Merge timestamps into the job's machine-owned state (spec untouched).
+
+        The merged payload is validated against the kind's ``state_model``
+        (shape only — the stored ISO strings are never rewritten).
+        """
+        import interloper as il
+
+        state = {**(job.state or {}), **{key: value.isoformat() for key, value in timestamps.items()}}
+        model = il.KINDS.state_model(job.kind)
+        if model is not None:
+            model.model_validate(state)
+        job.state = state
         session.add(job)
         session.flush()
 


### PR DESCRIPTION
Phase 1 of [ITLPR-87](https://digitlgroup.atlassian.net/browse/ITLPR-87) (epic [ITLPR-79](https://digitlgroup.atlassian.net/browse/ITLPR-79)) — the hook kind in core, per the plan on the ticket.

A **hook** reacts to what watched components do: declarative intent ("when X happens to what I watch, do Y") that an operator evaluates — the exact Job/cron pattern. This PR ships the kind; the scheduler-side evaluator (LISTEN on the #121 transport + watermark sweep) is phase 2.

## The kind

- **`Hook` anchor**: `watch` → `[source, asset, job]`, `target` → `[source, asset, job]`, slotted `resource` (credentials ride the existing encrypted-connection mechanism). Config: `events: [run_completed | run_failed]` — deliberately not `on:`, which YAML 1.1 parses as boolean `True` in spec files — and `enabled`.
- **`fire(context)` contract**: concrete classes own the side effect. Operator capabilities are injected via `HookContext` (`trigger: Callable`), so core stays free of persistence — `TriggerHook.fire` is three lines.
- **Builtins**, always in the catalog like Job: `TriggerHook` (cascading pipelines — phase 2 wires `context.trigger` to `create_run`, courtesy of ITLPR-82) and `WebhookHook` (POSTs a fixed event document).

## The ITLPR-86 rider

Hook is the "second stateful kind" the deferred items were gated on: `Component.state_model` ClassVar (`HookState`, `JobState`), a `KINDS.state_model()` accessor, and **non-normalizing** validation where the scheduler/store write state — shape is checked, but the stored ISO strings are never rewritten, preserving the lexicographic-comparison contract the cron query relies on.

## Proof of the epic's promise

Live on the dev instance, with **zero interloper-db / api / frontend changes**: `create_component(kind="hook", …, relations={"watch": [(source_id, "")]})` persisted through the generic store, hydrated back to a live `WebhookHook` with config and watch relation intact, and the #129 vocabulary enforcement rejected a hook-watching-hook with a clean error. A brand-new kind, fully served by the machinery this epic built.

816 tests (13 new), ruff + ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)