### PR TITLE
fix(core): detect IPv6-only listeners in the dev-up port fail-fast

### DIFF
--- a/packages/interloper-core/src/interloper/cli/services.py
+++ b/packages/interloper-core/src/interloper/cli/services.py
@@ -294,12 +294,22 @@ def _kill_process_group(process: subprocess.Popen[bytes], sig: int) -> None:
 def _port_in_use(port: int) -> bool:
     """Check whether something is already listening on localhost:``port``.
 
+    Probes both loopback stacks: Nuxt dev binds only ``::1`` on macOS, so an
+    IPv4-only probe misses it — and Nuxt's own port check doesn't, sending it
+    to its silent fall-back-to-3000 path instead of our fail-fast.
+
     Returns:
-        True if a connection to the port succeeds.
+        True if a connection to the port succeeds on either loopback.
     """
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.settimeout(0.5)
-        return sock.connect_ex(("127.0.0.1", port)) == 0
+    for family, addr in ((socket.AF_INET, "127.0.0.1"), (socket.AF_INET6, "::1")):
+        try:
+            with socket.socket(family, socket.SOCK_STREAM) as sock:
+                sock.settimeout(0.5)
+                if sock.connect_ex((addr, port)) == 0:
+                    return True
+        except OSError:
+            continue
+    return False
 
 
 def _mount_spa(app: Any, directory: Any) -> None:

--- a/packages/interloper-core/tests/cli/test_services.py
+++ b/packages/interloper-core/tests/cli/test_services.py
@@ -18,6 +18,15 @@ def test_port_in_use_detects_listener() -> None:
         assert _port_in_use(port) is True
 
 
+def test_port_in_use_detects_ipv6_only_listener() -> None:
+    """A listener bound only to ``::1`` (how Nuxt dev binds on macOS) is detected."""
+    with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as server:
+        server.bind(("::1", 0))
+        server.listen(1)
+        port = server.getsockname()[1]
+        assert _port_in_use(port) is True
+
+
 def test_port_in_use_free_port() -> None:
     """A free port reports not in use."""
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:


### PR DESCRIPTION
## What

`_port_in_use()` (the dev-up occupied-port fail-fast from #126) now probes both loopback stacks — `127.0.0.1` **and** `::1` — instead of IPv4 only. Adds a test for an IPv6-only listener.

## Why

`INTERLOPER_SERVER_PORT=3100 make dev-up` appeared to silently ignore the override: the Nuxt log printed `Local: http://localhost:3000/`. The env-var plumbing was fine end to end (make → pydantic settings → the env handed to `pnpm dev` → `nuxt.config.ts`). The actual chain:

1. A stale Nuxt dev server from an earlier session was still listening on 3100 — but only on `[::1]`, since Nuxt dev binds just the IPv6 loopback on macOS.
2. The fail-fast probed only `127.0.0.1`, saw 3100 as free, and let startup proceed.
3. Nuxt's own `get-port` check does look at both stacks, found 3100 taken, and silently fell back to its default 3000 — exactly the stacked half-broken instance (OAuth/CORS pinned to the configured port, SPA on another) the fail-fast was meant to prevent. The tell-tale, easy-to-miss log line: `[get-port] Unable to find an available port (tried 3100 on host "localhost"). Using alternative port 3000.`

So the check had never been able to see a running Nuxt instance at all.

## Verification (live)

- Port free: `INTERLOPER_SERVER_PORT=3100 make dev-up` → `Local: http://localhost:3100/`, no get-port fallback.
- Port held by a real Nuxt on `[::1]:3100`: a second dev-up exits with `Port 3100 is already in use — … Stop it, or set INTERLOPER_SERVER_PORT to a free port.` instead of silently landing on 3000.
- ruff / ty / pytest pass (pre-commit).

By Digitl