### PR TITLE
feat(agent): connection setup through the chat

### DIFF
--- a/packages/interloper-agent/src/interloper_agent/agent.py
+++ b/packages/interloper-agent/src/interloper_agent/agent.py
@@ -10,11 +10,12 @@ from interloper.settings import AppSettings
 from interloper_agent.prompts import (
     ANALYTICS_INSTRUCTION,
     CATALOG_INSTRUCTION,
+    CONNECTION_INSTRUCTION,
     LINEAGE_INSTRUCTION,
     ROOT_INSTRUCTION,
     SCHEDULING_INSTRUCTION,
 )
-from interloper_agent.tools import analytics, catalog, lineage, scheduling
+from interloper_agent.tools import analytics, catalog, connections, lineage, scheduling
 
 if TYPE_CHECKING:
     from google.adk.models import BaseLlm
@@ -104,10 +105,25 @@ analytics_agent = Agent(
     ],
 )
 
+connection_agent = Agent(
+    name="ConnectionAgent",
+    model=_model,
+    description=(
+        "Lists configured connections and sets up new ones by presenting the app's secure "
+        "setup form (OAuth sign-in or manual credentials) — never collects credentials in chat."
+    ),
+    instruction=CONNECTION_INSTRUCTION,
+    tools=[
+        connections.list_connection_types,
+        connections.list_connections,
+        connections.request_connection_setup,
+    ],
+)
+
 root_agent = Agent(
     name="InterloperAgent",
     model=_model,
     instruction=ROOT_INSTRUCTION,
     description="Main Interloper assistant that routes queries to specialized sub-agents.",
-    sub_agents=[catalog_agent, lineage_agent, scheduling_agent, analytics_agent],
+    sub_agents=[catalog_agent, lineage_agent, scheduling_agent, analytics_agent, connection_agent],
 )

--- a/packages/interloper-agent/src/interloper_agent/prompts.py
+++ b/packages/interloper-agent/src/interloper_agent/prompts.py
@@ -35,8 +35,29 @@ Route questions to the appropriate specialist:
   for yesterday", "Backfill March 1-15", "Disable the campaign_matcher job"
 - **AnalyticsAgent** — "How often do runs fail?", "Any partition gaps?",
   "When was the last successful run for each job?"
+- **ConnectionAgent** — "Connect Facebook Ads", "Set up a new connection",
+  "What connections do we have?"
 
 Always be concise.
+""" + PRESENTATION
+
+CONNECTION_INSTRUCTION = """\
+You are the Connection specialist for Interloper.
+
+You help users see their configured connections and set up new ones.
+Connections hold credentials (OAuth tokens, API keys, service accounts).
+
+Credentials are sensitive: NEVER ask the user to paste credentials, tokens,
+or secrets into the chat, and never repeat a credential value. Setup happens
+in a secure form in the app, not in the conversation.
+
+To set up a new connection:
+1. Find the right type with list_connection_types. Tell the user whether
+   they can sign in with the provider (oauth_available) or will need to
+   enter credentials manually in the form.
+2. Call request_connection_setup — the app shows the user the setup form.
+3. Ask the user to complete the form and say so when done.
+4. Verify with list_connections and confirm the result.
 """ + PRESENTATION
 
 CATALOG_INSTRUCTION = """\

--- a/packages/interloper-agent/src/interloper_agent/tools/connections.py
+++ b/packages/interloper-agent/src/interloper_agent/tools/connections.py
@@ -1,0 +1,106 @@
+"""Connection tools — discovery and setup orchestration.
+
+Credentials never transit the model: ``request_connection_setup`` only
+signals the app to present a secure setup form (OAuth sign-in or manual
+entry), and the browser submits credentials to the API directly. Listing
+tools return identity and metadata only, never credential values.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from google.adk.tools.tool_context import ToolContext
+from interloper.oauth import is_provider_configured
+
+from interloper_agent.context import get_catalog, get_org_id, get_store, serialize
+
+
+def list_connection_types(tool_context: ToolContext) -> dict[str, Any]:
+    """List the connection types available in the catalog.
+
+    Use this to pick the right type before requesting setup. Each entry
+    notes its required config fields and whether OAuth sign-in is supported
+    by the type (``oauth``) and usable in this deployment
+    (``oauth_available``) — when OAuth is not available, the user will have
+    to enter credentials manually in the setup form.
+    """
+    try:
+        catalog = get_catalog()
+        results = []
+        for key, defn in catalog.items():
+            if defn.get("kind") != "connection":
+                continue
+            schema = defn.get("config_schema") or {}
+            oauth = schema.get("x-oauth")
+            results.append({
+                "key": key,
+                "name": defn.get("name", key),
+                "description": defn.get("description"),
+                "provider": defn.get("provider"),
+                "required_fields": schema.get("required", []),
+                "oauth": oauth is not None,
+                "oauth_available": is_provider_configured(oauth["provider"]) if oauth else False,
+            })
+        return {"status": "success", "count": len(results), "connection_types": results}
+    except Exception as e:
+        return {"status": "error", "error": str(e)}
+
+
+def list_connections(tool_context: ToolContext) -> dict[str, Any]:
+    """List the connections configured in the organisation.
+
+    Returns identity and metadata only — never credential values.
+    """
+    try:
+        org_id = get_org_id(tool_context)
+        store = get_store()
+        catalog = get_catalog()
+        connections = [
+            {
+                "id": serialize(c.id),
+                "key": c.key,
+                "name": c.name,
+                "type_name": (catalog.get(c.key) or {}).get("name", c.key),
+                "created_at": serialize(c.created_at),
+            }
+            for c in store.list_components(org_id, kinds=["connection"])
+        ]
+        return {"status": "success", "count": len(connections), "connections": connections}
+    except Exception as e:
+        return {"status": "error", "error": str(e)}
+
+
+def request_connection_setup(
+    connection_key: str,
+    name: str | None = None,
+    tool_context: ToolContext | None = None,
+) -> dict[str, Any]:
+    """Present a secure connection setup form to the user in the app.
+
+    Call this to let the user create a connection: the app renders the form
+    for the given type (OAuth sign-in when available, manual credential
+    entry otherwise) and the credentials go directly to the API. Never ask
+    the user to share credentials in the chat instead.
+
+    Args:
+        connection_key: Catalog key of the connection type
+            (e.g. 'facebook_ads_connection'), from list_connection_types.
+        name: Optional display name to prefill in the form.
+    """
+    try:
+        catalog = get_catalog()
+        defn = catalog.get(connection_key)
+        if defn is None or defn.get("kind") != "connection":
+            return {"status": "error", "error": f"Connection type '{connection_key}' not found in catalog"}
+        return {
+            "status": "success",
+            "message": (
+                "Setup form presented to the user. Ask them to complete it "
+                "(and to say so when done), then verify with list_connections."
+            ),
+            "connection_key": connection_key,
+            "name": name,
+        }
+    except Exception as e:
+        return {"status": "error", "error": str(e)}

--- a/packages/interloper-api/src/interloper_api/app.py
+++ b/packages/interloper-api/src/interloper_api/app.py
@@ -122,4 +122,6 @@ def create_app(
 
     app.include_router(api)
 
+    oauth.log_provider_status()
+
     return app

--- a/packages/interloper-api/src/interloper_api/routes/oauth.py
+++ b/packages/interloper-api/src/interloper_api/routes/oauth.py
@@ -26,7 +26,7 @@ from typing import Any
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException
-from interloper.oauth import PROVIDERS, OAuthProvider
+from interloper.oauth import PROVIDERS, OAuthProvider, is_provider_configured
 from interloper_db import Profile
 from pydantic import BaseModel
 
@@ -52,7 +52,7 @@ class _ProviderConfig:
 
     @property
     def configured(self) -> bool:
-        return bool(self.client_id and self.client_secret and self.redirect_uri)
+        return is_provider_configured(self.key)
 
 
 def _load_providers() -> dict[str, _ProviderConfig]:

--- a/packages/interloper-api/src/interloper_api/routes/oauth.py
+++ b/packages/interloper-api/src/interloper_api/routes/oauth.py
@@ -26,7 +26,7 @@ from typing import Any
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException
-from interloper.oauth import PROVIDERS, OAuthProvider, is_provider_configured
+from interloper.oauth import PROVIDERS, OAuthAppCredentials, OAuthProvider, provider_env_names
 from interloper_db import Profile
 from pydantic import BaseModel
 
@@ -37,26 +37,22 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/oauth", tags=["oauth"])
 
 
-# -- App credentials (environment) ---------------------------------------------
+def log_provider_status() -> None:
+    """Log which OAuth providers are usable, warning on partial credential trios.
 
-
-class _ProviderConfig:
-    """In-house OAuth credentials resolved from environment variables."""
-
-    def __init__(self, key: str, *, env_prefix: str | None = None) -> None:
-        prefix = (env_prefix or key).upper()
-        self.key = key
-        self.client_id = os.environ.get(f"INTERLOPER_{prefix}_CLIENT_ID", "")
-        self.client_secret = os.environ.get(f"INTERLOPER_{prefix}_CLIENT_SECRET", "")
-        self.redirect_uri = os.environ.get(f"INTERLOPER_{prefix}_REDIRECT_URI", "")
-
-    @property
-    def configured(self) -> bool:
-        return is_provider_configured(self.key)
-
-
-def _load_providers() -> dict[str, _ProviderConfig]:
-    return {key: _ProviderConfig(key) for key in PROVIDERS.keys()}
+    Called at app startup: a provider with only some of its three env vars set
+    is invisible everywhere else (it simply isn't offered), so this warning is
+    the one place a typo'd or forgotten variable surfaces.
+    """
+    active = []
+    for key in PROVIDERS.keys():
+        names = provider_env_names(key)
+        missing = [n for n in names.values() if not os.environ.get(n)]
+        if not missing:
+            active.append(key)
+        elif len(missing) < len(names):
+            logger.warning("OAuth provider '%s' is partially configured — missing %s", key, ", ".join(sorted(missing)))
+    logger.info("OAuth sign-in providers: %s", ", ".join(sorted(active)) if active else "none configured")
 
 
 # -- Generic token exchange ----------------------------------------------------
@@ -65,7 +61,7 @@ def _load_providers() -> dict[str, _ProviderConfig]:
 async def _exchange(
     client: httpx.AsyncClient,
     spec: OAuthProvider,
-    cfg: _ProviderConfig,
+    cfg: OAuthAppCredentials,
     code: str,
 ) -> dict[str, Any]:
     """Exchange an authorization code for tokens, driven by the provider spec.
@@ -136,18 +132,17 @@ def list_providers() -> list[ProviderInfo]:
     ``REDIRECT_URI`` environment variables set are included.  Metadata
     (auth_url, label, icon) comes from the provider registry.
     """
-    specs = dict(PROVIDERS.items())
     return [
         ProviderInfo(
-            key=cfg.key,
-            client_id=cfg.client_id,
-            redirect_uri=cfg.redirect_uri,
-            auth_url=specs[cfg.key].auth_url,
-            label=specs[cfg.key].label,
-            icon=specs[cfg.key].icon,
+            key=key,
+            client_id=creds.client_id,
+            redirect_uri=creds.redirect_uri,
+            auth_url=spec.auth_url,
+            label=spec.label,
+            icon=spec.icon,
         )
-        for cfg in _load_providers().values()
-        if cfg.configured
+        for key, spec in PROVIDERS.items()
+        if (creds := OAuthAppCredentials.from_env(key)) is not None
     ]
 
 
@@ -167,8 +162,8 @@ async def exchange_token(
     if spec is None:
         raise HTTPException(status_code=400, detail=f"Unknown OAuth provider: {provider}")
 
-    cfg = _ProviderConfig(provider)
-    if not cfg.configured:
+    cfg = OAuthAppCredentials.from_env(provider)
+    if cfg is None:
         raise HTTPException(status_code=400, detail=f"OAuth provider {provider} is not configured")
 
     try:

--- a/packages/interloper-api/tests/test_oauth.py
+++ b/packages/interloper-api/tests/test_oauth.py
@@ -17,7 +17,7 @@ import httpx
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from interloper.oauth import PROVIDERS
+from interloper.oauth import PROVIDERS, OAuthAppCredentials
 
 from interloper_api.dependencies import get_current_user, get_store
 from interloper_api.routes import oauth as oauth_module
@@ -46,24 +46,36 @@ def _client() -> TestClient:
     return TestClient(app)
 
 
-def test_provider_config_reads_bare_env(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_credentials_read_from_provider_env(monkeypatch: pytest.MonkeyPatch) -> None:
     _configure(monkeypatch, "amazon", client_id="id", client_secret="secret", redirect_uri="uri")
 
-    cfg = oauth_module._ProviderConfig("amazon")
+    creds = OAuthAppCredentials.from_env("amazon")
 
-    assert (cfg.client_id, cfg.client_secret, cfg.redirect_uri) == ("id", "secret", "uri")
-    assert cfg.configured is True
+    assert creds == OAuthAppCredentials(client_id="id", client_secret="secret", redirect_uri="uri")
 
 
-def test_load_providers_marks_only_fully_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_partially_configured_provider_resolves_to_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
     _configure(monkeypatch, "amazon", client_id="id", client_secret="secret", redirect_uri="uri")
     _configure(monkeypatch, "criteo", client_id="id-only")  # incomplete -> not configured
 
-    providers = oauth_module._load_providers()
+    assert OAuthAppCredentials.from_env("amazon") is not None
+    assert OAuthAppCredentials.from_env("criteo") is None
+    assert OAuthAppCredentials.from_env("tiktok") is None
 
-    assert providers["amazon"].configured is True
-    assert providers["criteo"].configured is False
-    assert providers["tiktok"].configured is False
+
+def test_startup_status_warns_on_partial_trio(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    _configure(monkeypatch, "amazon", client_id="id", client_secret="secret", redirect_uri="uri")
+    _configure(monkeypatch, "criteo", client_id="id-only")
+
+    with caplog.at_level("INFO", logger=oauth_module.logger.name):
+        oauth_module.log_provider_status()
+
+    warnings = [r.message for r in caplog.records if r.levelname == "WARNING"]
+    assert len(warnings) == 1
+    assert "criteo" in warnings[0] and "INTERLOPER_CRITEO_CLIENT_SECRET" in warnings[0]
+    assert any("amazon" in r.message for r in caplog.records if r.levelname == "INFO")
 
 
 def test_list_providers_returns_configured_only_with_registry_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -121,9 +133,11 @@ def _capture_client(captured: list[httpx.Request]) -> httpx.AsyncClient:
     return httpx.AsyncClient(transport=httpx.MockTransport(handler))
 
 
-def _cfg(monkeypatch: pytest.MonkeyPatch, provider: str) -> oauth_module._ProviderConfig:
+def _cfg(monkeypatch: pytest.MonkeyPatch, provider: str) -> OAuthAppCredentials:
     _configure(monkeypatch, provider, client_id="cid", client_secret="cs", redirect_uri="https://r")
-    return oauth_module._ProviderConfig(provider)
+    creds = OAuthAppCredentials.from_env(provider)
+    assert creds is not None
+    return creds
 
 
 async def test_exchange_post_json(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/packages/interloper-app/app/app/components/AgentPanel.vue
+++ b/packages/interloper-app/app/app/components/AgentPanel.vue
@@ -17,13 +17,19 @@ const { messages, streaming, error, send } = useAgentChat(sessionId)
  * `submitted` status' thinking indicator covers.
  */
 const displayMessages = computed(() => messages.value
-    .filter(m => m.text || m.role === 'user')
+    .filter(m => m.text || m.role === 'user' || m.connectionSetup)
     .map(m => ({
         id: m.id,
         role: m.role,
         text: m.text,
         parts: [{ type: 'text' as const, text: m.text }],
+        connectionSetup: m.connectionSetup,
     })))
+
+/** Report a completed connection setup back into the chat so the agent continues. */
+function onConnectionCreated(name: string) {
+    send(`I completed the setup — connection "${name}" is created.`)
+}
 
 const status = computed(() => {
     if (!streaming.value) return 'ready' as const
@@ -106,12 +112,15 @@ const SUGGESTIONS = [
                                :status="status"
                                compact
                                should-auto-scroll
-                               :assistant="{ icon: 'i-lucide-sparkles', ui: { content: 'text-[13.5px]', leadingIcon: 'text-primary' } }"
+                               :assistant="{ icon: 'i-lucide-sparkles', ui: { body: 'flex-1', content: 'text-[13.5px]', leadingIcon: 'text-primary' } }"
                                :user="{ ui: { content: 'text-[13.5px]' } }"
                                :auto-scroll="{ size: 'xs', color: 'neutral', variant: 'outline' }"
                                class="pb-2">
                     <template #content="{ message }">
-                        <MDC v-if="message.role === 'assistant'"
+                        <AgentConnectCard v-if="(message as any).connectionSetup"
+                                          :request="(message as any).connectionSetup"
+                                          @created="onConnectionCreated" />
+                        <MDC v-else-if="message.role === 'assistant'"
                              :value="message.text"
                              :cache-key="message.id"
                              class="*:first:mt-0 *:last:mb-0 [&_code]:text-[12px]" />

--- a/packages/interloper-app/app/app/components/agent/ConnectCard.vue
+++ b/packages/interloper-app/app/app/components/agent/ConnectCard.vue
@@ -1,0 +1,112 @@
+<script setup lang="ts">
+/**
+ * Inline connection-setup card rendered in the agent chat.
+ *
+ * Triggered by the agent's `request_connection_setup` tool: reuses
+ * SchemaForm (OAuth sign-in or manual credentials) so secrets go straight
+ * from the form to the API, never through the conversation. On success the
+ * parent reports completion back into the chat so the agent can continue.
+ */
+import type { ConnectionSetupRequest } from '~/types/agent'
+
+const props = defineProps<{
+    request: ConnectionSetupRequest
+}>()
+
+const emit = defineEmits<{
+    created: [name: string]
+}>()
+
+const catalogStore = useCatalogStore()
+const componentsStore = useComponentsStore()
+const toast = useToast()
+
+const defn = computed(() => catalogStore.catalog[props.request.connectionKey])
+const schema = computed(() => (defn.value as any)?.config_schema ?? null)
+
+const name = ref(props.request.name ?? '')
+const formData = ref<Record<string, unknown>>({})
+const formValid = ref(false)
+const submitting = ref(false)
+const createdName = ref<string | null>(null)
+
+watch(defn, (d) => {
+    if (d && !name.value) name.value = `My ${d.name} Connection`
+}, { immediate: true })
+
+const canSubmit = computed(() => !!name.value.trim() && (formValid.value || !schema.value))
+
+async function submit() {
+    submitting.value = true
+    try {
+        await componentsStore.create({
+            kind: 'connection',
+            key: props.request.connectionKey,
+            name: name.value.trim(),
+            config: formData.value,
+        })
+        createdName.value = name.value.trim()
+        toast.add({ title: `Connection "${createdName.value}" created`, color: 'success' })
+        emit('created', createdName.value)
+    }
+    catch {
+        toast.add({ title: 'Failed to create connection', color: 'error' })
+    }
+    submitting.value = false
+}
+</script>
+
+<template>
+    <div class="border border-default rounded-[14px] p-5 my-2 w-full min-w-72 max-w-md">
+        <!-- Unknown type: the catalog may not carry this key anymore -->
+        <div v-if="!defn"
+             class="flex items-center gap-2 text-sm text-muted">
+            <UIcon name="i-lucide-circle-alert"
+                   class="size-4 shrink-0" />
+            Connection type "{{ request.connectionKey }}" is not in the catalog.
+        </div>
+
+        <!-- Created: locked summary -->
+        <div v-else-if="createdName"
+             class="flex items-center gap-3">
+            <UIcon :name="componentIcon(request.connectionKey)"
+                   class="size-6 shrink-0" />
+            <div class="flex-1 text-sm">
+                <span class="font-semibold">{{ createdName }}</span>
+                <span class="text-muted"> — {{ defn.name }} connection created</span>
+            </div>
+            <UIcon name="i-lucide-check-circle-2"
+                   class="size-5 text-success shrink-0" />
+        </div>
+
+        <!-- Setup form -->
+        <div v-else
+             class="flex flex-col gap-4">
+            <div class="flex items-center gap-3">
+                <UIcon :name="componentIcon(request.connectionKey)"
+                       class="size-6 shrink-0" />
+                <div class="text-sm font-semibold">
+                    Set up {{ defn.name }} connection
+                </div>
+            </div>
+
+            <UFormField label="Connection name"
+                        required>
+                <UInput v-model="name"
+                        placeholder="Enter a name for this connection"
+                        class="w-full" />
+            </UFormField>
+
+            <SchemaForm v-if="schema"
+                        v-model:data="formData"
+                        v-model:is-valid="formValid"
+                        :schema="schema" />
+
+            <UButton :label="submitting ? 'Creating…' : 'Create connection'"
+                     :loading="submitting"
+                     :disabled="!canSubmit"
+                     block
+                     @click="submit" />
+        </div>
+    </div>
+</template>

--- a/packages/interloper-app/app/app/composables/agentChat.ts
+++ b/packages/interloper-app/app/app/composables/agentChat.ts
@@ -1,4 +1,4 @@
-import type { AgentEvent, ChatMessage } from '~/types/agent'
+import type { AgentEvent, ChatMessage, ConnectionSetupRequest } from '~/types/agent'
 
 /**
  * Composable for managing an agent chat session with SSE streaming.
@@ -20,13 +20,19 @@ export function useAgentChat(sessionId: Ref<string>) {
 
             const restored: ChatMessage[] = []
             for (const event of session.events) {
+                const setup = _extractConnectionSetup(event)
+                if (setup) {
+                    restored.push({ id: event.id || crypto.randomUUID(), role: 'assistant', text: '', connectionSetup: setup })
+                    continue
+                }
+
                 const text = _extractText(event)
                 if (!text) continue
 
                 const role = event.author === 'user' ? 'user' as const : 'assistant' as const
                 // Merge consecutive assistant messages from the same invocation
                 const last = restored[restored.length - 1]
-                if (role === 'assistant' && last?.role === 'assistant') {
+                if (role === 'assistant' && last?.role === 'assistant' && !last.connectionSetup) {
                     last.text += text
                 }
                 else {
@@ -99,6 +105,10 @@ export function useAgentChat(sessionId: Ref<string>) {
 
                     try {
                         const event: AgentEvent = JSON.parse(json)
+                        const setup = _extractConnectionSetup(event)
+                        if (setup) {
+                            messages.value.push({ id: crypto.randomUUID(), role: 'assistant', text: '', connectionSetup: setup })
+                        }
                         const eventText = _extractText(event)
                         if (eventText && event.author !== 'user') {
                             const msg = messages.value.find(m => m.id === assistantId)
@@ -140,4 +150,21 @@ function _extractText(event: any): string {
         .filter((p: any) => p.text)
         .map((p: any) => p.text)
         .join('')
+}
+
+/**
+ * Extract a connection-setup request from an ADK event.
+ *
+ * Keys on the tool's function *response* (not the call), so a card only
+ * renders for requests the tool validated against the catalog.
+ */
+function _extractConnectionSetup(event: any): ConnectionSetupRequest | null {
+    for (const part of event?.content?.parts ?? []) {
+        const fr = part.functionResponse
+        if (fr?.name !== 'request_connection_setup') continue
+        const response = fr.response
+        if (response?.status !== 'success' || !response.connection_key) continue
+        return { connectionKey: response.connection_key, name: response.name ?? undefined }
+    }
+    return null
 }

--- a/packages/interloper-app/app/app/pages/agent/chat/[id].vue
+++ b/packages/interloper-app/app/app/pages/agent/chat/[id].vue
@@ -20,6 +20,11 @@ function onSubmit(e: Event) {
     input.value = ''
 }
 
+/** Report a completed connection setup back into the chat so the agent continues. */
+function onConnectionCreated(name: string) {
+    send(`I completed the setup — connection "${name}" is created.`)
+}
+
 onMounted(async () => {
     await loadHistory()
     const initialQuery = route.query.q as string | undefined
@@ -57,10 +62,14 @@ onMounted(async () => {
                                   :parts="[{ type: 'text', text: message.text }]"
                                   :variant="message.role === 'user' ? 'soft' : 'naked'"
                                   :side="message.role === 'user' ? 'right' : 'left'"
-                                  :icon="message.role === 'assistant' ? 'i-lucide-sparkles' : undefined">
+                                  :icon="message.role === 'assistant' ? 'i-lucide-sparkles' : undefined"
+                                  :ui="message.role === 'assistant' ? { body: 'flex-1' } : undefined">
                         <template #content>
-                            <!-- Render markdown for assistant, plain text for user -->
-                            <MDC v-if="message.role === 'assistant'"
+                            <!-- Render the connect card, markdown for assistant, plain text for user -->
+                            <AgentConnectCard v-if="message.connectionSetup"
+                                              :request="message.connectionSetup"
+                                              @created="onConnectionCreated" />
+                            <MDC v-else-if="message.role === 'assistant'"
                                  :value="message.text"
                                  :cache-key="message.id"
                                  class="*:first:mt-0 *:last:mb-0" />

--- a/packages/interloper-app/app/app/types/agent.ts
+++ b/packages/interloper-app/app/app/types/agent.ts
@@ -38,10 +38,18 @@ export interface AgentEvent {
     timestamp?: number
 }
 
+/** Inline connection-setup request emitted by the agent's request_connection_setup tool. */
+export interface ConnectionSetupRequest {
+    connectionKey: string
+    name?: string
+}
+
 /** Simplified chat message for UI rendering. */
 export interface ChatMessage {
     id: string
     role: 'user' | 'assistant'
     text: string
     loading?: boolean
+    /** When set, the message renders the inline connection setup card. */
+    connectionSetup?: ConnectionSetupRequest
 }

--- a/packages/interloper-core/src/interloper/connection/base.py
+++ b/packages/interloper-core/src/interloper/connection/base.py
@@ -8,7 +8,7 @@ from typing import Any, ClassVar
 from pydantic import model_validator
 from pydantic_settings import BaseSettings
 
-from interloper.oauth import OAuthConfig
+from interloper.oauth import OAuthConfig, provider_env_name
 from interloper.resource import InputField, Resource, ResourceDefinition, SecretField
 
 
@@ -94,7 +94,7 @@ class OAuthConnection(Connection):
         """
         if not isinstance(cls.oauth, OAuthConfig):
             return None
-        return os.environ.get(f"INTERLOPER_{cls.oauth.provider.upper()}_{suffix}")
+        return os.environ.get(provider_env_name(cls.oauth.provider, suffix))
 
     @staticmethod
     def resolve_field(data: dict[str, Any], field: str, value: str | None) -> None:

--- a/packages/interloper-core/src/interloper/oauth/__init__.py
+++ b/packages/interloper-core/src/interloper/oauth/__init__.py
@@ -1,4 +1,4 @@
-from interloper.oauth.base import DEFAULT_TOKEN_PARAMS, PROVIDERS, OAuthProvider, token_params
+from interloper.oauth.base import DEFAULT_TOKEN_PARAMS, PROVIDERS, OAuthProvider, is_provider_configured, token_params
 from interloper.oauth.config import OAuthConfig
 
 __all__ = [
@@ -6,5 +6,6 @@ __all__ = [
     "PROVIDERS",
     "OAuthConfig",
     "OAuthProvider",
+    "is_provider_configured",
     "token_params",
 ]

--- a/packages/interloper-core/src/interloper/oauth/__init__.py
+++ b/packages/interloper-core/src/interloper/oauth/__init__.py
@@ -1,11 +1,23 @@
-from interloper.oauth.base import DEFAULT_TOKEN_PARAMS, PROVIDERS, OAuthProvider, is_provider_configured, token_params
+from interloper.oauth.base import (
+    DEFAULT_TOKEN_PARAMS,
+    PROVIDERS,
+    OAuthAppCredentials,
+    OAuthProvider,
+    is_provider_configured,
+    provider_env_name,
+    provider_env_names,
+    token_params,
+)
 from interloper.oauth.config import OAuthConfig
 
 __all__ = [
     "DEFAULT_TOKEN_PARAMS",
     "PROVIDERS",
+    "OAuthAppCredentials",
     "OAuthConfig",
     "OAuthProvider",
     "is_provider_configured",
+    "provider_env_name",
+    "provider_env_names",
     "token_params",
 ]

--- a/packages/interloper-core/src/interloper/oauth/base.py
+++ b/packages/interloper-core/src/interloper/oauth/base.py
@@ -23,6 +23,7 @@ dependence, no explicit registration calls.
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
@@ -108,3 +109,15 @@ def _adopt_provider(_name: str, loaded: Any) -> tuple[str, OAuthProvider]:
 
 
 PROVIDERS: Registry[OAuthProvider] = Registry("interloper.oauth_providers", adopt=_adopt_provider)
+
+
+def is_provider_configured(key: str) -> bool:
+    """Whether the in-house OAuth app credentials for ``key`` are set in the environment.
+
+    Returns:
+        True only when ``INTERLOPER_<KEY>_CLIENT_ID``, ``INTERLOPER_<KEY>_CLIENT_SECRET``,
+        and ``INTERLOPER_<KEY>_REDIRECT_URI`` are all set — the provider is usable for sign-in.
+    """
+    prefix = key.upper()
+    suffixes = ("CLIENT_ID", "CLIENT_SECRET", "REDIRECT_URI")
+    return all(os.environ.get(f"INTERLOPER_{prefix}_{suffix}") for suffix in suffixes)

--- a/packages/interloper-core/src/interloper/oauth/base.py
+++ b/packages/interloper-core/src/interloper/oauth/base.py
@@ -111,13 +111,74 @@ def _adopt_provider(_name: str, loaded: Any) -> tuple[str, OAuthProvider]:
 PROVIDERS: Registry[OAuthProvider] = Registry("interloper.oauth_providers", adopt=_adopt_provider)
 
 
+# -- In-house app credentials (environment) -------------------------------------
+
+#: Credential field → env var suffix. The trio a provider needs for sign-in.
+_ENV_FIELDS: dict[str, str] = {
+    "client_id": "CLIENT_ID",
+    "client_secret": "CLIENT_SECRET",
+    "redirect_uri": "REDIRECT_URI",
+}
+
+
+def provider_env_name(key: str, suffix: str) -> str:
+    """The environment variable carrying one in-house credential for provider ``key``.
+
+    Single owner of the ``INTERLOPER_<PROVIDER>_<SUFFIX>`` naming convention —
+    every consumer (token exchange, connection credential injection,
+    availability checks) builds names through here.
+
+    Returns:
+        The environment variable name.
+    """
+    return f"INTERLOPER_{key.upper()}_{suffix.upper()}"
+
+
+def provider_env_names(key: str) -> dict[str, str]:
+    """The environment variable carrying each credential field for provider ``key``.
+
+    Returns:
+        ``{field: env_name}`` for the ``client_id`` / ``client_secret`` /
+        ``redirect_uri`` trio.
+    """
+    return {field: provider_env_name(key, suffix) for field, suffix in _ENV_FIELDS.items()}
+
+
+@dataclass(frozen=True)
+class OAuthAppCredentials:
+    """The in-house OAuth app credential trio for one provider.
+
+    Resolved from the environment complete-or-nothing: :meth:`from_env`
+    never yields a partial set, so consumers cannot observe a
+    half-configured provider.
+    """
+
+    client_id: str
+    client_secret: str
+    redirect_uri: str
+
+    @classmethod
+    def from_env(cls, key: str) -> OAuthAppCredentials | None:
+        """Resolve the trio for provider ``key`` from the environment.
+
+        Returns:
+            The credentials, or ``None`` unless all three variables are set
+            and non-empty.
+        """
+        names = provider_env_names(key)
+        client_id = os.environ.get(names["client_id"])
+        client_secret = os.environ.get(names["client_secret"])
+        redirect_uri = os.environ.get(names["redirect_uri"])
+        if not (client_id and client_secret and redirect_uri):
+            return None
+        return cls(client_id=client_id, client_secret=client_secret, redirect_uri=redirect_uri)
+
+
 def is_provider_configured(key: str) -> bool:
     """Whether the in-house OAuth app credentials for ``key`` are set in the environment.
 
     Returns:
-        True only when ``INTERLOPER_<KEY>_CLIENT_ID``, ``INTERLOPER_<KEY>_CLIENT_SECRET``,
-        and ``INTERLOPER_<KEY>_REDIRECT_URI`` are all set — the provider is usable for sign-in.
+        True only when the full credential trio is set — the provider is
+        usable for sign-in.
     """
-    prefix = key.upper()
-    suffixes = ("CLIENT_ID", "CLIENT_SECRET", "REDIRECT_URI")
-    return all(os.environ.get(f"INTERLOPER_{prefix}_{suffix}") for suffix in suffixes)
+    return OAuthAppCredentials.from_env(key) is not None

--- a/packages/interloper-core/tests/oauth/test_base.py
+++ b/packages/interloper-core/tests/oauth/test_base.py
@@ -1,8 +1,19 @@
 """Tests for the OAuth provider registry."""
 
+from typing import ClassVar
+
 import pytest
 
-from interloper.oauth import DEFAULT_TOKEN_PARAMS, PROVIDERS, OAuthProvider, token_params
+from interloper.oauth import (
+    DEFAULT_TOKEN_PARAMS,
+    PROVIDERS,
+    OAuthAppCredentials,
+    OAuthProvider,
+    is_provider_configured,
+    provider_env_name,
+    provider_env_names,
+    token_params,
+)
 
 
 class TestRegistry:
@@ -48,3 +59,44 @@ class TestOAuthProvider:
     def test_token_params_helper_omits_and_renames(self):
         params = token_params("grant_type", "redirect_uri", code="auth_code")
         assert params == {"code": "auth_code", "client_id": "client_id", "client_secret": "client_secret"}
+
+
+class TestAppCredentials:
+    """In-house app credentials: the INTERLOPER_<PROVIDER>_* env convention."""
+
+    TRIO: ClassVar[dict[str, str]] = {
+        "INTERLOPER_ACME_CLIENT_ID": "id",
+        "INTERLOPER_ACME_CLIENT_SECRET": "secret",
+        "INTERLOPER_ACME_REDIRECT_URI": "https://cb",
+    }
+
+    def test_env_names_own_the_convention(self):
+        assert provider_env_name("acme", "client_id") == "INTERLOPER_ACME_CLIENT_ID"
+        assert provider_env_names("acme") == {
+            "client_id": "INTERLOPER_ACME_CLIENT_ID",
+            "client_secret": "INTERLOPER_ACME_CLIENT_SECRET",
+            "redirect_uri": "INTERLOPER_ACME_REDIRECT_URI",
+        }
+
+    def test_from_env_resolves_complete_trio(self, monkeypatch):
+        for name, value in self.TRIO.items():
+            monkeypatch.setenv(name, value)
+        creds = OAuthAppCredentials.from_env("acme")
+        assert creds == OAuthAppCredentials(client_id="id", client_secret="secret", redirect_uri="https://cb")
+        assert is_provider_configured("acme")
+
+    def test_partial_trio_resolves_to_nothing(self, monkeypatch):
+        for name, value in list(self.TRIO.items())[:2]:
+            monkeypatch.setenv(name, value)
+        assert OAuthAppCredentials.from_env("acme") is None
+        assert not is_provider_configured("acme")
+
+    def test_empty_value_counts_as_unset(self, monkeypatch):
+        for name, value in self.TRIO.items():
+            monkeypatch.setenv(name, value)
+        monkeypatch.setenv("INTERLOPER_ACME_CLIENT_SECRET", "")
+        assert OAuthAppCredentials.from_env("acme") is None
+
+    def test_unset_provider_is_not_configured(self):
+        assert OAuthAppCredentials.from_env("acme") is None
+        assert not is_provider_configured("acme")


### PR DESCRIPTION
## What

The agent can now set up connections from scratch — without credentials ever transiting the model.

**Backend**
- New `ConnectionAgent` sub-agent with three tools (`tools/connections.py`):
  - `list_connection_types` — catalog connection types with required fields, whether the type supports OAuth, and whether OAuth is usable in this deployment (`oauth_available`).
  - `list_connections` — the org's configured connections, identity/metadata only (explicit projection; credential values never leave the store).
  - `request_connection_setup` — validates the catalog key and returns a "form presented" result; its function-response event is the signal the frontend keys on.
- Instruction hard-codes the boundary: never ask for or repeat credentials in chat; setup happens in the app's secure form.
- `is_provider_configured()` moves into `interloper.oauth` as the single source of the "provider env creds present" rule; the `/oauth/providers` route now delegates to it.

**Frontend**
- `agentChat.ts` scans ADK events (live stream + history restore) for the `request_connection_setup` function response — only tool-validated requests render — and inserts a card message.
- New `AgentConnectCard`: name field + the existing `SchemaForm`, so OAuth sign-in vs manual credentials comes free from the schema's `x-oauth` metadata. Credentials POST browser → API through the existing components/oauth endpoints. After creation the card locks to a ✅ summary and reports completion back into the chat so the agent verifies with `list_connections` and continues.
- Rendered in both the chat page and the side `AgentPanel`; assistant message bodies get `flex-1` so the card fills the message width (the theme's body slot otherwise shrinks to content).

## Why

"Set up Facebook Ads" previously dead-ended: the agent had no connection awareness and no safe way to collect credentials — chat input would put secrets into the model context, session events, and history, and OAuth needs a browser. This design keeps the agent in charge of everything *around* the secret (choosing the type, checking OAuth availability, verifying afterwards) while the secret itself moves through the already-hardened popup/BroadcastChannel + encrypted-components path.

## Verification

- Live end-to-end run with the real Gemini-backed runner: "Connect Facebook Ads for me" routed to `ConnectionAgent`, called the tool, and emitted `functionResponse.response.{status, connection_key}` exactly as the frontend parser expects.
- Tool-level checks against the seeded dev DB: `oauth_available` flips with `INTERLOPER_<PROVIDER>_*` env; unknown keys rejected.
- Manually exercised in the app (screenshot-verified): manual-credentials path for a non-OAuth type renders and submits.
- ruff / ty / pytest (908) / frontend lint + `nuxt typecheck` all pass.

## Follow-up

Source creation on top of this flow (conversational config + connection binding) is analysed and queued as the next PR.

By Digitl