### PR TITLE
feat: discriminator fields drive per-instance table names and display names

### DIFF
--- a/packages/interloper-app/app/app/composables/assetDisplayName.ts
+++ b/packages/interloper-app/app/app/composables/assetDisplayName.ts
@@ -7,7 +7,7 @@ export function useAssetDisplayName() {
         const map = new Map<string, string>()
         for (const source of componentsStore.byKind('source')) {
             const sourceDefn = catalogStore.getSourceDefinition(source.key)
-            const sourceName = sourceDefn?.name ?? source.name ?? source.key
+            const sourceName = source.name ?? sourceDefn?.name ?? source.key
             for (const asset of source.children) {
                 const assetDefn = sourceDefn?.assets?.find(a => a.key === asset.key)
                 const assetName = assetDefn?.name ?? asset.key

--- a/packages/interloper-app/app/app/composables/catalog.ts
+++ b/packages/interloper-app/app/app/composables/catalog.ts
@@ -264,7 +264,7 @@ export function useCatalogRows(options: UseCatalogRowsOptions) {
             })
 
             map.set(source.id, {
-                name: sourceDefn?.name ?? source.name ?? source.key,
+                name: source.name ?? sourceDefn?.name ?? source.key,
                 icon: componentIcon(source.key, 'i-lucide-database'),
                 assetCount: source.children.length,
                 warnings,

--- a/packages/interloper-app/app/app/composables/destinationBadge.ts
+++ b/packages/interloper-app/app/app/composables/destinationBadge.ts
@@ -29,7 +29,7 @@ export function useDestinationBadge() {
 
         return {
             icon: defn?.icon ?? 'i-lucide-hard-drive',
-            label: defn?.name ?? destination.name ?? destination.key,
+            label: destination.name ?? defn?.name ?? destination.key,
             count: 1,
             isMulti: false,
         }

--- a/packages/interloper-assets/src/interloper_assets/amazon_ads/source.py
+++ b/packages/interloper-assets/src/interloper_assets/amazon_ads/source.py
@@ -180,11 +180,8 @@ class AmazonAds(il.Source):
         provider="connection.profiles",
         label_key="name",
         value_key="profile_id",
+        discriminator=True,
     )
-
-    def asset_table(self, asset: il.Asset) -> str:
-        """Suffix tables with the profile_id so instances materialize side by side."""
-        return f"{asset.key}__{self.profile_id}"
 
     @il.asset(schema=schemas.Profiles, tags=["Entity"])
     def profiles(self, connection: AmazonAdsConnection) -> list[dict[str, Any]]:

--- a/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/source.py
+++ b/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/source.py
@@ -40,8 +40,5 @@ class AmazonSellingPartner(il.Source):
             {"label": "Singapore", "value": "A19VAU5U5O7RUS"},
         ],
         description="Amazon marketplace",
+        discriminator=True,
     )
-
-    def asset_table(self, asset: il.Asset) -> str:
-        """Suffix tables with the marketplace so instances materialize side by side."""
-        return f"{asset.key}__{self.marketplace}"

--- a/packages/interloper-assets/src/interloper_assets/awin/source.py
+++ b/packages/interloper-assets/src/interloper_assets/awin/source.py
@@ -111,11 +111,8 @@ class Awin(il.Source):
         label_key="name",
         value_key="advertiser_id",
         description="Awin advertiser account",
+        discriminator=True,
     )
-
-    def asset_table(self, asset: il.Asset) -> str:
-        """Suffix tables with the advertiser_id so instances materialize side by side."""
-        return f"{asset.key}__{self.advertiser_id}"
 
     @il.asset(
         schema=Transactions,

--- a/packages/interloper-assets/src/interloper_assets/bing_ads/source.py
+++ b/packages/interloper-assets/src/interloper_assets/bing_ads/source.py
@@ -175,11 +175,8 @@ class BingAds(il.Source):
         provider="connection.accounts",
         label_key="name",
         value_key="account_id",
+        discriminator=True,
     )
-
-    def asset_table(self, asset: il.Asset) -> str:
-        """Suffix tables with the account_id so instances materialize side by side."""
-        return f"{asset.key}__{self.account_id}"
 
     @il.asset(
         schema=AdsStats,

--- a/packages/interloper-assets/src/interloper_assets/criteo/source.py
+++ b/packages/interloper-assets/src/interloper_assets/criteo/source.py
@@ -62,11 +62,8 @@ class Criteo(il.Source):
         label_key="name",
         value_key="id",
         description="Criteo advertiser account",
+        discriminator=True,
     )
-
-    def asset_table(self, asset: il.Asset) -> str:
-        """Suffix tables with the advertiser_id so instances materialize side by side."""
-        return f"{asset.key}__{self.advertiser_id}"
 
     @il.asset(
         schema=AdsStats,

--- a/packages/interloper-assets/src/interloper_assets/facebook_ads/source.py
+++ b/packages/interloper-assets/src/interloper_assets/facebook_ads/source.py
@@ -285,11 +285,8 @@ class FacebookAds(il.Source):
         label_key="name",
         value_key="account_id",
         description="Facebook Ads account ID",
+        discriminator=True,
     )
-
-    def asset_table(self, asset: il.Asset) -> str:
-        """Suffix tables with the account_id so instances materialize side by side."""
-        return f"{asset.key}__{self.account_id}"
 
     @il.asset(
         schema=schemas.CampaignsStats,

--- a/packages/interloper-assets/src/interloper_assets/facebook_insights/source.py
+++ b/packages/interloper-assets/src/interloper_assets/facebook_insights/source.py
@@ -19,8 +19,5 @@ class FacebookInsights(il.Source):
         label_key="name",
         value_key="id",
         description="Facebook Page to retrieve insights for",
+        discriminator=True,
     )
-
-    def asset_table(self, asset: il.Asset) -> str:
-        """Suffix tables with the page_id so instances materialize side by side."""
-        return f"{asset.key}__{self.page_id}"

--- a/packages/interloper-assets/src/interloper_assets/google_ads/source.py
+++ b/packages/interloper-assets/src/interloper_assets/google_ads/source.py
@@ -19,12 +19,9 @@ class GoogleAds(il.Source):
         label_key="name",
         value_key="customer_id",
         description="Google Ads customer ID (without hyphens)",
+        discriminator=True,
     )
     login_customer_id: str | None = il.InputField(
         default=None,
         description="Manager account customer ID (required if accessing through a manager account)",
     )
-
-    def asset_table(self, asset: il.Asset) -> str:
-        """Suffix tables with the customer_id so instances materialize side by side."""
-        return f"{asset.key}__{self.customer_id}"

--- a/packages/interloper-assets/src/interloper_assets/impact/source.py
+++ b/packages/interloper-assets/src/interloper_assets/impact/source.py
@@ -163,11 +163,8 @@ class Impact(il.Source):
         label_key="Name",
         value_key="Id",
         description="Impact program (campaign) ID",
+        discriminator=True,
     )
-
-    def asset_table(self, asset: il.Asset) -> str:
-        """Suffix tables with the program_id so instances materialize side by side."""
-        return f"{asset.key}__{self.program_id}"
 
     @il.asset(
         schema=schemas.Actions,

--- a/packages/interloper-assets/src/interloper_assets/instagram_insights/source.py
+++ b/packages/interloper-assets/src/interloper_assets/instagram_insights/source.py
@@ -16,8 +16,5 @@ class InstagramInsights(il.Source):
         label_key="name",
         value_key="id",
         description="Instagram Business or Creator account ID",
+        discriminator=True,
     )
-
-    def asset_table(self, asset: il.Asset) -> str:
-        """Suffix tables with the account_id so instances materialize side by side."""
-        return f"{asset.key}__{self.account_id}"

--- a/packages/interloper-assets/src/interloper_assets/linkedin_ads/source.py
+++ b/packages/interloper-assets/src/interloper_assets/linkedin_ads/source.py
@@ -21,8 +21,5 @@ class LinkedinAds(il.Source):
         label_key="name",
         value_key="id",
         description="LinkedIn Ads account",
+        discriminator=True,
     )
-
-    def asset_table(self, asset: il.Asset) -> str:
-        """Suffix tables with the account_id so instances materialize side by side."""
-        return f"{asset.key}__{self.account_id}"

--- a/packages/interloper-assets/src/interloper_assets/linkedin_organic/source.py
+++ b/packages/interloper-assets/src/interloper_assets/linkedin_organic/source.py
@@ -21,8 +21,5 @@ class LinkedinOrganic(il.Source):
         label_key="name",
         value_key="id",
         description="LinkedIn Organization page ID",
+        discriminator=True,
     )
-
-    def asset_table(self, asset: il.Asset) -> str:
-        """Suffix tables with the organization_id so instances materialize side by side."""
-        return f"{asset.key}__{self.organization_id}"

--- a/packages/interloper-assets/src/interloper_assets/pinterest_ads/source.py
+++ b/packages/interloper-assets/src/interloper_assets/pinterest_ads/source.py
@@ -19,10 +19,7 @@ class PinterestAds(il.Source):
         label_key="name",
         value_key="id",
         description="Pinterest Ads account",
+        discriminator=True,
     )
 
     # --- Entity assets ---
-
-    def asset_table(self, asset: il.Asset) -> str:
-        """Suffix tables with the account_id so instances materialize side by side."""
-        return f"{asset.key}__{self.account_id}"

--- a/packages/interloper-assets/src/interloper_assets/search_console/source.py
+++ b/packages/interloper-assets/src/interloper_assets/search_console/source.py
@@ -14,8 +14,7 @@ from interloper_assets.search_console.connection import SearchConsoleConnection
 class SearchConsole(il.Source):
     """Google Search Console integration for search analytics data."""
 
-    site_url: str = il.InputField(description="Site URL (e.g. https://example.com/ or sc-domain:example.com)")
-
-    def asset_table(self, asset: il.Asset) -> str:
-        """Suffix tables with the site_url so instances materialize side by side."""
-        return f"{asset.key}__{self.site_url}"
+    site_url: str = il.InputField(
+        description="Site URL (e.g. https://example.com/ or sc-domain:example.com)",
+        discriminator=True,
+    )

--- a/packages/interloper-assets/src/interloper_assets/snapchat_ads/source.py
+++ b/packages/interloper-assets/src/interloper_assets/snapchat_ads/source.py
@@ -125,13 +125,10 @@ class SnapchatAds(il.Source):
         label_key="name",
         value_key="id",
         description="Snapchat Ads ad account",
+        discriminator=True,
     )
 
     # --- Time-series reports (SnapchatStatsNormalizer from the source) ---
-
-    def asset_table(self, asset: il.Asset) -> str:
-        """Suffix tables with the account_id so instances materialize side by side."""
-        return f"{asset.key}__{self.account_id}"
 
     @il.asset(schema=AdsStats, partitioning=il.TimePartitionConfig(column="date"), tags=["Report"])
     async def ads_stats(self, context: il.ExecutionContext, connection: SnapchatAdsConnection) -> list[_RECORD]:

--- a/packages/interloper-assets/src/interloper_assets/tiktok_ads/source.py
+++ b/packages/interloper-assets/src/interloper_assets/tiktok_ads/source.py
@@ -130,13 +130,10 @@ class TiktokAds(il.Source):
         label_key="name",
         value_key="advertiser_id",
         description="TikTok Ads advertiser account",
+        discriminator=True,
     )
 
     # --- Time-series reports (TiktokStatsNormalizer from the source) ---
-
-    def asset_table(self, asset: il.Asset) -> str:
-        """Suffix tables with the advertiser_id so instances materialize side by side."""
-        return f"{asset.key}__{self.advertiser_id}"
 
     @il.asset(schema=AdsStats, partitioning=il.TimePartitionConfig(column="date"), tags=["Report"])
     async def ads_stats(self, context: il.ExecutionContext, connection: TiktokAdsConnection) -> list[dict[str, Any]]:

--- a/packages/interloper-core/src/interloper/component/base.py
+++ b/packages/interloper-core/src/interloper/component/base.py
@@ -164,6 +164,18 @@ class Component(Serializable):
         cls._infer_resource_refs()
 
     @classmethod
+    def __pydantic_init_subclass__(cls, **kwargs: Any) -> None:
+        """Validate that at most one config field is marked as the discriminator.
+
+        Raises:
+            TypeError: If several fields carry ``discriminator=True``.
+        """
+        super().__pydantic_init_subclass__(**kwargs)
+        marked = cls._discriminator_fields()
+        if len(marked) > 1:
+            raise TypeError(f"Component '{cls.__name__}' marks multiple discriminator fields: {sorted(marked)}")
+
+    @classmethod
     def _infer_resource_refs(cls) -> None:
         """Convert Resource-typed annotations into ``ResourceRef`` descriptors.
 
@@ -261,6 +273,61 @@ class Component(Serializable):
         """Default ``id`` to a generated UUID if not provided."""
         if not self.id:
             self.id = str(uuid.uuid4())
+
+    # -- Instance discrimination -------------------------------------------------
+
+    @classmethod
+    def _discriminator_fields(cls) -> list[str]:
+        """Names of the config fields marked ``discriminator=True``.
+
+        Returns:
+            The marked field names (normally zero or one).
+        """
+        return [
+            name
+            for name, field in cls.model_fields.items()
+            if isinstance(field.json_schema_extra, dict) and field.json_schema_extra.get("x-discriminator")
+        ]
+
+    @classmethod
+    def discriminator_field(cls) -> str | None:
+        """The config field marked ``discriminator=True``, if any.
+
+        Returns:
+            The field name, or ``None`` when the class declares no discriminator.
+        """
+        marked = cls._discriminator_fields()
+        return marked[0] if marked else None
+
+    @property
+    def discriminator(self) -> str | None:
+        """This instance's discriminator value, if declared and set.
+
+        The value of the config field marked ``discriminator=True`` — what
+        distinguishes instances of the same component class (an ad account
+        id, a site URL, …). Drives the derived :meth:`instance_name` and, for
+        sources, the per-instance asset table names.
+        """
+        field_name = type(self).discriminator_field()
+        if field_name is None:
+            return None
+        value = getattr(self, field_name)
+        return str(value) if value else None
+
+    def instance_name(self) -> str:
+        """Display name for this instance: the class label plus the discriminator.
+
+        A derived *default*, not an identity: the persistence layer uses it to
+        seed a blank component name, and users may override it freely. It never
+        feeds physical naming.
+
+        Returns:
+            E.g. ``"Facebook Ads act_123"``, or just ``"Facebook Ads"`` without
+            a discriminator.
+        """
+        base = type(self).name or to_label(type(self).__name__)
+        discriminator = self.discriminator
+        return f"{base} {discriminator}" if discriminator else base
 
     # -- Resources -------------------------------------------------------------
     def trickle_resources(self, target: Component) -> None:

--- a/packages/interloper-core/src/interloper/resource/fields.py
+++ b/packages/interloper-core/src/interloper/resource/fields.py
@@ -147,11 +147,19 @@ def strip_internal_fields(schema: dict[str, Any], extra: Iterable[str] = ()) -> 
 def _extra(kwargs: dict[str, Any], widget: str) -> dict[str, Any]:
     """Pop json_schema_extra from kwargs and inject the widget hint.
 
+    Also lifts the ``discriminator=True`` marker (accepted by every field
+    factory) into ``x-discriminator``: it marks the config field whose value
+    distinguishes instances of a component, driving the derived display name
+    (:meth:`Component.instance_name`) and — for sources — the per-instance
+    asset table names (:meth:`Source.asset_table`).
+
     Returns:
-        The extra dict with ``x-widget`` set.
+        The extra dict with ``x-widget`` (and possibly ``x-discriminator``) set.
     """
     extra = kwargs.pop("json_schema_extra", {})
     extra["x-widget"] = widget
+    if kwargs.pop("discriminator", False):
+        extra["x-discriminator"] = True
     return extra
 
 
@@ -163,7 +171,8 @@ def InputField(default: Any = ..., **kwargs: Any) -> Any:
 
     Args:
         default: Default value (``...`` means required).
-        **kwargs: Forwarded to ``pydantic.Field``.
+        **kwargs: Forwarded to ``pydantic.Field``. Pass ``discriminator=True``
+            to mark the field as the component's instance discriminator.
 
     Returns:
         A Pydantic Field descriptor.
@@ -292,7 +301,8 @@ def FetchField(
             method on the resource in slot ``<slot>``.
         label_key: Key in each response item used as the display label.
         value_key: Key in each response item used as the stored value.
-        **kwargs: Forwarded to ``pydantic.Field``.
+        **kwargs: Forwarded to ``pydantic.Field``. Pass ``discriminator=True``
+            to mark the field as the component's instance discriminator.
 
     Returns:
         A Pydantic Field descriptor.

--- a/packages/interloper-core/src/interloper/source/base.py
+++ b/packages/interloper-core/src/interloper/source/base.py
@@ -391,22 +391,22 @@ class Source(Component):
     def asset_table(self, asset: Asset) -> str:
         """Physical table name for one of this source's assets.
 
-        Override to give each instance of the source its own tables — e.g.
-        suffix the asset key with the account id the instance is configured
-        for, so two accounts materialize side by side in one dataset instead
-        of overwriting each other's data::
+        Defaults to suffixing the asset key with the instance's
+        :attr:`~interloper.component.base.Component.discriminator` (the config
+        field marked ``discriminator=True``), so instances of a multi-account
+        source materialize side by side in one dataset instead of overwriting
+        each other's data. Without a discriminator the asset key is used as-is.
 
-            def asset_table(self, asset: il.Asset) -> str:
-                return f"{asset.key}__{self.account_id}"
-
-        Keep the ``{asset.key}__{suffix}`` shape so a source's tables stay
-        wildcard-queryable per asset. The return value is coerced to a valid
-        identifier by :attr:`Asset.table`.
+        Override for full control over the composition; keep the
+        ``{asset.key}__{suffix}`` shape so tables stay wildcard-queryable per
+        asset. The return value is coerced to a valid identifier by
+        :attr:`Asset.table`.
 
         Returns:
-            The physical table name for the asset (defaults to the asset key).
+            The physical table name for the asset.
         """
-        return asset.key
+        discriminator = self.discriminator
+        return f"{asset.key}__{discriminator}" if discriminator else asset.key
 
     def _resolve(self) -> None:
         """Apply source-level defaults to assets that don't define their own."""

--- a/packages/interloper-core/tests/component/test_base.py
+++ b/packages/interloper-core/tests/component/test_base.py
@@ -121,6 +121,37 @@ class TestIdentity:
         assert not FakeResource.has_own_field("does_not_exist")
 
 
+class TestDiscriminator:
+    """The config field marked ``discriminator=True`` identifies instances."""
+
+    def test_none_declared_by_default(self):
+        assert FakeComponent.discriminator_field() is None
+        assert FakeComponent().discriminator is None
+
+    def test_marked_field_discovered_and_value_exposed(self):
+        class FakeDiscriminated(Component):
+            account_id: str = il.InputField(default="", discriminator=True)
+
+        assert FakeDiscriminated.discriminator_field() == "account_id"
+        assert FakeDiscriminated(account_id="42").discriminator == "42"
+        # An empty value means "not discriminated" rather than an empty suffix.
+        assert FakeDiscriminated().discriminator is None
+
+    def test_multiple_marked_fields_rejected_at_class_definition(self):
+        with pytest.raises(TypeError, match="multiple discriminator fields"):
+
+            class FakeDoublyDiscriminated(Component):
+                a: str = il.InputField(default="", discriminator=True)
+                b: str = il.InputField(default="", discriminator=True)
+
+    def test_instance_name_appends_discriminator(self):
+        class FakeShop(Component):
+            shop_id: str = il.InputField(default="", discriminator=True)
+
+        assert FakeShop().instance_name() == "Fake Shop"
+        assert FakeShop(shop_id="99").instance_name() == "Fake Shop 99"
+
+
 class TestAnchor:
     def test_subclass_resolves_to_the_kind_declarer(self):
         assert FakeResource.anchor() is il.Resource

--- a/packages/interloper-core/tests/destination/test_database.py
+++ b/packages/interloper-core/tests/destination/test_database.py
@@ -50,16 +50,13 @@ def plain_asset() -> list:  # noqa: D103
     return []
 
 
-class AliasedSource(il.Source):
+class DiscriminatedSource(il.Source):
     """Source whose assets materialize under instance-suffixed table names."""
 
-    account_id: str = ""
+    account_id: str = il.InputField(default="", discriminator=True)
 
-    class AliasedRows(il.Asset):
+    class DiscriminatedRows(il.Asset):
         """Asset carrying the instance discriminator in its table name."""
-
-    def asset_table(self, asset: il.Asset) -> str:
-        return f"{asset.key}__{self.account_id}"
 
 
 def make_ctx(asset: il.Asset, partition_or_window=None, schema=None) -> IOContext:  # noqa: D103
@@ -107,14 +104,14 @@ class TestWrite:
         assert dest.calls == []
 
     def test_write_targets_instance_aliased_table(self):
-        source = AliasedSource(account_id="42")
+        source = DiscriminatedSource(account_id="42")
         (asset,) = source.assets
         dest = RecordingDB(id="db")
         rows = [{"a": 1}]
         dest.write(make_ctx(asset), rows)
         assert dest.calls == [
-            ("delete_all", ("aliased_rows__42", "aliased_source")),
-            ("insert", ("aliased_rows__42", "aliased_source", rows)),
+            ("delete_all", ("discriminated_rows__42", "discriminated_source")),
+            ("insert", ("discriminated_rows__42", "discriminated_source", rows)),
         ]
 
     def test_dataframe_converts_via_null_safe_fallback(self):

--- a/packages/interloper-core/tests/resource/test_fields.py
+++ b/packages/interloper-core/tests/resource/test_fields.py
@@ -25,6 +25,22 @@ class TestFetchProvider:
         assert not is_fetch_field_provider(Conn.not_a_provider)
 
 
+class TestDiscriminatorMarker:
+    def test_marker_serialized_as_x_discriminator(self):
+        class FakeMarkedSource(il.Source):
+            account_id: str = il.InputField(default="", discriminator=True)
+
+        prop = FakeMarkedSource.definition().config_schema["properties"]["account_id"]
+        assert prop["x-discriminator"] is True
+
+    def test_unmarked_field_carries_no_marker(self):
+        class FakeUnmarkedSource(il.Source):
+            account_id: str = il.InputField(default="")
+
+        prop = FakeUnmarkedSource.definition().config_schema["properties"]["account_id"]
+        assert "x-discriminator" not in prop
+
+
 class TestFetchField:
     def test_emits_provider_only(self):
         @il.source(resources={"connection": Conn})

--- a/packages/interloper-core/tests/source/test_base.py
+++ b/packages/interloper-core/tests/source/test_base.py
@@ -63,16 +63,13 @@ class FakeSourceWithAssets(il.Source):
             return None
 
 
-class FakeAliasedSource(il.Source):
+class FakeDiscriminatedSource(il.Source):
     """Source whose asset tables carry the instance's account id."""
 
-    account_id: str = ""
+    account_id: str = il.InputField(default="", discriminator=True)
 
-    class FakeAliased(il.Asset):
+    class FakeDiscriminated(il.Asset):
         """Asset whose table name carries the source instance discriminator."""
-
-    def asset_table(self, asset: il.Asset) -> str:
-        return f"{asset.key}__{self.account_id}" if self.account_id else asset.key
 
 
 # -- Identity and class metadata -----------------------------------------------
@@ -121,36 +118,44 @@ class TestAssetTable:
         source = FakeSourceWithAssets()
         assert [a.table for a in source.assets] == ["fake_first", "fake_second"]
 
-    def test_asset_table_override_suffixes_table(self):
-        source = FakeAliasedSource(account_id="123")
+    def test_discriminator_suffixes_table(self):
+        source = FakeDiscriminatedSource(account_id="123")
         (asset,) = source.assets
-        assert source.asset_table(asset) == "fake_aliased__123"
-        assert asset.table == "fake_aliased__123"
+        assert source.asset_table(asset) == "fake_discriminated__123"
+        assert asset.table == "fake_discriminated__123"
         # The logical identity is untouched — only the physical name varies.
-        assert type(asset).key == "fake_aliased"
-        assert asset.dataset == "fake_aliased_source"
+        assert type(asset).key == "fake_discriminated"
+        assert asset.dataset == "fake_discriminated_source"
 
     def test_asset_table_is_sanitized(self):
-        source = FakeAliasedSource(account_id="act_123-DE")
+        source = FakeDiscriminatedSource(account_id="act_123-DE")
         (asset,) = source.assets
-        assert asset.table == "fake_aliased__act_123_de"
+        assert asset.table == "fake_discriminated__act_123_de"
 
     def test_default_asset_table_is_the_asset_key(self):
-        source = FakeAliasedSource()
+        source = FakeDiscriminatedSource()
         (asset,) = source.assets
-        assert asset.table == "fake_aliased"
+        assert asset.table == "fake_discriminated"
 
     def test_table_survives_spec_round_trip(self):
-        source = FakeAliasedSource(account_id="123")
-        restored = FakeAliasedSource.from_spec(source.to_spec())
-        assert [a.table for a in restored.assets] == ["fake_aliased__123"]
+        source = FakeDiscriminatedSource(account_id="123")
+        restored = FakeDiscriminatedSource.from_spec(source.to_spec())
+        assert [a.table for a in restored.assets] == ["fake_discriminated__123"]
+
+    def test_asset_table_override_takes_full_control(self):
+        class FakeOverridingSource(FakeDiscriminatedSource):
+            def asset_table(self, asset: il.Asset) -> str:
+                return f"custom__{asset.key}"
+
+        (asset,) = FakeOverridingSource(account_id="123").assets
+        assert asset.table == "custom__fake_discriminated"
 
     def test_invalid_asset_table_raises_at_init(self):
         # The composed name is validated during ``_resolve``; ``validate_key``
         # raises a ValueError, so pydantic wraps it at init time.
         from pydantic import ValidationError
 
-        class FakeBadTableSource(FakeAliasedSource):
+        class FakeBadTableSource(FakeDiscriminatedSource):
             def asset_table(self, asset: il.Asset) -> str:
                 """Return a name that sanitizes to an invalid identifier."""
                 return f"123_{asset.key}"

--- a/packages/interloper-db/src/interloper_db/drift.py
+++ b/packages/interloper-db/src/interloper_db/drift.py
@@ -69,8 +69,8 @@ def _discovered_catalog() -> Catalog:
     return Catalog.discover()
 
 
-def resolve_source_cls(catalog: Catalog, key: str) -> type[il.Source] | None:
-    """Return the source class for *key*, or ``None`` if it does not resolve.
+def resolve_component_cls(catalog: Catalog, key: str) -> type[il.Component] | None:
+    """Return the component class for *key*, or ``None`` if it does not resolve.
 
     Value-based counterpart to the raise-on-miss lookup used by writes. The
     catalog only holds keys whose classes imported cleanly at build time, but
@@ -84,7 +84,13 @@ def resolve_source_cls(catalog: Catalog, key: str) -> type[il.Source] | None:
         obj = import_from_path(definition.path)
     except (ImportError, AttributeError):
         return None
-    return obj if isinstance(obj, type) and issubclass(obj, il.Source) else None
+    return obj if isinstance(obj, type) and issubclass(obj, il.Component) else None
+
+
+def resolve_source_cls(catalog: Catalog, key: str) -> type[il.Source] | None:
+    """Return the source class for *key*, or ``None`` if it does not resolve."""
+    obj = resolve_component_cls(catalog, key)
+    return obj if obj is not None and issubclass(obj, il.Source) else None
 
 
 def source_status(

--- a/packages/interloper-db/src/interloper_db/store/components.py
+++ b/packages/interloper-db/src/interloper_db/store/components.py
@@ -36,7 +36,7 @@ from interloper.errors import (
 from sqlalchemy.orm import selectinload
 from sqlmodel import Session, col, select
 
-from interloper_db.drift import ComponentStatus, asset_status, resolve_source_cls, source_status
+from interloper_db.drift import ComponentStatus, asset_status, resolve_component_cls, resolve_source_cls, source_status
 from interloper_db.models import Component, ComponentRelation
 from interloper_db.store.base import StoreBase
 
@@ -95,6 +95,8 @@ class ComponentMixin(StoreBase):
         with self._session() as session:
             db_component = Component(org_id=org_id, kind=kind, key=key, name=name)
             self._apply_config(db_component, config, encrypted)
+            if name is None:
+                db_component.name = self._derived_name(db_component, config)
             session.add(db_component)
             session.flush()
             if kind == "source":
@@ -172,6 +174,7 @@ class ComponentMixin(StoreBase):
             if name is not None:
                 db_component.name = name
             if config is not None:
+                self._refresh_derived_name(db_component, new_config=config, explicit_rename=name is not None)
                 self._apply_config(db_component, config, encrypted)
             if db_component.kind == "source":
                 self._check_source_collision(session, db_component)
@@ -359,6 +362,45 @@ class ComponentMixin(StoreBase):
                 )
             raw = self._encrypt(raw)
         return raw, should_encrypt
+
+    def _derived_name(self, db_component: Component, config: dict[str, Any] | None) -> str | None:
+        """The display name the component class derives from *config*.
+
+        Returns:
+            ``instance_name()`` of an instance constructed from the config, or
+            ``None`` when the key doesn't resolve or the config can't construct
+            the class.
+        """
+        cls = resolve_component_cls(self._catalog, db_component.key)
+        if cls is None or cls.kind != db_component.kind:
+            return None
+        try:
+            instance = cls(**(config or {}))
+        except Exception:  # noqa: BLE001 — incomplete/stale config: nothing to derive
+            return None
+        return instance.instance_name()
+
+    def _refresh_derived_name(
+        self, db_component: Component, *, new_config: dict[str, Any], explicit_rename: bool
+    ) -> None:
+        """Let a never-customized display name follow a config change.
+
+        A name equal to the old config's derived default (or blank) is
+        system-owned and follows along; anything else — including a rename in
+        this same call — is user-owned and untouched.
+        """
+        if explicit_rename:
+            return
+        old_default = self._derived_name(db_component, self._current_config(db_component))
+        if db_component.name is None or db_component.name == old_default:
+            db_component.name = self._derived_name(db_component, new_config) or db_component.name
+
+    def _current_config(self, db_component: Component) -> dict[str, Any] | None:
+        """The row's stored config payload, decoding secret kinds (``None`` when undecodable)."""
+        try:
+            return self.decode_config(db_component)
+        except Exception:  # noqa: BLE001 — no cipher / corrupt payload: treat as underivable
+            return None
 
     def _check_source_collision(self, session: Session, db_source: Component) -> None:
         """Reject a source instance whose materialization target collides with a sibling.

--- a/packages/interloper-db/tests/store/test_components.py
+++ b/packages/interloper-db/tests/store/test_components.py
@@ -148,17 +148,13 @@ class TestCrud:
             store.get_component(dest.id, kind="asset")
 
 
-class AliasedSource(il.Source):
+class DiscriminatedSource(il.Source):
     """Source class whose instances are discriminated by ``account_id``."""
 
-    account_id: str = ""
+    account_id: str = il.InputField(default="", discriminator=True)
 
-    class AliasedRows(il.Asset):
+    class DiscriminatedRows(il.Asset):
         """Asset whose table name carries the instance discriminator."""
-
-    def asset_table(self, asset: il.Asset) -> str:
-        """Suffix tables with the account id when one is configured."""
-        return f"{asset.key}__{self.account_id}" if self.account_id else asset.key
 
 
 class TestSourceCollisionGuard:
@@ -168,24 +164,28 @@ class TestSourceCollisionGuard:
     def guard_store(self, component_db: Engine) -> Store:
         from interloper_assets.demo.source import DemoSource
 
-        return Store(catalog=il.Catalog.from_assets([DemoSource, AliasedSource]))
+        return Store(catalog=il.Catalog.from_assets([DemoSource, DiscriminatedSource]))
 
     def test_same_alias_rejected(self, guard_store: Store):
-        guard_store.create_component(_ORG, kind="source", key="aliased_source", config={"account_id": "1"})
+        guard_store.create_component(_ORG, kind="source", key="discriminated_source", config={"account_id": "1"})
         with pytest.raises(ConfigError, match="materializing to"):
-            guard_store.create_component(_ORG, kind="source", key="aliased_source", config={"account_id": "1"})
+            guard_store.create_component(_ORG, kind="source", key="discriminated_source", config={"account_id": "1"})
 
     def test_distinct_alias_allowed(self, guard_store: Store):
-        guard_store.create_component(_ORG, kind="source", key="aliased_source", config={"account_id": "1"})
-        second = guard_store.create_component(_ORG, kind="source", key="aliased_source", config={"account_id": "2"})
+        guard_store.create_component(_ORG, kind="source", key="discriminated_source", config={"account_id": "1"})
+        second = guard_store.create_component(
+            _ORG, kind="source", key="discriminated_source", config={"account_id": "2"}
+        )
         assert second.id is not None
 
     def test_alias_compared_after_sanitization(self, guard_store: Store):
-        guard_store.create_component(_ORG, kind="source", key="aliased_source", config={"account_id": "act-1"})
+        guard_store.create_component(_ORG, kind="source", key="discriminated_source", config={"account_id": "act-1"})
         with pytest.raises(ConfigError, match="materializing to"):
-            guard_store.create_component(_ORG, kind="source", key="aliased_source", config={"account_id": "ACT_1"})
+            guard_store.create_component(
+                _ORG, kind="source", key="discriminated_source", config={"account_id": "ACT_1"}
+            )
 
-    def test_unaliased_source_needs_distinct_dataset(self, guard_store: Store):
+    def test_undiscriminated_source_needs_distinct_dataset(self, guard_store: Store):
         guard_store.create_component(_ORG, kind="source", key="demo_source")
         with pytest.raises(ConfigError, match="materializing to"):
             guard_store.create_component(_ORG, kind="source", key="demo_source")
@@ -193,15 +193,58 @@ class TestSourceCollisionGuard:
         assert second.id is not None
 
     def test_update_into_collision_rejected(self, guard_store: Store):
-        guard_store.create_component(_ORG, kind="source", key="aliased_source", config={"account_id": "1"})
-        second = guard_store.create_component(_ORG, kind="source", key="aliased_source", config={"account_id": "2"})
+        guard_store.create_component(_ORG, kind="source", key="discriminated_source", config={"account_id": "1"})
+        second = guard_store.create_component(
+            _ORG, kind="source", key="discriminated_source", config={"account_id": "2"}
+        )
         with pytest.raises(ConfigError, match="materializing to"):
             guard_store.update_component(second.id, config={"account_id": "1"})
 
     def test_other_org_does_not_collide(self, guard_store: Store):
-        guard_store.create_component(_ORG, kind="source", key="aliased_source", config={"account_id": "1"})
-        other = guard_store.create_component(uuid4(), kind="source", key="aliased_source", config={"account_id": "1"})
+        guard_store.create_component(_ORG, kind="source", key="discriminated_source", config={"account_id": "1"})
+        other = guard_store.create_component(
+            uuid4(), kind="source", key="discriminated_source", config={"account_id": "1"}
+        )
         assert other.id is not None
+
+
+class TestDerivedNames:
+    """A blank ``components.name`` defaults to the instance's derived display name."""
+
+    @pytest.fixture
+    def name_store(self, component_db: Engine) -> Store:
+        return Store(catalog=il.Catalog.from_assets([DiscriminatedSource]))
+
+    def test_blank_name_defaults_to_instance_name(self, name_store: Store):
+        row = name_store.create_component(
+            _ORG, kind="source", key="discriminated_source", config={"account_id": "1"}
+        )
+        assert row.name == "Discriminated Source 1"
+
+    def test_explicit_name_wins(self, name_store: Store):
+        row = name_store.create_component(
+            _ORG, kind="source", key="discriminated_source", name="Mine", config={"account_id": "1"}
+        )
+        assert row.name == "Mine"
+
+    def test_default_name_follows_config_change(self, name_store: Store):
+        row = name_store.create_component(
+            _ORG, kind="source", key="discriminated_source", config={"account_id": "1"}
+        )
+        updated = name_store.update_component(row.id, config={"account_id": "2"})
+        assert updated.name == "Discriminated Source 2"
+
+    def test_customized_name_untouched_by_config_change(self, name_store: Store):
+        row = name_store.create_component(
+            _ORG, kind="source", key="discriminated_source", config={"account_id": "1"}
+        )
+        name_store.update_component(row.id, name="Mine")
+        updated = name_store.update_component(row.id, config={"account_id": "2"})
+        assert updated.name == "Mine"
+
+    def test_unresolvable_key_leaves_name_blank(self, store: Store):
+        row = store.create_component(_ORG, kind="destination", key="ghost")
+        assert row.name is None
 
 
 class TestRelationKindEnforcement:


### PR DESCRIPTION
Follow-up to #134, which gave sources per-instance asset tables via `asset_table()` overrides. This PR replaces the 16 repeated method overrides with a single declarative concept and extends it to display naming.

## The concept

A config field marked `discriminator=True` declares what distinguishes instances of a component class:

```python
class FacebookAds(il.Source):
    account_id: str = il.FetchField(
        provider="connection.accounts",
        ...,
        discriminator=True,
    )
```

One declaration now drives:

- **Physical naming** — `Source.asset_table(asset)` defaults to `{asset.key}__{discriminator}` (→ `facebook_ads.ads_stats__act_123`). Still a plain overridable method for full control; sanitization and validation stay in core.
- **Display naming** — new `Component.instance_name()` defaults to `{class label} {discriminator}` (→ "Facebook Ads act_123"). The store seeds a blank `components.name` with it, and a never-customized name follows config changes; explicit renames always win. It never feeds physical naming.
- **Machine-readability** — the marker rides `json_schema_extra` (like `x-widget`) into `config_schema` as `x-discriminator`, so the UI can badge the field and future consumers don't need hydration.

## Mechanics

- Every field factory accepts `discriminator=True` (lifted in `_extra`, one place). At most one marked field per class, validated at class definition.
- `Component` gains `discriminator_field()` / `.discriminator` / `instance_name()`; empty value means "not discriminated", not an empty suffix.
- `resolve_component_cls` generalizes catalog class resolution beyond sources (`resolve_source_cls` now delegates to it).
- Frontend: instance name now takes precedence over the definition name (`source.name ?? sourceDefn?.name ?? source.key`) in `assetDisplayName`, `catalog`, and `destinationBadge` composables — previously a user-supplied instance name was shadowed by the class label.
- interloper-assets: the 16 `asset_table` overrides from #134 are deleted in favor of the marker — net-negative diff for the package.

## Notes for reviewers

- The collision guard from #134 is unchanged (instantiate-and-compare) — it remains exact under method overrides, which a config-key comparison can't be.
- Store name-defaulting constructs the class from the supplied config and fails soft (unresolvable key / unconstructible config → name stays blank).
- No physical table names change relative to #134 — same `{key}__{value}` composition, so no additional migration on top of #134's.

Checks: ruff, ty, 899 Python tests, frontend lint + `nuxt typecheck` all green.

By Digitl