### PR TITLE
feat(app): source form derives the instance name from the discriminator

### DIFF
--- a/packages/interloper-app/app/app/components/SchemaForm.vue
+++ b/packages/interloper-app/app/app/components/SchemaForm.vue
@@ -36,6 +36,7 @@ interface JsonSchemaProperty {
     'x-options'?: { label: string, value: string }[]
     'x-options-from'?: string
     'x-fetch'?: FetchMeta
+    'x-discriminator'?: boolean
     minimum?: number
     maximum?: number
     minLength?: number
@@ -365,6 +366,40 @@ const fields = computed(() => {
             fetchMeta: prop['x-fetch'] ?? null,
         }))
 })
+
+// ── Discriminator label ──────────────────────────────────────────
+
+/**
+ * Display label of the discriminator field's current value (the field marked
+ * `x-discriminator` — what distinguishes instances of the component). For
+ * fetch/select widgets this is the selected option's label, so parents can
+ * derive a human-friendly instance name; otherwise the raw value.
+ */
+const discriminatorLabel = defineModel<string | null>('discriminatorLabel', { default: null })
+
+const discriminatorKey = computed<string | null>(() => {
+    const properties = props.schema?.properties ?? {}
+    return Object.entries(properties).find(([, prop]) => prop['x-discriminator'])?.[0] ?? null
+})
+
+watch(
+    [data, fetchState, discriminatorKey],
+    () => {
+        const key = discriminatorKey.value
+        const value = key ? data.value[key] : undefined
+        if (!key || value === undefined || value === '') {
+            discriminatorLabel.value = null
+            return
+        }
+        const prop = props.schema?.properties?.[key]
+        const options = prop?.['x-fetch'] ? fetchState.value[key]?.options : resolveOptions(prop!)
+        const match = (options ?? []).find(
+            o => typeof o === 'object' && o !== null && String((o as { value: unknown }).value) === String(value),
+        )
+        discriminatorLabel.value = match ? (match as { label: string }).label : String(value)
+    },
+    { deep: true, immediate: true },
+)
 
 /** Fields visible in the current mode. */
 const visibleFields = computed(() => {

--- a/packages/interloper-app/app/app/components/sources/Stepper.vue
+++ b/packages/interloper-app/app/app/components/sources/Stepper.vue
@@ -209,11 +209,29 @@ const resourceContext = computed<Record<string, Record<string, unknown>>>(() => 
     return ctx
 })
 
+// ── Derived source name ──────────────────────────────────────────
+
+/** Label of the discriminator field's selected option, reported by the SchemaForm. */
+const discriminatorLabel = ref<string | null>(null)
+
+/** Default name: the source type's label plus the instance discriminator. */
+const derivedName = computed(() => {
+    const base = sourceDefn.value?.name ?? ''
+    return discriminatorLabel.value ? `${base} ${discriminatorLabel.value}` : base
+})
+
+// The name follows the derived default until the user edits it: a manual edit
+// makes sourceName diverge from the previous derived value, which stops the
+// following (editing it back to the derived value resumes it).
+watch(derivedName, (val, old) => {
+    if (!sourceName.value || sourceName.value === old) sourceName.value = val
+})
+
 // ── Auto-advance on source selection ────────────────────────────
 
 watch(selectedSourceKey, (key) => {
     if (key && sourceDefn.value && !isEditMode.value) {
-        sourceName.value = `My ${sourceDefn.value.name} Source`
+        sourceName.value = derivedName.value
         selectedAssetKeys.value = sourceDefn.value.assets.map(a => a.key)
         resourceSelections.value = {}
         configData.value = {}
@@ -401,6 +419,7 @@ defineExpose({ canProceed, hasPrev, isLastStep, submitting, submitLabel, title, 
                 <SchemaForm v-if="sourceDefn?.config_schema"
                             v-model:data="configData"
                             v-model:is-valid="configValid"
+                            v-model:discriminator-label="discriminatorLabel"
                             :schema="sourceDefn.config_schema"
                             :component-key="sourceDefn.key"
                             :resource-context="resourceContext"


### PR DESCRIPTION
Follow-up to #135, wiring the `x-discriminator` marker into the create/edit source form — previously the form pre-filled a static "My Facebook Ads Source" and never touched it again, so two instances of a source type were created with identical names and the backend name-seeding never fired (the UI always sends an explicit name).

## Behavior

- **SchemaForm** finds the property marked `x-discriminator` and reports the display label of its current value via `v-model:discriminator-label` — the selected option's **label** for fetch/select widgets ("My Client DE" rather than `act_123`), the raw value for text inputs or while options are still loading.
- **The source stepper** derives the name as `{type label} {discriminator label}` ("Facebook Ads My Client DE") and the name input **follows it live** as the user picks an account — until the user edits the name manually. The follow rule is "current name still equals the previous derived value": a manual edit diverges and stops the following; editing back to the derived value resumes it. Works in both create and edit mode (changing the account on an unrenamed source renames it accordingly).
- The static `My {type} Source` pre-fill is gone; the initial default is the type label.

## Notes

- **Label vs value (deliberate choice):** the UI derives from the option *label* while the backend's `instance_name()` derives from the raw config *value*. A UI-created name is therefore treated as user-chosen by the store's follow-config rule — which is fine, because the form itself implements the following behavior with the nicer label. A backend-seeded (value-based) name converges: the form recognizes it via the raw-value fallback and upgrades it to the label form on the next edit.
- Connections have no discriminator-marked fields yet; the resources stepper keeps its current pre-fill and can adopt the same `v-model:discriminator-label` pattern when one appears.

Checks: `pnpm run lint` and `nuxt typecheck` green (one pre-existing v-html warning in an untouched file). Verified by type-level and code-path tracing; not driven end-to-end in a browser — the label path needs a real ad-platform connection to populate FetchField options, which the dev seed doesn't have.

By Digitl