### PR TITLE
feat: discriminator markers for remaining multi-instance components

### DIFF
--- a/packages/interloper-assets/src/interloper_assets/amazon_ads/connection.py
+++ b/packages/interloper-assets/src/interloper_assets/amazon_ads/connection.py
@@ -46,6 +46,7 @@ class AmazonAdsConnection(il.RefreshTokenOAuthConnection):
             {"label": "Far East", "value": "FE"},
         ],
         description="API region",
+        discriminator=True,
     )
 
     @cached_property

--- a/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/connection.py
+++ b/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/connection.py
@@ -44,6 +44,7 @@ class AmazonSellingPartnerConnection(il.Connection):
             {"label": "Far East", "value": "FE"},
         ],
         description="API region",
+        discriminator=True,
     )
     client_id: str = il.InputField(title="Client ID", description="LWA client ID")
     client_secret: str = il.SecretField(title="Client Secret", description="LWA client secret")

--- a/packages/interloper-assets/src/interloper_assets/brandwatch/connection.py
+++ b/packages/interloper-assets/src/interloper_assets/brandwatch/connection.py
@@ -17,7 +17,11 @@ class BrandwatchConnection(il.Connection):
     model_config = SettingsConfigDict(env_prefix="brandwatch_")
 
     api_key: str = il.SecretField(title="API Key", description="Brandwatch API key")
-    channel_id: str = il.InputField(title="Channel ID", description="Channel ID to fetch insights for")
+    channel_id: str = il.InputField(
+        title="Channel ID",
+        description="Channel ID to fetch insights for",
+        discriminator=True,
+    )
     network: str = il.SelectField(
         options=[
             {"label": "Facebook", "value": "facebook"},

--- a/packages/interloper-assets/src/interloper_assets/campaign_manager_360/source.py
+++ b/packages/interloper-assets/src/interloper_assets/campaign_manager_360/source.py
@@ -16,4 +16,4 @@ class CampaignManager360(il.Source):
     """Campaign Manager 360 advertising platform integration."""
 
     profile_id: str = il.InputField(description="CM360 user profile ID")
-    account_id: str = il.InputField(description="CM360 account ID")
+    account_id: str = il.InputField(description="CM360 account ID", discriminator=True)

--- a/packages/interloper-assets/src/interloper_assets/display_video_360/source.py
+++ b/packages/interloper-assets/src/interloper_assets/display_video_360/source.py
@@ -17,5 +17,5 @@ from interloper_assets.display_video_360.connection import DisplayVideo360Connec
 class DisplayVideo360(il.Source):
     """Display & Video 360 advertising platform integration."""
 
-    partner_id: str = il.InputField(description="DV360 partner ID")
+    partner_id: str = il.InputField(description="DV360 partner ID", discriminator=True)
     advertiser_id: str = il.InputField(description="DV360 advertiser ID (optional, used for audience queries)")

--- a/packages/interloper-assets/src/interloper_assets/double_click_bid_manager/source.py
+++ b/packages/interloper-assets/src/interloper_assets/double_click_bid_manager/source.py
@@ -14,5 +14,5 @@ from interloper_assets.double_click_bid_manager.connection import DoubleClickBid
 class DoubleClickBidManager(il.Source):
     """DoubleClick Bid Manager (DBM/DV360) reporting integration."""
 
-    partner_id: str = il.InputField(description="DV360 partner ID for report filtering")
+    partner_id: str = il.InputField(description="DV360 partner ID for report filtering", discriminator=True)
     advertiser_id: str = il.InputField(description="DV360 advertiser ID for report filtering (optional)")

--- a/packages/interloper-assets/src/interloper_assets/impact/connection.py
+++ b/packages/interloper-assets/src/interloper_assets/impact/connection.py
@@ -17,7 +17,7 @@ class ImpactConnection(il.Connection):
 
     model_config = SettingsConfigDict(env_prefix="impact_")
 
-    account_sid: str = il.InputField(title="Account SID", description="Impact account SID")
+    account_sid: str = il.InputField(title="Account SID", description="Impact account SID", discriminator=True)
     auth_token: str = il.SecretField(description="Impact auth token")
 
     @cached_property

--- a/packages/interloper-assets/src/interloper_assets/search_ads_360/source.py
+++ b/packages/interloper-assets/src/interloper_assets/search_ads_360/source.py
@@ -16,4 +16,4 @@ class SearchAds360(il.Source):
     """Search Ads 360 advertising platform integration."""
 
     manager_customer_id: str = il.InputField(description="SA360 manager account customer ID")
-    customer_client_id: str = il.InputField(description="SA360 customer client ID to report on")
+    customer_client_id: str = il.InputField(description="SA360 customer client ID to report on", discriminator=True)

--- a/packages/interloper-assets/src/interloper_assets/thetradedesk/connection.py
+++ b/packages/interloper-assets/src/interloper_assets/thetradedesk/connection.py
@@ -17,7 +17,7 @@ class TheTradeDeskConnection(il.Connection):
     model_config = SettingsConfigDict(env_prefix="thetradedesk_")
 
     api_key: str = il.SecretField(title="API Key", description="The Trade Desk API key")
-    partner_id: str = il.InputField(title="Partner ID", description="The Trade Desk partner ID")
+    partner_id: str = il.InputField(title="Partner ID", description="The Trade Desk partner ID", discriminator=True)
 
     @cached_property
     def client(self) -> il.AsyncRESTClient:

--- a/packages/interloper-assets/src/interloper_assets/usercentrics/connection.py
+++ b/packages/interloper-assets/src/interloper_assets/usercentrics/connection.py
@@ -17,7 +17,7 @@ class UsercentricsConnection(il.Connection):
     model_config = SettingsConfigDict(env_prefix="usercentrics_")
 
     api_key: str = il.SecretField(title="API Key", description="Usercentrics API key")
-    analytics_id: str = il.InputField(title="Analytics ID", description="Usercentrics analytics ID")
+    analytics_id: str = il.InputField(title="Analytics ID", description="Usercentrics analytics ID", discriminator=True)
 
     @cached_property
     def client(self) -> il.AsyncRESTClient:

--- a/packages/interloper-google-cloud/src/interloper_google_cloud/bigquery/destination.py
+++ b/packages/interloper-google-cloud/src/interloper_google_cloud/bigquery/destination.py
@@ -45,6 +45,7 @@ class BigQueryDestination(DatabaseDestination):
         label_key="name",
         value_key="project_id",
         description="Google Cloud project ID",
+        discriminator=True,
     )
     location: str = SelectField(
         description="BigQuery dataset location",


### PR DESCRIPTION
Applies the reviewed discriminator recommendations across the remaining components — each a one-line `discriminator=True` on the field that distinguishes instances.

## Sources (drive per-instance asset tables + names)

| Source | Field | Why this field |
|---|---|---|
| campaign_manager_360 | `account_id` | `profile_id` is the user's profile within the account (per-credential) |
| display_video_360 | `partner_id` | required; `advertiser_id` is an optional query filter |
| double_click_bid_manager | `partner_id` | same structure as DV360 |
| search_ads_360 | `customer_client_id` | the account reported on; `manager_customer_id` is the access path |

## Connections & destinations (display names only)

| Component | Field |
|---|---|
| BigQuery destination | `project` |
| amazon_ads / amazon_selling_partner connections | `location` |
| impact connection | `account_sid` |
| thetradedesk connection | `partner_id` |
| brandwatch connection | `channel_id` |
| usercentrics connection | `analytics_id` |

## Deliberately not marked

- **thetradedesk source** (`report_template_id`) — a report selector makes an odd table suffix; the natural identity (`partner_id`) is on the connection. Revisit when someone runs two TTD instances.
- **file/csv destinations** (`base_path`) — bare pydantic fields, low-value dev/test backends.
- **brandwatch / usercentrics sources** — no config fields; their instance identity lives on the connection, so the connection markers fix names but two sources would still collide on tables (blocked by the store guard). Tracked in #140.

No secret fields are marked (the discriminator flows into plaintext `components.name` and table names).

Checks: ruff, ty, 908 tests green. Composes with #139 (discriminator-only names) — this PR is off main, so the two are independent.

By Digitl