### PR TITLE
refactor(core): the target verb moves from Hook to TriggerHook

### DIFF
--- a/docs/features/hooks.md
+++ b/docs/features/hooks.md
@@ -80,6 +80,11 @@ The context carries the event's identity plus the capabilities the scheduler inj
 | `metadata` | Event details (e.g. the run's status). |
 | `trigger` | Capability to queue a run for a component id — how `TriggerHook` acts without any persistence dependency. |
 
+A subclass may extend the relation vocabulary — this is how `TriggerHook` adds the `target`
+verb. Declarations are **extend-only**: they merge over the anchor's vocabulary (redeclaring
+a type replaces its definition; nothing is ever removed), so each class's definition
+advertises exactly the relations it acts on.
+
 Like any component kind, custom hook classes become catalog components by declaring them
 under the entry-point group — see [Catalog](catalog.md).
 

--- a/packages/interloper-app/app/app/components/hooks/Stepper.vue
+++ b/packages/interloper-app/app/app/components/hooks/Stepper.vue
@@ -100,16 +100,20 @@ watch(selectedType, (newKey, oldKey) => {
 })
 
 // ── Stepper ─────────────────────────────────────────────────────
+// Only hook classes whose definition declares the `target` relation
+// (trigger-style hooks) act on other components — the step follows.
+const hasTargets = computed(() => !!selectedDefinition.value?.relations?.target)
+
 const steps = computed<StepperItem[]>(() => {
     const items: StepperItem[] = []
     if (!isEditing.value) {
         items.push({ title: 'Type', icon: 'i-lucide-shapes', slot: 'type' as const })
     }
-    items.push(
-        { title: 'Watches', icon: 'i-lucide-eye', slot: 'watches' as const },
-        { title: 'Targets', icon: 'i-lucide-crosshair', slot: 'targets' as const },
-        { title: 'Details', icon: 'i-lucide-settings-2', slot: 'details' as const },
-    )
+    items.push({ title: 'Watches', icon: 'i-lucide-eye', slot: 'watches' as const })
+    if (hasTargets.value) {
+        items.push({ title: 'Targets', icon: 'i-lucide-crosshair', slot: 'targets' as const })
+    }
+    items.push({ title: 'Details', icon: 'i-lucide-settings-2', slot: 'details' as const })
     return items
 })
 
@@ -123,10 +127,11 @@ const recapRows = computed(() => {
         .map(id => componentsStore.byId(id)?.name)
         .filter(Boolean)
         .join(', ')
-    return [
-        { icon: 'i-lucide-eye', label: 'Watches', value: names(watchIds.value) || 'None' },
-        { icon: 'i-lucide-crosshair', label: 'Targets', value: names(targetIds.value) || 'None' },
-    ]
+    const rows = [{ icon: 'i-lucide-eye', label: 'Watches', value: names(watchIds.value) || 'None' }]
+    if (hasTargets.value) {
+        rows.push({ icon: 'i-lucide-crosshair', label: 'Targets', value: names(targetIds.value) || 'None' })
+    }
+    return rows
 })
 
 // ── Validation ──────────────────────────────────────────────────
@@ -158,7 +163,7 @@ async function submit() {
             },
             relations: {
                 watch: watchIds.value.map(id => ({ dst_id: id })),
-                target: targetIds.value.map(id => ({ dst_id: id })),
+                ...(hasTargets.value ? { target: targetIds.value.map(id => ({ dst_id: id })) } : {}),
             },
         }
 

--- a/packages/interloper-core/src/interloper/catalog/base.py
+++ b/packages/interloper-core/src/interloper/catalog/base.py
@@ -35,7 +35,7 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 from interloper.asset.base import Asset
-from interloper.component import KINDS, Component, ComponentDefinition
+from interloper.component import KINDS, Component, ComponentDefinition, RelationDefinition
 from interloper.errors import ConfigError
 from interloper.settings import AppSettings
 from interloper.source.base import Source
@@ -140,6 +140,27 @@ class Catalog(BaseModel):
             The component definition, or *default* if not found.
         """
         return self.components.get(key, default)
+
+    def vocabulary(self, kind: str, key: str) -> dict[str, RelationDefinition]:
+        """The relation vocabulary governing a persisted component row.
+
+        The class definition is authoritative — a concrete class may extend
+        its anchor's vocabulary (``TriggerHook`` adds ``target``). The
+        kind's anchor is the fallback when the key does not resolve to a
+        matching definition (source-owned assets, drifted keys), keeping
+        validation fail-closed on the kind's shared minimum.
+
+        Args:
+            kind: The row's component kind.
+            key: The row's catalog key.
+
+        Returns:
+            Relation type → definition.
+        """
+        definition = self.get(key)
+        if definition is not None and definition.kind == kind:
+            return definition.relations
+        return KINDS[kind].relation_types
 
     def to_paths(self) -> list[str]:
         """Extract the import paths of all components in the catalog.

--- a/packages/interloper-core/src/interloper/component/base.py
+++ b/packages/interloper-core/src/interloper/component/base.py
@@ -135,12 +135,18 @@ class Component(Serializable):
 
     # -- Construction ----------------------------------------------------------
     def __init_subclass__(cls, **kwargs: Any) -> None:
-        """Auto-derive ``kind`` and infer resource references.
+        """Auto-derive ``kind``, merge the relation vocabulary, infer resources.
 
         ``kind`` is set only for direct children of ``Component``
         (``Source``, ``Asset``, ``Config``, ...).  Further subclasses
         inherit their parent's ``kind`` unless they explicitly declare one.
         (``key`` derivation comes from :class:`Serializable`.)
+
+        A subclass's ``relation_types`` declaration is **extend-only**: it
+        merges over the nearest ancestor's vocabulary (a redeclared type
+        replaces that type's definition; nothing is ever removed), so the
+        anchor stays the kind's shared minimum while concrete classes add
+        the verbs only they act on (``TriggerHook`` adds ``target``).
 
         Annotations typed as ``Resource`` subclasses are automatically
         converted to ``ResourceRef`` descriptors, registering them in
@@ -149,6 +155,12 @@ class Component(Serializable):
         super().__init_subclass__(**kwargs)
         if "kind" not in cls.__dict__ and any(base is Component for base in cls.__bases__):
             cls.kind = to_snake_case(cls.__name__)
+        if own_relations := cls.__dict__.get("relation_types"):
+            for base in cls.__mro__[1:]:
+                inherited = getattr(base, "relation_types", None)
+                if isinstance(inherited, dict):
+                    cls.relation_types = {**inherited, **own_relations}
+                    break
         cls._infer_resource_refs()
 
     @classmethod
@@ -296,16 +308,11 @@ class Component(Serializable):
         The anchor is the base-most class in the MRO that declares the
         kind (``Connection`` for any connection subclass), so any component
         class resolves to the single per-kind authority. The anchor's
-        relation vocabulary is validated on the way out: a relation type
-        naming a field the anchor lacks would silently drop persisted
-        relations on reconstruction.
+        relation vocabulary is validated on the way out — errors propagate
+        from ``_check_relation_fields``.
 
         Returns:
             The anchoring class.
-
-        Raises:
-            ValueError: If a declared relation type's ``field`` does not
-                exist on the anchor.
         """
         anchor = cls
         for base in cls.__mro__:
@@ -316,13 +323,24 @@ class Component(Serializable):
                 and getattr(base, "kind", "") == cls.kind
             ):
                 anchor = base
-        for type_, definition in anchor.relation_types.items():
-            if definition.field not in anchor.model_fields:
-                raise ValueError(
-                    f"Kind '{anchor.kind}' declares relation type '{type_}' with "
-                    f"field '{definition.field}', but {anchor.__name__} has no such field"
-                )
+        anchor._check_relation_fields()
         return anchor
+
+    @classmethod
+    def _check_relation_fields(cls) -> None:
+        """Check the class's relation vocabulary against its fields.
+
+        Raises:
+            ValueError: If a declared relation type's ``field`` does not
+                exist on the class — a misdeclared field would silently
+                drop persisted relations on reconstruction.
+        """
+        for type_, definition in cls.relation_types.items():
+            if definition.field not in cls.model_fields:
+                raise ValueError(
+                    f"'{cls.__name__}' (kind '{cls.kind}') declares relation type '{type_}' "
+                    f"with field '{definition.field}', but has no such field"
+                )
 
     # -- Serialization & resolution --------------------------------------------
     def to_spec(self) -> Spec:
@@ -367,9 +385,15 @@ class Component(Serializable):
     def definition(cls) -> ComponentDefinition:
         """Produce a structured definition of this component class.
 
+        Validates the class's (possibly extended) relation vocabulary on the
+        way out — the per-class counterpart of the anchor check in
+        :meth:`anchor`, run for every declared class at catalog build.
+        Validation errors propagate from ``_check_relation_fields``.
+
         Returns:
             A ComponentDefinition with metadata derived from the class.
         """
+        cls._check_relation_fields()
         return ComponentDefinition(
             kind=cls.kind,
             key=cls.key,
@@ -387,9 +411,10 @@ class Component(Serializable):
     def relation_definitions(cls) -> dict[str, RelationDefinition]:
         """The class's relation vocabulary, enriched with its declared slots.
 
-        The anchor's ``relation_types`` gives the vocabulary; the concrete
-        class contributes the slots — resource slots come from
-        ``resource_types`` here, subclasses layer in what they declare
+        The class's merged ``relation_types`` gives the vocabulary (the
+        anchor's shared minimum plus whatever the concrete class extends it
+        with); the class also contributes the slots — resource slots come
+        from ``resource_types`` here, subclasses layer in what they declare
         (dependency parameters, allowed destination keys).
 
         Returns:

--- a/packages/interloper-core/src/interloper/hook/base.py
+++ b/packages/interloper-core/src/interloper/hook/base.py
@@ -56,21 +56,21 @@ class Hook(Component):
             def fire(self, context: HookContext) -> None:
                 post_message(self.channel, context.metadata)
 
-    Trigger-style hooks act on their ``targets`` through the operator-injected
-    ``context.trigger`` capability.
+    The base hook is only an observer. Hooks that *act on* other components
+    (``TriggerHook``) extend the vocabulary with the ``target`` verb and the
+    ``targets`` field — each class's definition advertises exactly what it
+    acts on.
     """
 
     icon: ClassVar[str] = "carbon:lightning"
     relation_types: ClassVar[dict[str, RelationDefinition]] = {
         "watch": RelationDefinition(kinds=["source", "asset", "job"], field="watches"),
-        "target": RelationDefinition(kinds=["source", "asset", "job"], field="targets"),
         "resource": RelationDefinition(kinds=["connection", "config", "resource"], field="resources", slotted=True),
     }
-    internal_fields: ClassVar[frozenset[str]] = frozenset({"watches", "targets"})
+    internal_fields: ClassVar[frozenset[str]] = frozenset({"watches"})
     state_model: ClassVar[type[BaseModel] | None] = HookState
 
     watches: list[Source | Asset | Job] = Field(default_factory=list)
-    targets: list[Source | Asset | Job] = Field(default_factory=list)
     events: list[str] = Field(
         default_factory=lambda: ["run_failed"],
         description="Run outcomes this hook reacts to (run_completed, run_failed)",

--- a/packages/interloper-core/src/interloper/hook/trigger.py
+++ b/packages/interloper-core/src/interloper/hook/trigger.py
@@ -2,8 +2,16 @@
 
 from __future__ import annotations
 
+from typing import ClassVar
+
+from pydantic import Field
+
+from interloper.asset.base import Asset
+from interloper.component.base import RelationDefinition
 from interloper.errors import ConfigError
 from interloper.hook.base import Hook, HookContext
+from interloper.job.base import Job
+from interloper.source.base import Source
 
 
 class TriggerHook(Hook):
@@ -13,7 +21,17 @@ class TriggerHook(Hook):
     target the downstream workload. Execution goes through the operator's
     injected ``context.trigger`` capability, so the hook itself carries no
     persistence dependency.
+
+    The ``target`` verb lives here, not on the base hook: only trigger-style
+    hooks act on other components, so only their definitions advertise it.
     """
+
+    relation_types: ClassVar[dict[str, RelationDefinition]] = {
+        "target": RelationDefinition(kinds=["source", "asset", "job"], field="targets"),
+    }
+    internal_fields: ClassVar[frozenset[str]] = frozenset({"watches", "targets"})
+
+    targets: list[Source | Asset | Job] = Field(default_factory=list)
 
     def fire(self, context: HookContext) -> None:
         """Trigger a run for every target.

--- a/packages/interloper-core/tests/catalog/test_base.py
+++ b/packages/interloper-core/tests/catalog/test_base.py
@@ -67,3 +67,21 @@ class TestKindContract:
 
         with pytest.raises(ConfigError, match="kind 'fake_unregistered_kind'"):
             _definitions_from([FakeUnregisteredKind])
+
+
+class TestVocabulary:
+    """catalog.vocabulary: class definition first, anchor as drift fallback."""
+
+    def test_class_definition_is_authoritative(self):
+        catalog = Catalog.discover()
+        assert "target" in catalog.vocabulary("hook", "trigger_hook")
+        assert "target" not in catalog.vocabulary("hook", "webhook_hook")
+
+    def test_unresolved_key_falls_back_to_the_anchor(self):
+        catalog = Catalog(components={})
+        assert set(catalog.vocabulary("hook", "gone_hook")) == {"watch", "resource"}
+
+    def test_kind_mismatch_falls_back_to_the_anchor(self):
+        catalog = Catalog.discover()
+        # 'cron_job' resolves, but as a job — a hook row with that key is drift.
+        assert set(catalog.vocabulary("hook", "cron_job")) == {"watch", "resource"}

--- a/packages/interloper-core/tests/component/test_base.py
+++ b/packages/interloper-core/tests/component/test_base.py
@@ -140,6 +140,42 @@ class TestAnchor:
             Broken.anchor()
 
 
+class TestVocabularyMerge:
+    """Subclass ``relation_types`` declarations extend, never replace."""
+
+    def test_subclass_extends_the_inherited_vocabulary(self):
+        assert set(FakeConcreteKind.relation_types) == {"link"}
+
+        class FakeExtendedKind(FakeKind):
+            relation_types: ClassVar[dict[str, RelationDefinition]] = {
+                "wire": RelationDefinition(kinds=["asset"], field="wires"),
+            }
+
+            wires: list[str] = Field(default_factory=list)
+
+        assert set(FakeExtendedKind.relation_types) == {"link", "wire"}
+        # Extend-only: the parent's vocabulary is untouched.
+        assert set(FakeKind.relation_types) == {"link"}
+
+    def test_redeclared_type_replaces_that_definition(self):
+        class FakeNarrowedKind(FakeKind):
+            relation_types: ClassVar[dict[str, RelationDefinition]] = {
+                "link": RelationDefinition(kinds=["job"], field="links", slotted=True),
+            }
+
+        assert FakeNarrowedKind.relation_types["link"].kinds == ["job"]
+        assert FakeKind.relation_types["link"].kinds == ["asset"]
+
+    def test_definition_validates_the_extended_vocabulary(self):
+        class FakeBrokenExtension(FakeKind):
+            relation_types: ClassVar[dict[str, RelationDefinition]] = {
+                "wire": RelationDefinition(kinds=["asset"], field="wiress"),
+            }
+
+        with pytest.raises(ValueError, match="no such field"):
+            FakeBrokenExtension.definition()
+
+
 class TestKinds:
     """The framework's kinds are registered on package import."""
 
@@ -216,6 +252,8 @@ class TestDefinition:
             relation_types: ClassVar[dict[str, RelationDefinition]] = {
                 "wires": RelationDefinition(kinds=["fake_component"], field="wires", slotted=True)
             }
+
+            wires: dict[str, Any] = Field(default_factory=dict)
 
         relations = FakeRelated.definition().relations
         assert relations["wires"].kinds == ["fake_component"]

--- a/packages/interloper-core/tests/hook/test_base.py
+++ b/packages/interloper-core/tests/hook/test_base.py
@@ -37,11 +37,23 @@ class TestDefinition:
         assert il.KINDS["hook"].sensitive is False
 
     def test_vocabulary(self):
+        # The anchor is only an observer; TriggerHook extends it with `target`.
         relations = il.KINDS["hook"].relation_types
         assert relations["watch"].field == "watches"
         assert relations["watch"].kinds == ["source", "asset", "job"]
-        assert relations["target"].field == "targets"
         assert relations["resource"].slotted is True
+        assert "target" not in relations
+
+    def test_trigger_hook_extends_the_vocabulary(self):
+        relations = il.TriggerHook.relation_definitions()
+        assert relations["target"].field == "targets"
+        assert relations["target"].kinds == ["source", "asset", "job"]
+        assert relations["watch"].field == "watches"  # inherited, not replaced
+
+    def test_webhook_hook_has_no_targets(self):
+        assert "target" not in il.WebhookHook.relation_definitions()
+        with pytest.raises(TypeError, match="unexpected keyword argument"):
+            il.WebhookHook(url="https://x.test", targets=[])  # type: ignore[call-arg]  # ty: ignore[unknown-argument]
 
     def test_state_model(self):
         assert il.KINDS["hook"].state_model is il.HookState

--- a/packages/interloper-db/src/interloper_db/hydration.py
+++ b/packages/interloper-db/src/interloper_db/hydration.py
@@ -13,9 +13,10 @@ happens at the call site via ``spec.reconstruct()``::
 
 One builder covers every kind: a component's init is its ``config`` (or its
 decrypted ``data`` for secret-bearing kinds) plus whatever its outgoing
-relations and children contribute. The relation types are constrained per
-kind at the schema level, so the walk needs no kind dispatch — an asset
-simply has no ``target`` relations, a destination no ``dependency`` ones.
+relations and children contribute. Relations are mapped through the row's
+own vocabulary (the catalog class's definition, anchor as drift fallback),
+so the walk needs no kind dispatch — an asset simply has no ``target``
+relations, a destination no ``dependency`` ones.
 
 The Store wraps this pattern in thin ``load_*`` convenience methods, but
 any caller can use the hydrator directly to assemble a spec (for example,
@@ -130,7 +131,7 @@ class Hydrator:
         else:
             init = dict(db_component.config or {})
 
-        vocabulary = KINDS[db_component.kind].relation_types
+        vocabulary = self._catalog.vocabulary(db_component.kind, db_component.key)
         for type_, rels in self._relations_by_type(session, db_component.id).items():
             definition = vocabulary.get(type_)
             if definition is None:

--- a/packages/interloper-db/src/interloper_db/migrations/versions/008_webhook_targets.py
+++ b/packages/interloper-db/src/interloper_db/migrations/versions/008_webhook_targets.py
@@ -1,0 +1,37 @@
+"""Drop target relations from webhook hooks.
+
+The ``target`` verb moved from the ``Hook`` anchor to ``TriggerHook`` —
+only trigger-style hooks act on other components. ``WebhookHook`` rows
+could previously accumulate ``target`` relations (the wizard offered the
+step, the store accepted them, nothing ever consulted them); with the
+vocabulary now class-level, such rows would fail hydration closed, so the
+meaningless relations are removed.
+
+Revision ID: 008
+Revises: 007
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "008"
+down_revision: str | None = "007"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        DELETE FROM component_relations
+        WHERE type = 'target'
+          AND src_id IN (SELECT id FROM components WHERE key = 'webhook_hook')
+        """
+    )
+
+
+def downgrade() -> None:
+    # The relations were meaningless; there is nothing to restore.
+    pass

--- a/packages/interloper-db/src/interloper_db/store/components.py
+++ b/packages/interloper-db/src/interloper_db/store/components.py
@@ -12,9 +12,11 @@ genuinely owns are applied where the row's ``kind`` demands them:
   status cascades through the parent's.
 - **job**: hydration drift-checks every target before reconstruction.
 
-Relation writes are validated against the kind's class-declared relation
-vocabulary (``Component.relation_types``) and stamped with the denormalized
-``org_id``/``src_kind``/``dst_kind`` triple the composite foreign keys verify.
+Relation writes are validated against the row's relation vocabulary — the
+catalog class's definition is authoritative (a concrete class may extend its
+anchor's vocabulary), the kind's anchor is the drift fallback — and stamped
+with the denormalized ``org_id``/``src_kind``/``dst_kind`` triple the
+composite foreign keys verify.
 """
 
 from __future__ import annotations
@@ -221,7 +223,7 @@ class ComponentMixin(StoreBase):
             src = session.get(Component, component_id)
             if not src:
                 raise NotFoundError(f"Component {component_id} not found")
-            self._check_vocabulary(src.kind, type)
+            self._check_vocabulary(src, type)
             relation = _add_relation(session, src, self._resolve_dst(session, src, type, slot, dst_id), type, slot)
             session.commit()
             return relation
@@ -481,7 +483,7 @@ class ComponentMixin(StoreBase):
     ) -> None:
         """Replace the relation types present in *relations* (empty list clears)."""
         for type_, bindings in (relations or {}).items():
-            self._check_vocabulary(src.kind, type_)
+            self._check_vocabulary(src, type_)
             existing = session.exec(
                 select(ComponentRelation).where(ComponentRelation.src_id == src.id, ComponentRelation.type == type_)
             ).all()
@@ -491,23 +493,21 @@ class ComponentMixin(StoreBase):
             for dst_id, slot in bindings:
                 _add_relation(session, src, self._resolve_dst(session, src, type_, slot, dst_id), type_, slot)
 
-    @staticmethod
-    def _check_vocabulary(kind: str, type_: str) -> None:
-        """Reject relation types the kind's class vocabulary doesn't declare."""
-        vocabulary = il.KINDS[kind].relation_types
+    def _check_vocabulary(self, src: Component, type_: str) -> None:
+        """Reject relation types the row's class vocabulary doesn't declare."""
+        vocabulary = self._catalog.vocabulary(src.kind, src.key)
         if type_ not in vocabulary:
             raise ConfigError(
-                f"Components of kind '{kind}' declare no '{type_}' relations "
+                f"Components of kind '{src.kind}' ('{src.key}') declare no '{type_}' relations "
                 f"(allowed: {sorted(vocabulary) or 'none'})"
             )
 
-    @staticmethod
-    def _resolve_dst(session: Session, src: Component, type_: str, slot: str, dst_id: UUID) -> Component:
+    def _resolve_dst(self, session: Session, src: Component, type_: str, slot: str, dst_id: UUID) -> Component:
         """Resolve a relation destination, enforcing existence, same-org, and the vocabulary's shape."""
         dst = session.get(Component, dst_id)
         if dst is None or dst.org_id != src.org_id:
             raise NotFoundError(f"Component {dst_id} not found (relation '{type_}'{f'/{slot}' if slot else ''})")
-        definition = il.KINDS[src.kind].relation_types[type_]
+        definition = self._catalog.vocabulary(src.kind, src.key)[type_]
         if dst.kind not in definition.kinds:
             raise ConfigError(
                 f"Relation '{type_}' on kind '{src.kind}' may not point at a '{dst.kind}' "

--- a/packages/interloper-db/tests/store/test_components.py
+++ b/packages/interloper-db/tests/store/test_components.py
@@ -213,6 +213,18 @@ class TestRelationKindEnforcement:
 
         return Store(catalog=il.Catalog.from_assets([DemoSource, demo_asset]))
 
+    def test_class_vocabulary_governs_writes(self, demo_store: Store):
+        db_job = demo_store.create_component(_ORG, kind="job", key="cron_job", name="J")
+        # TriggerHook declares `target`; WebhookHook does not.
+        ok = demo_store.create_component(
+            _ORG, kind="hook", key="trigger_hook", name="T", relations={"target": [(db_job.id, "")]}
+        )
+        assert ok.id is not None
+        with pytest.raises(ConfigError, match="'webhook_hook'.*declare no 'target' relations"):
+            demo_store.create_component(
+                _ORG, kind="hook", key="webhook_hook", name="W", relations={"target": [(db_job.id, "")]}
+            )
+
     def test_relation_to_disallowed_kind_rejected(self, demo_store: Store):
         db_source = demo_store.create_component(_ORG, kind="source", key="demo_source", name="Demo")
         db_job = demo_store.create_component(_ORG, kind="job", key="cron_job", name="Job")


### PR DESCRIPTION
## What

The base `Hook` is only an observer (`watch` + `resource`); **`TriggerHook` owns the concept of targets** — the `target` relation verb and the `targets` field live on it. Each hook class's definition now advertises exactly what it acts on:

- the wizard's Targets step appears only for trigger-style hooks (definition-driven: gated on `definition.relations.target`),
- the store rejects `target` relations on `webhook_hook` rows at write time,
- `WebhookHook(targets=…)` raises via the strict-init guard.

Closes [ITLPR-88](https://digitlgroup.atlassian.net/browse/ITLPR-88).

## The enabler: class-level vocabulary

1. **Extend-only MRO merge** — a subclass's `relation_types` declaration merges over the nearest ancestor's vocabulary: types can be added or redefined, never removed; the anchor stays the kind's shared minimum. Parent dicts are untouched.
2. **`Catalog.vocabulary(kind, key)`** — the class definition is authoritative; the kind's anchor is the fallback when the key doesn't resolve to a matching definition (source-owned assets, drifted keys — fail-closed on the shared minimum). Consumed by the store's relation validation (`_check_vocabulary`, `_resolve_dst`) and the hydrator's init builder.
3. **Per-class field validation** — the field-exists check runs for every concrete class at `definition()`/catalog build, not just on anchors (it immediately caught a sloppy test fixture).

Trade accepted (per the ticket): a permanent two-level lookup rule — *class definition is authoritative, anchor is the fallback* — replaces "the anchor is the vocabulary". `sensitive`/`runnable` stay kind-level.

Migration 008 drops the meaningless `target` relations webhook hooks could previously accumulate (they would otherwise fail hydration closed under the class-level vocabulary).

## Testing

- 866 passed, ruff + ty clean, frontend lint/typecheck clean, docs build clean.
- New tests: extend-only merge semantics (adds, replaces-in-place, parent untouched, broken extensions rejected at `definition()`), `Catalog.vocabulary` (authoritative / unresolved-key fallback / kind-mismatch fallback), store write enforcement (`target` accepted on `trigger_hook`, rejected on `webhook_hook`), `WebhookHook` strict-init.
- ⚠️ The wizard change is typechecked but **not click-through-tested in a browser** — recommend a quick live check (create a WebhookHook: no Targets step; create/edit a TriggerHook: step present) before merging.

Note: the PR also lists main's unpushed `docs: hooks feature page` commit until local main is pushed.

By Digitl