### PR TITLE
fix(app): keep the table empty state stable during background refetches

### DIFF
--- a/packages/interloper-app/app/app/components/DataTable.vue
+++ b/packages/interloper-app/app/app/components/DataTable.vue
@@ -120,8 +120,18 @@ function onRowContextMenu(e: Event, row: { original: TData }) {
 
 // ── Empty state ──
 const slots = useSlots()
+/**
+ * Loading has completed at least once. Before that, an empty `data` just means
+ * "not fetched yet"; after, background refetches (the store's loading flag is
+ * global, e.g. a wizard fetching candidate components) must not swap the empty
+ * state out for the table.
+ */
+const hasLoaded = ref(!props.loading)
+watch(() => props.loading, (loading) => {
+    if (!loading) hasLoaded.value = true
+})
 /** With no data at all (not just filtered out), render the #empty slot instead of the table. */
-const showEmpty = computed(() => !props.loading && props.data.length === 0 && !!slots.empty)
+const showEmpty = computed(() => hasLoaded.value && props.data.length === 0 && !!slots.empty)
 </script>
 
 <template>


### PR DESCRIPTION
## What

On list pages showing the empty-state placeholder (e.g. Hooks with no hooks configured), clicking "New hook" made the table skeleton and search toolbar flash behind the drawer for a split second before the placeholder came back.

## Why

The components store exposes a single global `loading` flag that every `fetchAll` flips, and `DataTable` gated its empty state on `!props.loading`. The hook wizard fetches its watch/target candidates (`fetchAll(['source', 'asset', 'job'])`) on mount, so opening it briefly knocked the empty state out. The same race existed on Jobs (its stepper fetches `['source']` on mount) and mid-wizard on Sources (`ResourceStep`/`DestinationStep` fetch on mount) — and latently on every other page bound to the shared flag.

## How

`DataTable` now tracks whether at least one load has completed (`hasLoaded`) and gates the empty state on that instead of the live `loading` flag. First-visit behavior is unchanged (skeleton until the initial fetch resolves); once the collection is known to be empty, background refetches no longer swap the empty state out. One change covers every consumer.

By Digitl