### PR TITLE
fix(agent): inject the current time into agent instructions

### DIFF
--- a/packages/interloper-agent/src/interloper_agent/agent.py
+++ b/packages/interloper-agent/src/interloper_agent/agent.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import datetime
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from google.adk.agents import Agent
@@ -20,7 +22,22 @@ from interloper_agent.prompts import (
 from interloper_agent.tools import analytics, catalog, collection, lineage, scheduling
 
 if TYPE_CHECKING:
+    from google.adk.agents.readonly_context import ReadonlyContext
     from google.adk.models import BaseLlm
+
+
+def with_current_time(instruction: str) -> Callable[[ReadonlyContext], str]:
+    """Turn a static instruction into a provider that appends the current UTC time.
+
+    The model has no reliable notion of "now", so without this the relative
+    timestamps the presentation rules ask for drift to its training data.
+    """
+
+    def provider(_: ReadonlyContext) -> str:
+        now = datetime.datetime.now(datetime.timezone.utc)
+        return f"{instruction}\nCurrent date and time: {now:%Y-%m-%d %H:%M} UTC. Compute relative timestamps from it."
+
+    return provider
 
 
 def resolve_model(name: str | None = None) -> str | BaseLlm:
@@ -74,7 +91,7 @@ catalog_consultant = Agent(
         "(available sources and connections, asset schemas, fields, comparisons) and get a concise, "
         "grounded answer back as a tool result."
     ),
-    instruction=CATALOG_CONSULT_INSTRUCTION,
+    instruction=with_current_time(CATALOG_CONSULT_INSTRUCTION),
     tools=_catalog_tools(),
 )
 
@@ -86,7 +103,7 @@ collection_agent = Agent(
         "destinations, checks connection health, and sets up new connections by presenting the app's "
         "secure setup form (OAuth sign-in or manual credentials) — never collects credentials in chat."
     ),
-    instruction=COLLECTION_INSTRUCTION,
+    instruction=with_current_time(COLLECTION_INSTRUCTION),
     tools=[
         collection.list_components,
         collection.request_connection_setup,
@@ -99,7 +116,7 @@ lineage_agent = Agent(
     name="LineageAgent",
     model=_model,
     description="Analyzes asset dependencies — upstream/downstream traversal, impact analysis, and cross-source edges.",
-    instruction=LINEAGE_INSTRUCTION,
+    instruction=with_current_time(LINEAGE_INSTRUCTION),
     tools=[
         lineage.get_upstream,
         lineage.get_downstream,
@@ -116,7 +133,7 @@ scheduling_agent = Agent(
         "Monitors run health, recent failures, job schedules, and backfill progress; "
         "triggers runs, starts backfills, and toggles jobs or assets on/off."
     ),
-    instruction=SCHEDULING_INSTRUCTION,
+    instruction=with_current_time(SCHEDULING_INSTRUCTION),
     tools=[
         scheduling.list_jobs,
         scheduling.get_job_health,
@@ -135,7 +152,7 @@ analytics_agent = Agent(
     name="AnalyticsAgent",
     model=_model,
     description="Provides run statistics, partition coverage analysis, and data freshness checks.",
-    instruction=ANALYTICS_INSTRUCTION,
+    instruction=with_current_time(ANALYTICS_INSTRUCTION),
     tools=[
         analytics.run_history_summary,
         analytics.partition_coverage,
@@ -146,7 +163,7 @@ analytics_agent = Agent(
 root_agent = Agent(
     name="InterloperAgent",
     model=_model,
-    instruction=ROOT_INSTRUCTION,
+    instruction=with_current_time(ROOT_INSTRUCTION),
     description="Main Interloper assistant that routes queries to specialized sub-agents.",
     sub_agents=[catalog_agent, collection_agent, lineage_agent, scheduling_agent, analytics_agent],
 )

--- a/packages/interloper-agent/tests/test_agent.py
+++ b/packages/interloper-agent/tests/test_agent.py
@@ -1,0 +1,34 @@
+"""Tests for interloper_agent.agent."""
+
+import datetime
+from typing import cast
+
+from google.adk.agents.readonly_context import ReadonlyContext
+
+from interloper_agent import agent as agent_module
+
+
+def test_with_current_time_appends_now():
+    provider = agent_module.with_current_time("BASE")
+    text = provider(cast(ReadonlyContext, None))
+    now = datetime.datetime.now(datetime.timezone.utc)
+    assert text.startswith("BASE\n")
+    assert f"Current date and time: {now:%Y-%m-%d}" in text
+    assert "Compute relative timestamps from it" in text
+
+
+def test_all_agents_carry_the_current_time():
+    agents = [
+        agent_module.root_agent,
+        agent_module.catalog_agent,
+        agent_module.collection_agent,
+        agent_module.lineage_agent,
+        agent_module.scheduling_agent,
+        agent_module.analytics_agent,
+    ]
+    for agent in agents:
+        instruction = agent.instruction
+        assert not isinstance(instruction, str), f"{agent.name} has a static instruction"
+        text = instruction(cast(ReadonlyContext, None))
+        assert isinstance(text, str)
+        assert "Current date and time:" in text


### PR DESCRIPTION
## What

Wraps every agent's static instruction in an ADK instruction provider (`with_current_time`) that appends the current UTC time on each LLM request, and adds the first tests for the `interloper-agent` package covering it.

## Why

The `PRESENTATION` rules ask the model to render relative timestamps ("2 h ago (06:12 UTC)"), but nothing ever told the model what "now" is. An LLM has no clock — without an anchor in context it guesses the present from its training data, which produced answers like **"Created at: 2 years ago (2026-07-14 09:38 UTC)"** for a connection created minutes earlier.

## Notes for review

- A provider (rather than a string built at import time) keeps the anchor fresh across long-running sessions — ADK re-evaluates it per request.
- ADK's `global_instruction` would have been a single-point alternative, but it is deprecated in the installed version, so each of the six agents wraps its own instruction.
- The model still does the subtraction itself, so small delta errors remain possible, but the anchor is now ground truth; deterministic pre-formatting in tool output was rejected because relative strings freeze at serialization time and go stale across turns, and the injected "now" is needed anyway to resolve user-relative language ("yesterday", "last night's runs").

By Digitl