### PR TITLE
refactor(agent): tools split by component kind, catalog/collection taxonomy

### DIFF
--- a/packages/interloper-agent/src/interloper_agent/agent.py
+++ b/packages/interloper-agent/src/interloper_agent/agent.py
@@ -15,7 +15,7 @@ from interloper_agent.prompts import (
     ROOT_INSTRUCTION,
     SCHEDULING_INSTRUCTION,
 )
-from interloper_agent.tools import analytics, catalog, connections, lineage, scheduling
+from interloper_agent.tools import analytics, assets, connections, destinations, lineage, scheduling, sources
 
 if TYPE_CHECKING:
     from google.adk.models import BaseLlm
@@ -42,18 +42,18 @@ catalog_agent = Agent(
     name="CatalogAgent",
     model=_model,
     description=(
-        "Discovers the organisation's configured sources and the catalog of available source types, "
-        "inspects asset schemas, searches fields across the catalog, and compares schemas."
+        "Discovers the catalog of available source definitions and the organisation's collection of sources "
+        "and destinations, inspects asset schemas, searches fields across the catalog, and compares schemas."
     ),
     instruction=CATALOG_INSTRUCTION,
     tools=[
-        catalog.list_sources,
-        catalog.list_available_sources,
-        catalog.get_source_detail,
-        catalog.get_asset_schema,
-        catalog.search_fields,
-        catalog.compare_schemas,
-        catalog.list_destinations,
+        sources.list_sources,
+        sources.list_catalog_sources,
+        sources.get_source_detail,
+        assets.get_asset_schema,
+        assets.search_fields,
+        assets.compare_schemas,
+        destinations.list_destinations,
     ],
 )
 
@@ -109,12 +109,13 @@ connection_agent = Agent(
     name="ConnectionAgent",
     model=_model,
     description=(
-        "Lists configured connections and sets up new ones by presenting the app's secure "
-        "setup form (OAuth sign-in or manual credentials) — never collects credentials in chat."
+        "Lists the organisation's collection of connections, checks their health, and sets up new ones by "
+        "presenting the app's secure setup form (OAuth sign-in or manual credentials) — never collects "
+        "credentials in chat."
     ),
     instruction=CONNECTION_INSTRUCTION,
     tools=[
-        connections.list_connection_types,
+        connections.list_catalog_connections,
         connections.list_connections,
         connections.request_connection_setup,
         connections.check_connection,

--- a/packages/interloper-agent/src/interloper_agent/prompts.py
+++ b/packages/interloper-agent/src/interloper_agent/prompts.py
@@ -18,10 +18,14 @@ You are Interloper Assistant, an AI agent for the Interloper data asset platform
 You help users understand their data catalog, asset dependencies, operational health,
 and can take actions like triggering runs or backfills.
 
-Interloper distinguishes the **catalog** — the library of source types the platform
-supports — from the organisation's **configured sources**, the instances the user has
-actually set up. "My/our sources" means configured instances; "available" or
-"supported" sources means the catalog.
+Interloper distinguishes two spaces — use these words consistently:
+
+- The **catalog**: the library of component *definitions* the platform ships —
+  source types, connection types, destination types. Org-independent, nothing
+  in it is set up. "Available", "supported", "could we add X?" → catalog.
+- The **collection**: the component *instances* actually set up and persisted
+  for the user's organisation — their sources, connections, jobs, destinations.
+  "My/our X", "what do we have?" → collection.
 
 Route questions to the appropriate specialist:
 
@@ -44,17 +48,18 @@ Always be concise.
 CONNECTION_INSTRUCTION = """\
 You are the Connection specialist for Interloper.
 
-You help users see their configured connections and set up new ones.
-Connections hold credentials (OAuth tokens, API keys, service accounts).
+You help users see the connections in their organisation's collection and set
+up new ones from the catalog of connection definitions. Connections hold
+credentials (OAuth tokens, API keys, service accounts).
 
 Credentials are sensitive: NEVER ask the user to paste credentials, tokens,
 or secrets into the chat, and never repeat a credential value. Setup happens
 in a secure form in the app, not in the conversation.
 
 To set up a new connection:
-1. Find the right type with list_connection_types. Tell the user whether
-   they can sign in with the provider (oauth_available) or will need to
-   enter credentials manually in the form.
+1. Find the right definition with list_catalog_connections. Tell the user
+   whether they can sign in with the provider (oauth_available) or will need
+   to enter credentials manually in the form.
 2. Call request_connection_setup — the app shows the user the setup form.
 3. Ask the user to complete the form and say so when done.
 4. Verify: find the new connection with list_connections and confirm. The
@@ -73,13 +78,12 @@ You help users discover sources, understand asset schemas, find fields across th
 catalog, and compare schemas between different assets.
 
 Two distinct questions — pick the right tool:
-- "What sources do we/I have?" → `list_sources` (instances configured in the
-  user's organisation)
+- "What sources do we/I have?" → `list_sources` (the organisation's collection)
 - "What sources are available/supported?", "Could we add X?" →
-  `list_available_sources` (the catalog of source types)
+  `list_catalog_sources` (the catalog of definitions)
 
 Schemas and field search operate on the catalog: an asset's schema is a property
-of the source type, shared by every configured instance.
+of the source definition, shared by every instance in the collection.
 
 When presenting schemas:
 - List field names, types, and descriptions clearly

--- a/packages/interloper-agent/src/interloper_agent/tools/assets.py
+++ b/packages/interloper-agent/src/interloper_agent/tools/assets.py
@@ -1,4 +1,8 @@
-"""Catalog tools — discovery, schema inspection, and field search."""
+"""Asset tools — schema inspection, field search, and schema comparison.
+
+Asset schemas live in the catalog: a schema is a property of the source
+definition, shared by every instance in an org's collection.
+"""
 
 from __future__ import annotations
 
@@ -6,108 +10,14 @@ from typing import Any
 
 from google.adk.tools.tool_context import ToolContext
 
-from interloper_agent.context import get_catalog, get_org_id, get_store, serialize
-
-
-def list_sources(tool_context: ToolContext) -> dict[str, Any]:
-    """List the sources configured in the user's organisation.
-
-    This answers "what sources do we/I have?" — it returns only configured
-    instances, each with its key, instance name, asset count, and creation
-    date, enriched with catalog metadata (display name, icon). For the
-    catalog of source types that *could* be connected, use
-    ``list_available_sources`` instead.
-    """
-    try:
-        org_id = get_org_id(tool_context)
-        store = get_store()
-        catalog = get_catalog()
-
-        sources = store.list_components(org_id, kinds=["source"])
-        results = []
-        for s in sources:
-            entry = serialize(s)
-            entry["asset_count"] = len(s.children)
-            defn = catalog.get(s.key)
-            if defn is not None:
-                entry["catalog"] = {
-                    "name": defn.get("name", s.key),
-                    "description": defn.get("description"),
-                    "icon": defn.get("icon"),
-                    "tags": defn.get("tags", []),
-                }
-            results.append(entry)
-
-        return {"status": "success", "count": len(results), "sources": results}
-    except Exception as e:
-        return {"status": "error", "error": str(e)}
-
-
-def list_available_sources(tool_context: ToolContext) -> dict[str, Any]:
-    """List the source types available in the catalog.
-
-    This answers "what sources does Interloper support / could we add?" — it
-    returns every source type in the catalog, whether configured or not, with
-    how many instances the organisation has configured. For the sources the
-    organisation actually has, use ``list_sources`` instead.
-    """
-    try:
-        org_id = get_org_id(tool_context)
-        store = get_store()
-        catalog = get_catalog()
-
-        configured_counts: dict[str, int] = {}
-        for s in store.list_components(org_id, kinds=["source"]):
-            configured_counts[s.key] = configured_counts.get(s.key, 0) + 1
-
-        results = []
-        for key, defn in catalog.items():
-            if defn.get("kind") != "source":
-                continue
-            count = configured_counts.get(key, 0)
-            results.append({
-                "key": key,
-                "name": defn.get("name", key),
-                "description": defn.get("description"),
-                "icon": defn.get("icon"),
-                "asset_count": len(defn.get("assets", [])),
-                "tags": defn.get("tags", []),
-                "configured": count > 0,
-                "configured_count": count,
-            })
-
-        return {"status": "success", "count": len(results), "sources": results}
-    except Exception as e:
-        return {"status": "error", "error": str(e)}
-
-
-def get_source_detail(source_key: str, tool_context: ToolContext) -> dict[str, Any]:
-    """Get full catalog detail for a source type.
-
-    This is the catalog definition (the source *type*), not an org-configured
-    instance — use ``list_sources`` to see what the organisation has configured.
-
-    Args:
-        source_key: The source key (e.g. 'facebook_ads').
-
-    Returns the source definition including config schema, resource types,
-    destination types, and a list of all its assets with their schemas.
-    """
-    try:
-        catalog = get_catalog()
-        defn = catalog.get(source_key)
-        if defn is None or defn.get("kind") != "source":
-            return {"status": "error", "error": f"Source '{source_key}' not found in catalog"}
-        return {"status": "success", "source": defn}
-    except Exception as e:
-        return {"status": "error", "error": str(e)}
+from interloper_agent.context import get_catalog
 
 
 def get_asset_schema(source_key: str, asset_key: str, tool_context: ToolContext) -> dict[str, Any]:
     """Get the JSON schema for a specific asset within a source.
 
-    Schemas come from the catalog: they are a property of the source type,
-    shared by every configured instance of that source.
+    Schemas come from the catalog: they are a property of the source
+    definition, shared by every instance in the org's collection.
 
     Args:
         source_key: The source key (e.g. 'facebook_ads').
@@ -122,28 +32,13 @@ def get_asset_schema(source_key: str, asset_key: str, tool_context: ToolContext)
             return {"status": "error", "error": f"Source '{source_key}' not found in catalog"}
 
         for asset_def in defn.get("assets", []):
-            if asset_def.get("key") == asset_key:
-                schema = asset_def.get("asset_schema")
+            if asset_def.get("key") == asset_key or asset_def.get("qualified_key") == f"{source_key}.{asset_key}":
                 return {
                     "status": "success",
                     "source_key": source_key,
                     "asset_key": asset_key,
                     "qualified_key": f"{source_key}.{asset_key}",
-                    "schema": schema,
-                    "partitioning": asset_def.get("partitioning"),
-                    "tags": asset_def.get("tags", []),
-                    "requires": asset_def.get("requires", {}),
-                    "optional_requires": asset_def.get("optional_requires", {}),
-                }
-            # Also match by qualified_key
-            if asset_def.get("qualified_key") == f"{source_key}.{asset_key}":
-                schema = asset_def.get("asset_schema")
-                return {
-                    "status": "success",
-                    "source_key": source_key,
-                    "asset_key": asset_key,
-                    "qualified_key": f"{source_key}.{asset_key}",
-                    "schema": schema,
+                    "schema": asset_def.get("asset_schema"),
                     "partitioning": asset_def.get("partitioning"),
                     "tags": asset_def.get("tags", []),
                     "requires": asset_def.get("requires", {}),
@@ -158,7 +53,8 @@ def get_asset_schema(source_key: str, asset_key: str, tool_context: ToolContext)
 def search_fields(query: str, tool_context: ToolContext) -> dict[str, Any]:
     """Search for fields across all asset schemas in the catalog matching a query string.
 
-    Searches every source type's schemas, configured or not.
+    Searches every source definition's schemas, whether or not the source is
+    in the org's collection.
 
     Args:
         query: Substring to search for in field names and descriptions (case-insensitive).
@@ -252,20 +148,6 @@ def compare_schemas(
             "only_in_a": sorted(only_a),
             "only_in_b": sorted(only_b),
         }
-    except Exception as e:
-        return {"status": "error", "error": str(e)}
-
-
-def list_destinations(tool_context: ToolContext) -> dict[str, Any]:
-    """List all configured destinations in the organisation.
-
-    Returns each destination with its key, name, config, and resource bindings.
-    """
-    try:
-        org_id = get_org_id(tool_context)
-        store = get_store()
-        destinations = store.list_components(org_id, kinds=["destination"])
-        return {"status": "success", "destinations": [serialize(d) for d in destinations]}
     except Exception as e:
         return {"status": "error", "error": str(e)}
 

--- a/packages/interloper-agent/src/interloper_agent/tools/connections.py
+++ b/packages/interloper-agent/src/interloper_agent/tools/connections.py
@@ -29,14 +29,15 @@ logger = logging.getLogger(__name__)
 _CHECK_TIMEOUT = 15.0
 
 
-def list_connection_types(tool_context: ToolContext) -> dict[str, Any]:
-    """List the connection types available in the catalog.
+def list_catalog_connections(tool_context: ToolContext) -> dict[str, Any]:
+    """List the connection definitions available in the catalog.
 
-    Use this to pick the right type before requesting setup. Each entry
-    notes its required config fields and whether OAuth sign-in is supported
-    by the type (``oauth``) and usable in this deployment
+    Use this to pick the right definition before requesting setup. Each
+    entry notes its required config fields and whether OAuth sign-in is
+    supported by the definition (``oauth``) and usable in this deployment
     (``oauth_available``) — when OAuth is not available, the user will have
-    to enter credentials manually in the setup form.
+    to enter credentials manually in the setup form. For the connections the
+    organisation actually has, use ``list_connections`` instead.
     """
     try:
         catalog = get_catalog()
@@ -55,15 +56,16 @@ def list_connection_types(tool_context: ToolContext) -> dict[str, Any]:
                 "oauth": oauth is not None,
                 "oauth_available": is_provider_configured(oauth["provider"]) if oauth else False,
             })
-        return {"status": "success", "count": len(results), "connection_types": results}
+        return {"status": "success", "count": len(results), "connections": results}
     except Exception as e:
         return {"status": "error", "error": str(e)}
 
 
 def list_connections(tool_context: ToolContext) -> dict[str, Any]:
-    """List the connections configured in the organisation.
+    """List the connections in the organisation's collection.
 
-    Returns identity and metadata only — never credential values.
+    Returns identity and metadata only — never credential values. For the
+    catalog of connection definitions, use ``list_catalog_connections``.
     """
     try:
         org_id = get_org_id(tool_context)
@@ -184,8 +186,8 @@ def request_connection_setup(
     the user to share credentials in the chat instead.
 
     Args:
-        connection_key: Catalog key of the connection type
-            (e.g. 'facebook_ads_connection'), from list_connection_types.
+        connection_key: Catalog key of the connection definition
+            (e.g. 'facebook_ads_connection'), from list_catalog_connections.
         name: Optional display name to prefill in the form.
     """
     try:

--- a/packages/interloper-agent/src/interloper_agent/tools/destinations.py
+++ b/packages/interloper-agent/src/interloper_agent/tools/destinations.py
@@ -1,0 +1,23 @@
+"""Destination tools — the org's collection of destinations."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from google.adk.tools.tool_context import ToolContext
+
+from interloper_agent.context import get_org_id, get_store, serialize
+
+
+def list_destinations(tool_context: ToolContext) -> dict[str, Any]:
+    """List the destinations in the organisation's collection.
+
+    Returns each destination with its key, name, config, and resource bindings.
+    """
+    try:
+        org_id = get_org_id(tool_context)
+        store = get_store()
+        destinations = store.list_components(org_id, kinds=["destination"])
+        return {"status": "success", "destinations": [serialize(d) for d in destinations]}
+    except Exception as e:
+        return {"status": "error", "error": str(e)}

--- a/packages/interloper-agent/src/interloper_agent/tools/sources.py
+++ b/packages/interloper-agent/src/interloper_agent/tools/sources.py
@@ -1,0 +1,103 @@
+"""Source tools — the catalog of source definitions and the org's collection."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from google.adk.tools.tool_context import ToolContext
+
+from interloper_agent.context import get_catalog, get_org_id, get_store, serialize
+
+
+def list_sources(tool_context: ToolContext) -> dict[str, Any]:
+    """List the sources in the organisation's collection.
+
+    This answers "what sources do we/I have?" — it returns only the source
+    instances persisted for the org, each with its key, instance name, asset
+    count, and creation date, enriched with catalog metadata (display name,
+    icon). For the catalog of source definitions that *could* be added, use
+    ``list_catalog_sources`` instead.
+    """
+    try:
+        org_id = get_org_id(tool_context)
+        store = get_store()
+        catalog = get_catalog()
+
+        sources = store.list_components(org_id, kinds=["source"])
+        results = []
+        for s in sources:
+            entry = serialize(s)
+            entry["asset_count"] = len(s.children)
+            defn = catalog.get(s.key)
+            if defn is not None:
+                entry["catalog"] = {
+                    "name": defn.get("name", s.key),
+                    "description": defn.get("description"),
+                    "icon": defn.get("icon"),
+                    "tags": defn.get("tags", []),
+                }
+            results.append(entry)
+
+        return {"status": "success", "count": len(results), "sources": results}
+    except Exception as e:
+        return {"status": "error", "error": str(e)}
+
+
+def list_catalog_sources(tool_context: ToolContext) -> dict[str, Any]:
+    """List the source definitions available in the catalog.
+
+    This answers "what sources does Interloper support / could we add?" — it
+    returns every source definition in the catalog, whether or not it is in
+    the org's collection, with how many instances the collection holds. For
+    the sources the organisation actually has, use ``list_sources`` instead.
+    """
+    try:
+        org_id = get_org_id(tool_context)
+        store = get_store()
+        catalog = get_catalog()
+
+        collection_counts: dict[str, int] = {}
+        for s in store.list_components(org_id, kinds=["source"]):
+            collection_counts[s.key] = collection_counts.get(s.key, 0) + 1
+
+        results = []
+        for key, defn in catalog.items():
+            if defn.get("kind") != "source":
+                continue
+            count = collection_counts.get(key, 0)
+            results.append({
+                "key": key,
+                "name": defn.get("name", key),
+                "description": defn.get("description"),
+                "icon": defn.get("icon"),
+                "asset_count": len(defn.get("assets", [])),
+                "tags": defn.get("tags", []),
+                "in_collection": count > 0,
+                "collection_count": count,
+            })
+
+        return {"status": "success", "count": len(results), "sources": results}
+    except Exception as e:
+        return {"status": "error", "error": str(e)}
+
+
+def get_source_detail(source_key: str, tool_context: ToolContext) -> dict[str, Any]:
+    """Get full catalog detail for a source definition.
+
+    This is the catalog definition (the source *type*), not an instance from
+    the org's collection — use ``list_sources`` for what the organisation has.
+
+    Args:
+        source_key: The source key (e.g. 'facebook_ads').
+
+    Returns the source definition including config schema, resource types,
+    destination types, and a list of all its assets with their schemas.
+    """
+    try:
+        catalog = get_catalog()
+        defn = catalog.get(source_key)
+        if defn is None or defn.get("kind") != "source":
+            return {"status": "error", "error": f"Source '{source_key}' not found in catalog"}
+        return {"status": "success", "source": defn}
+    except Exception as e:
+        return {"status": "error", "error": str(e)}


### PR DESCRIPTION
> Stacked on #146 — GitHub will retarget to `main` when that merges.

## What

**1. Tool modules namespace by component kind.** The grab-bag `tools/catalog.py` is gone: `sources.py` (collection + catalog listing, source detail), `assets.py` (schema, field search, comparison), `destinations.py`, alongside the existing `connections.py`, `lineage.py`, `scheduling.py`, `analytics.py`. Tool bodies move unchanged (one duplicated return block in `get_asset_schema` folded).

**2. The catalog/collection taxonomy, spoken everywhere.**
- **Catalog** = the library of component *definitions* the platform ships (source types, connection types, …) — org-independent.
- **Collection** = the component *instances* persisted for the organisation.

Renames: `list_available_sources` → `list_catalog_sources`, `list_connection_types` → `list_catalog_connections`; tool outputs use `in_collection` / `collection_count`. The root instruction defines both terms once; every sub-agent instruction, agent description, and tool docstring uses them consistently, so the agent can resolve "what do we have?" vs "what could we add?" reliably.

## Notes

- `request_connection_setup` keeps its name — the frontend keys on it in the SSE stream.
- `CatalogAgent` keeps its name for now even though it serves both spaces; renaming the sub-agent (e.g. DiscoveryAgent) is a cheap follow-up if wanted.
- App-side taxonomy (the frontend "catalog" page actually showing collection content, etc.) is being audited separately and will be its own session/PR.

ruff / ty / pytest (928) green; sub-agent wiring smoke-tested.

By Digitl