### PR TITLE
feat: hook evaluator in the scheduler

### DIFF
--- a/packages/interloper-core/src/interloper/cli/services.py
+++ b/packages/interloper-core/src/interloper/cli/services.py
@@ -98,9 +98,12 @@ def run_services(
         )
         api_server = uvicorn.Server(uvi_config)
 
-    # -- Cron controller ------------------------------------------------------
+    # -- Cron controller + hook evaluator ---------------------------------------
+    # The hook evaluator rides the cron service: both are cluster singletons
+    # that turn declarative component intent into runs/side effects.
+    hook_controller = None
     if run_cron:
-        from interloper_scheduler import CronController
+        from interloper_scheduler import CronController, HookController
 
         cron_controller = CronController(
             store=store,
@@ -108,6 +111,7 @@ def run_services(
             max_execution_delay=settings.cron.max_execution_delay,
             batch_size=settings.cron.batch_size,
         )
+        hook_controller = HookController(store=store)
 
     # -- Queue worker / reaper ------------------------------------------------
     # Both need a Launcher; build it once if either is enabled.
@@ -153,6 +157,8 @@ def run_services(
         signal_nuxt(signal.SIGTERM)
         if cron_controller:
             cron_controller.stop()
+        if hook_controller:
+            hook_controller.stop()
         if queue_controller:
             queue_controller.stop()
         if reaper:
@@ -221,6 +227,8 @@ def run_services(
     threads: list[threading.Thread] = []
     if cron_controller:
         threads.append(threading.Thread(target=cron_controller.start, name="cron", daemon=True))
+    if hook_controller:
+        threads.append(threading.Thread(target=hook_controller.start, name="hooks", daemon=True))
     if queue_controller:
         threads.append(threading.Thread(target=queue_controller.start, name="worker", daemon=True))
     if reaper:

--- a/packages/interloper-core/src/interloper/events/types.py
+++ b/packages/interloper-core/src/interloper/events/types.py
@@ -17,6 +17,10 @@ class EventType(Enum):
     - **User logging**: messages emitted via ``context.logger``.
     """
 
+    # Hooks (recorded by the hook evaluator)
+    HOOK_FIRED = "hook_fired"
+    HOOK_FAILED = "hook_failed"
+
     # Asset lifecycle (managed by Runner)
     ASSET_QUEUED = "asset_queued"
     ASSET_STARTED = "asset_started"

--- a/packages/interloper-db/src/interloper_db/hydration.py
+++ b/packages/interloper-db/src/interloper_db/hydration.py
@@ -75,7 +75,7 @@ class Hydrator:
         """
         init = self._build_init(session, db_component)
         return ComponentSpec(
-            path=self._resolve_path(db_component),
+            path=self._resolve_path(session, db_component),
             id=str(db_component.id) if db_component.id else "",
             init=init or None,
         )
@@ -179,8 +179,13 @@ class Hydrator:
             raise HydrationError(f"Relation {rel.src_id} -[{rel.type}]-> {rel.dst_id} points at a missing component")
         return self.build_component_spec(session, db_dst)
 
-    def _resolve_path(self, db_component: Component) -> str:
+    def _resolve_path(self, session: Session, db_component: Component) -> str:
         """Look up a component's import path via the catalog.
+
+        Source-owned assets are not top-level catalog entries: their composite
+        path (``module:Source.Asset``) comes from the parent source's
+        definition, so an asset row referenced as a relation destination
+        (a job target, a hook watch) builds a reconstructible spec.
 
         Returns:
             The resolved import path.
@@ -188,6 +193,13 @@ class Hydrator:
         Raises:
             CatalogKeyError: If the catalog has no entry for the row's key.
         """
+        if db_component.kind == "asset" and db_component.parent_id is not None:
+            parent = session.get(Component, db_component.parent_id)
+            parent_definition = self._catalog.get(parent.key) if parent else None
+            for asset_definition in getattr(parent_definition, "assets", []):
+                if asset_definition.key == db_component.key:
+                    return asset_definition.path
+
         definition = self._catalog.get(db_component.key)
         if not definition:
             raise CatalogKeyError(f"Unknown {db_component.kind} key: {db_component.key}")

--- a/packages/interloper-db/src/interloper_db/migrations/versions/006_open_relation_vocabulary.py
+++ b/packages/interloper-db/src/interloper_db/migrations/versions/006_open_relation_vocabulary.py
@@ -1,0 +1,38 @@
+"""Drop the per-type relation CHECK constraints.
+
+The four CHECKs pinned each relation type to the kinds it pointed at when
+the schema was written — a closed-world snapshot of what is now an open
+vocabulary (class-declared ``relation_types``, e.g. the hook kind reuses
+``target``). The store enforces the vocabulary's shape at write time, so
+the snapshot is redundant where it agrees and wrong where it doesn't.
+
+Revision ID: 006
+Revises: 005
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "006"
+down_revision: str | None = "005"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+_CONSTRAINTS = (
+    "ck_component_relations_dependency",
+    "ck_component_relations_resource",
+    "ck_component_relations_destination",
+    "ck_component_relations_target",
+)
+
+
+def upgrade() -> None:
+    """Drop the closed-world relation CHECKs."""
+    for name in _CONSTRAINTS:
+        op.execute(f"ALTER TABLE component_relations DROP CONSTRAINT IF EXISTS {name}")
+
+
+def downgrade() -> None:
+    """No-op: the constraints encode a closed world the vocabulary has outgrown."""

--- a/packages/interloper-db/src/interloper_db/models.py
+++ b/packages/interloper-db/src/interloper_db/models.py
@@ -222,22 +222,9 @@ class ComponentRelation(SQLModel, table=True):
             ondelete="CASCADE",
             name="fk_component_relations_dst",
         ),
-        CheckConstraint(
-            "type <> 'dependency' OR (src_kind = 'asset' AND dst_kind = 'asset')",
-            name="ck_component_relations_dependency",
-        ),
-        CheckConstraint(
-            "type <> 'resource' OR dst_kind IN ('connection', 'config', 'resource')",
-            name="ck_component_relations_resource",
-        ),
-        CheckConstraint(
-            "type <> 'destination' OR (dst_kind = 'destination' AND slot = '')",
-            name="ck_component_relations_destination",
-        ),
-        CheckConstraint(
-            "type <> 'target' OR (src_kind = 'job' AND dst_kind IN ('source', 'asset') AND slot = '')",
-            name="ck_component_relations_target",
-        ),
+        # Relation shapes (which types a kind may declare, which kinds they may
+        # point at, slotted or not) are enforced by the store from the class
+        # vocabulary — an open set, so it is deliberately not mirrored in CHECKs.
         Index(
             "uq_component_relations_slot",
             "src_id",

--- a/packages/interloper-db/src/interloper_db/store/components.py
+++ b/packages/interloper-db/src/interloper_db/store/components.py
@@ -459,16 +459,18 @@ class ComponentMixin:
 
     @staticmethod
     def _resolve_dst(session: Session, src: Component, type_: str, slot: str, dst_id: UUID) -> Component:
-        """Resolve a relation destination, enforcing existence, same-org, and the vocabulary's kinds."""
+        """Resolve a relation destination, enforcing existence, same-org, and the vocabulary's shape."""
         dst = session.get(Component, dst_id)
         if dst is None or dst.org_id != src.org_id:
             raise NotFoundError(f"Component {dst_id} not found (relation '{type_}'{f'/{slot}' if slot else ''})")
-        allowed = il.KINDS.relation_types(src.kind)[type_].kinds
-        if dst.kind not in allowed:
+        definition = il.KINDS.relation_types(src.kind)[type_]
+        if dst.kind not in definition.kinds:
             raise ConfigError(
                 f"Relation '{type_}' on kind '{src.kind}' may not point at a '{dst.kind}' "
-                f"component (allowed: {allowed})"
+                f"component (allowed: {definition.kinds})"
             )
+        if not definition.slotted and slot:
+            raise ConfigError(f"Relation '{type_}' on kind '{src.kind}' is not slotted (got slot '{slot}')")
         return dst
 
     def _row_status(self, session: Session, db_component: Component) -> ComponentStatus:

--- a/packages/interloper-scheduler/src/interloper_scheduler/__init__.py
+++ b/packages/interloper-scheduler/src/interloper_scheduler/__init__.py
@@ -1,11 +1,13 @@
 from interloper_scheduler.cron import CronController
 from interloper_scheduler.executor import RunExecutor
+from interloper_scheduler.hooks import HookController
 from interloper_scheduler.launcher import InProcessLauncher, Launcher, build_launcher
 from interloper_scheduler.queue import QueueController
 from interloper_scheduler.reaper import Reaper
 
 __all__ = [
     "CronController",
+    "HookController",
     "InProcessLauncher",
     "Launcher",
     "QueueController",

--- a/packages/interloper-scheduler/src/interloper_scheduler/hooks.py
+++ b/packages/interloper-scheduler/src/interloper_scheduler/hooks.py
@@ -1,0 +1,239 @@
+"""Hook evaluator: fires hooks in reaction to terminal runs.
+
+A single background loop (a singleton, running alongside the cron
+controller) sweeps recently-terminal runs with a watermark and an overlap
+window, matches them against hooks watching the run's target component (or
+its parent source), and calls each matching hook's ``fire()``.
+
+Delivery is **at-least-evaluated, at-most-fired-once**: every firing is
+claimed by an ``events`` row whose id is deterministic (uuid5 of hook + run),
+so the overlap window and restarts re-evaluate runs without re-firing hooks.
+Failures are recorded on the same claim (``hook_failed``) and are not
+retried. The watermark starts at boot, so runs that ended while the
+scheduler was down are not replayed.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+import uuid
+from threading import Event
+from uuid import UUID
+
+import interloper as il
+from interloper_db import Store, get_engine
+from interloper_db.models import Component, ComponentRelation, Run
+from interloper_db.models import Event as EventRow
+from sqlmodel import Session, col, select
+
+logger = logging.getLogger(__name__)
+
+#: Namespace for deterministic firing-claim event ids.
+_CLAIM_NAMESPACE = uuid.UUID("f6c1a9de-7b6e-4dbb-9f43-1a2b3c4d5e6f")
+
+#: How far behind the watermark each sweep re-reads, so a run committing
+#: just before a cycle's cutoff is still seen by the next cycle.
+_OVERLAP = dt.timedelta(seconds=30)
+
+_TERMINAL_EVENT_TYPES = {"success": "run_completed", "failed": "run_failed"}
+
+
+def _claim_id(hook_id: UUID, run_id: UUID) -> str:
+    """Deterministic event id for one hook firing on one run.
+
+    Returns:
+        The uuid5-derived id string.
+    """
+    return str(uuid.uuid5(_CLAIM_NAMESPACE, f"hook:{hook_id}:{run_id}"))
+
+
+class HookController:
+    """Evaluates hooks against terminal runs.
+
+    Runs in a loop:
+    1. sweep runs that reached a terminal status since the last watermark
+       (minus an overlap window)
+    2. match each run against enabled hooks watching its target component
+       or the target's parent
+    3. fire unclaimed matches, recording each firing as an ``events`` row
+       and stamping the hook's machine-owned state
+    """
+
+    def __init__(self, store: Store | None = None, poll_interval: int = 5) -> None:
+        """Initialize the hook controller.
+
+        Args:
+            store: The Store for hydration, run creation, and events.
+                Creates a default if not provided.
+            poll_interval: Seconds between sweep cycles.
+        """
+        if store is None:
+            from interloper.catalog import Catalog
+
+            store = Store.from_settings(catalog=Catalog.from_settings())
+        self._store = store
+        self._poll_interval = poll_interval
+        self._stop_event = Event()
+        self._watermark = dt.datetime.now(dt.timezone.utc)
+
+    def start(self) -> None:
+        """Run the evaluation loop until stopped."""
+        logger.info("Starting hook controller...")
+        self._watermark = dt.datetime.now(dt.timezone.utc)
+
+        try:
+            while not self._stop_event.is_set():
+                try:
+                    self._process()
+                except Exception as e:
+                    logger.exception("Failed to evaluate hooks: %s", e)
+
+                if self._stop_event.wait(self._poll_interval):
+                    break
+        except KeyboardInterrupt:
+            logger.info("Shutting down hook controller...")
+
+    def stop(self) -> None:
+        """Signal the loop to stop."""
+        self._stop_event.set()
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _process(self) -> None:
+        """Sweep one watermark window of terminal runs."""
+        now = dt.datetime.now(dt.timezone.utc)
+        since = self._watermark - _OVERLAP
+
+        with Session(get_engine()) as session:
+            runs = session.exec(
+                select(Run)
+                .where(col(Run.status).in_(tuple(_TERMINAL_EVENT_TYPES)))
+                .where(col(Run.completed_at) > since)
+                .order_by(col(Run.completed_at))
+            ).all()
+
+            for run in runs:
+                self._evaluate(session, run)
+
+        self._watermark = now
+
+    def _evaluate(self, session: Session, run: Run) -> None:
+        """Fire every unclaimed, matching hook for one terminal run."""
+        if run.component_id is None or run.status not in _TERMINAL_EVENT_TYPES:
+            return
+        event_type = _TERMINAL_EVENT_TYPES[run.status]
+
+        for hook_row in self._matching_hooks(session, run):
+            claim = _claim_id(hook_row.id, run.id)
+            if session.get(EventRow, UUID(claim)) is not None:
+                continue
+
+            hook = self._store.load(hook_row.id)
+            if not isinstance(hook, il.Hook) or not hook.enabled or event_type not in hook.events:
+                continue
+
+            self._fire(session, hook_row, hook, run, event_type, claim)
+
+    def _matching_hooks(self, session: Session, run: Run) -> list[Component]:
+        """Hooks watching the run's target component or its parent.
+
+        Returns:
+            The matching hook rows.
+        """
+        target = session.get(Component, run.component_id)
+        if target is None:
+            return []
+        watched_ids = [target.id] + ([target.parent_id] if target.parent_id else [])
+
+        return list(
+            session.exec(
+                select(Component)
+                .join(ComponentRelation, onclause=ComponentRelation.src_id == Component.id)  # ty: ignore[invalid-argument-type]
+                .where(Component.kind == "hook")
+                .where(Component.org_id == run.org_id)
+                .where(ComponentRelation.type == "watch")
+                .where(col(ComponentRelation.dst_id).in_(watched_ids))
+                .distinct()
+            ).all()
+        )
+
+    def _fire(
+        self,
+        session: Session,
+        hook_row: Component,
+        hook: il.Hook,
+        run: Run,
+        event_type: str,
+        claim: str,
+    ) -> None:
+        """Fire one hook and record the outcome on its claim."""
+        watched_ids = {str(w.id) for w in hook.watches}
+        context = il.HookContext(
+            event_type=event_type,
+            component_id=str(run.component_id),
+            run_id=str(run.id),
+            partition_date=run.partition_date.isoformat() if run.partition_date else None,
+            metadata={"status": run.status},
+            trigger=lambda component_id: self._trigger(session, run, component_id, watched_ids),
+        )
+
+        error: str | None = None
+        try:
+            hook.fire(context)
+            logger.info("Hook '%s' fired for run %s (%s)", hook_row.name, run.id, event_type)
+        except Exception as e:
+            error = str(e)
+            logger.exception("Hook '%s' failed for run %s: %s", hook_row.name, run.id, e)
+
+        outcome = il.EventType.HOOK_FAILED if error else il.EventType.HOOK_FIRED
+        self._store.save_event(
+            il.Event(
+                id=claim,
+                type=outcome,
+                metadata={
+                    "message": f"Hook '{hook_row.name}' ({hook_row.key}) reacted to {event_type}",
+                    "error": error,
+                },
+            ),
+            org_id=run.org_id,
+            run_id=run.id,
+        )
+
+        state = {
+            **(hook_row.state or {}),
+            "last_fired_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+            "last_run_id": str(run.id),
+        }
+        model = il.KINDS.state_model(hook_row.kind)
+        if model is not None:
+            model.model_validate(state)
+        hook_row.state = state
+        session.add(hook_row)
+        session.commit()
+
+    def _trigger(self, session: Session, run: Run, component_id: str, watched_ids: set[str]) -> None:
+        """The trigger capability handed to hooks: queue a run for a component.
+
+        The originating run's partition date is propagated, so cascading
+        pipelines stay on the same partition. Triggering a component the
+        firing hook itself watches (directly or through the component's
+        parent) is refused — each such run would fire the hook again with a
+        fresh claim, an infinite loop. Cycles across *multiple* hooks remain
+        the operator's responsibility, like any recursive schedule.
+
+        Raises:
+            ConfigError: If the trigger would re-enter the hook's own watch set.
+        """
+        from interloper.errors import ConfigError
+
+        target = session.get(Component, UUID(component_id))
+        target_closure = {component_id} | ({str(target.parent_id)} if target and target.parent_id else set())
+        if target_closure & watched_ids:
+            raise ConfigError(
+                f"Refusing to trigger component {component_id}: the hook watches it "
+                "(directly or via its parent), which would loop forever"
+            )
+        self._store.create_run(run.org_id, component_id=UUID(component_id), partition_date=run.partition_date)

--- a/packages/interloper-scheduler/tests/test_hooks.py
+++ b/packages/interloper-scheduler/tests/test_hooks.py
@@ -1,0 +1,238 @@
+"""Tests for the hook evaluator (``interloper_scheduler.hooks``).
+
+SQLite stands in for Postgres; ``save_event`` (a pg-dialect upsert) is
+replaced with a plain insert so the claim-dedup reads work.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from collections.abc import Iterator
+from typing import Any
+from uuid import UUID, uuid4
+
+import interloper as il
+import pytest
+from interloper_assets.demo.source import DemoSource, demo_asset
+from interloper_db import Store
+from interloper_db import engine as engine_module
+from interloper_db.models import Component, ComponentRelation, Run
+from interloper_db.models import Event as EventRow
+from sqlalchemy import event
+from sqlalchemy.pool import StaticPool
+from sqlmodel import Session, select
+
+from interloper_scheduler.hooks import HookController
+
+_ORG = uuid4()
+_PAST = dt.datetime(2026, 1, 1, tzinfo=dt.timezone.utc)
+
+
+@pytest.fixture
+def store(monkeypatch: pytest.MonkeyPatch) -> Iterator[Store]:
+    """A store over an in-memory database, with a SQLite-friendly save_event."""
+    eng = engine_module.init_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(eng, "connect")
+    def _sqlite_uuid(dbapi_connection: Any, _record: Any) -> None:
+        dbapi_connection.create_function("gen_random_uuid", 0, lambda: uuid4().hex)
+
+    for model in (Component, ComponentRelation, Run, EventRow):
+        model.__table__.create(eng)  # ty: ignore[unresolved-attribute]
+
+    store = Store(catalog=il.Catalog.from_assets([DemoSource, demo_asset]))
+
+    def sqlite_save_event(event: il.Event, org_id: UUID, run_id: UUID | None = None) -> EventRow:
+        row = EventRow(
+            id=UUID(event.id),
+            org_id=org_id,
+            run_id=run_id,
+            event_type=event.type.value,
+            message=event.metadata.get("message"),
+            error=event.metadata.get("error"),
+            timestamp=event.timestamp,
+        )
+        with Session(eng) as session:
+            if session.get(EventRow, row.id) is None:
+                session.add(row)
+                session.commit()
+        return row
+
+    monkeypatch.setattr(store, "save_event", sqlite_save_event)
+    try:
+        yield store
+    finally:
+        eng.dispose()
+        engine_module._engine = None
+
+
+def _terminal_run(store: Store, component_id: UUID, *, status: str = "success") -> Run:
+    run = store.create_run(_ORG, component_id=component_id, partition_date=dt.date(2026, 7, 6))
+    with Session(engine_module.get_engine()) as session:
+        db_run = session.get(Run, run.id)
+        assert db_run is not None
+        db_run.status = status
+        db_run.completed_at = dt.datetime.now(dt.timezone.utc)
+        session.add(db_run)
+        session.commit()
+        session.refresh(db_run)
+        return db_run
+
+
+def _sweep(store: Store) -> HookController:
+    controller = HookController(store=store, poll_interval=999)
+    controller._watermark = _PAST
+    controller._process()
+    return controller
+
+
+class TestHookEvaluation:
+    def test_trigger_hook_cascades_with_partition(self, store: Store):
+        source = store.create_component(_ORG, kind="source", key="demo_source", name="Demo")
+        leaf = next(c for c in source.children if c.key == "e")
+        root = next(c for c in source.children if c.key == "a")
+        store.create_component(
+            _ORG, kind="hook", key="trigger_hook", name="Cascade",
+            config={"events": ["run_completed"]},
+            relations={"watch": [(leaf.id, "")], "target": [(root.id, "")]},
+        )
+        run = _terminal_run(store, leaf.id)
+
+        _sweep(store)
+
+        with Session(engine_module.get_engine()) as session:
+            queued = session.exec(select(Run).where(Run.status == "queued")).all()
+            assert len(queued) == 1
+            assert queued[0].component_id == root.id
+            assert queued[0].partition_date == run.partition_date
+            events = session.exec(select(EventRow)).all()
+            assert [e.event_type for e in events] == ["hook_fired"]
+            assert events[0].run_id == run.id
+
+    def test_claim_prevents_refiring(self, store: Store):
+        source = store.create_component(_ORG, kind="source", key="demo_source", name="Demo")
+        leaf = next(c for c in source.children if c.key == "e")
+        root = next(c for c in source.children if c.key == "a")
+        store.create_component(
+            _ORG, kind="hook", key="trigger_hook", name="Cascade",
+            config={"events": ["run_completed"]},
+            relations={"watch": [(leaf.id, "")], "target": [(root.id, "")]},
+        )
+        _terminal_run(store, leaf.id)
+
+        controller = _sweep(store)
+        controller._watermark = _PAST
+        controller._process()  # second sweep over the same window
+
+        with Session(engine_module.get_engine()) as session:
+            assert len(session.exec(select(Run).where(Run.status == "queued")).all()) == 1
+            assert len(session.exec(select(EventRow)).all()) == 1
+
+    def test_event_type_mismatch_does_not_fire(self, store: Store):
+        source = store.create_component(_ORG, kind="source", key="demo_source", name="Demo")
+        leaf = next(c for c in source.children if c.key == "e")
+        root = next(c for c in source.children if c.key == "a")
+        store.create_component(
+            _ORG, kind="hook", key="trigger_hook", name="OnFailureOnly",
+            config={"events": ["run_failed"]},
+            relations={"watch": [(leaf.id, "")], "target": [(root.id, "")]},
+        )
+        _terminal_run(store, leaf.id, status="success")
+
+        _sweep(store)
+
+        with Session(engine_module.get_engine()) as session:
+            assert session.exec(select(Run).where(Run.status == "queued")).all() == []
+            assert session.exec(select(EventRow)).all() == []
+
+    def test_watching_parent_matches_child_run(self, store: Store, monkeypatch: pytest.MonkeyPatch):
+        import httpx
+
+        posted: list[str] = []
+
+        def fake_post(url: str, **kwargs: Any) -> httpx.Response:
+            posted.append(url)
+            return httpx.Response(200, request=httpx.Request("POST", url))
+
+        monkeypatch.setattr(httpx, "post", fake_post)
+
+        source = store.create_component(_ORG, kind="source", key="demo_source", name="Demo")
+        child = next(c for c in source.children if c.key == "a")
+        store.create_component(
+            _ORG, kind="hook", key="webhook_hook", name="OnAnyAsset",
+            config={"events": ["run_completed"], "url": "https://example.test/n"},
+            relations={"watch": [(source.id, "")]},
+        )
+        _terminal_run(store, child.id)
+
+        _sweep(store)
+
+        assert posted == ["https://example.test/n"]
+
+    def test_failure_recorded_on_claim(self, store: Store, monkeypatch: pytest.MonkeyPatch):
+        import httpx
+
+        def boom(*args: Any, **kwargs: Any) -> None:
+            raise httpx.ConnectError("no route")
+
+        monkeypatch.setattr(httpx, "post", boom)
+
+        source = store.create_component(_ORG, kind="source", key="demo_source", name="Demo")
+        store.create_component(
+            _ORG, kind="hook", key="webhook_hook", name="Notify",
+            config={"events": ["run_failed"], "url": "https://example.test/x"},
+            relations={"watch": [(source.id, "")]},
+        )
+        run = _terminal_run(store, source.id, status="failed")
+
+        _sweep(store)
+        _sweep(store)  # failure claim is terminal: no retry
+
+        with Session(engine_module.get_engine()) as session:
+            events = session.exec(select(EventRow)).all()
+            assert [e.event_type for e in events] == ["hook_failed"]
+            assert events[0].error is not None and "no route" in events[0].error
+            hook_row = session.exec(select(Component).where(Component.kind == "hook")).one()
+            assert (hook_row.state or {}).get("last_run_id") == str(run.id)
+
+    def test_self_targeting_trigger_is_refused(self, store: Store):
+        source = store.create_component(_ORG, kind="source", key="demo_source", name="Demo")
+        # Watches the source AND targets it: would loop forever without the guard.
+        store.create_component(
+            _ORG, kind="hook", key="trigger_hook", name="Ouroboros",
+            config={"events": ["run_completed"]},
+            relations={"watch": [(source.id, "")], "target": [(source.id, "")]},
+        )
+        _terminal_run(store, source.id)
+
+        _sweep(store)
+
+        with Session(engine_module.get_engine()) as session:
+            assert session.exec(select(Run).where(Run.status == "queued")).all() == []
+            events = session.exec(select(EventRow)).all()
+            assert [e.event_type for e in events] == ["hook_failed"]
+            assert events[0].error is not None and "loop" in events[0].error
+
+    def test_chain_to_unwatched_target_is_allowed(self, store: Store):
+        source = store.create_component(_ORG, kind="source", key="demo_source", name="Demo")
+        leaf = next(c for c in source.children if c.key == "e")
+        root = next(c for c in source.children if c.key == "a")
+        # Watches only the leaf asset; targets the root asset: no loop possible
+        # through this hook (the triggered run never matches its watch set...
+        # except via the shared parent — which is exactly what the guard checks).
+        store.create_component(
+            _ORG, kind="hook", key="trigger_hook", name="Chain",
+            config={"events": ["run_completed"]},
+            relations={"watch": [(leaf.id, "")], "target": [(root.id, "")]},
+        )
+        _terminal_run(store, leaf.id)
+
+        _sweep(store)
+
+        with Session(engine_module.get_engine()) as session:
+            queued = session.exec(select(Run).where(Run.status == "queued")).all()
+            assert [q.component_id for q in queued] == [root.id]


### PR DESCRIPTION
Phase 2 of [ITLPR-87](https://digitlgroup.atlassian.net/browse/ITLPR-87) (epic [ITLPR-79](https://digitlgroup.atlassian.net/browse/ITLPR-79)) — the operator that turns hook declarations into side effects. Follows #130 (the kind).

## Evaluator

`HookController` rides the cron singleton service (both turn declarative component intent into runs/side effects):

- **Sweep**: a watermark loop with a 30s overlap window over terminal runs — simpler than the LISTEN fast-path the plan sketched, with equivalent guarantees at a 5s poll; LISTEN can be layered on later if sub-second latency ever matters.
- **Match**: terminal run → its target component or the target's parent → enabled hooks with a `watch` relation and a matching `events` entry.
- **Claim**: every firing is recorded as an `events` row with a deterministic id (uuid5 of hook + run) **before the overlap window can re-see the run** — re-evaluation never re-fires. Failures are recorded on the same claim (`hook_failed`, error preserved, visible in the run's event stream) and not retried. The watermark starts at boot, so downtime runs are not replayed.
- **Trigger capability**: queues a run for the target with the origin's partition propagated (cascades stay on-partition) — and **refuses to trigger a component the firing hook itself watches** (directly or via parent), since each such run would fire the hook again with a fresh claim: an infinite loop. The guard promptly caught my own first tests doing exactly that. Multi-hook cycles remain the operator's responsibility, like any recursive schedule.

## Two debts the hook exposed and this PR pays

- **The per-type relation CHECK constraints were a closed world.** `ck_component_relations_target` pinned `target` to `src_kind = 'job'` — a snapshot from before the vocabulary opened (#127) and before the store enforced kinds from it (#129). Hooks reuse `target`, so the four CHECKs are dropped (migration 006); the store now also enforces slot-emptiness for unslotted types, the one bit the CHECKs had that it didn't.
- **Relation destinations pointing at source-owned assets didn't hydrate** (child asset keys aren't top-level catalog entries) — latent for job-targets-an-asset too. The hydrator now resolves them through the parent's composite path.

## Verification

- 823 tests (7 new: cascade with partition propagation, claim dedup, event-type mismatch, parent matching, failure claims, the loop guard both ways), ruff + ty clean.
- **Live on the dev instance**: `Started services: cron, hooks, worker, reaper, api…`; a `TriggerHook` watching asset `e` and targeting asset `a` — ran `e` via the API, the evaluator fired within one poll cycle, the cascaded run of `a` was queued with the propagated partition and ran to success; `hook_fired` event attached to the origin run; `state.last_fired_at`/`last_run_id` stamped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)