### PR TITLE
fix(agent): contain google-adk's BaseAgentConfig deprecation at the import site

### DIFF
--- a/packages/interloper-agent/src/interloper_agent/__init__.py
+++ b/packages/interloper-agent/src/interloper_agent/__init__.py
@@ -1,3 +1,14 @@
+import warnings
+
+with warnings.catch_warnings():
+    # google-adk's own config classes subclass their deprecated BaseAgentConfig,
+    # tripping four DeprecationWarnings on first import (their bug, present through
+    # 2.4.0 and main). Import it once here with exactly that message contained, so
+    # no consumer of this package sees the noise — while a genuine use of the
+    # deprecated class in our code would still warn at its own definition site.
+    warnings.filterwarnings("ignore", message="BaseAgentConfig is deprecated", category=DeprecationWarning)
+    import google.adk.agents  # noqa: F401
+
 from interloper_agent import agent
 from interloper_agent.context import init, set_catalog, set_store
 

--- a/packages/interloper-agent/tests/conftest.py
+++ b/packages/interloper-agent/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Package-first import: google.adk must enter through interloper_agent.
+
+The package __init__ contains google-adk's self-inflicted BaseAgentConfig
+deprecation noise at the import site; test modules importing google.adk
+directly would otherwise trigger it first, before the containment runs.
+"""
+
+import interloper_agent  # noqa: F401

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,12 @@ extend-select = ["E", "I", "UP", "ANN001", "ANN201", "ANN202"]
 [tool.pytest.ini_options]
 markers = ["integration", "functional"]
 addopts = ["--import-mode=importlib", "-m not functional"]
-filterwarnings = ["ignore::FutureWarning:google.api_core"]
+filterwarnings = [
+    "ignore::FutureWarning:google.api_core",
+    # google-adk's own config classes subclass their deprecated BaseAgentConfig,
+    # warning at import — upstream noise (still present in 2.4.0), not our usage.
+    "ignore:BaseAgentConfig is deprecated:DeprecationWarning",
+]
 asyncio_mode = "auto"
 
 # ###############

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,12 +112,7 @@ extend-select = ["E", "I", "UP", "ANN001", "ANN201", "ANN202"]
 [tool.pytest.ini_options]
 markers = ["integration", "functional"]
 addopts = ["--import-mode=importlib", "-m not functional"]
-filterwarnings = [
-    "ignore::FutureWarning:google.api_core",
-    # google-adk's own config classes subclass their deprecated BaseAgentConfig,
-    # warning at import — upstream noise (still present in 2.4.0), not our usage.
-    "ignore:BaseAgentConfig is deprecated:DeprecationWarning",
-]
+filterwarnings = ["ignore::FutureWarning:google.api_core"]
 asyncio_mode = "auto"
 
 # ###############


### PR DESCRIPTION
`uv run pytest` emitted four `DeprecationWarning: BaseAgentConfig is deprecated`. Root cause is google-adk's own bug: `LlmAgentConfig`/`LoopAgentConfig`/… subclass their `@deprecated` base, warning on first import of `google.adk.agents`. Our code never references the class, and the pattern is unchanged upstream through 2.4.0 **and current main** (verified against both), so no upgrade fixes it.

Since nothing of ours can be "fixed", the warning is contained at the import site rather than in test config: `interloper_agent/__init__.py` imports `google.adk.agents` once inside a `catch_warnings` scoped to exactly that message. Effects:

- Clean imports for **every** consumer — API runtime logs included, not just pytest.
- A genuine use of the deprecated class in our code would still warn (at its own definition site, outside the containment).
- A one-line tests `conftest.py` imports the package first, so test modules importing `google.adk` directly also enter through the containment.
- No `filterwarnings` entry — an earlier commit on this branch added one and is reverted here.

Suite: 6 warnings → 2 (remainder are non-agent: starlette testclient, a pydantic field-shadow in core tests). Verified strictest-case with `python -W error::DeprecationWarning -c "import interloper_agent"` — clean.

**Merge note:** squash, please — the branch history contains the superseded filter approach and a `chore(test)` scope the title validator rejects; the squashed PR title is the validated one.

The true fix is upstream (adk-python should suppress its own internal subclassing); no issue exists there yet.

By Digitl