### PR TITLE
feat: hooks page and definition-driven state columns

### DIFF
--- a/packages/interloper-app/app/app/components/hooks/ComponentSelect.vue
+++ b/packages/interloper-app/app/app/components/hooks/ComponentSelect.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+/**
+ * Checkbox multi-select over components of mixed kinds (sources, assets,
+ * jobs) — the watch/target pickers of the hook wizard.
+ */
+import type { ComponentRecord } from '~/types/component'
+
+const selectedIds = defineModel<string[]>({ default: () => [] })
+
+defineProps<{
+    components: ComponentRecord[]
+    /** Noun for the counter line, e.g. "watched" / "targeted". */
+    noun?: string
+}>()
+
+function toggle(id: string) {
+    const idx = selectedIds.value.indexOf(id)
+    if (idx >= 0) selectedIds.value.splice(idx, 1)
+    else selectedIds.value.push(id)
+}
+</script>
+
+<template>
+    <div class="flex flex-col gap-3">
+        <span class="text-sm text-muted">
+            {{ selectedIds.length }} of {{ components.length }} components {{ noun ?? 'selected' }}
+        </span>
+
+        <InlineEmptyState v-if="components.length === 0"
+                          icon="i-lucide-plug"
+                          message="No sources, assets or jobs configured yet."
+                          action-label="Go to Sources"
+                          @action="navigateTo('/sources')" />
+
+        <div v-else
+             class="flex flex-col gap-2.5">
+            <SelectionCard v-for="component in components"
+                           :key="component.id"
+                           :selected="selectedIds.includes(component.id)"
+                           class="flex items-center gap-3 px-4 py-3"
+                           @select="toggle(component.id)">
+                <UCheckbox :model-value="selectedIds.includes(component.id)"
+                           @click.stop
+                           @update:model-value="toggle(component.id)" />
+                <div class="size-10 shrink-0 rounded-[11px] border border-default bg-default flex items-center justify-center">
+                    <UIcon :name="componentIcon(component.key)"
+                           class="size-6" />
+                </div>
+                <div class="flex flex-col min-w-0">
+                    <span class="text-[14.5px] font-semibold text-highlighted truncate">{{ component.name }}</span>
+                    <span class="text-xs text-dimmed truncate">{{ component.key }}</span>
+                </div>
+                <UBadge color="neutral"
+                        variant="subtle"
+                        size="xs"
+                        class="ml-auto capitalize">
+                    {{ component.kind }}
+                </UBadge>
+            </SelectionCard>
+        </div>
+    </div>
+</template>

--- a/packages/interloper-app/app/app/components/hooks/Stepper.vue
+++ b/packages/interloper-app/app/app/components/hooks/Stepper.vue
@@ -1,0 +1,280 @@
+<script setup lang="ts">
+/**
+ * Multi-step form for creating and editing hooks.
+ *
+ * Step 1: Type selection (create mode only)
+ * Step 2: Watches (components the hook observes)
+ * Step 3: Targets (components a trigger-style hook acts on)
+ * Step 4: Details (name, events, per-type config, enabled)
+ *
+ * Container-agnostic: the parent wraps this in a UDrawer, modal, or
+ * any other container. Navigation state is exposed via defineExpose.
+ */
+import type { StepperItem } from '@nuxt/ui'
+import type { ComponentRecord } from '~/types/component'
+import { hookEnabled, hookEvents, relationIds } from '~/types/component'
+
+const props = defineProps<{
+    /** Pass an existing hook to edit, or null to create. */
+    hook: ComponentRecord | null
+}>()
+
+const emit = defineEmits<{
+    created: []
+    updated: []
+}>()
+
+const componentsStore = useComponentsStore()
+const catalogStore = useCatalogStore()
+const toast = useToast()
+
+const definitions = computed(() => catalogStore.definitionsForKind('hook'))
+
+// ── Form state ──────────────────────────────────────────────────
+const selectedType = ref('')
+const name = ref('')
+const events = ref<string[]>(['run_failed'])
+const enabled = ref(true)
+const watchIds = ref<string[]>([])
+const targetIds = ref<string[]>([])
+const formData = ref<Record<string, any>>({})
+const formValid = ref(false)
+const submitting = ref(false)
+
+const isEditing = computed(() => !!props.hook)
+
+const EVENT_OPTIONS = [
+    { label: 'Run completed', value: 'run_completed' },
+    { label: 'Run failed', value: 'run_failed' },
+]
+
+/** Config fields owned by dedicated widgets, hidden from the schema form. */
+const OWN_FIELDS = ['id', 'events', 'enabled']
+
+// ── Data fetching ────────────────────────────────────────────────
+
+onMounted(async () => {
+    await componentsStore.fetchAll(['source', 'asset', 'job'])
+    if (props.hook) {
+        selectedType.value = props.hook.key
+        name.value = props.hook.name ?? ''
+        events.value = [...hookEvents(props.hook)]
+        enabled.value = hookEnabled(props.hook)
+        watchIds.value = relationIds(props.hook, 'watch')
+        targetIds.value = relationIds(props.hook, 'target')
+        formData.value = { ...props.hook.config }
+    }
+})
+
+// ── Definition-derived pieces ────────────────────────────────────
+
+const selectedDefinition = computed(() =>
+    definitions.value.find(d => d.key === selectedType.value),
+)
+
+/** Candidates for a relation type, from the definition's allowed kinds. */
+function relationCandidates(type: string): ComponentRecord[] {
+    const kinds = selectedDefinition.value?.relations?.[type]?.kinds ?? []
+    return kinds.flatMap(kind => componentsStore.byKind(kind))
+}
+
+const watchCandidates = computed(() => relationCandidates('watch'))
+const targetCandidates = computed(() => relationCandidates('target'))
+
+const selectedSchema = computed(() => (selectedDefinition.value as any)?.config_schema ?? null)
+
+/** Whether the type has config fields beyond the shared events/enabled pair. */
+const hasExtraFields = computed(() => {
+    const properties = (selectedSchema.value?.properties ?? {}) as Record<string, unknown>
+    return Object.keys(properties).some(key => !OWN_FIELDS.includes(key))
+})
+
+// When a type is selected (create mode only), reset form and advance
+watch(selectedType, (newKey, oldKey) => {
+    if (newKey && newKey !== oldKey && !isEditing.value) {
+        formData.value = {}
+        formValid.value = false
+        name.value = `My ${selectedDefinition.value?.name ?? 'Hook'}`
+        nextStep()
+    }
+})
+
+// ── Stepper ─────────────────────────────────────────────────────
+const steps = computed<StepperItem[]>(() => {
+    const items: StepperItem[] = []
+    if (!isEditing.value) {
+        items.push({ title: 'Type', icon: 'i-lucide-shapes', slot: 'type' as const })
+    }
+    items.push(
+        { title: 'Watches', icon: 'i-lucide-eye', slot: 'watches' as const },
+        { title: 'Targets', icon: 'i-lucide-crosshair', slot: 'targets' as const },
+        { title: 'Details', icon: 'i-lucide-settings-2', slot: 'details' as const },
+    )
+    return items
+})
+
+const { activeStep, hasPrev, isLastStep, next: nextStep, prev: prevStep } = useStepperFlow(computed(() => steps.value.length))
+
+const displaySteps = useCheckedSteps(steps, activeStep)
+
+/** Recap of the components picked on earlier steps. */
+const recapRows = computed(() => {
+    const names = (ids: string[]) => ids
+        .map(id => componentsStore.byId(id)?.name)
+        .filter(Boolean)
+        .join(', ')
+    return [
+        { icon: 'i-lucide-eye', label: 'Watches', value: names(watchIds.value) || 'None' },
+        { icon: 'i-lucide-crosshair', label: 'Targets', value: names(targetIds.value) || 'None' },
+    ]
+})
+
+// ── Validation ──────────────────────────────────────────────────
+const detailsValid = computed(() =>
+    !!name.value.trim()
+    && events.value.length > 0
+    && (!hasExtraFields.value || formValid.value),
+)
+
+const canProceed = computed(() => {
+    const slot = steps.value[activeStep.value]?.slot
+    if (slot === 'type') return !!selectedType.value
+    if (slot === 'watches') return watchIds.value.length > 0
+    if (slot === 'targets') return true
+    if (slot === 'details') return detailsValid.value
+    return false
+})
+
+// ── Submit ──────────────────────────────────────────────────────
+async function submit() {
+    submitting.value = true
+    try {
+        const input = {
+            name: name.value.trim(),
+            config: {
+                ...formData.value,
+                events: [...events.value],
+                enabled: enabled.value,
+            },
+            relations: {
+                watch: watchIds.value.map(id => ({ dst_id: id })),
+                target: targetIds.value.map(id => ({ dst_id: id })),
+            },
+        }
+
+        if (props.hook) {
+            await componentsStore.update(props.hook.id, input)
+            toast.add({ title: 'Hook updated', color: 'success' })
+            emit('updated')
+        }
+        else {
+            await componentsStore.create({ ...input, kind: 'hook', key: selectedType.value })
+            toast.add({ title: 'Hook created', color: 'success' })
+            emit('created')
+        }
+    }
+    catch {
+        toast.add({ title: `Failed to ${isEditing.value ? 'update' : 'create'} hook`, color: 'error' })
+    }
+    finally {
+        submitting.value = false
+    }
+}
+
+function handleNext() {
+    if (isLastStep.value) submit()
+    else nextStep()
+}
+
+// ── Expose navigation state ──────────────────────────────────────
+
+const title = computed(() => isEditing.value ? 'Edit Hook' : 'New Hook')
+const submitLabel = computed(() => {
+    if (!isLastStep.value) return 'Next'
+    return isEditing.value ? 'Save Hook' : 'Create Hook'
+})
+
+defineExpose({ canProceed, hasPrev, isLastStep, submitting, submitLabel, title, next: handleNext, prev: prevStep })
+</script>
+
+<template>
+    <UStepper v-model="activeStep"
+              :items="displaySteps"
+              linear
+              disabled
+              class="w-full">
+        <!-- Type (create mode only) -->
+        <template #type>
+            <TypeSelect v-model="selectedType"
+                        :definitions="definitions" />
+        </template>
+
+        <!-- Watches -->
+        <template #watches>
+            <div class="flex flex-col gap-4">
+                <p class="text-sm text-muted">
+                    Components this hook observes — it fires when one of their runs matches the selected events.
+                </p>
+                <HooksComponentSelect v-model="watchIds"
+                                      :components="watchCandidates"
+                                      noun="watched" />
+            </div>
+        </template>
+
+        <!-- Targets -->
+        <template #targets>
+            <div class="flex flex-col gap-4">
+                <p class="text-sm text-muted">
+                    Components a trigger-style hook runs when it fires. Optional — leave empty for hooks that only notify.
+                </p>
+                <HooksComponentSelect v-model="targetIds"
+                                      :components="targetCandidates"
+                                      noun="targeted" />
+            </div>
+        </template>
+
+        <!-- Details -->
+        <template #details>
+            <div class="flex flex-col gap-6">
+                <UFormField label="Hook name"
+                            required>
+                    <UInput v-model="name"
+                            placeholder="My hook"
+                            class="w-full" />
+                </UFormField>
+
+                <UFormField label="Events"
+                            description="Run outcomes this hook reacts to."
+                            required>
+                    <USelectMenu v-model="events"
+                                 :items="EVENT_OPTIONS"
+                                 value-key="value"
+                                 multiple
+                                 placeholder="Select events..."
+                                 class="w-full" />
+                </UFormField>
+
+                <WizardRecap :rows="recapRows" />
+
+                <template v-if="hasExtraFields">
+                    <USeparator label="Configuration" />
+
+                    <SchemaForm v-model:data="formData"
+                                v-model:is-valid="formValid"
+                                :schema="selectedSchema!"
+                                :exclude="OWN_FIELDS" />
+                </template>
+
+                <USeparator label="Options" />
+
+                <div class="flex items-center justify-between">
+                    <div>
+                        <p class="text-sm font-medium">Enabled</p>
+                        <p class="text-xs text-muted">Hook will fire on matching events.</p>
+                    </div>
+                    <USwitch v-model="enabled" />
+                </div>
+            </div>
+        </template>
+    </UStepper>
+</template>

--- a/packages/interloper-app/app/app/layouts/default.vue
+++ b/packages/interloper-app/app/app/layouts/default.vue
@@ -90,6 +90,12 @@ const items = computed<NavigationMenuItem[]>(() => {
             active: route.path === '/jobs',
         },
         {
+            label: 'Hooks',
+            icon: 'i-carbon-lightning',
+            to: '/hooks',
+            active: route.path === '/hooks',
+        },
+        {
             label: 'Executions',
             icon: 'i-lucide-activity',
             to: '/executions',

--- a/packages/interloper-app/app/app/pages/hooks.vue
+++ b/packages/interloper-app/app/app/pages/hooks.vue
@@ -1,0 +1,139 @@
+<script setup lang="ts">
+import { h, resolveComponent } from 'vue'
+import type { TableColumn } from '@nuxt/ui'
+import type { ComponentRecord } from '~/types/component'
+import { hookEnabled, hookEvents, relationIds } from '~/types/component'
+
+definePageMeta({ title: 'Hooks' })
+
+const UBadge = resolveComponent('UBadge')
+
+const componentsStore = useComponentsStore()
+const catalogStore = useCatalogStore()
+const toast = useToast()
+
+const hooks = computed(() => componentsStore.byKind('hook'))
+
+const stepperRef = ref<any>(null)
+
+const {
+    open: drawerOpen,
+    editing: editingHook,
+    openCreate: handleCreate,
+    openEdit: handleEdit,
+} = useWizardDrawer<ComponentRecord>()
+
+componentsStore.fetchAll(['hook', 'source', 'asset', 'job'])
+
+const columns = computed<TableColumn<ComponentRecord>[]>(() => [
+    { accessorKey: 'select' as any, header: '' },
+    {
+        accessorKey: 'name',
+        header: 'Name',
+        cell: ({ row }) => h('span', { class: 'font-medium' }, row.original.name ?? ''),
+    },
+    {
+        accessorKey: 'key',
+        header: 'Type',
+        accessorFn: (row: ComponentRecord) => catalogStore.catalog[row.key]?.name ?? row.key,
+    },
+    {
+        accessorKey: 'events',
+        header: 'Events',
+        cell: ({ row }) => h('div', { class: 'flex flex-wrap gap-1' }, hookEvents(row.original).map(event =>
+            h(UBadge, {
+                key: event,
+                color: 'neutral',
+                variant: 'subtle',
+            }, () => event),
+        )),
+    },
+    {
+        accessorKey: 'watches',
+        header: 'Watches',
+        cell: ({ row }) => {
+            const count = relationIds(row.original, 'watch').length
+            return h(UBadge, {
+                color: 'neutral',
+                variant: 'subtle',
+            }, () => `${count} watched`)
+        },
+    },
+    {
+        accessorKey: 'enabled',
+        header: 'Status',
+        cell: ({ row }) => h(UBadge, {
+            color: hookEnabled(row.original) ? 'success' : 'neutral',
+            variant: 'subtle',
+        }, () => hookEnabled(row.original) ? 'Enabled' : 'Disabled'),
+    },
+    ...stateSchemaColumns(catalogStore.definitionsForKind('hook')[0]),
+    {
+        accessorKey: 'created_at',
+        header: 'Created',
+        accessorFn: (row: ComponentRecord) => row.created_at ? formatDate(row.created_at) : '—',
+    },
+])
+
+function handleSaved() {
+    componentsStore.fetchAll(['hook'])
+    drawerOpen.value = false
+}
+
+async function handleDelete(ids: string[]) {
+    try {
+        await componentsStore.remove(ids)
+        toast.add({ title: `${ids.length} hook${ids.length > 1 ? 's' : ''} deleted`, color: 'success' })
+    }
+    catch {
+        toast.add({ title: 'Failed to delete hook', color: 'error' })
+    }
+}
+</script>
+
+<template>
+    <div>
+        <div class="flex flex-col flex-1 min-h-0">
+            <DataTable :columns="columns"
+                       :data="hooks"
+                       :loading="componentsStore.loading"
+                       search-placeholder="Search hooks..."
+                       @delete="handleDelete"
+                       @edit="handleEdit">
+                <template #toolbar>
+                    <UButton icon="i-lucide-plus"
+                             label="New hook"
+                             @click="handleCreate" />
+                </template>
+
+                <template #empty>
+                    <EmptyState icon="i-carbon-lightning"
+                                title="No hooks yet"
+                                description="A hook reacts to what your pipelines do. Watch a source, asset, or job and trigger downstream runs or notify an external system when runs complete or fail." />
+
+                    <div class="flex items-center gap-3 border border-default rounded-[14px] px-5 py-4 bg-(--ui-bg-band) mt-9">
+                        <div class="flex-1 text-sm text-toned">
+                            Create a hook to react to run outcomes on your components.
+                        </div>
+                        <UButton icon="i-lucide-plus"
+                                 label="New hook"
+                                 size="md"
+                                 @click="handleCreate" />
+                    </div>
+                </template>
+            </DataTable>
+        </div>
+
+        <WizardDrawer v-model:open="drawerOpen"
+                      :default-title="editingHook ? 'Edit Hook' : 'New Hook'"
+                      description="Configure hook"
+                      :stepper="stepperRef">
+            <HooksStepper v-if="drawerOpen"
+                          :key="editingHook?.id ?? 'new'"
+                          ref="stepperRef"
+                          :hook="editingHook"
+                          @created="handleSaved"
+                          @updated="handleSaved" />
+        </WizardDrawer>
+    </div>
+</template>

--- a/packages/interloper-app/app/app/pages/jobs.vue
+++ b/packages/interloper-app/app/app/pages/jobs.vue
@@ -3,13 +3,14 @@ import { h, resolveComponent } from 'vue'
 import cronstrue from 'cronstrue'
 import type { TableColumn, DropdownMenuItem } from '@nuxt/ui'
 import type { ComponentRecord } from '~/types/component'
-import { jobCron, jobEnabled, jobLastRunAt, jobTargetIds } from '~/types/component'
+import { jobCron, jobEnabled, jobTargetIds } from '~/types/component'
 
 definePageMeta({ title: 'Jobs' })
 
 const UBadge = resolveComponent('UBadge')
 
 const componentsStore = useComponentsStore()
+const catalogStore = useCatalogStore()
 const toast = useToast()
 
 const jobs = computed(() => componentsStore.byKind('job'))
@@ -47,7 +48,7 @@ const SETUP_STEPS = [
     { to: '/destinations', icon: 'i-lucide-database', title: 'Step 2 · Add a destination', sub: 'Choose where assets are materialized', link: 'Go to Destinations' },
 ]
 
-const columns: TableColumn<ComponentRecord>[] = [
+const columns = computed<TableColumn<ComponentRecord>[]>(() => [
     { accessorKey: 'select' as any, header: '' },
     {
         accessorKey: 'name',
@@ -81,17 +82,13 @@ const columns: TableColumn<ComponentRecord>[] = [
             variant: 'subtle',
         }, () => jobEnabled(row.original) ? 'Enabled' : 'Disabled'),
     },
-    {
-        accessorKey: 'last_run_at',
-        header: 'Last run',
-        accessorFn: (row: ComponentRecord) => jobLastRunAt(row) ? formatDate(jobLastRunAt(row)!) : '—',
-    },
+    ...stateSchemaColumns(catalogStore.definitionsForKind('job')[0]),
     {
         accessorKey: 'created_at',
         header: 'Created',
         accessorFn: (row: ComponentRecord) => row.created_at ? formatDate(row.created_at) : '—',
     },
-]
+])
 
 function rowActions(job: ComponentRecord): DropdownMenuItem[][] {
     return [[

--- a/packages/interloper-app/app/app/types/catalog.ts
+++ b/packages/interloper-app/app/app/types/catalog.ts
@@ -29,6 +29,8 @@ export interface ComponentDefinition {
     description: string
     tags: string[]
     config_schema: Record<string, unknown>
+    /** JSON Schema of the kind's machine-owned state (`{}` = stateless). */
+    state_schema: Record<string, unknown>
     /** Relation vocabulary: type → allowed dst kinds, keys and slots. */
     relations: Record<string, RelationDefinition>
     provider?: string
@@ -73,6 +75,30 @@ export function requiredDependencies(defn: ComponentDefinition): Record<string, 
 /** Compatible destination keys from the `destination` relation. Empty = all compatible. */
 export function allowedDestinationKeys(defn: ComponentDefinition): string[] {
     return defn.relations?.destination?.keys ?? []
+}
+
+// ─── State schema ────────────────────────────────────────────────────
+
+/** A displayable column derived from a definition's `state_schema`. */
+export interface StateColumn {
+    key: string
+    label: string
+    format: 'datetime' | 'text'
+}
+
+/** Humanize a snake_case key: `last_run_at` → "Last Run At". */
+function humanizeKey(key: string): string {
+    return key.split('_').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ')
+}
+
+/** Columns for a definition's `state_schema` properties. `_at` keys are datetimes. */
+export function stateColumns(defn: ComponentDefinition): StateColumn[] {
+    const properties = (defn.state_schema?.properties ?? {}) as Record<string, JsonSchemaProperty>
+    return Object.entries(properties).map(([key, prop]) => ({
+        key,
+        label: prop.title ?? humanizeKey(key),
+        format: key.endsWith('_at') ? 'datetime' as const : 'text' as const,
+    }))
 }
 
 // ─── Qualified keys ──────────────────────────────────────────────────

--- a/packages/interloper-app/app/app/types/component.ts
+++ b/packages/interloper-app/app/app/types/component.ts
@@ -125,3 +125,13 @@ export function jobTargetIds(c: ComponentRecord, kind: string): string[] {
         .filter(r => r.dst_kind === kind)
         .map(r => r.dst_id)
 }
+
+// ─── Hook accessors (config fields) ──────────────────────────────────
+
+export function hookEvents(c: ComponentRecord): string[] {
+    return c.config?.events ?? []
+}
+
+export function hookEnabled(c: ComponentRecord): boolean {
+    return c.config?.enabled ?? true
+}

--- a/packages/interloper-app/app/app/utils/table.ts
+++ b/packages/interloper-app/app/app/utils/table.ts
@@ -2,6 +2,9 @@ import { h } from 'vue'
 import { UButton } from '#components'
 import type { Column } from '@tanstack/vue-table'
 import type { TableColumn } from '@nuxt/ui'
+import { stateColumns, type ComponentDefinition } from '~/types/catalog'
+import type { ComponentRecord } from '~/types/component'
+import { formatDate } from '~/utils/time'
 
 /**
  * Builds a clickable column header that toggles sorting (none → asc → desc)
@@ -28,6 +31,36 @@ export function sortableHeader<T>(label: string) {
             onClick: () => column.toggleSorting(column.getIsSorted() === 'asc'),
         })
     }
+}
+
+/**
+ * Table columns for a component row's `state`, derived from its definition's
+ * `state_schema`. Datetime values render via `formatDate`; `_id` values as a
+ * short monospace id.
+ */
+export function stateSchemaColumns(defn: ComponentDefinition | undefined): TableColumn<ComponentRecord>[] {
+    if (!defn) return []
+    return stateColumns(defn).map((col) => {
+        if (col.format === 'datetime') {
+            return {
+                accessorKey: col.key,
+                header: col.label,
+                accessorFn: (row: ComponentRecord) => row.state?.[col.key] ? formatDate(row.state[col.key]) : '—',
+            } as TableColumn<ComponentRecord>
+        }
+        return {
+            accessorKey: col.key,
+            header: col.label,
+            accessorFn: (row: ComponentRecord) => row.state?.[col.key] ?? '',
+            cell: ({ row }: { row: { original: ComponentRecord } }) => {
+                const value = row.original.state?.[col.key]
+                if (value == null || value === '') return '—'
+                const text = String(value)
+                if (col.key.endsWith('_id')) return h('span', { class: 'font-mono text-xs' }, text.substring(0, 8))
+                return text
+            },
+        } as TableColumn<ComponentRecord>
+    })
 }
 
 /**

--- a/packages/interloper-core/src/interloper/component/base.py
+++ b/packages/interloper-core/src/interloper/component/base.py
@@ -103,6 +103,7 @@ class ComponentDefinition(BaseModel):
     description: str = ""
     tags: list[str] = Field(default_factory=list)
     config_schema: dict[str, Any] = Field(default_factory=dict)
+    state_schema: dict[str, Any] = Field(default_factory=dict)
     relations: dict[str, RelationDefinition] = Field(default_factory=dict)
 
 
@@ -591,6 +592,7 @@ class Component(BaseModel):
             description=cls.__doc__ or "",
             tags=list(getattr(cls, "tags", [])),
             config_schema=cls.config_schema(),
+            state_schema=cls.state_model.model_json_schema() if cls.state_model else {},
             relations=cls.relation_definitions(),
         )
 

--- a/packages/interloper-core/tests/hook/test_base.py
+++ b/packages/interloper-core/tests/hook/test_base.py
@@ -48,6 +48,11 @@ class TestDefinition:
         assert il.KINDS.state_model("job") is il.JobState
         assert il.KINDS.state_model("source") is None
 
+    def test_definition_describes_state(self):
+        assert set(il.Hook.definition().state_schema["properties"]) == {"last_fired_at", "last_run_id"}
+        assert set(il.Job.definition().state_schema["properties"]) == {"next_run_at", "last_run_at"}
+        assert il.Source.definition().state_schema == {}
+
     def test_config_schema_hides_relation_fields(self):
         schema = il.Hook.config_schema()
         assert "events" in schema["properties"]


### PR DESCRIPTION
Phase 3 of [ITLPR-87](https://digitlgroup.atlassian.net/browse/ITLPR-87) (epic [ITLPR-79](https://digitlgroup.atlassian.net/browse/ITLPR-79)) — the UI. Follows #130 (kind) and #131 (evaluator).

## Definitions describe state

`ComponentDefinition.state_schema` carries the kind's `state_model` JSON Schema (`{}` when stateless), flowing through the existing catalog routes untouched. This completes the last ITLPR-86 rider: **state columns are now definition-driven** — a `stateColumns()` helper turns the schema into table columns (datetime rendering for `*_at`, short mono ids for `*_id`), the jobs table's hardcoded "Last run" reader is replaced by declarative "Next Run At" / "Last Run At", and the hooks table gets "Last Fired At" / "Last Run Id" without writing a column.

## Hooks page

Modeled on the jobs page: list (name, type, events badges, watches count, enabled, state columns), create/edit wizard — Type (catalog cards for `trigger_hook` / `webhook_hook`) → Watches → Targets (both pickers driven by the definition's `relations.watch/target.kinds`, mixed source/asset/job candidates with kind badges; targets optional for notify-only hooks) → Details (SchemaForm for per-type config + a two-value events multi-select). Nav entry under Scheduling. Realtime rides the existing components-store subscriptions.

## Verification (live, click-through)

Created a `TriggerHook` **through the UI wizard** (watch asset `e`, target asset `a`, events `run_failed`), then queued a partition-less run of `e` (fails by design): the evaluator fired, the cascaded run of `a` appeared, the `hook_fired` event was recorded — and the open hooks page updated its "Last Fired At" / "Last Run Id" columns **live, no reload**, exercising kind → store → API → evaluator → pg_notify → realtime → declarative columns in one pass.

- 824 tests, ruff + ty clean; app lint clean, typecheck 0 TS errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)