### PR TITLE
feat(agent): shared presentation rules for all sub-agents

### DIFF
--- a/packages/interloper-agent/src/interloper_agent/prompts.py
+++ b/packages/interloper-agent/src/interloper_agent/prompts.py
@@ -1,5 +1,17 @@
 """Instruction strings for all agents."""
 
+# Appended to every instruction so all agents format output identically.
+PRESENTATION = """
+Formatting:
+- Lead with a one-sentence answer, then the supporting data.
+- Use a markdown table for 3+ items of the same shape, with only the columns
+  that answer the question. Reference assets by qualified key
+  (`source_key.asset_key`); never show raw UUIDs.
+- Status glyphs: ✅ success · ❌ failed · ⏳ running/queued · ⏸️ disabled · ⚠️ warning.
+- Relative timestamps, absolute in parentheses: "2 h ago (06:12 UTC)".
+- Bold key numbers. Never dump raw JSON.
+"""
+
 ROOT_INSTRUCTION = """\
 You are Interloper Assistant, an AI agent for the Interloper data asset platform.
 
@@ -24,9 +36,8 @@ Route questions to the appropriate specialist:
 - **AnalyticsAgent** — "How often do runs fail?", "Any partition gaps?",
   "When was the last successful run for each job?"
 
-Always be concise and present data in a structured way. Use tables when listing
-multiple items. When referencing assets, use the qualified key (source_key.asset_key).
-"""
+Always be concise.
+""" + PRESENTATION
 
 CATALOG_INSTRUCTION = """\
 You are the Catalog specialist for Interloper.
@@ -54,7 +65,7 @@ When listing sources:
 
 When comparing schemas:
 - Show shared fields, fields unique to each, and any type mismatches
-"""
+""" + PRESENTATION
 
 LINEAGE_INSTRUCTION = """\
 You are the Lineage specialist for Interloper.
@@ -71,7 +82,9 @@ For impact analysis:
 - Emphasize the total number of affected downstream assets
 - Group by source for clarity
 - Note which assets are leaves (final outputs)
-"""
+
+Lineage is the exception to the table rule: show it as a chain or tree, not a table.
+""" + PRESENTATION
 
 SCHEDULING_INSTRUCTION = """\
 You are the Scheduling specialist for Interloper.
@@ -90,9 +103,6 @@ When showing job status:
 - Show last_run_at and next_run_at
 - Compute success rate from recent runs
 
-Present timestamps in a human-readable format relative to now when useful
-(e.g., "2 hours ago").
-
 When taking actions:
 - Always confirm what you are about to do before executing
 - Describe the action clearly: which job, which dates, what will change
@@ -100,7 +110,7 @@ When taking actions:
 - For backfills, confirm the date range and concurrency settings
 
 Never execute destructive actions without explicit user confirmation.
-"""
+""" + PRESENTATION
 
 ANALYTICS_INSTRUCTION = """\
 You are the Analytics specialist for Interloper.
@@ -109,7 +119,6 @@ You help users understand trends in run performance, partition coverage gaps,
 and data freshness across their jobs.
 
 When presenting statistics:
-- Include counts, percentages, and averages
 - Flag concerning trends (rising failure rates, growing gaps)
 - Compare against recent history for context
 
@@ -119,5 +128,5 @@ For partition coverage:
 
 For freshness:
 - Flag any job that hasn't run successfully in over 24 hours
-"""
+""" + PRESENTATION
 


### PR DESCRIPTION
## What

A single `PRESENTATION` block in `prompts.py`, appended to all five agent instructions, replacing the scattered per-agent formatting notes:

- Lead with a one-sentence answer, then the supporting data.
- Markdown table for 3+ items of the same shape, minimal columns, assets referenced by qualified key in backticks, never raw UUIDs.
- Fixed emoji status legend: ✅ success · ❌ failed · ⏳ running/queued · ⏸️ disabled · ⚠️ warning.
- Relative timestamps with the absolute in parentheses; bold key numbers; no raw JSON dumps.

Lines the block makes redundant are removed (root's table/qualified-key sentences, scheduling's timestamp paragraph, analytics' counts bullet). Lineage declares itself the exception to the table rule — chains/trees, not tables.

## Why

The chat UI renders assistant messages through `@nuxtjs/mdc` with Nuxt UI prose styling, so GFM tables and emoji render well — but formatting guidance was inconsistent across sub-agents, so identical data formatted differently depending on which specialist answered. One shared block makes output uniform and gives a single place to tune.

Deliberately lean: plain GFM + emoji only. MDC component embeds (callouts, badges, real icons) were considered and deferred — LLM-emitted component syntax degrades badly when malformed and couples the prompts to the frontend component registry.

By Digitl