### PR TITLE
feat(agent): bulk multi-account sources and the job that schedules them

### DIFF
--- a/packages/interloper-agent/src/interloper_agent/agent.py
+++ b/packages/interloper-agent/src/interloper_agent/agent.py
@@ -111,6 +111,8 @@ collection_agent = Agent(
         collection.check_connection,
         collection.resolve_source_field_options,
         collection.create_source,
+        collection.create_sources,
+        collection.create_job,
         interaction.request_user_selection,
         interaction.request_confirmation,
         AgentTool(agent=catalog_consultant),

--- a/packages/interloper-agent/src/interloper_agent/agent.py
+++ b/packages/interloper-agent/src/interloper_agent/agent.py
@@ -138,7 +138,8 @@ scheduling_agent = Agent(
     model=_model,
     description=(
         "Monitors run health, recent failures, job schedules, and backfill progress; "
-        "triggers runs, starts backfills, and toggles jobs or assets on/off."
+        "triggers runs, starts backfills, toggles jobs or assets on/off, and creates "
+        "cron jobs over the collection's sources."
     ),
     instruction=with_current_time(SCHEDULING_INSTRUCTION),
     tools=[
@@ -152,6 +153,9 @@ scheduling_agent = Agent(
         scheduling.list_backfills,
         scheduling.trigger_backfill,
         scheduling.toggle_asset,
+        collection.list_components,
+        collection.create_job,
+        interaction.request_confirmation,
     ],
 )
 

--- a/packages/interloper-agent/src/interloper_agent/prompts.py
+++ b/packages/interloper-agent/src/interloper_agent/prompts.py
@@ -86,41 +86,44 @@ To set up a new connection:
 Also run check_connection when the user reports a connection problem or a
 source fails with authentication-looking errors.
 
-To set up a new source:
+To set up sources — the same flow covers one account or many; the user's
+selection decides, never assume how many they want:
 1. Identify the definition (consult the catalog specialist when the user
    describes a need rather than a product) and what it requires: a
    connection slot, and its config fields.
-2. Ensure the connection: reuse one from the collection, or run the
-   connection setup flow above first.
-3. Resolve the provider-backed config field (like the account) with
+2. Ensure the connection: reuse an existing one when possible.
+   request_connection_setup refuses and lists fitting connections when the
+   collection already has some — ask the user whether to reuse one, and
+   pass force_new only when they want another account connected.
+3. Accounts: resolve the account field's options with
    resolve_source_field_options — omit the field name, it is picked from
-   the definition — and present the options with request_user_selection
-   (single choice). The chosen option's label is the default source name.
+   the definition — and present them with request_user_selection (multi),
+   unless the user already named the account(s). Every ticked account
+   becomes one source, its option label the source's name.
 4. Assets: never decide the selection yourself, and never default to all.
    Unless the user has already named assets or explicitly said "all", get
    the definition's asset keys from the catalog specialist and present
-   them with request_user_selection (multi) before going further.
-5. Recap with request_confirmation: the title says what will be created,
-   the items carry name, account/config, assets, connection, and
+   them with request_user_selection (multi). One selection applies to
+   every account.
+5. Recap with request_confirmation: the title says what will be created
+   (and how many), the items carry the accounts, assets, connection, and
    destinations. Wait for the decision — only a confirmation of the recap
    counts; an answer to an earlier question (like an asset selection) is
    not confirmation.
-6. Only then call create_source and report the result, including any
-   unresolved cross-source requirements (those are wired in the app).
+6. Only then call create_sources — one instance per account — and report
+   the result, including per-account failures and any unresolved
+   cross-source requirements (those are wired in the app).
+7. Offer a schedule for the created sources: ask for the cadence, recap
+   the job (name, schedule in words, targets) with request_confirmation,
+   and create_job after the user confirms.
 
-Never create a source without the recap and the user's confirmation. The
+create_source (singular) is the fallback for definitions without an
+account field, or one-off config the account flow doesn't cover.
+
+Never create sources without the recap and the user's confirmation. The
 reverse also holds: a failing options fetch or connection check warns but
-does not block — when the user supplies the value themselves and explicitly
-confirms, create the source and note the connection concern in your report.
-
-To set up several accounts of the same source type at once, run the same
-flow with two differences: the account selection is multi
-(request_user_selection with multi=true over the resolved options), and
-after the confirmation you call create_sources — one source per account,
-option labels as names, shared assets and connection. Then offer a
-schedule: ask for the cadence, recap the job (name, schedule in words,
-targets) with request_confirmation, and create_job over the created
-sources.
+does not block — when the user supplies the values themselves and
+explicitly confirms, create and note the connection concern in your report.
 
 Whenever the user must pick from known options, use request_user_selection
 instead of listing choices as text.

--- a/packages/interloper-agent/src/interloper_agent/prompts.py
+++ b/packages/interloper-agent/src/interloper_agent/prompts.py
@@ -42,7 +42,8 @@ Route questions to the appropriate specialist:
   "If Google Ads breaks, what's affected?", "Show cross-source dependencies"
 - **SchedulingAgent** — "Did last night's runs succeed?", "Which assets failed?",
   "What's the cron schedule?", "Show backfill progress", "Re-run the Facebook job
-  for yesterday", "Backfill March 1-15", "Disable the campaign_matcher job"
+  for yesterday", "Backfill March 1-15", "Disable the campaign_matcher job",
+  "Run my Facebook sources daily at 6am"
 - **AnalyticsAgent** — "How often do runs fail?", "Any partition gaps?",
   "When was the last successful run for each job?"
 
@@ -200,10 +201,18 @@ When showing job status:
 - Compute success rate from recent runs
 
 When taking actions:
-- Always confirm what you are about to do before executing
+- Always confirm what you are about to do before executing — use
+  request_confirmation to present the recap, and proceed only on the
+  user's confirmation of it
 - Describe the action clearly: which job, which dates, what will change
 - After executing, report the result including the created run/backfill ID
 - For backfills, confirm the date range and concurrency settings
+
+You can also create cron jobs: find the target sources with
+list_components (kind 'source'), recap the job — name, schedule in words,
+targets — with request_confirmation, then end your turn. Never call
+create_job in the same turn as the recap: the user's next message must
+confirm it first.
 
 Never execute destructive actions without explicit user confirmation.
 """ + PRESENTATION

--- a/packages/interloper-agent/src/interloper_agent/prompts.py
+++ b/packages/interloper-agent/src/interloper_agent/prompts.py
@@ -112,6 +112,15 @@ reverse also holds: a failing options fetch or connection check warns but
 does not block — when the user supplies the value themselves and explicitly
 confirms, create the source and note the connection concern in your report.
 
+To set up several accounts of the same source type at once, run the same
+flow with two differences: the account selection is multi
+(request_user_selection with multi=true over the resolved options), and
+after the confirmation you call create_sources — one source per account,
+option labels as names, shared assets and connection. Then offer a
+schedule: ask for the cadence, recap the job (name, schedule in words,
+targets) with request_confirmation, and create_job over the created
+sources.
+
 Whenever the user must pick from known options, use request_user_selection
 instead of listing choices as text.
 """ + PRESENTATION

--- a/packages/interloper-agent/src/interloper_agent/tools/collection.py
+++ b/packages/interloper-agent/src/interloper_agent/tools/collection.py
@@ -323,6 +323,92 @@ async def resolve_source_field_options(
         return {"status": "error", "error": str(e)}
 
 
+def _normalized_asset_keys(
+    defn: dict[str, Any], source_key: str, asset_keys: list[str] | None
+) -> tuple[list[str] | None, dict[str, Any] | None]:
+    """Normalize an asset selection: empty means default-all, unknown keys error.
+
+    Models pass ``[]`` meaning "default" — and a zero-asset source is useless.
+
+    Returns:
+        ``(asset_keys, None)`` or ``(None, error_response)``.
+    """
+    if not asset_keys:
+        return None, None
+    valid = {a.get("key") for a in defn.get("assets", [])}
+    unknown = sorted(set(asset_keys) - valid)
+    if unknown:
+        return None, {
+            "status": "error",
+            "error": f"Unknown asset keys for '{source_key}': {', '.join(unknown)}",
+            "valid_asset_keys": sorted(valid),
+        }
+    return asset_keys, None
+
+
+def _source_relations(
+    store: Any,
+    org_id: UUID,
+    defn: dict[str, Any],
+    source_key: str,
+    connection_id: str | None,
+    destination_ids: list[str] | None,
+) -> tuple[dict[str, list[tuple[UUID, str]]] | None, dict[str, Any] | None]:
+    """Bind the connection into the definition's resource slot, plus destinations.
+
+    Returns:
+        ``(relations, None)`` or ``(None, error_response)``.
+    """
+    slots = (((defn.get("relations") or {}).get("resource") or {}).get("slots")) or {}
+    connection = None
+    if connection_id is not None:
+        connection = store.get_component(UUID(connection_id), kind="connection")
+        if connection.org_id != org_id:
+            return None, {"status": "error", "error": f"Connection '{connection_id}' not found"}
+    resource_bindings: list[tuple[UUID, str]] = []
+    for slot_name, spec in slots.items():
+        expected = spec.get("key")
+        if connection is not None and (not expected or connection.key == expected):
+            resource_bindings.append((connection.id, slot_name))
+            connection = None
+        elif spec.get("required"):
+            return None, {
+                "status": "error",
+                "error": (
+                    f"'{source_key}' requires a '{expected or 'connection'}' in slot '{slot_name}' — "
+                    "pick one from the collection or set one up first"
+                ),
+            }
+    if connection is not None:
+        return None, {
+            "status": "error",
+            "error": f"Connection '{connection.key}' does not fit any slot of '{source_key}'",
+        }
+
+    destination_bindings: list[tuple[UUID, str]] = []
+    for dest_id in destination_ids or []:
+        dest = store.get_component(UUID(dest_id), kind="destination")
+        if dest.org_id != org_id:
+            return None, {"status": "error", "error": f"Destination '{dest_id}' not found"}
+        destination_bindings.append((dest.id, ""))
+
+    return {"resource": resource_bindings, "destination": destination_bindings}, None
+
+
+def _unresolved_requirements(defn: dict[str, Any], row: Any) -> list[str]:
+    """Cross-source requirements of the enabled assets — reported, not auto-wired.
+
+    Returns:
+        One ``"asset: params"`` line per affected asset.
+    """
+    enabled = {a.key for a in row.children}
+    return sorted(
+        f"{a['key']}: {', '.join(sorted({**a.get('requires', {}), **a.get('optional_requires', {})}))}"
+        for a in defn.get("assets", [])
+        if a.get("key") in enabled and (a.get("requires") or a.get("optional_requires"))
+    )
+
+
 def create_source(
     source_key: str,
     name: str,
@@ -356,52 +442,13 @@ def create_source(
         if defn is None or defn.get("kind") != "source":
             return {"status": "error", "error": f"Source '{source_key}' not found in catalog"}
 
-        # Models pass [] meaning "default" — and a zero-asset source is useless.
-        if not asset_keys:
-            asset_keys = None
-        else:
-            valid = {a.get("key") for a in defn.get("assets", [])}
-            unknown = sorted(set(asset_keys) - valid)
-            if unknown:
-                return {
-                    "status": "error",
-                    "error": f"Unknown asset keys for '{source_key}': {', '.join(unknown)}",
-                    "valid_asset_keys": sorted(valid),
-                }
-
-        # Bind the connection into the definition's matching resource slot.
-        slots = (((defn.get("relations") or {}).get("resource") or {}).get("slots")) or {}
-        connection = None
-        if connection_id is not None:
-            connection = store.get_component(UUID(connection_id), kind="connection")
-            if connection.org_id != org_id:
-                return {"status": "error", "error": f"Connection '{connection_id}' not found"}
-        resource_bindings: list[tuple[UUID, str]] = []
-        for slot_name, spec in slots.items():
-            expected = spec.get("key")
-            if connection is not None and (not expected or connection.key == expected):
-                resource_bindings.append((connection.id, slot_name))
-                connection = None
-            elif spec.get("required"):
-                return {
-                    "status": "error",
-                    "error": (
-                        f"'{source_key}' requires a '{expected or 'connection'}' in slot '{slot_name}' — "
-                        "pick one from the collection or set one up first"
-                    ),
-                }
-        if connection is not None:
-            return {
-                "status": "error",
-                "error": f"Connection '{connection.key}' does not fit any slot of '{source_key}'",
-            }
-
-        destination_bindings: list[tuple[UUID, str]] = []
-        for dest_id in destination_ids or []:
-            dest = store.get_component(UUID(dest_id), kind="destination")
-            if dest.org_id != org_id:
-                return {"status": "error", "error": f"Destination '{dest_id}' not found"}
-            destination_bindings.append((dest.id, ""))
+        asset_keys, error = _normalized_asset_keys(defn, source_key, asset_keys)
+        if error:
+            return error
+        relations, error = _source_relations(store, org_id, defn, source_key, connection_id, destination_ids)
+        if error:
+            return error
+        assert relations is not None
 
         try:
             row = store.create_component(
@@ -411,19 +458,10 @@ def create_source(
                 name=name,
                 config=config,
                 children=asset_keys,
-                relations={"resource": resource_bindings, "destination": destination_bindings},
+                relations=relations,
             )
         except (ConfigError, CatalogKeyError) as e:
             return {"status": "error", "error": str(e)}
-
-        # Cross-source requirements are not auto-wired: report them so the
-        # agent can point the user at the app for dependency resolution.
-        enabled = {a.key for a in row.children}
-        unresolved = sorted(
-            f"{a['key']}: {', '.join(sorted({**a.get('requires', {}), **a.get('optional_requires', {})}))}"
-            for a in defn.get("assets", [])
-            if a.get("key") in enabled and (a.get("requires") or a.get("optional_requires"))
-        )
 
         return {
             "status": "success",
@@ -433,10 +471,184 @@ def create_source(
                 "key": row.key,
                 "name": row.name,
                 "asset_count": len(row.children),
-                "connection_bound": bool(resource_bindings),
-                "destination_count": len(destination_bindings),
+                "connection_bound": bool(relations["resource"]),
+                "destination_count": len(relations["destination"]),
             },
+            "unresolved_requirements": _unresolved_requirements(defn, row),
+        }
+    except Exception as e:
+        return {"status": "error", "error": str(e)}
+
+
+def create_sources(
+    source_key: str,
+    instances: list[dict[str, str]],
+    connection_id: str | None = None,
+    asset_keys: list[str] | None = None,
+    shared_config: dict[str, Any] | None = None,
+    field: str | None = None,
+    destination_ids: list[str] | None = None,
+    tool_context: ToolContext | None = None,
+) -> dict[str, Any]:
+    """Create several sources of one definition — one per account/profile value.
+
+    Use this when the user sets up multiple accounts of the same source type
+    at once: every instance shares the connection, asset selection, and any
+    shared config; its ``value`` fills the definition's account field and its
+    ``name`` becomes the source's display name (use the option labels from
+    the account selection).
+
+    Recap the choices and get the user's explicit confirmation BEFORE calling
+    this. Instances that fail (e.g. an account that already has a source)
+    are reported individually; the others are still created.
+
+    Args:
+        source_key: The source definition's catalog key (e.g. 'facebook_ads').
+        instances: One entry per source, each ``{"name": ..., "value": ...}``.
+        connection_id: UUID of the connection every source binds.
+        asset_keys: Child asset keys to enable on every source; omit for all.
+        shared_config: Config values common to all instances (e.g. dataset).
+        field: The config field receiving each value. Omit it — never guess
+            field names: the definition's fetchable field is picked
+            automatically.
+        destination_ids: Destination UUIDs to attach to every source.
+    """
+    try:
+        org_id = get_org_id(tool_context)
+        store = get_store()
+        catalog = get_catalog()
+
+        defn = catalog.get(source_key)
+        if defn is None or defn.get("kind") != "source":
+            return {"status": "error", "error": f"Source '{source_key}' not found in catalog"}
+        cleaned = [
+            {"name": str(i.get("name") or i.get("value")), "value": str(i.get("value"))}
+            for i in instances
+            if isinstance(i, dict) and i.get("value") is not None
+        ]
+        if not cleaned:
+            return {"status": "error", "error": "instances must carry at least one {name, value} entry"}
+
+        properties = (defn.get("config_schema") or {}).get("properties", {})
+        if field is None:
+            fetchable = sorted(k for k, p in properties.items() if p.get("x-fetch"))
+            discriminators = sorted(k for k, p in properties.items() if p.get("x-discriminator"))
+            candidates = fetchable or discriminators
+            if len(candidates) != 1:
+                return {
+                    "status": "error",
+                    "error": f"'{source_key}' has no single account field — pass one explicitly",
+                    "candidate_fields": candidates,
+                }
+            field = candidates[0]
+        elif field not in properties:
+            return {"status": "error", "error": f"Unknown config field '{field}' for '{source_key}'"}
+
+        asset_keys, error = _normalized_asset_keys(defn, source_key, asset_keys)
+        if error:
+            return error
+        relations, error = _source_relations(store, org_id, defn, source_key, connection_id, destination_ids)
+        if error:
+            return error
+        assert relations is not None
+
+        created, failed = [], []
+        unresolved: list[str] = []
+        for instance in cleaned:
+            try:
+                row = store.create_component(
+                    org_id,
+                    kind="source",
+                    key=source_key,
+                    name=instance["name"],
+                    config={**(shared_config or {}), field: instance["value"]},
+                    children=asset_keys,
+                    relations=relations,
+                )
+            except (ConfigError, CatalogKeyError) as e:
+                failed.append({"name": instance["name"], "value": instance["value"], "error": str(e)})
+                continue
+            created.append({"id": serialize(row.id), "name": row.name, "value": instance["value"]})
+            unresolved = _unresolved_requirements(defn, row)
+
+        return {
+            "status": "success" if created else "error",
+            "message": f"{len(created)} source(s) created" + (f", {len(failed)} failed" if failed else ""),
+            "field": field,
+            "created": created,
+            "failed": failed,
             "unresolved_requirements": unresolved,
+        }
+    except Exception as e:
+        return {"status": "error", "error": str(e)}
+
+
+# -- Job operations (kind-specific by nature) --------------------------------------
+
+
+def create_job(
+    name: str,
+    cron: str,
+    target_source_ids: list[str],
+    partitioned: bool = False,
+    backfill_days: int | None = None,
+    tool_context: ToolContext | None = None,
+) -> dict[str, Any]:
+    """Create a cron job that runs the given sources on a schedule.
+
+    Use this after creating sources to put them on a cadence — one job can
+    target several sources (e.g. every account of a source type). Recap the
+    name, the schedule in words, and the targets, and get the user's
+    explicit confirmation BEFORE calling this.
+
+    Args:
+        name: Display name for the job (e.g. 'Facebook Ads daily').
+        cron: Standard cron expression (e.g. '0 6 * * *' for daily at 06:00 UTC).
+        target_source_ids: UUIDs of the sources the job materializes.
+        partitioned: Whether runs are date-partitioned.
+        backfill_days: For partitioned jobs, how many days each run covers.
+    """
+    try:
+        org_id = get_org_id(tool_context)
+        store = get_store()
+
+        targets: list[tuple[UUID, str]] = []
+        for source_id in target_source_ids:
+            source = store.get_component(UUID(source_id), kind="source")
+            if source.org_id != org_id:
+                return {"status": "error", "error": f"Source '{source_id}' not found"}
+            targets.append((source.id, ""))
+        if not targets:
+            return {"status": "error", "error": "target_source_ids must name at least one source"}
+
+        try:
+            row = store.create_component(
+                org_id,
+                kind="job",
+                key="cron_job",
+                name=name,
+                config={
+                    "cron": cron,
+                    "enabled": True,
+                    "tags": [],
+                    "partitioned": partitioned,
+                    "backfill_days": backfill_days if partitioned else None,
+                },
+                relations={"target": targets},
+            )
+        except (ConfigError, CatalogKeyError) as e:
+            return {"status": "error", "error": str(e)}
+
+        return {
+            "status": "success",
+            "message": f"Job '{name}' created",
+            "job": {
+                "id": serialize(row.id),
+                "name": row.name,
+                "cron": cron,
+                "enabled": True,
+                "target_count": len(targets),
+            },
         }
     except Exception as e:
         return {"status": "error", "error": str(e)}

--- a/packages/interloper-agent/src/interloper_agent/tools/collection.py
+++ b/packages/interloper-agent/src/interloper_agent/tools/collection.py
@@ -96,6 +96,7 @@ def list_components(kind: str | None = None, tool_context: ToolContext | None = 
 def request_connection_setup(
     connection_key: str,
     name: str | None = None,
+    force_new: bool = False,
     tool_context: ToolContext | None = None,
 ) -> dict[str, Any]:
     """Present a secure connection setup form to the user in the app.
@@ -105,6 +106,11 @@ def request_connection_setup(
     credential entry otherwise) and the credentials go directly to the API.
     Never ask the user to share credentials in the chat instead.
 
+    When the collection already holds connections of this definition, the
+    form is NOT presented: the response lists them so you can ask the user
+    whether to reuse one — call again with ``force_new`` only when they
+    want another account connected.
+
     The response notes whether the user can sign in with the provider
     (``oauth_available``) or must enter credentials manually; an unknown key
     fails with the list of valid connection keys.
@@ -113,6 +119,7 @@ def request_connection_setup(
         connection_key: Catalog key of the connection definition — usually
             ``<source_key>_connection`` (e.g. 'facebook_ads_connection').
         name: Optional display name to prefill in the form.
+        force_new: Present the form even though fitting connections exist.
     """
     try:
         catalog = get_catalog()
@@ -124,6 +131,25 @@ def request_connection_setup(
                 "error": f"Connection definition '{connection_key}' not found in catalog",
                 "valid_keys": valid,
             }
+
+        if not force_new:
+            org_id = get_org_id(tool_context)
+            existing = [
+                {"id": serialize(c.id), "name": c.name}
+                for c in get_store().list_components(org_id, kinds=["connection"])
+                if c.key == connection_key
+            ]
+            if existing:
+                return {
+                    "status": "exists",
+                    "message": (
+                        "The collection already holds connections of this definition — no form was "
+                        "presented. Ask the user whether to reuse one; call again with force_new "
+                        "only if they want another account connected."
+                    ),
+                    "existing": existing,
+                }
+
         oauth = (defn.get("config_schema") or {}).get("x-oauth")
         return {
             "status": "success",

--- a/packages/interloper-agent/src/interloper_agent/tools/interaction.py
+++ b/packages/interloper-agent/src/interloper_agent/tools/interaction.py
@@ -43,7 +43,10 @@ def request_confirmation(
             return {"status": "error", "error": "items must carry at least one {label, value} entry"}
         return {
             "status": "success",
-            "message": "Confirmation presented to the user. Wait for their decision before continuing.",
+            "message": (
+                "Confirmation presented to the user. STOP: make no further tool "
+                "calls this turn — act only after their next message decides."
+            ),
             "title": title,
             "items": cleaned,
         }


### PR DESCRIPTION
## What

The fleet-setup flow on top of #153: **one connection, one asset selection, several accounts → all sources created, one job scheduling them.**

- **`create_sources(source_key, instances, connection_id, asset_keys, shared_config?, field?, destination_ids?)`** — one source per `{name, value}` instance, all sharing the connection, asset selection, and config. The account field is picked the way `resolve_source_field_options` picks it (single fetchable field, discriminator fallback) — never guessed by the model. Per-instance failure reporting: an account that already has a source is reported with the store's discriminator message while the rest are created. The slot-binding / asset-validation / requirements core is extracted into helpers shared with `create_source`, so single and bulk creation cannot drift.
- **`create_job(name, cron, target_source_ids, partitioned?, backfill_days?)`** — a `cron_job` with the job wizard's exact payload (config `{cron, enabled, tags, partitioned, backfill_days}` + `target` relations), org-scoped target validation.
- The collection instruction chains the flow: connection → assets (once) → **multi** account selection card → confirmation card → `create_sources` → schedule offer → job recap card → `create_job`. Both interactive cards from #153 are reused as-is.

## Verification

- Tool-level (tracked-id cleanup): 3 instances with one duplicate → 2 created + 1 individually-reported failure, `account_id` auto-picked; job persisted with 2 `target` relations and partitioned config intact.
- Four-turn live E2E (Gemini runner): confirmation card ("Create two Facebook Ads sources?" with an Accounts row) → `create_sources` → job recap card (Name / "Daily at 06:00 UTC" / targets) → `create_job` — final state exactly `[Acme DE (2 assets), Acme FR (2 assets), job 'FB daily' cron 0 6 * * * → 2 targets]`. Snapshot-diff cleanup.

ruff / ty / pytest (968) green.

By Digitl