### PR TITLE
feat: refuse deleting components that are still in use

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: verify
+description: Build, launch, and drive a seeded interloper dev instance headlessly to observe a change at its API/UI surface.
+---
+
+# Verifying interloper changes live
+
+## Launch
+
+`INTERLOPER_SERVER_PORT=3100 make dev-up` (background). Needs local Postgres at `localhost:5432` (`postgres/postgres/interloper`). Watch the log for the Nuxt port: if 3100 is held by a stale process, **Nuxt silently falls back to another port (even 3000)** — read the "Local:" line, don't assume.
+
+## Authenticate headlessly (no OAuth)
+
+Sessions are plain DB rows (`sessions.token_hash` = sha256 hexdigest of a `secrets.token_urlsafe(48)` token). Mint one with a short psycopg2 script inserting `(user_id, organisation_id, token_hash, expires_at)` for the seeded profile, keep the raw token in a scratchpad file, and send it as the `session_token` cookie. Delete the session row when done.
+
+Note: shell commands that interpolate the token (`TOK=$(cat …); curl -b …`) get denied — drive everything from python (httpx) / node scripts that read the token file themselves.
+
+## Drive
+
+- **API**: httpx with `follow_redirects=True` (collection routes 307-redirect to the trailing-slash form; httpx doesn't follow by default) against `http://localhost:<port>/api`.
+- **UI**: `npm install playwright-core` in the scratchpad, `chromium.launch({channel: 'chrome', headless: true})`, add the `session_token` cookie via `context.addCookies`, then click through the real pages and screenshot. Toasts are readable via `[role="alert"]` innerTexts.
+
+## Hygiene
+
+The dev DB is shared — track every component id you create and delete exactly those (children/referrers first: job → source → connection; the in-use guard 409s out-of-order deletes). Never key-filtered bulk deletes. Tear down with TaskStop on the dev-up task; confirm the port is free.

--- a/packages/interloper-api/src/interloper_api/routes/components.py
+++ b/packages/interloper-api/src/interloper_api/routes/components.py
@@ -30,6 +30,7 @@ from interloper.errors import (
     ConfigError,
     ConnectionCheckError,
     DataNotFoundError,
+    InUseError,
     NotFoundError,
 )
 from interloper.resource.fields import is_fetch_field_provider
@@ -307,12 +308,14 @@ def delete_component(
     user: Profile = Depends(get_current_user),
     store: Store = Depends(get_store),
 ) -> dict[str, str]:
-    """Delete a component. Children and relations cascade."""
+    """Delete a component. Refused (409) while other components are bound to it."""
     load_authorized(store.get_component, component_id, user, store, label="Component", minimum="editor")
     try:
         store.delete_component(component_id)
     except NotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
+    except InUseError as e:
+        raise HTTPException(status_code=409, detail={"message": str(e), "used_by": e.referrers})
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     return {"status": "deleted"}

--- a/packages/interloper-api/tests/test_components.py
+++ b/packages/interloper-api/tests/test_components.py
@@ -2,16 +2,20 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+from uuid import uuid4
+
 import httpx
 import interloper as il
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from interloper.errors import InUseError
 from interloper_assets.facebook_ads import connection as fb_connection
 from interloper_assets.facebook_ads.connection import FacebookAdsConnection
 from interloper_assets.facebook_ads.source import FacebookAds
 
-from interloper_api.dependencies import get_catalog, require_viewer
+from interloper_api.dependencies import get_catalog, get_current_user, get_store, require_viewer
 from interloper_api.routes import components as components_module
 
 CONNECTION_CONFIG = {"access_token": "TOK", "app_id": "A", "app_secret": "S", "_id": "x"}
@@ -165,3 +169,33 @@ class TestCheck:
             "/components/check", json={"component_key": "facebook_ads", "config": {}}
         )
         assert resp.status_code == 404
+
+
+class TestDelete:
+    """DELETE /components/{id} maps store errors to HTTP statuses."""
+
+    def test_in_use_maps_to_409_with_referrers(self):
+        org_id = uuid4()
+        referrers: list[dict[str, str | None]] = [
+            {"id": str(uuid4()), "kind": "source", "key": "facebook_ads", "name": "FB"}
+        ]
+
+        class FakeStore:
+            def get_component(self, component_id):
+                return SimpleNamespace(id=component_id, org_id=org_id)
+
+            def get_user_role(self, user_id, org_id):
+                return "admin"
+
+            def delete_component(self, component_id):
+                raise InUseError("Cannot delete connection 'C': in use by FB", referrers=referrers)
+
+        app = FastAPI()
+        app.include_router(components_module.router, prefix="/components")
+        app.dependency_overrides[get_store] = lambda: FakeStore()
+        app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(id=uuid4(), is_super_admin=False)
+
+        resp = TestClient(app).delete(f"/components/{uuid4()}")
+
+        assert resp.status_code == 409
+        assert resp.json()["detail"]["used_by"] == referrers

--- a/packages/interloper-app/app/app/components/collection/Table.vue
+++ b/packages/interloper-app/app/app/components/collection/Table.vue
@@ -86,8 +86,8 @@ async function deleteSource(sourceId: string) {
         await componentsStore.remove(sourceId)
         toast.add({ title: `Source "${info?.name ?? 'Source'}" deleted`, color: 'success' })
     }
-    catch {
-        toast.add({ title: 'Failed to delete source', color: 'error' })
+    catch (e) {
+        toast.add(inUseToast(e, 'Source') ?? { title: 'Failed to delete source', color: 'error' })
     }
 }
 

--- a/packages/interloper-app/app/app/components/drift/Banner.vue
+++ b/packages/interloper-app/app/app/components/drift/Banner.vue
@@ -46,8 +46,8 @@ async function handleCleanup() {
         await componentsStore.fetchAll(['source'])
         toast.add({ title: 'Catalog drift cleaned up', color: 'success' })
     }
-    catch {
-        toast.add({ title: 'Failed to clean up drift', color: 'error' })
+    catch (e) {
+        toast.add(inUseToast(e, 'Source') ?? { title: 'Failed to clean up drift', color: 'error' })
     }
     finally {
         cleaningUp.value = false

--- a/packages/interloper-app/app/app/pages/destinations.vue
+++ b/packages/interloper-app/app/app/pages/destinations.vue
@@ -85,8 +85,8 @@ async function handleDelete(ids: string[]) {
         await componentsStore.remove(ids)
         toast.add({ title: `${ids.length} destination${ids.length > 1 ? 's' : ''} deleted`, color: 'success' })
     }
-    catch {
-        toast.add({ title: 'Failed to delete destination', color: 'error' })
+    catch (e) {
+        toast.add(inUseToast(e, 'Destination') ?? { title: 'Failed to delete destination', color: 'error' })
     }
 }
 

--- a/packages/interloper-app/app/app/pages/graph.vue
+++ b/packages/interloper-app/app/app/pages/graph.vue
@@ -84,8 +84,8 @@ async function onDeleteSource(sourceId: string) {
         await componentsStore.remove(sourceId)
         toast.add({ title: `Source "${source?.name ?? 'Source'}" deleted`, color: 'success' })
     }
-    catch {
-        toast.add({ title: 'Failed to delete source', color: 'error' })
+    catch (e) {
+        toast.add(inUseToast(e, 'Source') ?? { title: 'Failed to delete source', color: 'error' })
     }
 }
 

--- a/packages/interloper-app/app/app/pages/hooks.vue
+++ b/packages/interloper-app/app/app/pages/hooks.vue
@@ -96,8 +96,8 @@ async function handleDelete(ids: string[]) {
         await componentsStore.remove(ids)
         toast.add({ title: `${ids.length} hook${ids.length > 1 ? 's' : ''} deleted`, color: 'success' })
     }
-    catch {
-        toast.add({ title: 'Failed to delete hook', color: 'error' })
+    catch (e) {
+        toast.add(inUseToast(e, 'Hook') ?? { title: 'Failed to delete hook', color: 'error' })
     }
 }
 </script>

--- a/packages/interloper-app/app/app/pages/jobs.vue
+++ b/packages/interloper-app/app/app/pages/jobs.vue
@@ -116,8 +116,8 @@ async function handleDelete(ids: string[]) {
         await componentsStore.remove(ids)
         toast.add({ title: `${ids.length} job${ids.length > 1 ? 's' : ''} deleted`, color: 'success' })
     }
-    catch {
-        toast.add({ title: 'Failed to delete job', color: 'error' })
+    catch (e) {
+        toast.add(inUseToast(e, 'Job') ?? { title: 'Failed to delete job', color: 'error' })
     }
 }
 </script>

--- a/packages/interloper-app/app/app/pages/resources/[kind].vue
+++ b/packages/interloper-app/app/app/pages/resources/[kind].vue
@@ -67,8 +67,8 @@ async function handleDelete(ids: string[]) {
         await componentsStore.remove(ids)
         toast.add({ title: `${ids.length} resource(s) deleted`, color: 'success' })
     }
-    catch {
-        toast.add({ title: 'Failed to delete resource', description: 'It may be in use by a source or destination.', color: 'error' })
+    catch (e) {
+        toast.add(inUseToast(e, pageTitle.value.slice(0, -1)) ?? { title: 'Failed to delete resource', color: 'error' })
     }
 }
 

--- a/packages/interloper-app/app/app/pages/sources.vue
+++ b/packages/interloper-app/app/app/pages/sources.vue
@@ -143,8 +143,8 @@ async function handleDelete(ids: string[]) {
         await componentsStore.remove(ids)
         toast.add({ title: `${ids.length} source${ids.length > 1 ? 's' : ''} deleted`, color: 'success' })
     }
-    catch {
-        toast.add({ title: 'Failed to delete source', color: 'error' })
+    catch (e) {
+        toast.add(inUseToast(e, 'Source') ?? { title: 'Failed to delete source', color: 'error' })
     }
 }
 </script>

--- a/packages/interloper-app/app/app/stores/components.ts
+++ b/packages/interloper-app/app/app/stores/components.ts
@@ -89,8 +89,12 @@ export const useComponentsStore = defineStore('components', () => {
 
     async function remove(ids: string | string[]) {
         const list = Array.isArray(ids) ? ids : [ids]
-        await Promise.all(list.map(id => apiFetch(`/components/${id}`, { method: 'DELETE' })))
-        list.forEach(_remove)
+        const results = await Promise.allSettled(list.map(id => apiFetch(`/components/${id}`, { method: 'DELETE' })))
+        list.forEach((id, i) => {
+            if (results[i]!.status === 'fulfilled') _remove(id)
+        })
+        const failed = results.find((r): r is PromiseRejectedResult => r.status === 'rejected')
+        if (failed) throw failed.reason
     }
 
     /** Fetch relations, optionally narrowed to a type (replaces that type only). */

--- a/packages/interloper-app/app/app/utils/apiErrors.ts
+++ b/packages/interloper-app/app/app/utils/apiErrors.ts
@@ -1,0 +1,36 @@
+/** One referencing component in a 409 in-use error payload. */
+export interface UsedByRef {
+    id: string
+    kind: string
+    key: string
+    name: string | null
+}
+
+/**
+ * Extract the `used_by` referrer list from a DELETE 409 response
+ * (`{detail: {message, used_by}}`), or `null` for any other error.
+ */
+export function usedByFromError(e: unknown): UsedByRef[] | null {
+    const err = e as { status?: number, statusCode?: number, data?: { detail?: { used_by?: UsedByRef[] } } }
+    const usedBy = err?.data?.detail?.used_by
+    return (err?.status ?? err?.statusCode) === 409 && Array.isArray(usedBy) && usedBy.length ? usedBy : null
+}
+
+/** Human-readable list of referrer names for a toast description. */
+export function usedByNames(refs: UsedByRef[]): string {
+    return refs.map(r => r.name ?? r.key).join(', ')
+}
+
+/**
+ * Toast payload for a 409 in-use delete failure, or `null` for any other
+ * error (callers fall back to their generic failure toast).
+ */
+export function inUseToast(e: unknown, entity: string): { title: string, description: string, color: 'error' } | null {
+    const usedBy = usedByFromError(e)
+    if (!usedBy) return null
+    return {
+        title: `${entity} is in use`,
+        description: `Used by: ${usedByNames(usedBy)}. Rebind or delete those first.`,
+        color: 'error',
+    }
+}

--- a/packages/interloper-core/src/interloper/errors.py
+++ b/packages/interloper-core/src/interloper/errors.py
@@ -136,6 +136,20 @@ class NotFoundError(InterloperError, KeyError):
     """
 
 
+class InUseError(InterloperError):
+    """A record cannot be deleted because other records still reference it.
+
+    Raised by the store layer; API routes catch it and return HTTP 409.
+    ``referrers`` carries the referencing records as ``{id, kind, key, name}``
+    mappings so callers can build structured error payloads.
+    """
+
+    def __init__(self, message: str, referrers: list[dict[str, str | None]] | None = None) -> None:
+        """Initialize with a user-facing message and the referencing records."""
+        super().__init__(message)
+        self.referrers = referrers or []
+
+
 # -- Hydration / Catalog -------------------------------------------------------
 
 

--- a/packages/interloper-db/src/interloper_db/store/components.py
+++ b/packages/interloper-db/src/interloper_db/store/components.py
@@ -31,6 +31,7 @@ from interloper.errors import (
     ComponentDriftError,
     ConfigError,
     HydrationError,
+    InUseError,
     NotFoundError,
 )
 from sqlalchemy.orm import selectinload
@@ -186,10 +187,13 @@ class ComponentMixin(StoreBase):
             return load_component(session, component_id)
 
     def delete_component(self, component_id: UUID) -> None:
-        """Delete a component. Children and relations cascade via FK.
+        """Delete a component. Children and out-bound relations cascade via FK.
 
         Raises:
             NotFoundError: If the component is not found.
+            InUseError: If other components hold relations into this one or
+                its children (a bound connection, a job's target) — those
+                must be unbound or deleted first.
             ValueError: If the component is source-owned (delete or update
                 the parent source instead).
         """
@@ -199,8 +203,45 @@ class ComponentMixin(StoreBase):
                 raise NotFoundError(f"Component {component_id} not found")
             if db_component.parent_id is not None:
                 raise ValueError("Cannot delete a source-owned asset directly. Delete or update the source instead.")
+            if referrers := self._external_referrers(session, db_component):
+                names = ", ".join(str(r["name"] or r["key"]) for r in referrers)
+                raise InUseError(
+                    f"Cannot delete {db_component.kind} '{db_component.name or db_component.key}': "
+                    f"in use by {names}",
+                    referrers=referrers,
+                )
             session.delete(db_component)
             session.commit()
+
+    def _external_referrers(self, session: Session, db_component: Component) -> list[dict[str, str | None]]:
+        """Components outside a component's subtree that hold relations into it.
+
+        Deleting a relation destination would cascade the binding row and leave
+        the referrer silently broken at its next run, so deletion is refused
+        while such referrers exist. Relations internal to the subtree (a
+        source's own asset dependencies) don't count, and a referrer that is a
+        source-owned asset is reported as its parent source — the unit the
+        user can act on.
+        """
+        subtree_ids = {db_component.id} | {child.id for child in db_component.children}
+        rows = session.exec(
+            select(ComponentRelation).where(
+                col(ComponentRelation.dst_id).in_(subtree_ids),
+                col(ComponentRelation.src_id).not_in(subtree_ids),
+            )
+        ).all()
+        referrers: dict[UUID, Component] = {}
+        for relation in rows:
+            src = session.get(Component, relation.src_id)
+            if src is None:
+                continue
+            if src.parent_id is not None and src.parent_id not in subtree_ids:
+                src = session.get(Component, src.parent_id) or src
+            referrers[src.id] = src
+        return [
+            {"id": str(c.id), "kind": c.kind, "key": c.key, "name": c.name}
+            for c in sorted(referrers.values(), key=lambda c: ((c.name or c.key).lower(), str(c.id)))
+        ]
 
     # -- Relations -------------------------------------------------------------
 

--- a/packages/interloper-db/tests/store/test_components.py
+++ b/packages/interloper-db/tests/store/test_components.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 
 import interloper as il
 import pytest
-from interloper.errors import ConfigError, NotFoundError
+from interloper.errors import ConfigError, InUseError, NotFoundError
 from sqlalchemy import Engine
 from sqlmodel import Session, select
 
@@ -124,12 +124,12 @@ class TestCrud:
         with pytest.raises(ValueError):
             store.delete_component(child_id)
 
-    def test_delete_cascades_relations(self, store: Store):
+    def test_delete_cascades_outbound_relations(self, store: Store):
         job = store.create_component(_ORG, kind="job", key="cron_job", name="J")
         asset = store.create_component(_ORG, kind="asset", key="a")
         store.add_relation(job.id, type="target", dst_id=asset.id)
 
-        store.delete_component(asset.id)
+        store.delete_component(job.id)
         assert store.list_relations(_ORG) == []
 
     def test_list_filters_org_and_kinds(self, store: Store):
@@ -146,6 +146,68 @@ class TestCrud:
         assert store.get_component(dest.id, kind="destination").id == dest.id
         with pytest.raises(NotFoundError):
             store.get_component(dest.id, kind="asset")
+
+
+class TestDeleteInUseGuard:
+    """A relation destination cannot be deleted while external referrers exist."""
+
+    def _connection(self, store: Store) -> Component:
+        return store.create_component(_ORG, kind="connection", key="conn", name="Conn", config={}, encrypted=False)
+
+    def test_bound_connection_blocks_delete_and_names_referrer(self, store: Store):
+        conn = self._connection(store)
+        asset = store.create_component(_ORG, kind="asset", key="a", name="A", relations={"resource": [(conn.id, "c")]})
+
+        with pytest.raises(InUseError) as excinfo:
+            store.delete_component(conn.id)
+        assert excinfo.value.referrers == [{"id": str(asset.id), "kind": "asset", "key": "a", "name": "A"}]
+        assert "in use by A" in str(excinfo.value)
+
+    def test_delete_succeeds_after_unbinding(self, store: Store):
+        conn = self._connection(store)
+        asset = store.create_component(_ORG, kind="asset", key="a", relations={"resource": [(conn.id, "c")]})
+
+        store.remove_relation(asset.id, type="resource", dst_id=conn.id)
+        store.delete_component(conn.id)
+        with pytest.raises(NotFoundError):
+            store.get_component(conn.id)
+
+    def test_job_target_blocks_component_delete(self, store: Store):
+        asset = store.create_component(_ORG, kind="asset", key="a")
+        job = store.create_component(_ORG, kind="job", key="cron_job", name="J", relations={"target": [(asset.id, "")]})
+
+        with pytest.raises(InUseError) as excinfo:
+            store.delete_component(asset.id)
+        assert [r["id"] for r in excinfo.value.referrers] == [str(job.id)]
+
+    def test_referrer_through_child_reports_parent(self, store: Store, component_db: Engine):
+        conn = self._connection(store)
+        parent = store.create_component(_ORG, kind="job", key="cron_job", name="P")  # parentable stand-in
+        with Session(component_db) as session:
+            child = Component(org_id=_ORG, kind="asset", key="a", parent_id=parent.id)
+            session.add(child)
+            session.commit()
+            child_id = child.id
+        store.add_relation(child_id, type="resource", dst_id=conn.id, slot="c")
+
+        with pytest.raises(InUseError) as excinfo:
+            store.delete_component(conn.id)
+        assert [r["id"] for r in excinfo.value.referrers] == [str(parent.id)]
+
+    def test_intra_subtree_relations_do_not_block(self, store: Store, component_db: Engine):
+        parent = store.create_component(_ORG, kind="job", key="cron_job", name="P")  # parentable stand-in
+        with Session(component_db) as session:
+            a = Component(org_id=_ORG, kind="asset", key="a", parent_id=parent.id)
+            b = Component(org_id=_ORG, kind="asset", key="b", parent_id=parent.id)
+            session.add(a)
+            session.add(b)
+            session.commit()
+            a_id, b_id = a.id, b.id
+        store.add_relation(b_id, type="dependency", dst_id=a_id, slot="a")
+
+        store.delete_component(parent.id)
+        with pytest.raises(NotFoundError):
+            store.get_component(parent.id)
 
 
 class DiscriminatedSource(il.Source):


### PR DESCRIPTION
## What

Deleting a component that other components are bound to — a connection used by a source, a source targeted by a job — used to succeed silently: the relation row cascaded away and the referrer broke with a confusing error at its next run, with no status surfaced anywhere. The connections page even showed an error toast claiming "it may be in use" for a rejection the backend never issued.

Deletion is now refused while external referrers exist, with the referrers named:

- **Store** — `delete_component` raises a new structured `InUseError` when relations point into the component or its children from outside its subtree. Intra-subtree edges (a source's own asset dependencies) don't block; a referrer that is a source-owned asset is reported as its parent source, the unit the user can act on.
- **API** — `DELETE /components/{id}` maps it to **409** with `{message, used_by: [{id, kind, key, name}]}`.
- **App** — every delete site (resources, sources, destinations, jobs, hooks, graph, collection table, drift banner) surfaces the referrer list: *"Connection is in use — Used by: X, Y. Rebind or delete those first."* Bulk `remove()` now uses `allSettled` so partial failures keep local state consistent and still rethrow.

## Why not cascade-warn?

An unbound slot has no "broken" status surface today — hydration succeeds and the failure shows up mid-run as auto-instantiation/auth errors. Blocking preserves the invariant that a persisted binding always resolves. The DB FK stays `ON DELETE CASCADE`; enforcement lives in the store, consistent with relation shapes being store-enforced rather than schema-mirrored.

## Notes for review

- This intentionally makes one behavior stricter: deleting a **source that a job targets** now 409s instead of silently orphaning the job.
- `test_delete_cascades_relations` asserted the old silent-orphan behavior; reworked to cover out-bound cascade (deleting the referrer side).
- Verified live end-to-end (dev instance): 409 payload for a bound connection, connection intact after refusal, unbind→delete succeeds, job→source guard, and the UI toast on `/resources/connection` via headless Chrome.
- Also adds a repo `.claude/skills/verify/SKILL.md` capturing the headless verification recipe — happy to drop it from this PR if you'd rather keep it separate.

Follow-up candidate: preview "used by" inside the confirm dialog (data is already client-side in `componentsStore.relations`) — the dialog still says "permanently delete" before a delete that may be refused.

By Digitl