### PR TITLE
feat(agent): conversational source setup

### DIFF
--- a/packages/interloper-agent/src/interloper_agent/agent.py
+++ b/packages/interloper-agent/src/interloper_agent/agent.py
@@ -112,6 +112,7 @@ collection_agent = Agent(
         collection.resolve_source_field_options,
         collection.create_source,
         interaction.request_user_selection,
+        interaction.request_confirmation,
         AgentTool(agent=catalog_consultant),
     ],
 )

--- a/packages/interloper-agent/src/interloper_agent/agent.py
+++ b/packages/interloper-agent/src/interloper_agent/agent.py
@@ -19,7 +19,7 @@ from interloper_agent.prompts import (
     ROOT_INSTRUCTION,
     SCHEDULING_INSTRUCTION,
 )
-from interloper_agent.tools import analytics, catalog, collection, lineage, scheduling
+from interloper_agent.tools import analytics, catalog, collection, interaction, lineage, scheduling
 
 if TYPE_CHECKING:
     from google.adk.agents.readonly_context import ReadonlyContext
@@ -111,6 +111,7 @@ collection_agent = Agent(
         collection.check_connection,
         collection.resolve_source_field_options,
         collection.create_source,
+        interaction.request_user_selection,
         AgentTool(agent=catalog_consultant),
     ],
 )

--- a/packages/interloper-agent/src/interloper_agent/agent.py
+++ b/packages/interloper-agent/src/interloper_agent/agent.py
@@ -76,7 +76,7 @@ catalog_agent = Agent(
         "The catalog of component definitions the platform ships: which sources and connections are "
         "available to add, asset schemas, field search, and schema comparison."
     ),
-    instruction=CATALOG_INSTRUCTION,
+    instruction=with_current_time(CATALOG_INSTRUCTION),
     tools=_catalog_tools(),
 )
 
@@ -100,14 +100,17 @@ collection_agent = Agent(
     model=_model,
     description=(
         "The organisation's collection of component instances: lists their sources, connections, and "
-        "destinations, checks connection health, and sets up new connections by presenting the app's "
-        "secure setup form (OAuth sign-in or manual credentials) — never collects credentials in chat."
+        "destinations, checks connection health, sets up new connections via the app's secure form "
+        "(never collecting credentials in chat), and creates sources conversationally — resolving "
+        "provider-backed options like the account to use through an existing connection."
     ),
     instruction=with_current_time(COLLECTION_INSTRUCTION),
     tools=[
         collection.list_components,
         collection.request_connection_setup,
         collection.check_connection,
+        collection.resolve_source_field_options,
+        collection.create_source,
         AgentTool(agent=catalog_consultant),
     ],
 )

--- a/packages/interloper-agent/src/interloper_agent/prompts.py
+++ b/packages/interloper-agent/src/interloper_agent/prompts.py
@@ -33,8 +33,8 @@ Route questions to the appropriate specialist:
   support TikTok?", "Show me the schema for X", "Which assets have a spend
   field?", "Compare Facebook and TikTok schemas"
 - **CollectionAgent** — the collection: "What sources do we have?", "What
-  connections do we have?", "Connect Facebook Ads", "Set up a new
-  connection", "Is the TikTok connection healthy?"
+  connections do we have?", "Connect Facebook Ads", "Set up the Facebook
+  Ads source", "Is the TikTok connection healthy?"
 - **LineageAgent** — "What depends on X?", "What's upstream of Y?",
   "If Google Ads breaks, what's affected?", "Show cross-source dependencies"
 - **SchedulingAgent** — "Did last night's runs succeed?", "Which assets failed?",
@@ -81,6 +81,25 @@ To set up a new connection:
 
 Also run check_connection when the user reports a connection problem or a
 source fails with authentication-looking errors.
+
+To set up a new source:
+1. Identify the definition (consult the catalog specialist when the user
+   describes a need rather than a product) and what it requires: a
+   connection slot, and its config fields.
+2. Ensure the connection: reuse one from the collection, or run the
+   connection setup flow above first.
+3. For provider-backed config fields (like the account), call
+   resolve_source_field_options and let the user pick — the chosen option's
+   label is the default source name.
+4. Recap type, name, config, assets (default: all), connection, and
+   destinations, and get the user's explicit confirmation.
+5. Only then call create_source and report the result, including any
+   unresolved cross-source requirements (those are wired in the app).
+
+Never create a source without the recap and the user's confirmation. The
+reverse also holds: a failing options fetch or connection check warns but
+does not block — when the user supplies the value themselves and explicitly
+confirms, create the source and note the connection concern in your report.
 """ + PRESENTATION
 
 CATALOG_CONSULT_INSTRUCTION = """\

--- a/packages/interloper-agent/src/interloper_agent/prompts.py
+++ b/packages/interloper-agent/src/interloper_agent/prompts.py
@@ -99,9 +99,11 @@ To set up a new source:
    Unless the user has already named assets or explicitly said "all", get
    the definition's asset keys from the catalog specialist and present
    them with request_user_selection (multi) before going further.
-5. Recap type, name, config, assets, connection, and destinations, and ask
-   for confirmation. Only an explicit yes to the recap counts — an answer
-   to an earlier question (like an asset selection) is not confirmation.
+5. Recap with request_confirmation: the title says what will be created,
+   the items carry name, account/config, assets, connection, and
+   destinations. Wait for the decision — only a confirmation of the recap
+   counts; an answer to an earlier question (like an asset selection) is
+   not confirmation.
 6. Only then call create_source and report the result, including any
    unresolved cross-source requirements (those are wired in the app).
 

--- a/packages/interloper-agent/src/interloper_agent/prompts.py
+++ b/packages/interloper-agent/src/interloper_agent/prompts.py
@@ -10,6 +10,9 @@ Formatting:
 - Status glyphs: ✅ success · ❌ failed · ⏳ running/queued · ⏸️ disabled · ⚠️ warning.
 - Relative timestamps, absolute in parentheses: "2 h ago (06:12 UTC)".
 - Bold key numbers. Never dump raw JSON.
+- Tool errors are yours to handle, not the user's: when an error carries
+  what you need (valid keys, fetchable fields), recover silently — never
+  narrate internal errors, raw field names, or your retries.
 """
 
 ROOT_INSTRUCTION = """\
@@ -88,18 +91,27 @@ To set up a new source:
    connection slot, and its config fields.
 2. Ensure the connection: reuse one from the collection, or run the
    connection setup flow above first.
-3. For provider-backed config fields (like the account), call
-   resolve_source_field_options and let the user pick — the chosen option's
-   label is the default source name.
-4. Recap type, name, config, assets (default: all), connection, and
-   destinations, and get the user's explicit confirmation.
-5. Only then call create_source and report the result, including any
+3. Resolve the provider-backed config field (like the account) with
+   resolve_source_field_options — omit the field name, it is picked from
+   the definition — and present the options with request_user_selection
+   (single choice). The chosen option's label is the default source name.
+4. Assets: never decide the selection yourself, and never default to all.
+   Unless the user has already named assets or explicitly said "all", get
+   the definition's asset keys from the catalog specialist and present
+   them with request_user_selection (multi) before going further.
+5. Recap type, name, config, assets, connection, and destinations, and ask
+   for confirmation. Only an explicit yes to the recap counts — an answer
+   to an earlier question (like an asset selection) is not confirmation.
+6. Only then call create_source and report the result, including any
    unresolved cross-source requirements (those are wired in the app).
 
 Never create a source without the recap and the user's confirmation. The
 reverse also holds: a failing options fetch or connection check warns but
 does not block — when the user supplies the value themselves and explicitly
 confirms, create the source and note the connection concern in your report.
+
+Whenever the user must pick from known options, use request_user_selection
+instead of listing choices as text.
 """ + PRESENTATION
 
 CATALOG_CONSULT_INSTRUCTION = """\

--- a/packages/interloper-agent/src/interloper_agent/tools/collection.py
+++ b/packages/interloper-agent/src/interloper_agent/tools/collection.py
@@ -232,22 +232,24 @@ async def check_connection(connection_id: str, tool_context: ToolContext) -> dic
 
 async def resolve_source_field_options(
     source_key: str,
-    field: str,
     connection_id: str,
+    field: str | None = None,
     tool_context: ToolContext | None = None,
 ) -> dict[str, Any]:
-    """List the live options for a provider-backed source config field.
+    """List the live options for a source's provider-backed config field.
 
     Fields marked fetchable in the source definition get their options from
-    the provider through a connection in the org's collection — e.g.
-    ``facebook_ads.account_id`` lists the ad accounts the connection can
-    access. Options are not secret: present them for the user to choose
-    from; the chosen option's label makes a good default source name.
+    the provider through a connection in the org's collection — e.g. the ad
+    accounts the connection can access. Options are not secret: present them
+    for the user to choose from; the chosen option's label makes a good
+    default source name.
 
     Args:
         source_key: The source definition's catalog key (e.g. 'facebook_ads').
-        field: The config field to resolve (must be provider-backed).
         connection_id: UUID of a connection from the org's collection.
+        field: The config field to resolve. Omit it — never guess field
+            names: most definitions have exactly one fetchable field and it
+            is picked automatically (the response names it).
     """
     try:
         org_id = get_org_id(tool_context)
@@ -258,9 +260,17 @@ async def resolve_source_field_options(
         if defn is None or defn.get("kind") != "source":
             return {"status": "error", "error": f"Source '{source_key}' not found in catalog"}
         properties = (defn.get("config_schema") or {}).get("properties", {})
+        fetchable = sorted(k for k, p in properties.items() if p.get("x-fetch"))
+        if field is None:
+            if len(fetchable) != 1:
+                return {
+                    "status": "error",
+                    "error": f"'{source_key}' has {len(fetchable)} fetchable fields — pass one explicitly",
+                    "fetchable_fields": fetchable,
+                }
+            field = fetchable[0]
         fetch = (properties.get(field) or {}).get("x-fetch")
         if not fetch:
-            fetchable = sorted(k for k, p in properties.items() if p.get("x-fetch"))
             return {
                 "status": "error",
                 "error": f"Field '{field}' on '{source_key}' is not provider-backed",
@@ -345,6 +355,19 @@ def create_source(
         defn = catalog.get(source_key)
         if defn is None or defn.get("kind") != "source":
             return {"status": "error", "error": f"Source '{source_key}' not found in catalog"}
+
+        # Models pass [] meaning "default" — and a zero-asset source is useless.
+        if not asset_keys:
+            asset_keys = None
+        else:
+            valid = {a.get("key") for a in defn.get("assets", [])}
+            unknown = sorted(set(asset_keys) - valid)
+            if unknown:
+                return {
+                    "status": "error",
+                    "error": f"Unknown asset keys for '{source_key}': {', '.join(unknown)}",
+                    "valid_asset_keys": sorted(valid),
+                }
 
         # Bind the connection into the definition's matching resource slot.
         slots = (((defn.get("relations") or {}).get("resource") or {}).get("slots")) or {}

--- a/packages/interloper-agent/src/interloper_agent/tools/collection.py
+++ b/packages/interloper-agent/src/interloper_agent/tools/collection.py
@@ -2,10 +2,12 @@
 
 Generic over component kinds, mirroring the framework's component
 architecture: one lister for any kind (sensitive kinds project
-identity-only, driven by ``KINDS``), plus the connection operations that
-are irreducibly kind-specific. Credentials never transit the model:
-``request_connection_setup`` only signals the app to present a secure
-setup form, and the browser submits credentials to the API directly.
+identity-only, driven by ``KINDS``), plus the connection and source
+operations that are irreducibly kind-specific. Credentials never transit
+the model: ``request_connection_setup`` only signals the app to present a
+secure setup form, and the browser submits credentials to the API
+directly; source setup is conversational because its inputs (accounts,
+datasets, asset selections) are not secrets.
 """
 
 from __future__ import annotations
@@ -19,8 +21,9 @@ import httpx
 from google.adk.tools.tool_context import ToolContext
 from interloper.component import KINDS
 from interloper.connection.base import Connection
-from interloper.errors import ComponentDriftError, ConnectionCheckError, HydrationError
+from interloper.errors import CatalogKeyError, ComponentDriftError, ConfigError, ConnectionCheckError, HydrationError
 from interloper.oauth import is_provider_configured
+from interloper.resource.fields import is_fetch_field_provider
 from interloper.utils.concurrency import invoke
 from pydantic import ValidationError
 
@@ -30,6 +33,10 @@ logger = logging.getLogger(__name__)
 
 #: Upper bound on a live connection check — the agent must never hang on a dead host.
 _CHECK_TIMEOUT = 15.0
+
+#: Upper bound on a provider options fetch, and the most options one response carries.
+_RESOLVE_TIMEOUT = 30.0
+_MAX_OPTIONS = 50
 
 
 def list_components(kind: str | None = None, tool_context: ToolContext | None = None) -> dict[str, Any]:
@@ -216,5 +223,197 @@ async def check_connection(connection_id: str, tool_context: ToolContext) -> dic
             return {"status": "success", "connection": info, "ok": False, "live": True,
                     "category": "error", "message": "The connection check failed."}
         return {"status": "success", "connection": info, "ok": True, "live": True}
+    except Exception as e:
+        return {"status": "error", "error": str(e)}
+
+
+# -- Source operations (kind-specific by nature) ----------------------------------
+
+
+async def resolve_source_field_options(
+    source_key: str,
+    field: str,
+    connection_id: str,
+    tool_context: ToolContext | None = None,
+) -> dict[str, Any]:
+    """List the live options for a provider-backed source config field.
+
+    Fields marked fetchable in the source definition get their options from
+    the provider through a connection in the org's collection — e.g.
+    ``facebook_ads.account_id`` lists the ad accounts the connection can
+    access. Options are not secret: present them for the user to choose
+    from; the chosen option's label makes a good default source name.
+
+    Args:
+        source_key: The source definition's catalog key (e.g. 'facebook_ads').
+        field: The config field to resolve (must be provider-backed).
+        connection_id: UUID of a connection from the org's collection.
+    """
+    try:
+        org_id = get_org_id(tool_context)
+        store = get_store()
+        catalog = get_catalog()
+
+        defn = catalog.get(source_key)
+        if defn is None or defn.get("kind") != "source":
+            return {"status": "error", "error": f"Source '{source_key}' not found in catalog"}
+        properties = (defn.get("config_schema") or {}).get("properties", {})
+        fetch = (properties.get(field) or {}).get("x-fetch")
+        if not fetch:
+            fetchable = sorted(k for k, p in properties.items() if p.get("x-fetch"))
+            return {
+                "status": "error",
+                "error": f"Field '{field}' on '{source_key}' is not provider-backed",
+                "fetchable_fields": fetchable,
+            }
+        _, _, method_name = str(fetch.get("provider", "")).partition(".")
+
+        component = store.get_component(UUID(connection_id), kind="connection")
+        if component.org_id != org_id:
+            return {"status": "error", "error": f"Connection '{connection_id}' not found"}
+        try:
+            conn = store.load(component.id)
+        except (ComponentDriftError, HydrationError) as e:
+            logger.error("Connection '%s' (%s) failed to load for resolve: %s", component.name, component.key, e)
+            return {"status": "error", "error": "The connection could not be loaded — check it with check_connection."}
+
+        # The @fetch_field_provider marker is the allowlist (same contract as
+        # the API's /components/resolve): only opted-in methods are callable.
+        fn = getattr(conn, method_name, None)
+        if not is_fetch_field_provider(fn):
+            return {
+                "status": "error",
+                "error": f"Connection '{component.key}' does not provide options for {source_key}.{field}",
+            }
+        assert fn is not None  # narrowed by the guard above
+
+        try:
+            items = list(await asyncio.wait_for(invoke(fn), timeout=_RESOLVE_TIMEOUT) or [])
+        except Exception as e:  # noqa: BLE001 — a provider failure is a categorised result, never a raise
+            logger.error("Resolving %s.%s via '%s' failed: %s", source_key, field, component.name, e)
+            category, message = _categorise(e)
+            return {"status": "error", "category": category, "error": message}
+
+        label_key, value_key = fetch.get("label_key"), fetch.get("value_key")
+        options = [
+            {"label": item.get(label_key), "value": item.get(value_key)}
+            if isinstance(item, dict)
+            else {"label": str(item), "value": item}
+            for item in items[:_MAX_OPTIONS]
+        ]
+        return {
+            "status": "success",
+            "source_key": source_key,
+            "field": field,
+            "total": len(items),
+            "returned": len(options),
+            "options": options,
+        }
+    except Exception as e:
+        return {"status": "error", "error": str(e)}
+
+
+def create_source(
+    source_key: str,
+    name: str,
+    config: dict[str, Any],
+    connection_id: str | None = None,
+    asset_keys: list[str] | None = None,
+    destination_ids: list[str] | None = None,
+    tool_context: ToolContext | None = None,
+) -> dict[str, Any]:
+    """Create a source in the organisation's collection.
+
+    Recap the choices — type, name, config, assets, connection, destinations
+    — and get the user's explicit confirmation BEFORE calling this.
+
+    Args:
+        source_key: The source definition's catalog key (e.g. 'facebook_ads').
+        name: Display name — default to the label of the chosen account /
+            discriminator option.
+        config: Values for the definition's config schema (e.g. account_id).
+        connection_id: UUID of the connection to bind — required when the
+            definition declares a required connection slot.
+        asset_keys: Child asset keys to enable; omit to enable all.
+        destination_ids: Destination UUIDs to attach (optional).
+    """
+    try:
+        org_id = get_org_id(tool_context)
+        store = get_store()
+        catalog = get_catalog()
+
+        defn = catalog.get(source_key)
+        if defn is None or defn.get("kind") != "source":
+            return {"status": "error", "error": f"Source '{source_key}' not found in catalog"}
+
+        # Bind the connection into the definition's matching resource slot.
+        slots = (((defn.get("relations") or {}).get("resource") or {}).get("slots")) or {}
+        connection = None
+        if connection_id is not None:
+            connection = store.get_component(UUID(connection_id), kind="connection")
+            if connection.org_id != org_id:
+                return {"status": "error", "error": f"Connection '{connection_id}' not found"}
+        resource_bindings: list[tuple[UUID, str]] = []
+        for slot_name, spec in slots.items():
+            expected = spec.get("key")
+            if connection is not None and (not expected or connection.key == expected):
+                resource_bindings.append((connection.id, slot_name))
+                connection = None
+            elif spec.get("required"):
+                return {
+                    "status": "error",
+                    "error": (
+                        f"'{source_key}' requires a '{expected or 'connection'}' in slot '{slot_name}' — "
+                        "pick one from the collection or set one up first"
+                    ),
+                }
+        if connection is not None:
+            return {
+                "status": "error",
+                "error": f"Connection '{connection.key}' does not fit any slot of '{source_key}'",
+            }
+
+        destination_bindings: list[tuple[UUID, str]] = []
+        for dest_id in destination_ids or []:
+            dest = store.get_component(UUID(dest_id), kind="destination")
+            if dest.org_id != org_id:
+                return {"status": "error", "error": f"Destination '{dest_id}' not found"}
+            destination_bindings.append((dest.id, ""))
+
+        try:
+            row = store.create_component(
+                org_id,
+                kind="source",
+                key=source_key,
+                name=name,
+                config=config,
+                children=asset_keys,
+                relations={"resource": resource_bindings, "destination": destination_bindings},
+            )
+        except (ConfigError, CatalogKeyError) as e:
+            return {"status": "error", "error": str(e)}
+
+        # Cross-source requirements are not auto-wired: report them so the
+        # agent can point the user at the app for dependency resolution.
+        enabled = {a.key for a in row.children}
+        unresolved = sorted(
+            f"{a['key']}: {', '.join(sorted({**a.get('requires', {}), **a.get('optional_requires', {})}))}"
+            for a in defn.get("assets", [])
+            if a.get("key") in enabled and (a.get("requires") or a.get("optional_requires"))
+        )
+
+        return {
+            "status": "success",
+            "message": f"Source '{name}' created",
+            "source": {
+                "id": serialize(row.id),
+                "key": row.key,
+                "name": row.name,
+                "asset_count": len(row.children),
+                "connection_bound": bool(resource_bindings),
+                "destination_count": len(destination_bindings),
+            },
+            "unresolved_requirements": unresolved,
+        }
     except Exception as e:
         return {"status": "error", "error": str(e)}

--- a/packages/interloper-agent/src/interloper_agent/tools/interaction.py
+++ b/packages/interloper-agent/src/interloper_agent/tools/interaction.py
@@ -1,0 +1,60 @@
+"""Interaction tools — structured user input through app-rendered components.
+
+Like ``request_connection_setup``, these tools' function responses are the
+signal the app keys on: the frontend renders an interactive card (checkboxes
+or radios) and reports the user's choice back into the chat.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from google.adk.tools.tool_context import ToolContext
+
+#: The most options one selection card carries.
+_MAX_CHOICES = 50
+
+
+def request_user_selection(
+    prompt: str,
+    options: list[dict[str, str]],
+    multi: bool = False,
+    tool_context: ToolContext | None = None,
+) -> dict[str, Any]:
+    """Present a selection card to the user in the app.
+
+    Use this instead of listing choices as text whenever the user must pick
+    from known options — an account from a provider, assets to enable. The
+    app renders checkboxes (``multi``) or radios and reports the selection
+    back as the user's next message.
+
+    Args:
+        prompt: Short question shown above the choices (e.g. "Which ad
+            account should this source use?").
+        options: The choices, each ``{"label": ..., "value": ...}`` — pass
+            provider options or asset keys through as-is.
+        multi: True when several options may be selected (e.g. assets);
+            False for exactly one (e.g. an account).
+    """
+    try:
+        cleaned = [
+            {"label": str(o.get("label") or o.get("value")), "value": str(o.get("value"))}
+            for o in options
+            if isinstance(o, dict) and o.get("value") is not None
+        ]
+        if not cleaned:
+            return {"status": "error", "error": "options must carry at least one {label, value} entry"}
+        if len(cleaned) > _MAX_CHOICES:
+            return {
+                "status": "error",
+                "error": f"Too many options ({len(cleaned)} > {_MAX_CHOICES}) — narrow them down first",
+            }
+        return {
+            "status": "success",
+            "message": "Selection presented to the user. Wait for their choice before continuing.",
+            "prompt": prompt,
+            "options": cleaned,
+            "multi": multi,
+        }
+    except Exception as e:
+        return {"status": "error", "error": str(e)}

--- a/packages/interloper-agent/src/interloper_agent/tools/interaction.py
+++ b/packages/interloper-agent/src/interloper_agent/tools/interaction.py
@@ -15,6 +15,42 @@ from google.adk.tools.tool_context import ToolContext
 _MAX_CHOICES = 50
 
 
+def request_confirmation(
+    title: str,
+    items: list[dict[str, str]],
+    tool_context: ToolContext | None = None,
+) -> dict[str, Any]:
+    """Present a confirmation summary card to the user in the app.
+
+    Use this for the recap before a creation or any other action that needs
+    the user's sign-off: the app renders the items as a summary with
+    Confirm / Cancel buttons and reports the decision back as the user's
+    next message. Wait for it — proceed only on confirmation.
+
+    Args:
+        title: What is about to happen (e.g. "Create the Facebook Ads
+            source 'FB Main'?").
+        items: The choices being confirmed, each ``{"label": ..., "value": ...}``
+            (e.g. Account, Assets, Connection, Destinations).
+    """
+    try:
+        cleaned = [
+            {"label": str(i.get("label")), "value": str(i.get("value") or "—")}
+            for i in items
+            if isinstance(i, dict) and i.get("label")
+        ]
+        if not cleaned:
+            return {"status": "error", "error": "items must carry at least one {label, value} entry"}
+        return {
+            "status": "success",
+            "message": "Confirmation presented to the user. Wait for their decision before continuing.",
+            "title": title,
+            "items": cleaned,
+        }
+    except Exception as e:
+        return {"status": "error", "error": str(e)}
+
+
 def request_user_selection(
     prompt: str,
     options: list[dict[str, str]],

--- a/packages/interloper-app/app/app/components/AgentPanel.vue
+++ b/packages/interloper-app/app/app/components/AgentPanel.vue
@@ -17,18 +17,24 @@ const { messages, streaming, error, send } = useAgentChat(sessionId)
  * `submitted` status' thinking indicator covers.
  */
 const displayMessages = computed(() => messages.value
-    .filter(m => m.text || m.role === 'user' || m.connectionSetup)
+    .filter(m => m.text || m.role === 'user' || m.connectionSetup || m.selection)
     .map(m => ({
         id: m.id,
         role: m.role,
         text: m.text,
         parts: [{ type: 'text' as const, text: m.text }],
         connectionSetup: m.connectionSetup,
+        selection: m.selection,
     })))
 
 /** Report a completed connection setup back into the chat so the agent continues. */
 function onConnectionCreated(name: string, verified: boolean) {
     send(`I completed the setup — connection "${name}" is created${verified ? ' and the connection check passed' : ''}.`)
+}
+
+/** Report a confirmed selection back into the chat so the agent continues. */
+function onSelection(labels: string[], values: string[]) {
+    send(`I selected: ${labels.map((label, i) => `${label} (${values[i]})`).join(', ')}`)
 }
 
 const status = computed(() => {
@@ -120,6 +126,9 @@ const SUGGESTIONS = [
                         <AgentConnectCard v-if="(message as any).connectionSetup"
                                           :request="(message as any).connectionSetup"
                                           @created="onConnectionCreated" />
+                        <AgentSelectCard v-else-if="(message as any).selection"
+                                         :request="(message as any).selection"
+                                         @selected="onSelection" />
                         <MDC v-else-if="message.role === 'assistant'"
                              :value="message.text"
                              :cache-key="message.id"

--- a/packages/interloper-app/app/app/components/AgentPanel.vue
+++ b/packages/interloper-app/app/app/components/AgentPanel.vue
@@ -17,7 +17,7 @@ const { messages, streaming, error, send } = useAgentChat(sessionId)
  * `submitted` status' thinking indicator covers.
  */
 const displayMessages = computed(() => messages.value
-    .filter(m => m.text || m.role === 'user' || m.connectionSetup || m.selection)
+    .filter(m => m.text || m.role === 'user' || m.connectionSetup || m.selection || m.confirmation)
     .map(m => ({
         id: m.id,
         role: m.role,
@@ -25,6 +25,7 @@ const displayMessages = computed(() => messages.value
         parts: [{ type: 'text' as const, text: m.text }],
         connectionSetup: m.connectionSetup,
         selection: m.selection,
+        confirmation: m.confirmation,
     })))
 
 /** Report a completed connection setup back into the chat so the agent continues. */
@@ -35,6 +36,11 @@ function onConnectionCreated(name: string, verified: boolean) {
 /** Report a confirmed selection back into the chat so the agent continues. */
 function onSelection(labels: string[], values: string[]) {
     send(`I selected: ${labels.map((label, i) => `${label} (${values[i]})`).join(', ')}`)
+}
+
+/** Report a confirmation decision back into the chat so the agent proceeds or stops. */
+function onDecision(confirmed: boolean) {
+    send(confirmed ? 'Confirmed — go ahead.' : 'Cancel that — do not proceed.')
 }
 
 const status = computed(() => {
@@ -129,6 +135,9 @@ const SUGGESTIONS = [
                         <AgentSelectCard v-else-if="(message as any).selection"
                                          :request="(message as any).selection"
                                          @selected="onSelection" />
+                        <AgentConfirmCard v-else-if="(message as any).confirmation"
+                                          :request="(message as any).confirmation"
+                                          @decided="onDecision" />
                         <MDC v-else-if="message.role === 'assistant'"
                              :value="message.text"
                              :cache-key="message.id"

--- a/packages/interloper-app/app/app/components/agent/ConfirmCard.vue
+++ b/packages/interloper-app/app/app/components/agent/ConfirmCard.vue
@@ -2,10 +2,10 @@
 /**
  * Inline confirmation summary card rendered in the agent chat.
  *
- * Triggered by the agent's `request_confirmation` tool: renders the recap
- * items as a WizardRecap summary with Confirm / Cancel actions. The parent
- * reports the decision back into the chat as the user's message so the
- * agent proceeds (or stops) with it.
+ * Triggered by the agent's `request_confirmation` tool: the wizard's
+ * WizardRecap summary, compacted for the agent panel, with Confirm /
+ * Cancel actions. The parent reports the decision back into the chat as
+ * the user's message so the agent proceeds (or stops) with it.
  */
 import type { ConfirmationRequest } from '~/types/agent'
 
@@ -42,34 +42,30 @@ function decide(confirmed: boolean) {
 </script>
 
 <template>
-    <div class="border border-default rounded-[14px] p-5 my-2 w-full min-w-72 max-w-md">
-        <div class="flex flex-col gap-4">
-            <div class="text-sm font-semibold">
-                {{ request.title }}
-            </div>
+    <div class="border border-default rounded-[13px] p-4 my-2 w-full min-w-72 max-w-md flex flex-col gap-3">
+        <span class="text-[13px] font-semibold text-highlighted">{{ request.title }}</span>
 
-            <WizardRecap :rows="rows" />
+        <WizardRecap :rows="rows" />
 
-            <!-- Decided: locked outcome -->
-            <div v-if="decision !== null"
-                 class="flex items-center gap-2 text-sm">
-                <UIcon :name="decision ? 'i-lucide-check-circle-2' : 'i-lucide-circle-x'"
-                       class="size-4 shrink-0"
-                       :class="decision ? 'text-success' : 'text-muted'" />
-                <span class="text-muted">{{ decision ? 'Confirmed' : 'Cancelled' }}</span>
-            </div>
+        <!-- Decided: locked outcome -->
+        <div v-if="decision !== null"
+             class="flex items-center gap-2 text-[13px]">
+            <UIcon :name="decision ? 'i-lucide-check-circle-2' : 'i-lucide-circle-x'"
+                   class="size-4 shrink-0"
+                   :class="decision ? 'text-success' : 'text-muted'" />
+            <span class="text-muted">{{ decision ? 'Confirmed' : 'Cancelled' }}</span>
+        </div>
 
-            <div v-else
-                 class="flex gap-2">
-                <UButton label="Cancel"
-                         color="neutral"
-                         variant="outline"
-                         class="flex-1 justify-center"
-                         @click="decide(false)" />
-                <UButton label="Confirm"
-                         class="flex-1 justify-center"
-                         @click="decide(true)" />
-            </div>
+        <div v-else
+             class="flex gap-2">
+            <UButton label="Cancel"
+                     color="neutral"
+                     variant="outline"
+                     class="flex-1 justify-center"
+                     @click="decide(false)" />
+            <UButton label="Confirm"
+                     class="flex-1 justify-center"
+                     @click="decide(true)" />
         </div>
     </div>
 </template>

--- a/packages/interloper-app/app/app/components/agent/ConfirmCard.vue
+++ b/packages/interloper-app/app/app/components/agent/ConfirmCard.vue
@@ -1,0 +1,75 @@
+<script setup lang="ts">
+/**
+ * Inline confirmation summary card rendered in the agent chat.
+ *
+ * Triggered by the agent's `request_confirmation` tool: renders the recap
+ * items as a WizardRecap summary with Confirm / Cancel actions. The parent
+ * reports the decision back into the chat as the user's message so the
+ * agent proceeds (or stops) with it.
+ */
+import type { ConfirmationRequest } from '~/types/agent'
+
+const props = defineProps<{
+    request: ConfirmationRequest
+}>()
+
+const emit = defineEmits<{
+    decided: [confirmed: boolean]
+}>()
+
+const decision = ref<boolean | null>(null)
+
+/** Recap rows want icons; the agent only sends labels — map the usual suspects. */
+const ROW_ICONS: [RegExp, string][] = [
+    [/source|type/i, 'i-lucide-plug'],
+    [/name/i, 'i-lucide-tag'],
+    [/account|profile|config|dataset/i, 'i-lucide-settings-2'],
+    [/asset/i, 'i-lucide-layers'],
+    [/connection/i, 'i-lucide-key-round'],
+    [/destination/i, 'i-lucide-hard-drive'],
+]
+
+const rows = computed(() => props.request.items.map(item => ({
+    icon: ROW_ICONS.find(([pattern]) => pattern.test(item.label))?.[1] ?? 'i-lucide-dot',
+    label: item.label,
+    value: item.value,
+})))
+
+function decide(confirmed: boolean) {
+    decision.value = confirmed
+    emit('decided', confirmed)
+}
+</script>
+
+<template>
+    <div class="border border-default rounded-[14px] p-5 my-2 w-full min-w-72 max-w-md">
+        <div class="flex flex-col gap-4">
+            <div class="text-sm font-semibold">
+                {{ request.title }}
+            </div>
+
+            <WizardRecap :rows="rows" />
+
+            <!-- Decided: locked outcome -->
+            <div v-if="decision !== null"
+                 class="flex items-center gap-2 text-sm">
+                <UIcon :name="decision ? 'i-lucide-check-circle-2' : 'i-lucide-circle-x'"
+                       class="size-4 shrink-0"
+                       :class="decision ? 'text-success' : 'text-muted'" />
+                <span class="text-muted">{{ decision ? 'Confirmed' : 'Cancelled' }}</span>
+            </div>
+
+            <div v-else
+                 class="flex gap-2">
+                <UButton label="Cancel"
+                         color="neutral"
+                         variant="outline"
+                         class="flex-1 justify-center"
+                         @click="decide(false)" />
+                <UButton label="Confirm"
+                         class="flex-1 justify-center"
+                         @click="decide(true)" />
+            </div>
+        </div>
+    </div>
+</template>

--- a/packages/interloper-app/app/app/components/agent/ConnectCard.vue
+++ b/packages/interloper-app/app/app/components/agent/ConnectCard.vue
@@ -135,10 +135,10 @@ async function submit() {
 </script>
 
 <template>
-    <div class="border border-default rounded-[14px] p-5 my-2 w-full min-w-72 max-w-md">
+    <div class="border border-default rounded-[13px] p-4 my-2 w-full min-w-72 max-w-md">
         <!-- Unknown type: the catalog may not carry this key anymore -->
         <div v-if="!defn"
-             class="flex items-center gap-2 text-sm text-muted">
+             class="flex items-center gap-2 text-[13px] text-muted">
             <UIcon name="i-lucide-circle-alert"
                    class="size-4 shrink-0" />
             Connection type "{{ request.connectionKey }}" is not in the catalog.
@@ -146,25 +146,32 @@ async function submit() {
 
         <!-- Created: locked summary -->
         <div v-else-if="createdName"
-             class="flex items-center gap-3">
-            <UIcon :name="componentIcon(request.connectionKey)"
-                   class="size-6 shrink-0" />
-            <div class="flex-1 text-sm">
-                <span class="font-semibold">{{ createdName }}</span>
+             class="flex items-center gap-2.5">
+            <div class="size-8 shrink-0 rounded-[9px] border border-default bg-(--ui-bg-band) flex items-center justify-center">
+                <UIcon :name="componentIcon(request.connectionKey)"
+                       class="size-4.5" />
+            </div>
+            <div class="flex-1 min-w-0 text-[13px]">
+                <span class="font-semibold text-highlighted">{{ createdName }}</span>
                 <span class="text-muted"> — {{ defn.name }} connection created</span>
             </div>
             <UIcon name="i-lucide-check-circle-2"
-                   class="size-5 text-success shrink-0" />
+                   class="size-4 text-success shrink-0" />
         </div>
 
         <!-- Setup form -->
         <div v-else
-             class="flex flex-col gap-4">
-            <div class="flex items-center gap-3">
-                <UIcon :name="componentIcon(request.connectionKey)"
-                       class="size-6 shrink-0" />
-                <div class="text-sm font-semibold">
-                    Set up {{ defn.name }} connection
+             class="flex flex-col gap-3">
+            <div class="flex items-center gap-2.5">
+                <div class="size-8 shrink-0 rounded-[9px] border border-default bg-(--ui-bg-band) flex items-center justify-center">
+                    <UIcon :name="componentIcon(request.connectionKey)"
+                           class="size-4.5" />
+                </div>
+                <div class="flex-1 min-w-0">
+                    <div class="text-[13px] font-semibold text-highlighted truncate">{{ defn.name }}</div>
+                    <div class="font-mono text-[10px] uppercase tracking-[0.05em] text-dimmed truncate">
+                        New connection
+                    </div>
                 </div>
             </div>
 

--- a/packages/interloper-app/app/app/components/agent/SelectCard.vue
+++ b/packages/interloper-app/app/app/components/agent/SelectCard.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+/**
+ * Inline selection card rendered in the agent chat.
+ *
+ * Triggered by the agent's `request_user_selection` tool: renders the
+ * choices as checkboxes (multi) or radios (single). On confirm the parent
+ * reports the selection back into the chat as the user's message so the
+ * agent continues with it.
+ */
+import type { SelectionRequest } from '~/types/agent'
+
+const props = defineProps<{
+    request: SelectionRequest
+}>()
+
+const emit = defineEmits<{
+    selected: [labels: string[], values: string[]]
+}>()
+
+const checked = ref<string[]>([])
+const single = ref<string | undefined>(undefined)
+const submitted = ref(false)
+
+const radioItems = computed(() => props.request.options.map(o => ({ label: o.label, value: o.value })))
+
+const selectedValues = computed(() => props.request.multi ? checked.value : (single.value ? [single.value] : []))
+
+const selectedLabels = computed(() =>
+    props.request.options.filter(o => selectedValues.value.includes(o.value)).map(o => o.label))
+
+function confirm() {
+    if (!selectedValues.value.length) return
+    submitted.value = true
+    emit('selected', selectedLabels.value, [...selectedValues.value])
+}
+</script>
+
+<template>
+    <div class="border border-default rounded-[14px] p-5 my-2 w-full min-w-72 max-w-md">
+        <div class="flex flex-col gap-4">
+            <div class="text-sm font-semibold">
+                {{ request.prompt }}
+            </div>
+
+            <!-- Answered: locked summary -->
+            <div v-if="submitted"
+                 class="flex items-center gap-2 text-sm">
+                <UIcon name="i-lucide-check-circle-2"
+                       class="size-4 text-success shrink-0" />
+                <span class="text-muted">{{ selectedLabels.join(', ') }}</span>
+            </div>
+
+            <template v-else>
+                <UCheckboxGroup v-if="request.multi"
+                                v-model="checked"
+                                :items="radioItems" />
+                <URadioGroup v-else
+                             v-model="single"
+                             :items="radioItems" />
+
+                <UButton :label="request.multi ? `Confirm selection (${selectedValues.length})` : 'Confirm'"
+                         :disabled="!selectedValues.length"
+                         block
+                         @click="confirm" />
+            </template>
+        </div>
+    </div>
+</template>

--- a/packages/interloper-app/app/app/components/agent/SelectCard.vue
+++ b/packages/interloper-app/app/app/components/agent/SelectCard.vue
@@ -2,8 +2,9 @@
 /**
  * Inline selection card rendered in the agent chat.
  *
- * Triggered by the agent's `request_user_selection` tool: renders the
- * choices as checkboxes (multi) or radios (single). On confirm the parent
+ * Triggered by the agent's `request_user_selection` tool: the wizard's
+ * SelectionCard rows, compacted for the agent panel — checkbox rows for
+ * multi-select, plain accent-border rows for single. On confirm the parent
  * reports the selection back into the chat as the user's message so the
  * agent continues with it.
  */
@@ -17,52 +18,82 @@ const emit = defineEmits<{
     selected: [labels: string[], values: string[]]
 }>()
 
-const checked = ref<string[]>([])
-const single = ref<string | undefined>(undefined)
+const picked = ref<string[]>([])
 const submitted = ref(false)
 
-const radioItems = computed(() => props.request.options.map(o => ({ label: o.label, value: o.value })))
+function toggle(value: string) {
+    if (submitted.value) return
+    if (!props.request.multi) {
+        picked.value = [value]
+        return
+    }
+    picked.value = picked.value.includes(value)
+        ? picked.value.filter(v => v !== value)
+        : [...picked.value, value]
+}
 
-const selectedValues = computed(() => props.request.multi ? checked.value : (single.value ? [single.value] : []))
+const allSelected = computed(() => picked.value.length === props.request.options.length)
+
+function toggleAll() {
+    picked.value = allSelected.value ? [] : props.request.options.map(o => o.value)
+}
 
 const selectedLabels = computed(() =>
-    props.request.options.filter(o => selectedValues.value.includes(o.value)).map(o => o.label))
+    props.request.options.filter(o => picked.value.includes(o.value)).map(o => o.label))
 
 function confirm() {
-    if (!selectedValues.value.length) return
+    if (!picked.value.length) return
     submitted.value = true
-    emit('selected', selectedLabels.value, [...selectedValues.value])
+    emit('selected', selectedLabels.value, [...picked.value])
 }
 </script>
 
 <template>
-    <div class="border border-default rounded-[14px] p-5 my-2 w-full min-w-72 max-w-md">
-        <div class="flex flex-col gap-4">
-            <div class="text-sm font-semibold">
-                {{ request.prompt }}
-            </div>
-
-            <!-- Answered: locked summary -->
-            <div v-if="submitted"
-                 class="flex items-center gap-2 text-sm">
-                <UIcon name="i-lucide-check-circle-2"
-                       class="size-4 text-success shrink-0" />
-                <span class="text-muted">{{ selectedLabels.join(', ') }}</span>
-            </div>
-
-            <template v-else>
-                <UCheckboxGroup v-if="request.multi"
-                                v-model="checked"
-                                :items="radioItems" />
-                <URadioGroup v-else
-                             v-model="single"
-                             :items="radioItems" />
-
-                <UButton :label="request.multi ? `Confirm selection (${selectedValues.length})` : 'Confirm'"
-                         :disabled="!selectedValues.length"
-                         block
-                         @click="confirm" />
-            </template>
+    <div class="border border-default rounded-[13px] p-4 my-2 w-full min-w-72 max-w-md flex flex-col gap-3">
+        <div class="flex items-center justify-between gap-2">
+            <span class="text-[13px] font-semibold text-highlighted">{{ request.prompt }}</span>
+            <UButton v-if="request.multi && request.options.length > 3 && !submitted"
+                     :label="allSelected ? 'Deselect all' : 'Select all'"
+                     variant="link"
+                     size="xs"
+                     class="shrink-0"
+                     @click="toggleAll" />
         </div>
+
+        <!-- Answered: locked summary -->
+        <div v-if="submitted"
+             class="flex items-center gap-2 text-[13px]">
+            <UIcon name="i-lucide-check-circle-2"
+                   class="size-4 text-success shrink-0" />
+            <span class="text-muted truncate">{{ selectedLabels.join(', ') }}</span>
+        </div>
+
+        <template v-else>
+            <div class="flex flex-col gap-1.5 max-h-64 overflow-y-auto">
+                <SelectionCard v-for="option in request.options"
+                               :key="option.value"
+                               :as="request.multi ? 'div' : 'button'"
+                               :selected="picked.includes(option.value)"
+                               class="shrink-0"
+                               @select="toggle(option.value)">
+                    <div class="flex items-center gap-2.5 px-3 py-2"
+                         :class="request.multi ? 'cursor-pointer' : ''">
+                        <UCheckbox v-if="request.multi"
+                                   :model-value="picked.includes(option.value)"
+                                   @click.stop
+                                   @update:model-value="toggle(option.value)" />
+                        <span class="text-[13px] font-medium truncate">{{ option.label }}</span>
+                        <UIcon v-if="!request.multi && picked.includes(option.value)"
+                               name="i-lucide-check"
+                               class="size-3.5 text-primary ml-auto shrink-0" />
+                    </div>
+                </SelectionCard>
+            </div>
+
+            <UButton :label="request.multi ? `Confirm selection (${picked.length})` : 'Confirm'"
+                     :disabled="!picked.length"
+                     block
+                     @click="confirm" />
+        </template>
     </div>
 </template>

--- a/packages/interloper-app/app/app/composables/agentChat.ts
+++ b/packages/interloper-app/app/app/composables/agentChat.ts
@@ -1,4 +1,4 @@
-import type { AgentEvent, ChatMessage, ConnectionSetupRequest } from '~/types/agent'
+import type { AgentEvent, ChatMessage, ConnectionSetupRequest, SelectionRequest } from '~/types/agent'
 
 /**
  * Composable for managing an agent chat session with SSE streaming.
@@ -25,6 +25,11 @@ export function useAgentChat(sessionId: Ref<string>) {
                     restored.push({ id: event.id || crypto.randomUUID(), role: 'assistant', text: '', connectionSetup: setup })
                     continue
                 }
+                const selection = _extractSelection(event)
+                if (selection) {
+                    restored.push({ id: event.id || crypto.randomUUID(), role: 'assistant', text: '', selection })
+                    continue
+                }
 
                 const text = _extractText(event)
                 if (!text) continue
@@ -32,7 +37,7 @@ export function useAgentChat(sessionId: Ref<string>) {
                 const role = event.author === 'user' ? 'user' as const : 'assistant' as const
                 // Merge consecutive assistant messages from the same invocation
                 const last = restored[restored.length - 1]
-                if (role === 'assistant' && last?.role === 'assistant' && !last.connectionSetup) {
+                if (role === 'assistant' && last?.role === 'assistant' && !last.connectionSetup && !last.selection) {
                     last.text += text
                 }
                 else {
@@ -109,6 +114,10 @@ export function useAgentChat(sessionId: Ref<string>) {
                         if (setup) {
                             messages.value.push({ id: crypto.randomUUID(), role: 'assistant', text: '', connectionSetup: setup })
                         }
+                        const selection = _extractSelection(event)
+                        if (selection) {
+                            messages.value.push({ id: crypto.randomUUID(), role: 'assistant', text: '', selection })
+                        }
                         const eventText = _extractText(event)
                         if (eventText && event.author !== 'user') {
                             const msg = messages.value.find(m => m.id === assistantId)
@@ -165,6 +174,23 @@ function _extractConnectionSetup(event: any): ConnectionSetupRequest | null {
         const response = fr.response
         if (response?.status !== 'success' || !response.connection_key) continue
         return { connectionKey: response.connection_key, name: response.name ?? undefined }
+    }
+    return null
+}
+
+/**
+ * Extract a selection request from an ADK event.
+ *
+ * Keys on the request_user_selection tool's function response, so a card
+ * only renders for requests the tool validated.
+ */
+function _extractSelection(event: any): SelectionRequest | null {
+    for (const part of event?.content?.parts ?? []) {
+        const fr = part.functionResponse
+        if (fr?.name !== 'request_user_selection') continue
+        const response = fr.response
+        if (response?.status !== 'success' || !response.options?.length) continue
+        return { prompt: response.prompt ?? '', options: response.options, multi: !!response.multi }
     }
     return null
 }

--- a/packages/interloper-app/app/app/composables/agentChat.ts
+++ b/packages/interloper-app/app/app/composables/agentChat.ts
@@ -1,4 +1,4 @@
-import type { AgentEvent, ChatMessage, ConnectionSetupRequest, SelectionRequest } from '~/types/agent'
+import type { AgentEvent, ChatMessage, ConfirmationRequest, ConnectionSetupRequest, SelectionRequest } from '~/types/agent'
 
 /**
  * Composable for managing an agent chat session with SSE streaming.
@@ -30,6 +30,11 @@ export function useAgentChat(sessionId: Ref<string>) {
                     restored.push({ id: event.id || crypto.randomUUID(), role: 'assistant', text: '', selection })
                     continue
                 }
+                const confirmation = _extractConfirmation(event)
+                if (confirmation) {
+                    restored.push({ id: event.id || crypto.randomUUID(), role: 'assistant', text: '', confirmation })
+                    continue
+                }
 
                 const text = _extractText(event)
                 if (!text) continue
@@ -37,7 +42,7 @@ export function useAgentChat(sessionId: Ref<string>) {
                 const role = event.author === 'user' ? 'user' as const : 'assistant' as const
                 // Merge consecutive assistant messages from the same invocation
                 const last = restored[restored.length - 1]
-                if (role === 'assistant' && last?.role === 'assistant' && !last.connectionSetup && !last.selection) {
+                if (role === 'assistant' && last?.role === 'assistant' && !last.connectionSetup && !last.selection && !last.confirmation) {
                     last.text += text
                 }
                 else {
@@ -118,6 +123,10 @@ export function useAgentChat(sessionId: Ref<string>) {
                         if (selection) {
                             messages.value.push({ id: crypto.randomUUID(), role: 'assistant', text: '', selection })
                         }
+                        const confirmation = _extractConfirmation(event)
+                        if (confirmation) {
+                            messages.value.push({ id: crypto.randomUUID(), role: 'assistant', text: '', confirmation })
+                        }
                         const eventText = _extractText(event)
                         if (eventText && event.author !== 'user') {
                             const msg = messages.value.find(m => m.id === assistantId)
@@ -191,6 +200,23 @@ function _extractSelection(event: any): SelectionRequest | null {
         const response = fr.response
         if (response?.status !== 'success' || !response.options?.length) continue
         return { prompt: response.prompt ?? '', options: response.options, multi: !!response.multi }
+    }
+    return null
+}
+
+/**
+ * Extract a confirmation summary from an ADK event.
+ *
+ * Keys on the request_confirmation tool's function response, so a card
+ * only renders for requests the tool validated.
+ */
+function _extractConfirmation(event: any): ConfirmationRequest | null {
+    for (const part of event?.content?.parts ?? []) {
+        const fr = part.functionResponse
+        if (fr?.name !== 'request_confirmation') continue
+        const response = fr.response
+        if (response?.status !== 'success' || !response.items?.length) continue
+        return { title: response.title ?? '', items: response.items }
     }
     return null
 }

--- a/packages/interloper-app/app/app/pages/agent/chat/[id].vue
+++ b/packages/interloper-app/app/app/pages/agent/chat/[id].vue
@@ -30,6 +30,11 @@ function onSelection(labels: string[], values: string[]) {
     send(`I selected: ${labels.map((label, i) => `${label} (${values[i]})`).join(', ')}`)
 }
 
+/** Report a confirmation decision back into the chat so the agent proceeds or stops. */
+function onDecision(confirmed: boolean) {
+    send(confirmed ? 'Confirmed — go ahead.' : 'Cancel that — do not proceed.')
+}
+
 onMounted(async () => {
     await loadHistory()
     const initialQuery = route.query.q as string | undefined
@@ -77,6 +82,9 @@ onMounted(async () => {
                             <AgentSelectCard v-else-if="message.selection"
                                              :request="message.selection"
                                              @selected="onSelection" />
+                            <AgentConfirmCard v-else-if="message.confirmation"
+                                              :request="message.confirmation"
+                                              @decided="onDecision" />
                             <MDC v-else-if="message.role === 'assistant'"
                                  :value="message.text"
                                  :cache-key="message.id"

--- a/packages/interloper-app/app/app/pages/agent/chat/[id].vue
+++ b/packages/interloper-app/app/app/pages/agent/chat/[id].vue
@@ -25,6 +25,11 @@ function onConnectionCreated(name: string, verified: boolean) {
     send(`I completed the setup — connection "${name}" is created${verified ? ' and the connection check passed' : ''}.`)
 }
 
+/** Report a confirmed selection back into the chat so the agent continues. */
+function onSelection(labels: string[], values: string[]) {
+    send(`I selected: ${labels.map((label, i) => `${label} (${values[i]})`).join(', ')}`)
+}
+
 onMounted(async () => {
     await loadHistory()
     const initialQuery = route.query.q as string | undefined
@@ -69,6 +74,9 @@ onMounted(async () => {
                             <AgentConnectCard v-if="message.connectionSetup"
                                               :request="message.connectionSetup"
                                               @created="onConnectionCreated" />
+                            <AgentSelectCard v-else-if="message.selection"
+                                             :request="message.selection"
+                                             @selected="onSelection" />
                             <MDC v-else-if="message.role === 'assistant'"
                                  :value="message.text"
                                  :cache-key="message.id"

--- a/packages/interloper-app/app/app/types/agent.ts
+++ b/packages/interloper-app/app/app/types/agent.ts
@@ -44,6 +44,19 @@ export interface ConnectionSetupRequest {
     name?: string
 }
 
+/** One choice within a selection request. */
+export interface SelectionOption {
+    label: string
+    value: string
+}
+
+/** Inline selection request emitted by the agent's request_user_selection tool. */
+export interface SelectionRequest {
+    prompt: string
+    options: SelectionOption[]
+    multi: boolean
+}
+
 /** Simplified chat message for UI rendering. */
 export interface ChatMessage {
     id: string
@@ -52,4 +65,6 @@ export interface ChatMessage {
     loading?: boolean
     /** When set, the message renders the inline connection setup card. */
     connectionSetup?: ConnectionSetupRequest
+    /** When set, the message renders the inline selection card. */
+    selection?: SelectionRequest
 }

--- a/packages/interloper-app/app/app/types/agent.ts
+++ b/packages/interloper-app/app/app/types/agent.ts
@@ -57,6 +57,12 @@ export interface SelectionRequest {
     multi: boolean
 }
 
+/** Inline confirmation summary emitted by the agent's request_confirmation tool. */
+export interface ConfirmationRequest {
+    title: string
+    items: { label: string, value: string }[]
+}
+
 /** Simplified chat message for UI rendering. */
 export interface ChatMessage {
     id: string
@@ -67,4 +73,6 @@ export interface ChatMessage {
     connectionSetup?: ConnectionSetupRequest
     /** When set, the message renders the inline selection card. */
     selection?: SelectionRequest
+    /** When set, the message renders the inline confirmation summary card. */
+    confirmation?: ConfirmationRequest
 }


### PR DESCRIPTION
## What

Closes the gap analysis: the agent can now complete the entire source-setup wizard flow conversationally. Source inputs (accounts, datasets, asset selections) aren't secrets, so unlike connections there's no form handoff — the only secret-bearing step remains the connect card, which slots into this flow unchanged.

Two new tools on `CollectionAgent` (`tools/collection.py`):

- **`resolve_source_field_options(source_key, field, connection_id)`** — the account picker's engine. Hydrates the connection via `store.load()` (the `check_connection` pattern) and calls the definition's `x-fetch` provider method under the same `@fetch_field_provider` allowlist `/components/resolve` enforces. Options return as label/value pairs (capped at 50 + total), the chosen label doubling as the default source name — mirroring the wizard's discriminator-derived naming. Provider failures reuse the curated categorisation; tool output never carries credentials (sentinel-tested).
- **`create_source(source_key, name, config, connection_id?, asset_keys?, destination_ids?)`** — binds the connection into the definition's resource slot (validating slot key + requiredness with actionable errors), enables the chosen assets (default: all), attaches destinations, forwards the store's config-validation and discriminator-uniqueness errors verbatim (they're user-actionable). Cross-source requirements are **reported, not auto-wired** — no shipped asset declares any today, so v1 doesn't guess at an unexercised shape.

`COLLECTION_INSTRUCTION` gains the setup script with two policies: a hard **recap-and-confirm gate** before creation, and the wizard's **never-block stance** — failing option fetches / connection checks warn but don't override an explicit user confirmation (a live eval showed flash otherwise refusing to create on a degraded connection the user had explicitly accepted).

Also: wraps `CatalogAgent`'s instruction with `with_current_time` — the one agent the recent time-injection work missed; its own test caught it here.

## Wizard-step coverage after this PR

| Step | How |
|---|---|
| 1. Source type | `list_definitions` / `get_definition` / `consult_catalog` |
| 2. Assets | `asset_keys` on create (cross-source requires reported for app-side wiring) |
| 3. Connection | reuse via `list_components`, or the connect card mid-flow |
| 4. Destination | select-existing via `list_components`; creation deliberately deferred |
| 5. Config / account | `resolve_source_field_options` |
| Create | `create_source` behind recap + confirm |

## Verification

- Tool-level (dev DB): slot binding, missing/wrong-type connection errors, subset asset enablement, duplicate-discriminator error surfaced from the store, non-fetchable-field error with the fetchable list, provider-failure categorisation, and a sentinel-secret leak check.
- Live three-turn E2E (Gemini runner): recap → connection disambiguation (two connections existed — the agent asked) → confirm → `create_source` → **real row: 8 child assets, connection bound in the `resource`/`connection` slot**, verified in the DB.

ruff / ty / pytest (930) green.

By Digitl