### PR TITLE
feat: per-instance asset table names via source alias_field

### DIFF
--- a/packages/interloper-assets/src/interloper_assets/amazon_ads/source.py
+++ b/packages/interloper-assets/src/interloper_assets/amazon_ads/source.py
@@ -182,6 +182,10 @@ class AmazonAds(il.Source):
         value_key="profile_id",
     )
 
+    def asset_table(self, asset: il.Asset) -> str:
+        """Suffix tables with the profile_id so instances materialize side by side."""
+        return f"{asset.key}__{self.profile_id}"
+
     @il.asset(schema=schemas.Profiles, tags=["Entity"])
     def profiles(self, connection: AmazonAdsConnection) -> list[dict[str, Any]]:
         """Advertising profiles associated with the account."""

--- a/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/source.py
+++ b/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/source.py
@@ -41,3 +41,7 @@ class AmazonSellingPartner(il.Source):
         ],
         description="Amazon marketplace",
     )
+
+    def asset_table(self, asset: il.Asset) -> str:
+        """Suffix tables with the marketplace so instances materialize side by side."""
+        return f"{asset.key}__{self.marketplace}"

--- a/packages/interloper-assets/src/interloper_assets/awin/source.py
+++ b/packages/interloper-assets/src/interloper_assets/awin/source.py
@@ -113,6 +113,10 @@ class Awin(il.Source):
         description="Awin advertiser account",
     )
 
+    def asset_table(self, asset: il.Asset) -> str:
+        """Suffix tables with the advertiser_id so instances materialize side by side."""
+        return f"{asset.key}__{self.advertiser_id}"
+
     @il.asset(
         schema=Transactions,
         partitioning=il.TimePartitionConfig(column="date"),

--- a/packages/interloper-assets/src/interloper_assets/bing_ads/source.py
+++ b/packages/interloper-assets/src/interloper_assets/bing_ads/source.py
@@ -177,6 +177,10 @@ class BingAds(il.Source):
         value_key="account_id",
     )
 
+    def asset_table(self, asset: il.Asset) -> str:
+        """Suffix tables with the account_id so instances materialize side by side."""
+        return f"{asset.key}__{self.account_id}"
+
     @il.asset(
         schema=AdsStats,
         partitioning=il.TimePartitionConfig(column="time_period"),

--- a/packages/interloper-assets/src/interloper_assets/criteo/source.py
+++ b/packages/interloper-assets/src/interloper_assets/criteo/source.py
@@ -64,6 +64,10 @@ class Criteo(il.Source):
         description="Criteo advertiser account",
     )
 
+    def asset_table(self, asset: il.Asset) -> str:
+        """Suffix tables with the advertiser_id so instances materialize side by side."""
+        return f"{asset.key}__{self.advertiser_id}"
+
     @il.asset(
         schema=AdsStats,
         partitioning=il.TimePartitionConfig(column="day"),

--- a/packages/interloper-assets/src/interloper_assets/facebook_ads/source.py
+++ b/packages/interloper-assets/src/interloper_assets/facebook_ads/source.py
@@ -287,6 +287,10 @@ class FacebookAds(il.Source):
         description="Facebook Ads account ID",
     )
 
+    def asset_table(self, asset: il.Asset) -> str:
+        """Suffix tables with the account_id so instances materialize side by side."""
+        return f"{asset.key}__{self.account_id}"
+
     @il.asset(
         schema=schemas.CampaignsStats,
         partitioning=il.TimePartitionConfig(column="date_start"),

--- a/packages/interloper-assets/src/interloper_assets/facebook_insights/source.py
+++ b/packages/interloper-assets/src/interloper_assets/facebook_insights/source.py
@@ -20,3 +20,7 @@ class FacebookInsights(il.Source):
         value_key="id",
         description="Facebook Page to retrieve insights for",
     )
+
+    def asset_table(self, asset: il.Asset) -> str:
+        """Suffix tables with the page_id so instances materialize side by side."""
+        return f"{asset.key}__{self.page_id}"

--- a/packages/interloper-assets/src/interloper_assets/google_ads/source.py
+++ b/packages/interloper-assets/src/interloper_assets/google_ads/source.py
@@ -24,3 +24,7 @@ class GoogleAds(il.Source):
         default=None,
         description="Manager account customer ID (required if accessing through a manager account)",
     )
+
+    def asset_table(self, asset: il.Asset) -> str:
+        """Suffix tables with the customer_id so instances materialize side by side."""
+        return f"{asset.key}__{self.customer_id}"

--- a/packages/interloper-assets/src/interloper_assets/impact/source.py
+++ b/packages/interloper-assets/src/interloper_assets/impact/source.py
@@ -165,6 +165,10 @@ class Impact(il.Source):
         description="Impact program (campaign) ID",
     )
 
+    def asset_table(self, asset: il.Asset) -> str:
+        """Suffix tables with the program_id so instances materialize side by side."""
+        return f"{asset.key}__{self.program_id}"
+
     @il.asset(
         schema=schemas.Actions,
         partitioning=il.TimePartitionConfig(column="date"),

--- a/packages/interloper-assets/src/interloper_assets/instagram_insights/source.py
+++ b/packages/interloper-assets/src/interloper_assets/instagram_insights/source.py
@@ -17,3 +17,7 @@ class InstagramInsights(il.Source):
         value_key="id",
         description="Instagram Business or Creator account ID",
     )
+
+    def asset_table(self, asset: il.Asset) -> str:
+        """Suffix tables with the account_id so instances materialize side by side."""
+        return f"{asset.key}__{self.account_id}"

--- a/packages/interloper-assets/src/interloper_assets/linkedin_ads/source.py
+++ b/packages/interloper-assets/src/interloper_assets/linkedin_ads/source.py
@@ -22,3 +22,7 @@ class LinkedinAds(il.Source):
         value_key="id",
         description="LinkedIn Ads account",
     )
+
+    def asset_table(self, asset: il.Asset) -> str:
+        """Suffix tables with the account_id so instances materialize side by side."""
+        return f"{asset.key}__{self.account_id}"

--- a/packages/interloper-assets/src/interloper_assets/linkedin_organic/source.py
+++ b/packages/interloper-assets/src/interloper_assets/linkedin_organic/source.py
@@ -22,3 +22,7 @@ class LinkedinOrganic(il.Source):
         value_key="id",
         description="LinkedIn Organization page ID",
     )
+
+    def asset_table(self, asset: il.Asset) -> str:
+        """Suffix tables with the organization_id so instances materialize side by side."""
+        return f"{asset.key}__{self.organization_id}"

--- a/packages/interloper-assets/src/interloper_assets/pinterest_ads/source.py
+++ b/packages/interloper-assets/src/interloper_assets/pinterest_ads/source.py
@@ -22,3 +22,7 @@ class PinterestAds(il.Source):
     )
 
     # --- Entity assets ---
+
+    def asset_table(self, asset: il.Asset) -> str:
+        """Suffix tables with the account_id so instances materialize side by side."""
+        return f"{asset.key}__{self.account_id}"

--- a/packages/interloper-assets/src/interloper_assets/search_console/source.py
+++ b/packages/interloper-assets/src/interloper_assets/search_console/source.py
@@ -15,3 +15,7 @@ class SearchConsole(il.Source):
     """Google Search Console integration for search analytics data."""
 
     site_url: str = il.InputField(description="Site URL (e.g. https://example.com/ or sc-domain:example.com)")
+
+    def asset_table(self, asset: il.Asset) -> str:
+        """Suffix tables with the site_url so instances materialize side by side."""
+        return f"{asset.key}__{self.site_url}"

--- a/packages/interloper-assets/src/interloper_assets/snapchat_ads/source.py
+++ b/packages/interloper-assets/src/interloper_assets/snapchat_ads/source.py
@@ -129,6 +129,10 @@ class SnapchatAds(il.Source):
 
     # --- Time-series reports (SnapchatStatsNormalizer from the source) ---
 
+    def asset_table(self, asset: il.Asset) -> str:
+        """Suffix tables with the account_id so instances materialize side by side."""
+        return f"{asset.key}__{self.account_id}"
+
     @il.asset(schema=AdsStats, partitioning=il.TimePartitionConfig(column="date"), tags=["Report"])
     async def ads_stats(self, context: il.ExecutionContext, connection: SnapchatAdsConnection) -> list[_RECORD]:
         """Ad-level performance with core, additional, and conversion metrics."""

--- a/packages/interloper-assets/src/interloper_assets/tiktok_ads/source.py
+++ b/packages/interloper-assets/src/interloper_assets/tiktok_ads/source.py
@@ -134,6 +134,10 @@ class TiktokAds(il.Source):
 
     # --- Time-series reports (TiktokStatsNormalizer from the source) ---
 
+    def asset_table(self, asset: il.Asset) -> str:
+        """Suffix tables with the advertiser_id so instances materialize side by side."""
+        return f"{asset.key}__{self.advertiser_id}"
+
     @il.asset(schema=AdsStats, partitioning=il.TimePartitionConfig(column="date"), tags=["Report"])
     async def ads_stats(self, context: il.ExecutionContext, connection: TiktokAdsConnection) -> list[dict[str, Any]]:
         """Ad-level performance with basic metrics including spend, clicks, and conversions."""

--- a/packages/interloper-core/src/interloper/asset/base.py
+++ b/packages/interloper-core/src/interloper/asset/base.py
@@ -26,7 +26,7 @@ from interloper.utils import concurrency
 from interloper.utils.concurrency import invoke
 from interloper.utils.data import is_empty
 from interloper.utils.imports import get_object_path
-from interloper.utils.text import to_label
+from interloper.utils.text import to_identifier, to_label
 
 if TYPE_CHECKING:
     from interloper.dag import DAG
@@ -202,6 +202,17 @@ class Asset(Component):
         if self._source is not None:
             return f"{self._source.key}.{self.key}"
         return self.key
+
+    @property
+    def table(self) -> str:
+        """The physical table (or leaf) name this asset materializes to.
+
+        Derived, never stored: the owning source composes it (see
+        :meth:`~interloper.source.base.Source.asset_table`) and the result is
+        coerced to a valid identifier. Standalone assets use their class key.
+        """
+        raw = self._source.asset_table(self) if self._source is not None else type(self).key
+        return to_identifier(raw)
 
     @classmethod
     def classpath(cls) -> str:

--- a/packages/interloper-core/src/interloper/destination/base.py
+++ b/packages/interloper-core/src/interloper/destination/base.py
@@ -106,7 +106,7 @@ class Destination(Component):
         value; each value is the number of rows in that partition.
 
         Args:
-            context: Destination context (uses ``asset.id``, ``asset.dataset``,
+            context: Destination context (uses ``asset.table``, ``asset.dataset``,
                 and ``asset.partitioning``).
 
         Returns:

--- a/packages/interloper-core/src/interloper/destination/csv.py
+++ b/packages/interloper-core/src/interloper/destination/csv.py
@@ -17,8 +17,8 @@ from interloper.representation import Representation
 class CSVDestination(PartitionedDestination):
     """Destination that reads and writes CSV files on the local filesystem.
 
-    Data is stored under ``{base_path}/{dataset}/{asset_key}/data.csv``
-    (or ``{base_path}/{asset_key}/data.csv`` when no dataset is set).
+    Data is stored under ``{base_path}/{dataset}/{table}/data.csv``
+    (or ``{base_path}/{table}/data.csv`` when no dataset is set).
     Partitioned assets add a ``{column}={id}`` subdirectory; the partition
     dispatch (including window splitting) comes from
     :class:`PartitionedDestination`.
@@ -35,7 +35,7 @@ class CSVDestination(PartitionedDestination):
 
     def _asset_path(self, context: IOContext) -> Path:
         """Return the base directory for an asset."""
-        return Path(self.base_path) / (context.asset.dataset or "") / type(context.asset).key
+        return Path(self.base_path) / (context.asset.dataset or "") / context.asset.table
 
     def _scope_path(self, context: IOContext, partition: Partition | None) -> Path:
         """Return the data file path for a scope.

--- a/packages/interloper-core/src/interloper/destination/database.py
+++ b/packages/interloper-core/src/interloper/destination/database.py
@@ -37,7 +37,7 @@ class DatabaseDestination(PartitionedDestination):
     implement a small set of abstract hooks for the actual database operations.
 
     The target table name and schema are derived from the asset at call time
-    (``asset.id`` -> table, ``asset.dataset`` -> schema) and passed as
+    (``asset.table`` -> table, ``asset.dataset`` -> schema) and passed as
     parameters to every hook.  The destination instance itself holds **no** table
     identity and can be safely shared across multiple assets.
 
@@ -106,7 +106,7 @@ class DatabaseDestination(PartitionedDestination):
         """Return row counts grouped by the asset's partition column."""
         assert context.asset.partitioning is not None
         return self._count_by_partition(
-            type(context.asset).key,
+            context.asset.table,
             context.asset.dataset or None,
             context.asset.partitioning.column,
         )
@@ -152,7 +152,7 @@ class DatabaseDestination(PartitionedDestination):
         inserting; with ``APPEND``, rows are inserted without any prior
         deletion.
         """
-        table = type(context.asset).key
+        table = context.asset.table
         schema = context.asset.dataset or None
 
         if is_empty(data):
@@ -199,7 +199,7 @@ class DatabaseDestination(PartitionedDestination):
         Returns:
             The scope's rows, materialized into the read representation.
         """
-        table = type(context.asset).key
+        table = context.asset.table
         schema = context.asset.dataset or None
         if partition is None:
             return self._from_rows(self._select_all(table, schema))

--- a/packages/interloper-core/src/interloper/destination/file.py
+++ b/packages/interloper-core/src/interloper/destination/file.py
@@ -15,7 +15,7 @@ from interloper.destination.decorator import destination
 class FileDestination(Destination):
     """Destination that reads and writes pickle files on the local filesystem.
 
-    Data is stored under ``{base_path}/{dataset}/{asset_key}/data.pkl``.
+    Data is stored under ``{base_path}/{dataset}/{table}/data.pkl``.
     """
 
     base_path: str = ""
@@ -26,8 +26,8 @@ class FileDestination(Destination):
         Returns:
             The resolved path to the data file.
         """
-        dataset = context.asset.dataset or type(context.asset).key
-        return Path(self.base_path) / dataset / type(context.asset).key / "data.pkl"
+        dataset = context.asset.dataset or context.asset.table
+        return Path(self.base_path) / dataset / context.asset.table / "data.pkl"
 
     def read(self, context: IOContext) -> Any:
         """Unpickle data from a file.
@@ -74,8 +74,8 @@ class FileDestination(Destination):
         """
         assert context.asset.partitioning is not None
         column = context.asset.partitioning.column
-        dataset = context.asset.dataset or type(context.asset).key
-        base_path = Path(self.base_path) / dataset / type(context.asset).key
+        dataset = context.asset.dataset or context.asset.table
+        base_path = Path(self.base_path) / dataset / context.asset.table
 
         counts: dict[str, int] = {}
         if not base_path.exists():

--- a/packages/interloper-core/src/interloper/destination/memory.py
+++ b/packages/interloper-core/src/interloper/destination/memory.py
@@ -13,7 +13,7 @@ from interloper.partitioning.base import Partition, PartitionConfig
 
 @destination(name="Memory")
 class MemoryDestination(PartitionedDestination):
-    """Destination that stores data in a class-level dict keyed by ``{dataset}/{key}/{partition}``.
+    """Destination that stores data in a class-level dict keyed by ``{dataset}/{table}/{partition}``.
 
     All instances share a single ``_storage`` dict so data written by one
     asset is visible to others.  The partition dispatch (including window
@@ -47,7 +47,7 @@ class MemoryDestination(PartitionedDestination):
         Returns:
             The constructed storage key string.
         """
-        return self._build_key(type(context.asset).key, context.asset.dataset, context.asset.partitioning, partition)
+        return self._build_key(context.asset.table, context.asset.dataset, context.asset.partitioning, partition)
 
     def _build_key(
         self,
@@ -75,7 +75,7 @@ class MemoryDestination(PartitionedDestination):
         """Return row counts grouped by partition from in-memory storage."""
         assert context.asset.partitioning is not None
         column = context.asset.partitioning.column
-        prefix = self._build_key(type(context.asset).key, context.asset.dataset, None, None)
+        prefix = self._build_key(context.asset.table, context.asset.dataset, None, None)
         partition_prefix = f"{prefix}/{column}="
 
         counts: dict[str, int] = {}

--- a/packages/interloper-core/src/interloper/source/base.py
+++ b/packages/interloper-core/src/interloper/source/base.py
@@ -17,7 +17,7 @@ from interloper.resource import Resource
 from interloper.resource.fields import InputField, SelectField, validate_fetch_field_providers
 from interloper.serializable import IgnoredDescriptor, Spec, dump_spec_value
 from interloper.utils.imports import get_object_path
-from interloper.utils.text import to_label
+from interloper.utils.text import to_label, validate_key
 
 
 class AssetRef(IgnoredDescriptor):
@@ -388,10 +388,31 @@ class Source(Component):
                 return defn
         raise KeyError(f"Source '{cls.key}' has no asset with key '{key}'")
 
+    def asset_table(self, asset: Asset) -> str:
+        """Physical table name for one of this source's assets.
+
+        Override to give each instance of the source its own tables — e.g.
+        suffix the asset key with the account id the instance is configured
+        for, so two accounts materialize side by side in one dataset instead
+        of overwriting each other's data::
+
+            def asset_table(self, asset: il.Asset) -> str:
+                return f"{asset.key}__{self.account_id}"
+
+        Keep the ``{asset.key}__{suffix}`` shape so a source's tables stay
+        wildcard-queryable per asset. The return value is coerced to a valid
+        identifier by :attr:`Asset.table`.
+
+        Returns:
+            The physical table name for the asset (defaults to the asset key).
+        """
+        return asset.key
+
     def _resolve(self) -> None:
         """Apply source-level defaults to assets that don't define their own."""
         if not self.dataset:
             self.dataset = self.key
+        validate_key(self.dataset)
 
         siblings: dict[str, Asset] = {type(a).key: a for a in self.assets}
 
@@ -399,6 +420,7 @@ class Source(Component):
             asset._source = self
             if not asset.dataset:
                 asset.dataset = self.dataset
+            validate_key(asset.table)
             if not asset.default_destination_key and self.default_destination_key:
                 asset.default_destination_key = self.default_destination_key
             if not asset.destinations and self.destinations:
@@ -529,6 +551,11 @@ class Source(Component):
         if destinations is not None:
             copy.destinations = destinations if isinstance(destinations, list) else [destinations]
         if dataset is not None:
+            # Assets resolved their dataset at construction: re-point those that
+            # inherited the source's, preserving per-asset overrides.
+            for a in copy.assets:
+                if a.dataset == copy.dataset:
+                    a.dataset = dataset
             copy.dataset = dataset
         if default_destination_key is not None:
             copy.default_destination_key = default_destination_key

--- a/packages/interloper-core/src/interloper/utils/__init__.py
+++ b/packages/interloper-core/src/interloper/utils/__init__.py
@@ -3,7 +3,7 @@
 from interloper.utils.concurrency import bounded_gather, invoke, run
 from interloper.utils.data import is_empty
 from interloper.utils.imports import get_object_path, import_from_path
-from interloper.utils.text import to_label, to_slug_case, to_snake_case, validate_key
+from interloper.utils.text import to_identifier, to_label, to_slug_case, to_snake_case, validate_key
 
 __all__ = [
     "bounded_gather",
@@ -12,6 +12,7 @@ __all__ = [
     "invoke",
     "is_empty",
     "run",
+    "to_identifier",
     "to_label",
     "to_slug_case",
     "to_snake_case",

--- a/packages/interloper-core/src/interloper/utils/text.py
+++ b/packages/interloper-core/src/interloper/utils/text.py
@@ -16,6 +16,8 @@ _LABEL_BOUNDARY = re.compile(r"([a-z])([A-Z])")
 _SNAKE_NON_ALNUM = re.compile(r"[^a-zA-Z0-9]+")
 _SNAKE_COLLAPSE = re.compile(r"_+")
 
+_IDENTIFIER_INVALID = re.compile(r"[^a-z0-9_]+")
+
 
 def validate_key(key: str) -> None:
     """Validate that *key* starts with a letter and contains only letters, numbers, and underscores.
@@ -26,6 +28,24 @@ def validate_key(key: str) -> None:
     if not _KEY_RE.match(key):
         msg = f"Key '{key}' is invalid. Must start with a letter and contain only letters, numbers, and underscores."
         raise ValueError(msg)
+
+
+def to_identifier(text: str) -> str:
+    """Coerce text into a lowercase identifier (letters, digits, underscores).
+
+    Unlike :func:`to_snake_case`, existing underscores are preserved verbatim
+    (including ``__`` runs used as name separators) — only invalid characters
+    are replaced.
+
+    Args:
+        text: The text to coerce.
+
+    Returns:
+        The coerced text.
+    """
+    if not text:
+        return ""
+    return _IDENTIFIER_INVALID.sub("_", text.lower()).strip("_")
 
 
 def to_slug_case(text: str) -> str:

--- a/packages/interloper-core/tests/asset/test_base.py
+++ b/packages/interloper-core/tests/asset/test_base.py
@@ -137,6 +137,15 @@ class TestIdentity:
         asset._source = source
         assert asset.qualified_key == f"{FakeParentSource.key}.{type(asset).key}"
 
+    def test_table_standalone_equals_key(self):
+        assert FakeAsset().table == "fake_asset"
+
+    def test_table_when_source_attached_uses_asset_table(self):
+        source = FakeParentSource()
+        asset = FakeSourceOwnedAsset()
+        asset._source = source
+        assert asset.table == source.asset_table(asset) == type(asset).key
+
     def test_data_default_raises_not_implemented(self):
         with pytest.raises(NotImplementedError):
             FakeAsset().data()

--- a/packages/interloper-core/tests/destination/test_database.py
+++ b/packages/interloper-core/tests/destination/test_database.py
@@ -50,6 +50,18 @@ def plain_asset() -> list:  # noqa: D103
     return []
 
 
+class AliasedSource(il.Source):
+    """Source whose assets materialize under instance-suffixed table names."""
+
+    account_id: str = ""
+
+    class AliasedRows(il.Asset):
+        """Asset carrying the instance discriminator in its table name."""
+
+    def asset_table(self, asset: il.Asset) -> str:
+        return f"{asset.key}__{self.account_id}"
+
+
 def make_ctx(asset: il.Asset, partition_or_window=None, schema=None) -> IOContext:  # noqa: D103
     return IOContext(asset=asset, partition_or_window=partition_or_window, schema=schema)
 
@@ -93,6 +105,17 @@ class TestWrite:
         dest = RecordingDB(id="db")
         dest.write(make_ctx(plain_asset()), [])
         assert dest.calls == []
+
+    def test_write_targets_instance_aliased_table(self):
+        source = AliasedSource(account_id="42")
+        (asset,) = source.assets
+        dest = RecordingDB(id="db")
+        rows = [{"a": 1}]
+        dest.write(make_ctx(asset), rows)
+        assert dest.calls == [
+            ("delete_all", ("aliased_rows__42", "aliased_source")),
+            ("insert", ("aliased_rows__42", "aliased_source", rows)),
+        ]
 
     def test_dataframe_converts_via_null_safe_fallback(self):
         pd = pytest.importorskip("pandas")

--- a/packages/interloper-core/tests/source/test_base.py
+++ b/packages/interloper-core/tests/source/test_base.py
@@ -63,6 +63,18 @@ class FakeSourceWithAssets(il.Source):
             return None
 
 
+class FakeAliasedSource(il.Source):
+    """Source whose asset tables carry the instance's account id."""
+
+    account_id: str = ""
+
+    class FakeAliased(il.Asset):
+        """Asset whose table name carries the source instance discriminator."""
+
+    def asset_table(self, asset: il.Asset) -> str:
+        return f"{asset.key}__{self.account_id}" if self.account_id else asset.key
+
+
 # -- Identity and class metadata -----------------------------------------------
 
 
@@ -92,6 +104,59 @@ class TestIdentity:
 
     def test_asset_types_default_empty_list(self):
         assert FakeSource.asset_types == []
+
+    def test_invalid_dataset_raises_at_init(self):
+        # ``validate_key`` raises a ValueError, so pydantic wraps it at init time.
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="invalid"):
+            FakeSource(dataset="bad dataset!")
+
+
+# -- Per-instance table names ----------------------------------------------------
+
+
+class TestAssetTable:
+    def test_table_defaults_to_asset_key(self):
+        source = FakeSourceWithAssets()
+        assert [a.table for a in source.assets] == ["fake_first", "fake_second"]
+
+    def test_asset_table_override_suffixes_table(self):
+        source = FakeAliasedSource(account_id="123")
+        (asset,) = source.assets
+        assert source.asset_table(asset) == "fake_aliased__123"
+        assert asset.table == "fake_aliased__123"
+        # The logical identity is untouched — only the physical name varies.
+        assert type(asset).key == "fake_aliased"
+        assert asset.dataset == "fake_aliased_source"
+
+    def test_asset_table_is_sanitized(self):
+        source = FakeAliasedSource(account_id="act_123-DE")
+        (asset,) = source.assets
+        assert asset.table == "fake_aliased__act_123_de"
+
+    def test_default_asset_table_is_the_asset_key(self):
+        source = FakeAliasedSource()
+        (asset,) = source.assets
+        assert asset.table == "fake_aliased"
+
+    def test_table_survives_spec_round_trip(self):
+        source = FakeAliasedSource(account_id="123")
+        restored = FakeAliasedSource.from_spec(source.to_spec())
+        assert [a.table for a in restored.assets] == ["fake_aliased__123"]
+
+    def test_invalid_asset_table_raises_at_init(self):
+        # The composed name is validated during ``_resolve``; ``validate_key``
+        # raises a ValueError, so pydantic wraps it at init time.
+        from pydantic import ValidationError
+
+        class FakeBadTableSource(FakeAliasedSource):
+            def asset_table(self, asset: il.Asset) -> str:
+                """Return a name that sanitizes to an invalid identifier."""
+                return f"123_{asset.key}"
+
+        with pytest.raises(ValidationError, match="invalid"):
+            FakeBadTableSource()
 
 
 # -- Definition metadata -------------------------------------------------------
@@ -306,6 +371,16 @@ class TestReconfiguration:
 
     def test_override_dataset(self):
         assert FakeSourceWithAssets()(dataset="override").dataset == "override"
+
+    def test_override_dataset_repropagates_to_assets(self):
+        reconfigured = FakeSourceWithAssets()(dataset="override")
+        assert all(a.dataset == "override" for a in reconfigured.assets)
+
+    def test_override_dataset_preserves_per_asset_overrides(self):
+        source = FakeSourceWithAssets()
+        source.assets[0].dataset = "pinned"
+        reconfigured = source(dataset="override")
+        assert [a.dataset for a in reconfigured.assets] == ["pinned", "override"]
 
     def test_override_destination(self):
         new_dest = FakeDestination()

--- a/packages/interloper-core/tests/utils/test_text.py
+++ b/packages/interloper-core/tests/utils/test_text.py
@@ -1,0 +1,37 @@
+"""Tests for ``interloper.utils.text``."""
+
+import pytest
+
+from interloper.utils.text import to_identifier, validate_key
+
+
+class TestToIdentifier:
+    def test_valid_identifier_passes_through(self):
+        assert to_identifier("ads_stats__act_123") == "ads_stats__act_123"
+
+    def test_lowercases(self):
+        assert to_identifier("Act_123DE") == "act_123de"
+
+    def test_invalid_runs_collapse_to_single_underscore(self):
+        assert to_identifier("act 123-DE/x") == "act_123_de_x"
+
+    def test_double_underscore_separator_preserved(self):
+        # Unlike ``to_snake_case``, ``__`` runs are kept verbatim — they
+        # separate the asset key from the instance alias in table names.
+        assert to_identifier("ads__act-1") == "ads__act_1"
+
+    def test_edges_stripped(self):
+        assert to_identifier("-act_123-") == "act_123"
+
+    def test_empty_returns_empty(self):
+        assert to_identifier("") == ""
+
+
+class TestValidateKey:
+    def test_valid_key_passes(self):
+        validate_key("ads_stats__123")
+
+    @pytest.mark.parametrize("key", ["", "1ads", "_ads", "ads-stats", "ads stats"])
+    def test_invalid_key_raises(self, key):
+        with pytest.raises(ValueError, match="invalid"):
+            validate_key(key)

--- a/packages/interloper-db/src/interloper_db/store/components.py
+++ b/packages/interloper-db/src/interloper_db/store/components.py
@@ -96,6 +96,7 @@ class ComponentMixin(StoreBase):
             session.add(db_component)
             session.flush()
             if kind == "source":
+                self._check_source_collision(session, db_component)
                 self._ensure_children(session, db_component, children)
             elif children is not None:
                 raise ConfigError(f"Components of kind '{kind}' have no children")
@@ -171,6 +172,7 @@ class ComponentMixin(StoreBase):
             if config is not None:
                 self._apply_config(db_component, config, encrypted)
             if db_component.kind == "source":
+                self._check_source_collision(session, db_component)
                 self._ensure_children(session, db_component, children)
             elif children is not None:
                 raise ConfigError(f"Components of kind '{db_component.kind}' have no children")
@@ -355,6 +357,53 @@ class ComponentMixin(StoreBase):
                 )
             raw = self._encrypt(raw)
         return raw, should_encrypt
+
+    def _check_source_collision(self, session: Session, db_source: Component) -> None:
+        """Reject a source instance whose materialization target collides with a sibling.
+
+        Two instances of the same source class write to the same physical
+        ``dataset.table`` set unless they differ in ``dataset`` or in what
+        the class's ``asset_table`` derives from their config — such an
+        instance would silently overwrite the sibling's data on every run.
+
+        Targets are computed by instantiating the class from each config, so
+        the check is exact under any ``asset_table`` override. An instance
+        whose config can't construct the class yet is skipped — it can't run
+        either, and the check re-fires on every update.
+
+        Raises:
+            ConfigError: If a same-key sibling in the org targets the same tables.
+        """
+        source_cls = resolve_source_cls(self._catalog, db_source.key)
+        if source_cls is None:
+            return  # drifted key: nothing to derive a target from
+
+        def targets(config: dict[str, Any] | None) -> set[tuple[str, str]] | None:
+            try:
+                source = source_cls(**(config or {}))
+            except Exception:  # noqa: BLE001 — incomplete/stale config: nothing to compare
+                return None
+            return {(asset.dataset, asset.table) for asset in source.assets}
+
+        mine = targets(db_source.config)
+        if not mine:
+            return
+        siblings = session.exec(
+            select(Component).where(
+                Component.org_id == db_source.org_id,
+                Component.kind == "source",
+                Component.key == db_source.key,
+                Component.id != db_source.id,
+            )
+        ).all()
+        for sibling in siblings:
+            overlap = mine & (targets(sibling.config) or set())
+            if overlap:
+                dataset, table = sorted(overlap)[0]
+                raise ConfigError(
+                    f"Source '{db_source.key}' already has an instance materializing to '{dataset}.{table}'. "
+                    f"Configure a distinct discriminator (or dataset) so the two don't overwrite each other's data."
+                )
 
     def _ensure_children(self, session: Session, db_source: Component, child_keys: list[str] | None) -> None:
         """Sync a source's child asset rows to match the desired set.

--- a/packages/interloper-db/tests/store/test_components.py
+++ b/packages/interloper-db/tests/store/test_components.py
@@ -148,6 +148,62 @@ class TestCrud:
             store.get_component(dest.id, kind="asset")
 
 
+class AliasedSource(il.Source):
+    """Source class whose instances are discriminated by ``account_id``."""
+
+    account_id: str = ""
+
+    class AliasedRows(il.Asset):
+        """Asset whose table name carries the instance discriminator."""
+
+    def asset_table(self, asset: il.Asset) -> str:
+        """Suffix tables with the account id when one is configured."""
+        return f"{asset.key}__{self.account_id}" if self.account_id else asset.key
+
+
+class TestSourceCollisionGuard:
+    """A second source instance may not target the same physical tables."""
+
+    @pytest.fixture
+    def guard_store(self, component_db: Engine) -> Store:
+        from interloper_assets.demo.source import DemoSource
+
+        return Store(catalog=il.Catalog.from_assets([DemoSource, AliasedSource]))
+
+    def test_same_alias_rejected(self, guard_store: Store):
+        guard_store.create_component(_ORG, kind="source", key="aliased_source", config={"account_id": "1"})
+        with pytest.raises(ConfigError, match="materializing to"):
+            guard_store.create_component(_ORG, kind="source", key="aliased_source", config={"account_id": "1"})
+
+    def test_distinct_alias_allowed(self, guard_store: Store):
+        guard_store.create_component(_ORG, kind="source", key="aliased_source", config={"account_id": "1"})
+        second = guard_store.create_component(_ORG, kind="source", key="aliased_source", config={"account_id": "2"})
+        assert second.id is not None
+
+    def test_alias_compared_after_sanitization(self, guard_store: Store):
+        guard_store.create_component(_ORG, kind="source", key="aliased_source", config={"account_id": "act-1"})
+        with pytest.raises(ConfigError, match="materializing to"):
+            guard_store.create_component(_ORG, kind="source", key="aliased_source", config={"account_id": "ACT_1"})
+
+    def test_unaliased_source_needs_distinct_dataset(self, guard_store: Store):
+        guard_store.create_component(_ORG, kind="source", key="demo_source")
+        with pytest.raises(ConfigError, match="materializing to"):
+            guard_store.create_component(_ORG, kind="source", key="demo_source")
+        second = guard_store.create_component(_ORG, kind="source", key="demo_source", config={"dataset": "other"})
+        assert second.id is not None
+
+    def test_update_into_collision_rejected(self, guard_store: Store):
+        guard_store.create_component(_ORG, kind="source", key="aliased_source", config={"account_id": "1"})
+        second = guard_store.create_component(_ORG, kind="source", key="aliased_source", config={"account_id": "2"})
+        with pytest.raises(ConfigError, match="materializing to"):
+            guard_store.update_component(second.id, config={"account_id": "1"})
+
+    def test_other_org_does_not_collide(self, guard_store: Store):
+        guard_store.create_component(_ORG, kind="source", key="aliased_source", config={"account_id": "1"})
+        other = guard_store.create_component(uuid4(), kind="source", key="aliased_source", config={"account_id": "1"})
+        assert other.id is not None
+
+
 class TestRelationKindEnforcement:
     """Relation writes are checked against the vocabulary's allowed kinds."""
 


### PR DESCRIPTION
## Problem

Two instances of the same source class (e.g. two Facebook Ads accounts) materialize every asset to the same physical `dataset.table`. Worse than cohabitation: partitioned writes delete-then-insert scoped only by the partition column, so the instances **silently destroy each other's data** on every run (unpartitioned assets: full clobber, last writer wins).

## What changed

**Core — one concept (`table`), one hook:**
- `Asset.table` — new derived property (never persisted, so specs/hydration are untouched): the physical table name destinations read, coerced to a valid identifier by the new `to_identifier` helper.
- `Source.asset_table(asset)` — the single override point, returning the full physical name (default: the asset key). Sources with multiple-instance semantics suffix the key with their discriminator:
  ```python
  def asset_table(self, asset: il.Asset) -> str:
      return f"{asset.key}__{self.account_id}"
  ```
  Plain typed Python — no string field pointers, ty-checked, and the asset parameter covers per-asset exceptions (e.g. account-independent entities keep the bare key).
- All destinations (`database` → BigQuery inherits, `file`, `csv`, `memory`) now target `context.asset.table` instead of reaching into the asset *class* key; stale "`asset.id` → table" docstrings fixed.
- `_resolve()` validates `dataset` and every `asset.table` (closes the pre-existing unvalidated-`dataset` gap).
- `source(dataset=...)` reconfiguration now re-propagates the dataset to assets that inherited it (was a silent no-op for the physical path).

**Store — collisions become upfront errors:**
- Creating/updating a source whose real `(dataset, table)` target set overlaps a same-key sibling's in the org raises `ConfigError`. Targets are computed by instantiating the class from each config, so the check is exact under any `asset_table` override; an instance whose config can't construct the class yet is skipped (it can't run either) and re-checked on every update.

**interloper-assets:**
- `asset_table` overridden on 16 account-scoped sources (facebook_ads/`account_id`, google_ads/`customer_id`, bing_ads, amazon_ads/`profile_id`, awin, criteo, facebook_insights/`page_id`, impact, instagram_insights, linkedin_ads, linkedin_organic, pinterest_ads, snapchat_ads, tiktok_ads, search_console/`site_url`, amazon_selling_partner/`marketplace`).
- Deliberately skipped (ambiguous discriminator, follow-up decision): campaign_manager_360, display_video_360, double_click_bid_manager, search_ads_360, thetradedesk, teads, brandwatch, usercentrics, adservice, adup. The `demo` source is unchanged.

## Resulting layout

`FacebookAds(account_id="act_123-DE")` → `facebook_ads.campaigns_stats__act_123_de`. One dataset per source type; tables wildcard-queryable per asset (`` `p.facebook_ads.ads_stats__*` `` with `_TABLE_SUFFIX` = account id). Sources that don't override `asset_table` keep today's names byte-for-byte.

## For reviewers / operators

⚠️ **Table rename on adoption:** for every source that gained an `asset_table` override, the next run writes to the suffixed table and the old bare-named table stops updating. Existing deployments should copy/rename (`CREATE TABLE ads_stats__x AS SELECT * FROM ads_stats`) to preserve history. Deliberately committed as `feat:` (minor bump), with the migration note in the commit body.

Checks: ruff, ty, and the full test suite (887 passed) are green; coverage for table composition/sanitization, destination targeting, spec round-trip, resolve-time validation, and the store guard.

By Digitl