### PR TITLE
refactor(app): drop encrypted column from resources table

### DIFF
--- a/packages/interloper-app/app/app/pages/resources/[kind].vue
+++ b/packages/interloper-app/app/app/pages/resources/[kind].vue
@@ -52,7 +52,6 @@ const columns: TableColumn<ComponentRecord>[] = [
             typeName(row.original.key),
         ]),
     },
-    { accessorKey: 'encrypted', header: 'Encrypted' },
     {
         accessorKey: 'created_at',
         header: 'Created',


### PR DESCRIPTION
Removes the `Encrypted` column from the resources table (`pages/resources/[kind].vue`). Resources are encrypted at rest by default, so the column carried no signal worth a slot in the table.

Follow-up to #156 (which was merged before this landed on its branch).

By Digitl