### PR TITLE
feat(agent): collection agent consults the catalog specialist as a tool

### DIFF
--- a/packages/interloper-agent/src/interloper_agent/agent.py
+++ b/packages/interloper-agent/src/interloper_agent/agent.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from google.adk.agents import Agent
+from google.adk.tools.agent_tool import AgentTool
 from interloper.settings import AppSettings
 
 from interloper_agent.prompts import (
     ANALYTICS_INSTRUCTION,
+    CATALOG_CONSULT_INSTRUCTION,
     CATALOG_INSTRUCTION,
     COLLECTION_INSTRUCTION,
     LINEAGE_INSTRUCTION,
@@ -38,6 +40,19 @@ def resolve_model(name: str | None = None) -> str | BaseLlm:
 
 _model = resolve_model()
 
+
+def _catalog_tools() -> list:
+    """The catalog toolset, shared by the routing agent and the consultant instance."""
+    return [
+        catalog.sources.list_sources,
+        catalog.sources.get_source_detail,
+        catalog.connections.list_connections,
+        catalog.assets.get_asset_schema,
+        catalog.assets.search_fields,
+        catalog.assets.compare_schemas,
+    ]
+
+
 catalog_agent = Agent(
     name="CatalogAgent",
     model=_model,
@@ -46,14 +61,22 @@ catalog_agent = Agent(
         "available to add, asset schemas, field search, and schema comparison."
     ),
     instruction=CATALOG_INSTRUCTION,
-    tools=[
-        catalog.sources.list_sources,
-        catalog.sources.get_source_detail,
-        catalog.connections.list_connections,
-        catalog.assets.get_asset_schema,
-        catalog.assets.search_fields,
-        catalog.assets.compare_schemas,
-    ],
+    tools=_catalog_tools(),
+)
+
+# A second instance (an ADK agent can only have one parent): the catalog
+# specialist as a consultable tool — the caller keeps the conversation and
+# receives the specialist's answer as a tool result, unlike a transfer.
+catalog_consultant = Agent(
+    name="consult_catalog",
+    model=_model,
+    description=(
+        "Consult the catalog specialist: ask a question about the catalog of component definitions "
+        "(available sources and connections, asset schemas, fields, comparisons) and get a concise, "
+        "grounded answer back as a tool result."
+    ),
+    instruction=CATALOG_CONSULT_INSTRUCTION,
+    tools=_catalog_tools(),
 )
 
 collection_agent = Agent(
@@ -71,6 +94,7 @@ collection_agent = Agent(
         collection.destinations.list_destinations,
         collection.connections.request_connection_setup,
         collection.connections.check_connection,
+        AgentTool(agent=catalog_consultant),
     ],
 )
 

--- a/packages/interloper-agent/src/interloper_agent/prompts.py
+++ b/packages/interloper-agent/src/interloper_agent/prompts.py
@@ -54,6 +54,14 @@ actually set up: their sources, connections, and destinations. You list
 them, check connection health, and set up new connections. What *could* be
 added (the catalog of definitions) is the Catalog specialist's domain.
 
+When a catalog question arises *mid-task* and needs reasoning — which source
+fits a need, what a definition's assets or schemas look like — consult the
+catalog specialist via the consult_catalog tool and continue with its
+answer. Don't consult it for facts your own tool responses already carry
+(request_connection_setup reports oauth_available itself), and when the
+user's question is entirely about the catalog, hand the conversation back to
+the root instead.
+
 Connections hold credentials (OAuth tokens, API keys, service accounts).
 Credentials are sensitive: NEVER ask the user to paste credentials, tokens,
 or secrets into the chat, and never repeat a credential value. Setup happens
@@ -74,6 +82,19 @@ To set up a new connection:
 Also run check_connection when the user reports a connection problem or a
 source fails with authentication-looking errors.
 """ + PRESENTATION
+
+CATALOG_CONSULT_INSTRUCTION = """\
+You are the catalog specialist, consulted by another agent — not by the user.
+
+Answer questions about the catalog — the component definitions the platform
+ships: available sources and connections, asset schemas, fields, and schema
+comparisons. Ground every answer in your tools.
+
+Your reply is consumed by another agent mid-task: return the requested facts
+or analysis directly and concisely — no greetings, no follow-up questions,
+and always include the exact keys (source_key, connection key,
+qualified_key) the caller needs to act.
+"""
 
 CATALOG_INSTRUCTION = """\
 You are the Catalog specialist for Interloper.


### PR DESCRIPTION
## What

The multi-agent collaboration pattern discussed on top of #149: `CollectionAgent` gains a **`consult_catalog`** tool — the catalog specialist wrapped as an ADK `AgentTool`. Unlike a transfer (which moves the user's conversation to the other agent), a consultation runs the specialist in a nested turn and hands its grounded answer back **as a tool result**, so the caller keeps the conversation and its flow state.

- A second catalog specialist `Agent` instance (`consult_catalog`) — ADK allows one parent per agent, so the routing tree's `CatalogAgent` can't be reused — sharing the same toolset via a `_catalog_tools()` factory, with a consultation-tuned instruction (`CATALOG_CONSULT_INSTRUCTION`): answer the calling agent concisely, ground in tools, always include the exact keys the caller needs to act.
- `COLLECTION_INSTRUCTION` teaches the layering: consult for mid-task catalog *reasoning*; don't consult for facts your own tool responses carry (`request_connection_setup` reports `oauth_available` itself); hand back to the root when the user's question is entirely catalog-shaped.

## Why

Establishes the collaboration layering for the upcoming source-creation flow: **facts → tool responses; cross-domain reasoning → AgentTool consultation; moving the user's conversation → transfer.**

## Verification

Live E2E (Gemini runner, seeded dev DB): *"I need to collect video performance stats from our ad platforms — set up the connection for whichever source provides that."*

```
CALL [InterloperAgent]  transfer_to_agent(CollectionAgent)
CALL [CollectionAgent]  consult_catalog("which source provides video performance stats from ad platforms?")
CALL [CollectionAgent]  request_connection_setup("facebook_ads_connection")
TEXT [CollectionAgent]  ...Facebook Ads, which provides video performance statistics... complete the sign-in...
```

The source was resolved mid-task via the consultation (facebook_ads owns `videos_stats`) without leaving the setup flow. ruff / ty / pytest (928) green.

By Digitl