### PR TITLE
feat: instance names derive from the discriminator alone

### DIFF
--- a/packages/interloper-app/app/app/components/sources/Stepper.vue
+++ b/packages/interloper-app/app/app/components/sources/Stepper.vue
@@ -214,11 +214,8 @@ const resourceContext = computed<Record<string, Record<string, unknown>>>(() => 
 /** Label of the discriminator field's selected option, reported by the SchemaForm. */
 const discriminatorLabel = ref<string | null>(null)
 
-/** Default name: the source type's label plus the instance discriminator. */
-const derivedName = computed(() => {
-    const base = sourceDefn.value?.name ?? ''
-    return discriminatorLabel.value ? `${base} ${discriminatorLabel.value}` : base
-})
+/** Default name: the instance discriminator (the type label until one is picked). */
+const derivedName = computed(() => discriminatorLabel.value ?? sourceDefn.value?.name ?? '')
 
 // The name follows the derived default until the user edits it: a manual edit
 // makes sourceName diverge from the previous derived value, which stops the

--- a/packages/interloper-core/src/interloper/component/base.py
+++ b/packages/interloper-core/src/interloper/component/base.py
@@ -315,19 +315,20 @@ class Component(Serializable):
         return str(value) if value else None
 
     def instance_name(self) -> str:
-        """Display name for this instance: the class label plus the discriminator.
+        """Display name for this instance: its discriminator value.
+
+        The class label is the fallback when no discriminator is declared or
+        set — the type is already visible alongside the name everywhere the
+        name is shown, so it isn't repeated in it.
 
         A derived *default*, not an identity: the persistence layer uses it to
         seed a blank component name, and users may override it freely. It never
         feeds physical naming.
 
         Returns:
-            E.g. ``"Facebook Ads act_123"``, or just ``"Facebook Ads"`` without
-            a discriminator.
+            E.g. ``"act_123"``, or ``"Facebook Ads"`` without a discriminator.
         """
-        base = type(self).name or to_label(type(self).__name__)
-        discriminator = self.discriminator
-        return f"{base} {discriminator}" if discriminator else base
+        return self.discriminator or type(self).name or to_label(type(self).__name__)
 
     # -- Resources -------------------------------------------------------------
     def trickle_resources(self, target: Component) -> None:

--- a/packages/interloper-core/tests/component/test_base.py
+++ b/packages/interloper-core/tests/component/test_base.py
@@ -144,12 +144,13 @@ class TestDiscriminator:
                 a: str = il.InputField(default="", discriminator=True)
                 b: str = il.InputField(default="", discriminator=True)
 
-    def test_instance_name_appends_discriminator(self):
+    def test_instance_name_is_the_discriminator(self):
         class FakeShop(Component):
             shop_id: str = il.InputField(default="", discriminator=True)
 
+        # Falls back to the class label until a discriminator value is set.
         assert FakeShop().instance_name() == "Fake Shop"
-        assert FakeShop(shop_id="99").instance_name() == "Fake Shop 99"
+        assert FakeShop(shop_id="99").instance_name() == "99"
 
 
 class TestAnchor:

--- a/packages/interloper-db/tests/store/test_components.py
+++ b/packages/interloper-db/tests/store/test_components.py
@@ -219,7 +219,7 @@ class TestDerivedNames:
         row = name_store.create_component(
             _ORG, kind="source", key="discriminated_source", config={"account_id": "1"}
         )
-        assert row.name == "Discriminated Source 1"
+        assert row.name == "1"
 
     def test_explicit_name_wins(self, name_store: Store):
         row = name_store.create_component(
@@ -232,7 +232,7 @@ class TestDerivedNames:
             _ORG, kind="source", key="discriminated_source", config={"account_id": "1"}
         )
         updated = name_store.update_component(row.id, config={"account_id": "2"})
-        assert updated.name == "Discriminated Source 2"
+        assert updated.name == "2"
 
     def test_customized_name_untouched_by_config_change(self, name_store: Store):
         row = name_store.create_component(


### PR DESCRIPTION
Follow-up to #135/#136: the derived instance name is now the discriminator value by itself — "act_123" / "My Client DE" — instead of "{type label} {discriminator}". The type label was redundant: it's already rendered alongside the name everywhere the name appears (catalog cards, steppers, badges). The class label remains the fallback when no discriminator is declared or set, so undiscriminated components are unaffected.

- `Component.instance_name()` → `discriminator or class label`
- Source form's derived name → selected option's label alone (type label until one is picked)

Checks: ruff, ty, 908 Python tests, frontend lint + typecheck green.

By Digitl