### PR TITLE
feat(assets): add Amazon Selling Partner source

### DIFF
--- a/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/connection.py
+++ b/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/connection.py
@@ -1,6 +1,8 @@
+from collections.abc import Generator
 from enum import Enum
 from functools import cached_property
 
+import httpx
 import interloper as il
 from pydantic_settings import SettingsConfigDict
 
@@ -25,6 +27,64 @@ class AmazonSellingPartnerLocation(Enum):
             AmazonSellingPartnerLocation.FAR_EAST: "https://api.amazon.co.jp",
             AmazonSellingPartnerLocation.NORTH_AMERICA: "https://api.amazon.com",
         }[self]
+
+
+# Marketplaces grouped by the region whose API host serves them. A connection is
+# bound to one region (its client host), so the source's marketplace picker is
+# scoped to the region's entries via the ``marketplaces`` fetch-field provider —
+# a request for an out-of-region marketplace is rejected by SP-API.
+MARKETPLACES_BY_LOCATION: dict[AmazonSellingPartnerLocation, list[tuple[str, str]]] = {
+    AmazonSellingPartnerLocation.NORTH_AMERICA: [
+        ("ATVPDKIKX0DER", "United States"),
+        ("A2EUQ1WTGCTBG2", "Canada"),
+        ("A1AM78C64UM0Y8", "Mexico"),
+        ("A2Q3Y263D00KWC", "Brazil"),
+    ],
+    AmazonSellingPartnerLocation.EUROPE: [
+        ("A1F83G8C2ARO7P", "United Kingdom"),
+        ("A1PA6795UKMFR9", "Germany"),
+        ("A13V1IB3VIYZZH", "France"),
+        ("APJ6JRA9NG5V4", "Italy"),
+        ("A1RKKUPIHCS9HS", "Spain"),
+        ("A1805IZSGTT6HS", "Netherlands"),
+        ("A2NODRKZP88ZB9", "Sweden"),
+        ("A1C3SOZRARQ6R3", "Poland"),
+        ("AMEN7PMS3EDWL", "Belgium"),
+        ("A21TJRUUN4KGV", "India"),
+        ("A33AVAJ2PDY3EV", "Turkey"),
+        ("A17E79C6D8DWNP", "Saudi Arabia"),
+        ("A2VIGQ35RCS4UG", "United Arab Emirates"),
+        ("ARBP9OOSHTCHU", "Egypt"),
+        ("AE08WJ6YKNBMC", "South Africa"),
+    ],
+    AmazonSellingPartnerLocation.FAR_EAST: [
+        ("A1VC38T7YXB528", "Japan"),
+        ("A39IBJ37TRP1C6", "Australia"),
+        ("A19VAU5U5O7RUS", "Singapore"),
+    ],
+}
+
+
+class LWATokenAuth(il.OAuth2RefreshTokenAuth):
+    """LWA refresh-token auth that carries the token in ``x-amz-access-token``.
+
+    SP-API authenticates with the Login-with-Amazon access token supplied in the
+    ``x-amz-access-token`` header (request signing with AWS SigV4 is no longer
+    required), not the ``Authorization`` header the base OAuth2 flow sets — so
+    override the flow to place the token there and refresh on 401/403.
+    """
+
+    def auth_flow(self, request: httpx.Request) -> Generator[httpx.Request, httpx.Response, None]:
+        if self._access_token is None:
+            self._store_token((yield self._token_request()))
+
+        request.headers["x-amz-access-token"] = self.access_token
+        response = yield request
+
+        if response.status_code in (401, 403):
+            self._store_token((yield self._token_request()))
+            request.headers["x-amz-access-token"] = self.access_token
+            yield request
 
 
 @il.connection(
@@ -54,19 +114,50 @@ class AmazonSellingPartnerConnection(il.Connection):
     def api_location(self) -> AmazonSellingPartnerLocation:
         return AmazonSellingPartnerLocation(self.location)
 
+    @il.fetch_field_provider
+    async def marketplaces(self) -> list[dict[str, str]]:
+        """Marketplaces served by this connection's region.
+
+        A static region→marketplaces lookup (no API call): SP-API exposes no
+        vendor-accessible endpoint to enumerate a connection's marketplaces, so
+        this scopes the picker to the region's valid ids rather than detecting
+        access. Requests for an out-of-region marketplace are rejected by SP-API.
+        """
+        return [{"label": label, "value": value} for value, label in MARKETPLACES_BY_LOCATION[self.api_location]]
+
     @cached_property
     def client(self) -> il.AsyncRESTClient:
         """Async REST client for the Amazon Selling Partner API."""
         location = self.api_location
-        client = il.AsyncRESTClient(
+        return il.AsyncRESTClient(
             location.api_url,
-            auth=il.OAuth2RefreshTokenAuth(
+            auth=LWATokenAuth(
                 base_url=location.auth_url,
                 token_endpoint="/auth/o2/token",
                 client_id=self.client_id,
                 client_secret=self.client_secret,
                 refresh_token=self.refresh_token,
             ),
+            headers={"user-agent": "interloper (Language=Python)"},
+            timeout=60,
         )
-        client.headers.update({"host": location.api_url.replace("https://", "")})
-        return client
+
+    async def check(self) -> bool:
+        """Prove the credentials work by exchanging the LWA refresh token.
+
+        Returns:
+            True — an invalid client id/secret or refresh token raises out of the
+            token exchange.
+        """
+        async with httpx.AsyncClient(timeout=30) as client:
+            response = await client.post(
+                f"{self.api_location.auth_url}/auth/o2/token",
+                data={
+                    "grant_type": "refresh_token",
+                    "refresh_token": self.refresh_token,
+                    "client_id": self.client_id,
+                    "client_secret": self.client_secret,
+                },
+            )
+            response.raise_for_status()
+        return True

--- a/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/schemas/__init__.py
+++ b/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/schemas/__init__.py
@@ -1,0 +1,27 @@
+from .geo_sales_stats_by_country import GeoSalesStatsByCountry
+from .product_fulfillment_stats import ProductFulfillmentStats
+from .products import Products
+from .vendor_forecasting_retail_stats import VendorForecastingRetailStats
+from .vendor_inventory_retail_manufacturing_stats import VendorInventoryRetailManufacturingStats
+from .vendor_inventory_retail_sourcing_stats import VendorInventoryRetailSourcingStats
+from .vendor_net_pure_product_margin_stats import VendorNetPureProductMarginStats
+from .vendor_sales_business_manufacturing_stats import VendorSalesBusinessManufacturingStats
+from .vendor_sales_business_sourcing_stats import VendorSalesBusinessSourcingStats
+from .vendor_sales_retail_manufacturing_stats import VendorSalesRetailManufacturingStats
+from .vendor_sales_retail_sourcing_stats import VendorSalesRetailSourcingStats
+from .vendor_traffic_stats import VendorTrafficStats
+
+__all__ = [
+    "GeoSalesStatsByCountry",
+    "ProductFulfillmentStats",
+    "Products",
+    "VendorForecastingRetailStats",
+    "VendorInventoryRetailManufacturingStats",
+    "VendorInventoryRetailSourcingStats",
+    "VendorNetPureProductMarginStats",
+    "VendorSalesBusinessManufacturingStats",
+    "VendorSalesBusinessSourcingStats",
+    "VendorSalesRetailManufacturingStats",
+    "VendorSalesRetailSourcingStats",
+    "VendorTrafficStats",
+]

--- a/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/schemas/geo_sales_stats_by_country.py
+++ b/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/schemas/geo_sales_stats_by_country.py
@@ -1,0 +1,46 @@
+import datetime as dt
+
+from interloper.schema import Schema
+from pydantic import Field
+
+
+class GeoSalesStatsByCountry(Schema):
+    """Shipped sales and cost metrics per ASIN per ship-to country per day (Data Kiosk sourcingView)."""
+
+    date: dt.date | None = Field(default=None, description="The day the metrics are aggregated over.")
+    asin: str | None = Field(default=None, description="Amazon Standard Identification Number for the product.")
+    ship_to_country_code: str | None = Field(
+        default=None, description="Customer country code for a shipment in ISO 3166-1 alpha-2 format"
+    )
+    shipped_units_with_revenue_value_amount: float | None = Field(
+        default=None, description="The value of associated gross price the customer paid for shipped units"
+    )
+    shipped_units_with_revenue_value_currency_code: str | None = Field(
+        default=None, description="The currency unit of associated gross price the customer paid for shipped units"
+    )
+    shipped_units_with_revenue_units: int | None = Field(default=None, description="The number of shipped items")
+    net_ppm: float | None = Field(
+        default=None,
+        description="Net Pure Product Margin: Amazon's margin after accounting for CCOGs and sales discounts",
+    )
+    shipped_cogs_amount: float | None = Field(
+        default=None, description="The shipped cost of goods sold, the price Amazon paid a vendor per item procurement"
+    )
+    shipped_cogs_currency_code: str | None = Field(default=None, description="Currency code for shipped_cogs_amount")
+    contra_cogs_per_unit_amount: float | None = Field(
+        default=None, description="The average Vendor Contra-COGS (VFCC) of shipped items, per shipped unit"
+    )
+    contra_cogs_per_unit_currency_code: str | None = Field(
+        default=None, description="Currency code for contra_cogs_per_unit_amount"
+    )
+    contra_cogs_amount: float | None = Field(
+        default=None,
+        description="The total Contra Cost of Goods Sold (COGS) realized by outbound shipments minus Display Ads CCOGs",
+    )
+    contra_cogs_currency_code: str | None = Field(default=None, description="Currency code for contra_cogs_amount")
+    average_sales_discount_amount: float | None = Field(
+        default=None, description="The average selling discount per unit of shipped items"
+    )
+    average_sales_discount_currency_code: str | None = Field(
+        default=None, description="Currency code for average_sales_discount_amount"
+    )

--- a/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/schemas/product_fulfillment_stats.py
+++ b/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/schemas/product_fulfillment_stats.py
@@ -1,0 +1,47 @@
+import datetime as dt
+
+from interloper.schema import Schema
+from pydantic import Field
+
+
+class ProductFulfillmentStats(Schema):
+    """Vendor sourcing and fulfillment metrics per ASIN per day (Data Kiosk sourcingView)."""
+
+    date: dt.date | None = Field(default=None, description="The day the metrics are aggregated over.")
+    asin: str | None = Field(default=None, description="Amazon Standard Identification Number for the product.")
+    customer_returns: int | None = Field(
+        default=None, description="The number of items returned as recorded on the Customer Returns transaction table"
+    )
+    open_purchase_order_quantity: int | None = Field(
+        default=None,
+        description="Number of products in the vendor's open POs (confirmed PO quantities not yet received)",
+    )
+    confirmed_units: int | None = Field(
+        default=None, description="Number of purchase order units confirmed to be shipped to Amazon"
+    )
+    most_recent_submitted: int | None = Field(
+        default=None, description="The number of units Amazon has ordered in the most recent purchase orders of the week"
+    )
+    net_received_units: int | None = Field(
+        default=None,
+        description="Net number of units received by Amazon after subtracting the units returned to the supplier",
+    )
+    net_received_value_amount: float | None = Field(
+        default=None,
+        description="Net cost of units received by Amazon after subtracting the units returned to the supplier",
+    )
+    net_received_value_currency_code: str | None = Field(
+        default=None, description="Net cost currency code of units received by Amazon"
+    )
+    overall_vendor_lead_time: float | None = Field(
+        default=None, description="Time (in days) from when a vendor receives a PO to when inventory is received in a FC"
+    )
+    procurable_product_oos: float | None = Field(
+        default=None, description="Out of stock rate on all products that are procurable"
+    )
+    received_fill_rate: float | None = Field(
+        default=None, description="PO units received by Amazon compared to PO units confirmed by the vendor"
+    )
+    vendor_confirmation_rate: float | None = Field(
+        default=None, description="How many units vendors confirm out of the units Amazon asks for"
+    )

--- a/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/schemas/products.py
+++ b/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/schemas/products.py
@@ -1,0 +1,24 @@
+from interloper.schema import Schema
+from pydantic import Field
+
+
+class Products(Schema):
+    """Product identifier lookup: one row per ASIN with its external identifiers.
+
+    Sourced from the Data Kiosk vendor analytics ``sourcingView`` group-by keys.
+    """
+
+    asin: str | None = Field(default=None, description="Amazon Standard Identification Number for the product.")
+    parent_asin: str | None = Field(
+        default=None,
+        description=(
+            "Generic overall parent ASIN (non-purchaseable) for different variations of a product. "
+            "Different variations have a different ASIN but the same parent ASIN."
+        ),
+    )
+    ean: str | None = Field(default=None, description="European Article Number")
+    upc: str | None = Field(default=None, description="Universal Product Code")
+    isbn_13: str | None = Field(
+        default=None,
+        description="13-digit International Standard Book Number. Only applicable to products that are books.",
+    )

--- a/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/schemas/vendor_forecasting_retail_stats.py
+++ b/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/schemas/vendor_forecasting_retail_stats.py
@@ -1,0 +1,31 @@
+import datetime as dt
+
+from interloper.schema import Schema
+from pydantic import Field
+
+
+class VendorForecastingRetailStats(Schema):
+    """Forward-looking demand forecast per ASIN (GET_VENDOR_FORECASTING_REPORT, RETAIL).
+
+    A snapshot of the latest generated forecast — mean and percentile forecast units
+    over the forecast horizon — rather than a per-day historical report.
+    """
+
+    asin: str | None = Field(default=None, description="Amazon Standard Identification Number for the product.")
+    start_date: dt.date | None = Field(default=None, description="The start date of the forecast period.")
+    end_date: dt.date | None = Field(default=None, description="The end date of the forecast period.")
+    forecast_generation_date: dt.date | None = Field(
+        default=None, description="The date when the forecast was generated."
+    )
+    mean_forecast_units: float | None = Field(
+        default=None, description="The average number of units forecasted to be sold."
+    )
+    p_70_forecast_units: float | None = Field(
+        default=None, description="The number of units forecasted to be sold with 70% confidence."
+    )
+    p_80_forecast_units: float | None = Field(
+        default=None, description="The number of units forecasted to be sold with 80% confidence."
+    )
+    p_90_forecast_units: float | None = Field(
+        default=None, description="The number of units forecasted to be sold with 90% confidence."
+    )

--- a/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/schemas/vendor_inventory_retail_manufacturing_stats.py
+++ b/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/schemas/vendor_inventory_retail_manufacturing_stats.py
@@ -1,0 +1,78 @@
+import datetime as dt
+
+from interloper.schema import Schema
+from pydantic import Field
+
+
+class VendorInventoryRetailManufacturingStats(Schema):
+    """Retail inventory health per ASIN per day, manufacturing (distributor) view.
+
+    Covers on-hand/received/aged inventory cost and units, lead time, fill rate,
+    sell-through and out-of-stock rates
+    (GET_VENDOR_INVENTORY_REPORT, sellingProgram=RETAIL, distributorView=MANUFACTURING).
+    """
+
+    asin: str | None = Field(default=None, description="The ASIN (Amazon Standard Identification Number) of the product")
+    start_date: dt.date | None = Field(default=None, description="The start date of the inventory data")
+    end_date: dt.date | None = Field(default=None, description="The end date of the inventory data")
+    aged_90_plus_days_sellable_inventory_cost_amount: float | None = Field(
+        default=None, description="The cost amount of aged 90+ days sellable inventory"
+    )
+    aged_90_plus_days_sellable_inventory_cost_currency_code: str | None = Field(
+        default=None, description="The currency code of the cost amount of aged 90+ days sellable inventory"
+    )
+    aged_90_plus_days_sellable_inventory_units: float | None = Field(
+        default=None, description="The number of units in aged 90+ days sellable inventory"
+    )
+    average_vendor_lead_time_days: float | None = Field(
+        default=None, description="The average lead time in days for vendors"
+    )
+    net_received_inventory_cost_amount: float | None = Field(
+        default=None, description="The cost amount of net received inventory"
+    )
+    net_received_inventory_cost_currency_code: str | None = Field(
+        default=None, description="The currency code of the cost amount of net received inventory"
+    )
+    net_received_inventory_units: float | None = Field(
+        default=None, description="The number of units in net received inventory"
+    )
+    open_purchase_order_units: float | None = Field(
+        default=None, description="The number of units in open purchase orders"
+    )
+    procurable_product_out_of_stock_rate: float | None = Field(
+        default=None, description="The rate at which procurable products are out of stock"
+    )
+    receive_fill_rate: float | None = Field(default=None, description="The fill rate of received inventory")
+    sell_through_rate: float | None = Field(default=None, description="The rate at which products are sold through")
+    sellable_on_hand_inventory_cost_amount: float | None = Field(
+        default=None, description="The cost amount of sellable on-hand inventory"
+    )
+    sellable_on_hand_inventory_cost_currency_code: str | None = Field(
+        default=None, description="The currency code of the cost amount of sellable on-hand inventory"
+    )
+    sellable_on_hand_inventory_units: float | None = Field(
+        default=None, description="The number of units in sellable on-hand inventory"
+    )
+    sourceable_product_out_of_stock_rate: float | None = Field(
+        default=None, description="The rate at which sourceable products are out of stock"
+    )
+    uft: int | None = Field(default=None, description="The UFT (Unfulfillable) value")
+    unfilled_customer_ordered_units: float | None = Field(
+        default=None, description="The number of units in unfilled customer orders"
+    )
+    unhealthy_inventory_cost: float | None = Field(default=None, description="The cost of unhealthy inventory")
+    unhealthy_inventory_units: float | None = Field(
+        default=None, description="The number of units in unhealthy inventory"
+    )
+    unsellable_on_hand_inventory_cost_amount: float | None = Field(
+        default=None, description="The cost amount of unsellable on-hand inventory"
+    )
+    unsellable_on_hand_inventory_cost_currency_code: str | None = Field(
+        default=None, description="The currency code of the cost amount of unsellable on-hand inventory"
+    )
+    unsellable_on_hand_inventory_units: float | None = Field(
+        default=None, description="The number of units in unsellable on-hand inventory"
+    )
+    vendor_confirmation_rate: float | None = Field(
+        default=None, description="The rate at which vendor confirmations are received"
+    )

--- a/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/schemas/vendor_inventory_retail_sourcing_stats.py
+++ b/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/schemas/vendor_inventory_retail_sourcing_stats.py
@@ -1,0 +1,78 @@
+import datetime as dt
+
+from interloper.schema import Schema
+from pydantic import Field
+
+
+class VendorInventoryRetailSourcingStats(Schema):
+    """Retail inventory health per ASIN per day, sourcing (distributor) view.
+
+    Covers on-hand/received/aged inventory cost and units, lead time, fill rate,
+    sell-through and out-of-stock rates
+    (GET_VENDOR_INVENTORY_REPORT, sellingProgram=RETAIL, distributorView=SOURCING).
+    """
+
+    asin: str | None = Field(default=None, description="The ASIN (Amazon Standard Identification Number) of the product")
+    start_date: dt.date | None = Field(default=None, description="The start date of the inventory retail sourcing")
+    end_date: dt.date | None = Field(default=None, description="The end date of the inventory retail sourcing")
+    aged_90_plus_days_sellable_inventory_cost_amount: float | None = Field(
+        default=None, description="The cost amount of aged 90+ days sellable inventory"
+    )
+    aged_90_plus_days_sellable_inventory_cost_currency_code: str | None = Field(
+        default=None, description="The currency code of the cost amount of aged 90+ days sellable inventory"
+    )
+    aged_90_plus_days_sellable_inventory_units: float | None = Field(
+        default=None, description="The number of units in aged 90+ days sellable inventory"
+    )
+    average_vendor_lead_time_days: float | None = Field(
+        default=None, description="The average lead time in days for vendors"
+    )
+    net_received_inventory_cost_amount: float | None = Field(
+        default=None, description="The cost amount of net received inventory"
+    )
+    net_received_inventory_cost_currency_code: str | None = Field(
+        default=None, description="The currency code of the cost amount of net received inventory"
+    )
+    net_received_inventory_units: float | None = Field(
+        default=None, description="The number of units in net received inventory"
+    )
+    open_purchase_order_units: float | None = Field(
+        default=None, description="The number of units in open purchase orders"
+    )
+    procurable_product_out_of_stock_rate: float | None = Field(
+        default=None, description="The rate of procurable products that are out of stock"
+    )
+    receive_fill_rate: float | None = Field(default=None, description="The fill rate of received products")
+    sell_through_rate: float | None = Field(default=None, description="The rate at which products are sold through")
+    sellable_on_hand_inventory_cost_amount: float | None = Field(
+        default=None, description="The cost amount of sellable on-hand inventory"
+    )
+    sellable_on_hand_inventory_cost_currency_code: str | None = Field(
+        default=None, description="The currency code of the cost amount of sellable on-hand inventory"
+    )
+    sellable_on_hand_inventory_units: float | None = Field(
+        default=None, description="The number of units in sellable on-hand inventory"
+    )
+    sourceable_product_out_of_stock_rate: float | None = Field(
+        default=None, description="The rate of sourceable products that are out of stock"
+    )
+    uft: int | None = Field(default=None, description="The UFT (Unfulfillable) status of the inventory")
+    unfilled_customer_ordered_units: float | None = Field(
+        default=None, description="The number of units in unfilled customer orders"
+    )
+    unhealthy_inventory_cost: float | None = Field(default=None, description="The cost of unhealthy inventory")
+    unhealthy_inventory_units: float | None = Field(
+        default=None, description="The number of units in unhealthy inventory"
+    )
+    unsellable_on_hand_inventory_cost_amount: float | None = Field(
+        default=None, description="The cost amount of unsellable on-hand inventory"
+    )
+    unsellable_on_hand_inventory_cost_currency_code: str | None = Field(
+        default=None, description="The currency code of the cost amount of unsellable on-hand inventory"
+    )
+    unsellable_on_hand_inventory_units: float | None = Field(
+        default=None, description="The number of units in unsellable on-hand inventory"
+    )
+    vendor_confirmation_rate: float | None = Field(
+        default=None, description="The rate at which vendors confirm orders"
+    )

--- a/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/schemas/vendor_net_pure_product_margin_stats.py
+++ b/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/schemas/vendor_net_pure_product_margin_stats.py
@@ -1,0 +1,15 @@
+import datetime as dt
+
+from interloper.schema import Schema
+from pydantic import Field
+
+
+class VendorNetPureProductMarginStats(Schema):
+    """Net pure product margin per ASIN per day (GET_VENDOR_NET_PURE_PRODUCT_MARGIN_REPORT)."""
+
+    asin: str | None = Field(default=None, description="Amazon Standard Identification Number for the product.")
+    start_date: dt.date | None = Field(default=None, description="The start date of the reporting period.")
+    end_date: dt.date | None = Field(default=None, description="The end date of the reporting period.")
+    net_pure_product_margin: float | None = Field(
+        default=None, description="The net pure product margin for the product."
+    )

--- a/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/schemas/vendor_sales_business_manufacturing_stats.py
+++ b/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/schemas/vendor_sales_business_manufacturing_stats.py
@@ -1,0 +1,31 @@
+import datetime as dt
+
+from interloper.schema import Schema
+from pydantic import Field
+
+
+class VendorSalesBusinessManufacturingStats(Schema):
+    """Business (B2B) sales performance per ASIN per day, manufacturing (distributor) view.
+
+    Covers ordered/shipped revenue, units, cost of goods sold and customer returns
+    (GET_VENDOR_SALES_REPORT, sellingProgram=BUSINESS, distributorView=MANUFACTURING).
+    """
+
+    asin: str | None = Field(default=None, description="The ASIN (Amazon Standard Identification Number) of the product")
+    start_date: dt.date | None = Field(default=None, description="The start date of the sales data")
+    end_date: dt.date | None = Field(default=None, description="The end date of the sales data")
+    customer_returns: int | None = Field(default=None, description="The number of customer returns")
+    ordered_revenue_amount: float | None = Field(default=None, description="The amount of revenue from ordered items")
+    ordered_revenue_currency_code: str | None = Field(
+        default=None, description="The currency code of the ordered revenue"
+    )
+    ordered_units: float | None = Field(default=None, description="The number of ordered units")
+    shipped_revenue_amount: float | None = Field(default=None, description="The amount of revenue from shipped items")
+    shipped_revenue_currency_code: str | None = Field(
+        default=None, description="The currency code of the shipped revenue"
+    )
+    shipped_cogs_amount: float | None = Field(
+        default=None, description="The amount of cost of goods sold for shipped items"
+    )
+    shipped_cogs_currency_code: str | None = Field(default=None, description="The currency code of the shipped COGS")
+    shipped_units: float | None = Field(default=None, description="The number of shipped units")

--- a/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/schemas/vendor_sales_business_sourcing_stats.py
+++ b/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/schemas/vendor_sales_business_sourcing_stats.py
@@ -1,0 +1,30 @@
+import datetime as dt
+
+from interloper.schema import Schema
+from pydantic import Field
+
+
+class VendorSalesBusinessSourcingStats(Schema):
+    """Business (B2B) sales performance per ASIN per day, sourcing (distributor) view.
+
+    Covers shipped revenue, units, cost of goods sold and customer returns
+    (GET_VENDOR_SALES_REPORT, sellingProgram=BUSINESS, distributorView=SOURCING).
+    """
+
+    asin: str | None = Field(default=None, description="The ASIN (Amazon Standard Identification Number) of the product")
+    start_date: dt.date | None = Field(default=None, description="The start date of the sales data")
+    end_date: dt.date | None = Field(default=None, description="The end date of the sales data")
+    customer_returns: int | None = Field(default=None, description="The number of customer returns")
+    shipped_revenue_amount: float | None = Field(
+        default=None, description="The amount of revenue generated from shipped items"
+    )
+    shipped_revenue_currency_code: str | None = Field(
+        default=None, description="The currency code for the revenue amount"
+    )
+    shipped_cogs_amount: float | None = Field(
+        default=None, description="The amount of cost of goods sold (COGS) for shipped items"
+    )
+    shipped_cogs_currency_code: str | None = Field(
+        default=None, description="The currency code for the cost of goods sold (COGS) amount"
+    )
+    shipped_units: float | None = Field(default=None, description="The number of units shipped")

--- a/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/schemas/vendor_sales_retail_manufacturing_stats.py
+++ b/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/schemas/vendor_sales_retail_manufacturing_stats.py
@@ -1,0 +1,31 @@
+import datetime as dt
+
+from interloper.schema import Schema
+from pydantic import Field
+
+
+class VendorSalesRetailManufacturingStats(Schema):
+    """Retail sales performance per ASIN per day, manufacturing (distributor) view.
+
+    Covers ordered/shipped revenue, units, cost of goods sold and customer returns
+    (GET_VENDOR_SALES_REPORT, sellingProgram=RETAIL, distributorView=MANUFACTURING).
+    """
+
+    asin: str | None = Field(default=None, description="The ASIN (Amazon Standard Identification Number) of the product")
+    start_date: dt.date | None = Field(default=None, description="The start date of the sales data")
+    end_date: dt.date | None = Field(default=None, description="The end date of the sales data")
+    customer_returns: int | None = Field(default=None, description="The number of customer returns")
+    ordered_revenue_amount: float | None = Field(default=None, description="The amount of revenue from ordered items")
+    ordered_revenue_currency_code: str | None = Field(
+        default=None, description="The currency code for the ordered revenue"
+    )
+    ordered_units: float | None = Field(default=None, description="The number of units ordered")
+    shipped_revenue_amount: float | None = Field(default=None, description="The amount of revenue from shipped items")
+    shipped_revenue_currency_code: str | None = Field(
+        default=None, description="The currency code for the shipped revenue"
+    )
+    shipped_cogs_amount: float | None = Field(
+        default=None, description="The amount of cost of goods sold for shipped items"
+    )
+    shipped_cogs_currency_code: str | None = Field(default=None, description="The currency code for the shipped COGS")
+    shipped_units: float | None = Field(default=None, description="The number of units shipped")

--- a/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/schemas/vendor_sales_retail_sourcing_stats.py
+++ b/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/schemas/vendor_sales_retail_sourcing_stats.py
@@ -1,0 +1,30 @@
+import datetime as dt
+
+from interloper.schema import Schema
+from pydantic import Field
+
+
+class VendorSalesRetailSourcingStats(Schema):
+    """Retail sales performance per ASIN per day, sourcing (distributor) view.
+
+    Covers shipped revenue, units, cost of goods sold and customer returns
+    (GET_VENDOR_SALES_REPORT, sellingProgram=RETAIL, distributorView=SOURCING).
+    """
+
+    asin: str | None = Field(default=None, description="The ASIN (Amazon Standard Identification Number) of the product")
+    start_date: dt.date | None = Field(default=None, description="The start date of the sales data")
+    end_date: dt.date | None = Field(default=None, description="The end date of the sales data")
+    customer_returns: int | None = Field(default=None, description="The number of customer returns")
+    shipped_revenue_amount: float | None = Field(
+        default=None, description="The amount of revenue generated from shipped items"
+    )
+    shipped_revenue_currency_code: str | None = Field(
+        default=None, description="The currency code for the revenue amount"
+    )
+    shipped_cogs_amount: float | None = Field(
+        default=None, description="The amount of cost of goods sold (COGS) for shipped items"
+    )
+    shipped_cogs_currency_code: str | None = Field(
+        default=None, description="The currency code for the cost of goods sold (COGS) amount"
+    )
+    shipped_units: float | None = Field(default=None, description="The number of units shipped")

--- a/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/schemas/vendor_traffic_stats.py
+++ b/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/schemas/vendor_traffic_stats.py
@@ -1,0 +1,15 @@
+import datetime as dt
+
+from interloper.schema import Schema
+from pydantic import Field
+
+
+class VendorTrafficStats(Schema):
+    """Glance views per ASIN per day on the Amazon marketplace (GET_VENDOR_TRAFFIC_REPORT)."""
+
+    asin: str | None = Field(default=None, description="The ASIN (Amazon Standard Identification Number) of the product")
+    start_date: dt.date | None = Field(default=None, description="The start date of the traffic data")
+    end_date: dt.date | None = Field(default=None, description="The end date of the traffic data")
+    glance_views: int | None = Field(
+        default=None, description="The number of times the product was viewed on the Amazon marketplace"
+    )

--- a/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/source.py
+++ b/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/source.py
@@ -1,44 +1,564 @@
+import asyncio
+import datetime as dt
+import gzip
+import json
+import logging
+from typing import Any
 
+import httpx
 import interloper as il
+from interloper_pandas import DataFrameNormalizer
 
+from interloper_assets.amazon_selling_partner import constants, schemas
 from interloper_assets.amazon_selling_partner.connection import AmazonSellingPartnerConnection
 
+logger = logging.getLogger(__name__)
+
+_Record = dict[str, Any]
+
+# Polling cadence for async reports and Data Kiosk queries (both queue server-side).
+_POLL_INTERVAL = 60.0  # seconds between status polls
+_REPORT_TIMEOUT = 7200.0  # 2h — vendor reports can queue for a long time
+_QUERY_TIMEOUT = 3600.0  # 1h for Data Kiosk queries
+
+
+# -- HELPERS — nested-dict access ----------------------------------------------
+def _nested(value: Any, *keys: str) -> Any:
+    """Walk *keys* through nested dicts, returning ``None`` on any missing hop."""
+    for key in keys:
+        value = value.get(key) if isinstance(value, dict) else None
+    return value
+
+
+def _scalars(row: dict[str, Any]) -> dict[str, Any]:
+    """Keep only scalar (str/int/float) values; blank out anything else with ``None``."""
+    return {k: (v if isinstance(v, (str, int, float)) else None) for k, v in row.items()}
+
+
+# -- HELPERS — async reports ---------------------------------------------------
+async def _request_report(
+    connection: AmazonSellingPartnerConnection,
+    report_type: str,
+    marketplace: str,
+    start_date: dt.date | None,
+    end_date: dt.date | None,
+    options: dict[str, str] | None,
+) -> str:
+    """Create an async report and return its report id."""
+    body: dict[str, Any] = {"reportType": report_type, "marketplaceIds": [marketplace]}
+    if start_date:
+        body["dataStartTime"] = start_date.strftime("%Y-%m-%dT00:00:00.000Z")
+    if end_date:
+        body["dataEndTime"] = end_date.strftime("%Y-%m-%dT23:59:59.999Z")
+    if options:
+        body["reportOptions"] = options
+
+    response = await connection.client.post(f"/reports/{constants.REPORT_API_VERSION}/reports", json=body)
+    response.raise_for_status()
+    return response.json()["reportId"]
+
+
+async def _wait_for_report(connection: AmazonSellingPartnerConnection, report_id: str) -> dict:
+    """Poll a report until it reaches a terminal state; return its final payload.
+
+    Each poll depends on the previous status, so this stays a sequential
+    fixed-interval loop bounded by ``_REPORT_TIMEOUT``. A failed report may still
+    attach a document carrying error details, so return the payload for the
+    caller to inspect rather than raising here.
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + _REPORT_TIMEOUT
+    while True:
+        logger.info(f"Waiting for report {report_id}...")
+        try:
+            response = await connection.client.get(f"/reports/{constants.REPORT_API_VERSION}/reports/{report_id}")
+            response.raise_for_status()
+            payload = response.json()
+            status = payload["processingStatus"]
+        except httpx.HTTPError as exc:
+            logger.debug(f"Transient error polling report {report_id}: {exc}")
+            if loop.time() >= deadline:
+                raise RuntimeError(f"Report {report_id} did not complete within {_REPORT_TIMEOUT:.0f}s") from exc
+            await asyncio.sleep(_POLL_INTERVAL)
+            continue
+
+        if status == "DONE":
+            return payload
+        if status in ("CANCELLED", "FATAL"):
+            if payload.get("reportDocumentId"):
+                return payload
+            raise RuntimeError(f"Report {report_id} failed with status {status}")
+
+        if loop.time() >= deadline:
+            raise RuntimeError(f"Report {report_id} did not complete within {_REPORT_TIMEOUT:.0f}s")
+        await asyncio.sleep(_POLL_INTERVAL)
+
+
+async def _report_document_url(connection: AmazonSellingPartnerConnection, document_id: str) -> str:
+    response = await connection.client.get(f"/reports/{constants.REPORT_API_VERSION}/documents/{document_id}")
+    response.raise_for_status()
+    return response.json()["url"]
+
+
+async def _download_gzip_json(url: str) -> dict:
+    """Download and gzip-decompress a report document from its pre-signed URL."""
+    async with httpx.AsyncClient(timeout=None) as client:
+        response = await client.get(url)
+        response.raise_for_status()
+    return json.loads(gzip.decompress(response.content))
+
+
+async def _get_report(
+    connection: AmazonSellingPartnerConnection,
+    report_type: str,
+    marketplace: str,
+    start_date: dt.date | None = None,
+    end_date: dt.date | None = None,
+    options: dict[str, str] | None = None,
+) -> dict | None:
+    """Request, wait for, and download an async report.
+
+    Returns the parsed document, or ``None`` when the report failed only because
+    the data for the requested range is not yet available.
+    """
+    report_id = await _request_report(connection, report_type, marketplace, start_date, end_date, options)
+    logger.info(f"Report id: {report_id} ({report_type})")
+
+    payload = await _wait_for_report(connection, report_id)
+    status = payload["processingStatus"]
+
+    document_id = payload.get("reportDocumentId")
+    if not document_id:
+        raise RuntimeError(f"Report {report_id} failed with status {status}")
+
+    url = await _report_document_url(connection, document_id)
+    document = await _download_gzip_json(url)
+
+    if status != "DONE":
+        details = document.get("errorDetails", "") if isinstance(document, dict) else ""
+        if "not yet available" in details:
+            logger.warning(f"Report {report_id}: {details}")
+            return None
+        raise RuntimeError(f"Report {report_id} failed: {details or status}")
+
+    return document
+
+
+# -- HELPERS — Data Kiosk ------------------------------------------------------
+async def _wait_for_query(connection: AmazonSellingPartnerConnection, query_id: str) -> dict:
+    """Poll a Data Kiosk query until it reaches a terminal state; return its payload."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + _QUERY_TIMEOUT
+    while True:
+        logger.info(f"Waiting for query {query_id}...")
+        try:
+            response = await connection.client.get(
+                f"/dataKiosk/{constants.DATAKIOSK_API_VERSION}/queries/{query_id}"
+            )
+            response.raise_for_status()
+            payload = response.json()
+            status = payload["processingStatus"]
+        except httpx.HTTPError as exc:
+            logger.debug(f"Transient error polling query {query_id}: {exc}")
+            if loop.time() >= deadline:
+                raise RuntimeError(f"Query {query_id} did not complete within {_QUERY_TIMEOUT:.0f}s") from exc
+            await asyncio.sleep(_POLL_INTERVAL)
+            continue
+
+        if status == "DONE":
+            return payload
+        if status in ("CANCELLED", "FATAL"):
+            raise RuntimeError(f"Query {query_id} failed with status {status}")
+
+        if loop.time() >= deadline:
+            raise RuntimeError(f"Query {query_id} did not complete within {_QUERY_TIMEOUT:.0f}s")
+        await asyncio.sleep(_POLL_INTERVAL)
+
+
+async def _download_json(url: str) -> Any:
+    """Download a Data Kiosk document (plain JSON) from its pre-signed URL."""
+    async with httpx.AsyncClient(timeout=None) as client:
+        response = await client.get(url)
+        response.raise_for_status()
+    return response.json()
+
+
+def _extract_metrics(document: Any) -> list[dict]:
+    """Pull the ``metrics`` record list out of a Data Kiosk result document.
+
+    The list may sit at the top level or nested under the queried view object,
+    so fall back to a shallow search of nested dicts.
+    """
+    if not isinstance(document, dict):
+        return []
+    if isinstance(document.get("metrics"), list):
+        return document["metrics"]
+    for value in document.values():
+        if isinstance(value, dict):
+            found = _extract_metrics(value)
+            if found:
+                return found
+    return []
+
+
+async def _run_query(connection: AmazonSellingPartnerConnection, query: str) -> list[dict]:
+    """Create, wait for, and download a Data Kiosk query; return its metric records."""
+    response = await connection.client.post(
+        f"/dataKiosk/{constants.DATAKIOSK_API_VERSION}/queries", json={"query": query}
+    )
+    response.raise_for_status()
+    query_id = response.json()["queryId"]
+    logger.info(f"Query id: {query_id}")
+
+    payload = await _wait_for_query(connection, query_id)
+    document_id = payload.get("dataDocumentId")
+    if not document_id:
+        # DONE with no document => the query produced no rows.
+        return []
+
+    response = await connection.client.get(
+        f"/dataKiosk/{constants.DATAKIOSK_API_VERSION}/documents/{document_id}"
+    )
+    response.raise_for_status()
+    document = await _download_json(response.json()["documentUrl"])
+    return _extract_metrics(document)
+
+
 # -- SOURCE --------------------------------------------------------------------
-
-
 @il.source(
     resources={"connection": AmazonSellingPartnerConnection},
     tags=["E-Commerce"],
     icon="icon:amazon",
+    # Vendor reports return nested camelCase money objects (inventory nests
+    # cost two levels deep, e.g. sellableOnHandInventory.cost.amount); flatten and
+    # snake-case (splitting digit groups, e.g. aged90Plus -> aged_90_plus) so the
+    # columns land on the flat schema fields. A concrete depth (not None) is used
+    # deliberately: the spec serializer drops None, degrading the child pod's
+    # normalizer to no flattening. Data Kiosk assets already return flat
+    # snake_case rows, so this is a no-op for them.
+    normalizer=DataFrameNormalizer(flatten_max_level=3, snake_case_digits=True),
 )
 class AmazonSellingPartner(il.Source):
     """Amazon Selling Partner integration for vendor and seller reporting."""
 
-    marketplace: str = il.SelectField(
-        options=[
-            {"label": "United States", "value": "ATVPDKIKX0DER"},
-            {"label": "Canada", "value": "A2EUQ1WTGCTBG2"},
-            {"label": "Mexico", "value": "A1AM78C64UM0Y8"},
-            {"label": "Brazil", "value": "A2Q3Y263D00KWC"},
-            {"label": "United Kingdom", "value": "A1F83G8C2ARO7P"},
-            {"label": "Germany", "value": "A1PA6795UKMFR9"},
-            {"label": "France", "value": "A13V1IB3VIYZZH"},
-            {"label": "Italy", "value": "APJ6JRA9NG5V4"},
-            {"label": "Spain", "value": "A1RKKUPIHCS9HS"},
-            {"label": "Netherlands", "value": "A1805IZSGTT6HS"},
-            {"label": "Sweden", "value": "A2NODRKZP88ZB9"},
-            {"label": "Poland", "value": "A1C3SOZRARQ6R3"},
-            {"label": "Belgium", "value": "AMEN7PMS3EDWL"},
-            {"label": "India", "value": "A21TJRUUN4KGV"},
-            {"label": "Turkey", "value": "A33AVAJ2PDY3EV"},
-            {"label": "Saudi Arabia", "value": "A17E79C6D8DWNP"},
-            {"label": "United Arab Emirates", "value": "A2VIGQ35RCS4UG"},
-            {"label": "Egypt", "value": "ARBP9OOSHTCHU"},
-            {"label": "South Africa", "value": "AE08WJ6YKNBMC"},
-            {"label": "Japan", "value": "A1VC38T7YXB528"},
-            {"label": "Australia", "value": "A39IBJ37TRP1C6"},
-            {"label": "Singapore", "value": "A19VAU5U5O7RUS"},
-        ],
-        description="Amazon marketplace",
+    marketplace: str = il.FetchField(
+        provider="connection.marketplaces",
+        label_key="label",
+        value_key="value",
+        description="Amazon marketplace (scoped to the connection's region)",
         discriminator=True,
     )
+
+    # --- Vendor Analytics — reports API ---
+
+    @il.asset(
+        schema=schemas.VendorTrafficStats,
+        partitioning=il.TimePartitionConfig(column="start_date"),
+        tags=["Report"],
+    )
+    async def vendor_traffic_stats(
+        self, context: il.ExecutionContext, connection: AmazonSellingPartnerConnection
+    ) -> list[_Record]:
+        """Glance views per ASIN per day."""
+        document = await _get_report(
+            connection,
+            report_type="GET_VENDOR_TRAFFIC_REPORT",
+            marketplace=self.marketplace,
+            start_date=context.partition_date,
+            end_date=context.partition_date,
+            options={"reportPeriod": "DAY"},
+        )
+        return document.get("trafficByAsin", []) if document else []
+
+    @il.asset(
+        schema=schemas.VendorSalesRetailManufacturingStats,
+        partitioning=il.TimePartitionConfig(column="start_date"),
+        tags=["Report"],
+    )
+    async def vendor_sales_retail_manufacturing_stats(
+        self, context: il.ExecutionContext, connection: AmazonSellingPartnerConnection
+    ) -> list[_Record]:
+        """Retail sales per ASIN per day, manufacturing (distributor) view."""
+        document = await _get_report(
+            connection,
+            report_type="GET_VENDOR_SALES_REPORT",
+            marketplace=self.marketplace,
+            start_date=context.partition_date,
+            end_date=context.partition_date,
+            options={"reportPeriod": "DAY", "sellingProgram": "RETAIL", "distributorView": "MANUFACTURING"},
+        )
+        return document.get("salesByAsin", []) if document else []
+
+    @il.asset(
+        schema=schemas.VendorSalesRetailSourcingStats,
+        partitioning=il.TimePartitionConfig(column="start_date"),
+        tags=["Report"],
+    )
+    async def vendor_sales_retail_sourcing_stats(
+        self, context: il.ExecutionContext, connection: AmazonSellingPartnerConnection
+    ) -> list[_Record]:
+        """Retail sales per ASIN per day, sourcing (distributor) view."""
+        document = await _get_report(
+            connection,
+            report_type="GET_VENDOR_SALES_REPORT",
+            marketplace=self.marketplace,
+            start_date=context.partition_date,
+            end_date=context.partition_date,
+            options={"reportPeriod": "DAY", "sellingProgram": "RETAIL", "distributorView": "SOURCING"},
+        )
+        return document.get("salesByAsin", []) if document else []
+
+    @il.asset(
+        schema=schemas.VendorSalesBusinessManufacturingStats,
+        partitioning=il.TimePartitionConfig(column="start_date"),
+        tags=["Report"],
+    )
+    async def vendor_sales_business_manufacturing_stats(
+        self, context: il.ExecutionContext, connection: AmazonSellingPartnerConnection
+    ) -> list[_Record]:
+        """Business (B2B) sales per ASIN per day, manufacturing (distributor) view."""
+        document = await _get_report(
+            connection,
+            report_type="GET_VENDOR_SALES_REPORT",
+            marketplace=self.marketplace,
+            start_date=context.partition_date,
+            end_date=context.partition_date,
+            options={"reportPeriod": "DAY", "sellingProgram": "BUSINESS", "distributorView": "MANUFACTURING"},
+        )
+        return document.get("salesByAsin", []) if document else []
+
+    @il.asset(
+        schema=schemas.VendorSalesBusinessSourcingStats,
+        partitioning=il.TimePartitionConfig(column="start_date"),
+        tags=["Report"],
+    )
+    async def vendor_sales_business_sourcing_stats(
+        self, context: il.ExecutionContext, connection: AmazonSellingPartnerConnection
+    ) -> list[_Record]:
+        """Business (B2B) sales per ASIN per day, sourcing (distributor) view."""
+        document = await _get_report(
+            connection,
+            report_type="GET_VENDOR_SALES_REPORT",
+            marketplace=self.marketplace,
+            start_date=context.partition_date,
+            end_date=context.partition_date,
+            options={"reportPeriod": "DAY", "sellingProgram": "BUSINESS", "distributorView": "SOURCING"},
+        )
+        return document.get("salesByAsin", []) if document else []
+
+    @il.asset(
+        schema=schemas.VendorInventoryRetailManufacturingStats,
+        partitioning=il.TimePartitionConfig(column="start_date"),
+        tags=["Report"],
+    )
+    async def vendor_inventory_retail_manufacturing_stats(
+        self, context: il.ExecutionContext, connection: AmazonSellingPartnerConnection
+    ) -> list[_Record]:
+        """Retail inventory health per ASIN per day, manufacturing (distributor) view."""
+        document = await _get_report(
+            connection,
+            report_type="GET_VENDOR_INVENTORY_REPORT",
+            marketplace=self.marketplace,
+            start_date=context.partition_date,
+            end_date=context.partition_date,
+            options={"reportPeriod": "DAY", "sellingProgram": "RETAIL", "distributorView": "MANUFACTURING"},
+        )
+        return document.get("inventoryByAsin", []) if document else []
+
+    @il.asset(
+        schema=schemas.VendorInventoryRetailSourcingStats,
+        partitioning=il.TimePartitionConfig(column="start_date"),
+        tags=["Report"],
+    )
+    async def vendor_inventory_retail_sourcing_stats(
+        self, context: il.ExecutionContext, connection: AmazonSellingPartnerConnection
+    ) -> list[_Record]:
+        """Retail inventory health per ASIN per day, sourcing (distributor) view."""
+        document = await _get_report(
+            connection,
+            report_type="GET_VENDOR_INVENTORY_REPORT",
+            marketplace=self.marketplace,
+            start_date=context.partition_date,
+            end_date=context.partition_date,
+            options={"reportPeriod": "DAY", "sellingProgram": "RETAIL", "distributorView": "SOURCING"},
+        )
+        return document.get("inventoryByAsin", []) if document else []
+
+    @il.asset(
+        schema=schemas.VendorNetPureProductMarginStats,
+        partitioning=il.TimePartitionConfig(column="start_date"),
+        tags=["Report"],
+    )
+    async def vendor_net_pure_product_margin_stats(
+        self, context: il.ExecutionContext, connection: AmazonSellingPartnerConnection
+    ) -> list[_Record]:
+        """Net pure product margin per ASIN per day."""
+        document = await _get_report(
+            connection,
+            report_type="GET_VENDOR_NET_PURE_PRODUCT_MARGIN_REPORT",
+            marketplace=self.marketplace,
+            start_date=context.partition_date,
+            end_date=context.partition_date,
+            options={"reportPeriod": "DAY"},
+        )
+        return document.get("netPureProductMarginByAsin", []) if document else []
+
+    @il.asset(schema=schemas.VendorForecastingRetailStats, tags=["Report"])
+    async def vendor_forecasting_retail_stats(
+        self, connection: AmazonSellingPartnerConnection
+    ) -> list[_Record]:
+        """Latest forward-looking demand forecast per ASIN (retail, snapshot)."""
+        document = await _get_report(
+            connection,
+            report_type="GET_VENDOR_FORECASTING_REPORT",
+            marketplace=self.marketplace,
+            options={"sellingProgram": "RETAIL"},
+        )
+        return document.get("forecastByAsin", []) if document else []
+
+    # --- Vendor Analytics — Data Kiosk (GraphQL) ---
+
+    @il.asset(schema=schemas.Products, tags=["Entity"])
+    async def products(self, connection: AmazonSellingPartnerConnection) -> list[_Record]:
+        """Product identifier lookup (ASIN, parent ASIN, EAN, UPC, ISBN)."""
+        date = dt.date.today() - dt.timedelta(days=1)
+        query = f"""{{
+          {constants.DATAKIOSK_SCHEMA} {{
+            sourcingView(aggregateBy: DAY, startDate: "{date:%Y-%m-%d}", endDate: "{date:%Y-%m-%d}") {{
+              metrics {{
+                groupByKey {{ asin parentAsin ean upc isbn13 }}
+              }}
+            }}
+          }}
+        }}"""
+        metrics = await _run_query(connection, query)
+        return [
+            _scalars(
+                {
+                    "asin": _nested(m, "groupByKey", "asin"),
+                    "parent_asin": _nested(m, "groupByKey", "parentAsin"),
+                    "ean": _nested(m, "groupByKey", "ean"),
+                    "upc": _nested(m, "groupByKey", "upc"),
+                    "isbn_13": _nested(m, "groupByKey", "isbn13"),
+                }
+            )
+            for m in metrics
+        ]
+
+    @il.asset(
+        schema=schemas.ProductFulfillmentStats,
+        partitioning=il.TimePartitionConfig(column="date"),
+        tags=["Report"],
+    )
+    async def product_fulfillment_stats(
+        self, context: il.ExecutionContext, connection: AmazonSellingPartnerConnection
+    ) -> list[_Record]:
+        """Vendor sourcing and fulfillment metrics per ASIN per day."""
+        date = context.partition_date
+        query = f"""{{
+          {constants.DATAKIOSK_SCHEMA} {{
+            sourcingView(aggregateBy: DAY, startDate: "{date:%Y-%m-%d}", endDate: "{date:%Y-%m-%d}") {{
+              metrics {{
+                groupByKey {{ asin }}
+                metrics {{
+                  customerSatisfaction {{ customerReturns }}
+                  sourcing {{
+                    openPurchaseOrderQuantity
+                    confirmedUnits
+                    mostRecentSubmitted
+                    netReceived {{ units value {{ amount currencyCode }} }}
+                    overallVendorLeadTime
+                    procurableProductOOS
+                    receivedFillRate
+                    vendorConfirmationRate
+                  }}
+                }}
+              }}
+            }}
+          }}
+        }}"""
+        metrics = await _run_query(connection, query)
+        rows: list[_Record] = []
+        for m in metrics:
+            metric = _nested(m, "metrics")
+            sourcing = _nested(metric, "sourcing")
+            row = _scalars(
+                {
+                    "asin": _nested(m, "groupByKey", "asin"),
+                    "customer_returns": _nested(metric, "customerSatisfaction", "customerReturns"),
+                    "open_purchase_order_quantity": _nested(sourcing, "openPurchaseOrderQuantity"),
+                    "confirmed_units": _nested(sourcing, "confirmedUnits"),
+                    "most_recent_submitted": _nested(sourcing, "mostRecentSubmitted"),
+                    "net_received_units": _nested(sourcing, "netReceived", "units"),
+                    "net_received_value_amount": _nested(sourcing, "netReceived", "value", "amount"),
+                    "net_received_value_currency_code": _nested(sourcing, "netReceived", "value", "currencyCode"),
+                    "overall_vendor_lead_time": _nested(sourcing, "overallVendorLeadTime"),
+                    "procurable_product_oos": _nested(sourcing, "procurableProductOOS"),
+                    "received_fill_rate": _nested(sourcing, "receivedFillRate"),
+                    "vendor_confirmation_rate": _nested(sourcing, "vendorConfirmationRate"),
+                }
+            )
+            row["date"] = date
+            rows.append(row)
+        return rows
+
+    @il.asset(
+        schema=schemas.GeoSalesStatsByCountry,
+        partitioning=il.TimePartitionConfig(column="date"),
+        tags=["Report"],
+    )
+    async def geo_sales_stats_by_country(
+        self, context: il.ExecutionContext, connection: AmazonSellingPartnerConnection
+    ) -> list[_Record]:
+        """Shipped sales and cost metrics per ASIN per ship-to country per day."""
+        date = context.partition_date
+        query = f"""{{
+          {constants.DATAKIOSK_SCHEMA} {{
+            sourcingView(aggregateBy: DAY, startDate: "{date:%Y-%m-%d}", endDate: "{date:%Y-%m-%d}") {{
+              metrics {{
+                groupByKey {{ asin shipToCountryCode }}
+                metrics {{
+                  shippedOrders {{ shippedUnitsWithRevenue {{ value {{ amount currencyCode }} units }} }}
+                  costs {{
+                    netPPM
+                    shippedCogs {{ amount currencyCode }}
+                    contraCogsPerUnit {{ amount currencyCode }}
+                    contraCogs {{ amount currencyCode }}
+                    averageSalesDiscount {{ amount currencyCode }}
+                  }}
+                }}
+              }}
+            }}
+          }}
+        }}"""
+        metrics = await _run_query(connection, query)
+        rows: list[_Record] = []
+        for m in metrics:
+            metric = _nested(m, "metrics")
+            shipped = _nested(metric, "shippedOrders")
+            costs = _nested(metric, "costs")
+            row = _scalars(
+                {
+                    "asin": _nested(m, "groupByKey", "asin"),
+                    "ship_to_country_code": _nested(m, "groupByKey", "shipToCountryCode"),
+                    "shipped_units_with_revenue_value_amount": _nested(
+                        shipped, "shippedUnitsWithRevenue", "value", "amount"
+                    ),
+                    "shipped_units_with_revenue_value_currency_code": _nested(
+                        shipped, "shippedUnitsWithRevenue", "value", "currencyCode"
+                    ),
+                    "shipped_units_with_revenue_units": _nested(shipped, "shippedUnitsWithRevenue", "units"),
+                    "net_ppm": _nested(costs, "netPPM"),
+                    "shipped_cogs_amount": _nested(costs, "shippedCogs", "amount"),
+                    "shipped_cogs_currency_code": _nested(costs, "shippedCogs", "currencyCode"),
+                    "contra_cogs_per_unit_amount": _nested(costs, "contraCogsPerUnit", "amount"),
+                    "contra_cogs_per_unit_currency_code": _nested(costs, "contraCogsPerUnit", "currencyCode"),
+                    "contra_cogs_amount": _nested(costs, "contraCogs", "amount"),
+                    "contra_cogs_currency_code": _nested(costs, "contraCogs", "currencyCode"),
+                    "average_sales_discount_amount": _nested(costs, "averageSalesDiscount", "amount"),
+                    "average_sales_discount_currency_code": _nested(costs, "averageSalesDiscount", "currencyCode"),
+                }
+            )
+            row["date"] = date
+            rows.append(row)
+        return rows

--- a/packages/interloper-assets/tests/test_amazon_selling_partner.py
+++ b/packages/interloper-assets/tests/test_amazon_selling_partner.py
@@ -1,0 +1,96 @@
+"""Regression tests for the AmazonSellingPartner source configuration.
+
+Vendor reports arrive as nested camelCase objects (money as
+``{amount, currencyCode}``, inventory cost nested two levels deep). The
+source-level ``DataFrameNormalizer`` must reach every asset instance — and
+survive the host→child DAG-spec round-trip — so those rows flatten and
+snake-case onto the flat schema fields instead of failing validation.
+
+These tests pin the whole chain: live instance → spec JSON → reconstructed
+child asset → normalize + validate a camelCase report row.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+from interloper.dag import DAGSpec
+from interloper.dag.base import DAG
+from interloper.representation import Representation
+from interloper_pandas import DataFrameNormalizer
+
+from interloper_assets.amazon_selling_partner import schemas
+from interloper_assets.amazon_selling_partner.source import AmazonSellingPartner
+
+_ASSET_KEY = "vendor_inventory_retail_manufacturing_stats"
+
+
+def _source() -> Any:
+    return AmazonSellingPartner(id="src-1", marketplace="A1PA6795UKMFR9")  # ty: ignore[unknown-argument]
+
+
+class TestSourceNormalizer:
+    """The decorator-configured normalizer must reach every asset instance."""
+
+    def test_source_instance_has_dataframe_normalizer(self):
+        src = _source()
+        assert isinstance(src.normalizer, DataFrameNormalizer)
+        assert src.normalizer.snake_case_digits is True
+        assert src.normalizer.flatten_max_level == 3
+
+    def test_all_assets_inherit_the_normalizer(self):
+        src = _source()
+        for asset in src.assets:
+            assert isinstance(asset.normalizer, DataFrameNormalizer), type(asset).key
+
+
+class TestSpecRoundtrip:
+    """The host→child spec round-trip must preserve the normalizer subclass."""
+
+    def test_child_asset_keeps_dataframe_normalizer(self):
+        src = _source()
+        asset = next(a for a in src.assets if type(a).key == _ASSET_KEY)
+
+        # Exactly what the k8s runner ships to the child pod.
+        spec_json = DAG(src).mini_dag(asset.id).to_spec().model_dump(mode="json")
+        child_dag = DAGSpec(**spec_json).reconstruct()
+        child_asset = next(a for a in child_dag.assets if type(a).key == _ASSET_KEY)
+
+        normalizer = child_asset.normalizer
+        assert isinstance(normalizer, DataFrameNormalizer)
+        assert normalizer.snake_case_digits is True
+        assert normalizer.flatten_max_level == 3
+
+    def test_nested_camelcase_report_row_conforms_after_roundtrip(self):
+        """A nested API-shaped inventory row must flatten, snake-case, and validate."""
+        src = _source()
+        asset = next(a for a in src.assets if type(a).key == _ASSET_KEY)
+        spec_json = DAG(src).mini_dag(asset.id).to_spec().model_dump(mode="json")
+        child_dag = DAGSpec(**spec_json).reconstruct()
+        child_asset = next(a for a in child_dag.assets if type(a).key == _ASSET_KEY)
+
+        # Nested money objects (cost two levels deep) and a digit-prefixed key,
+        # exactly as GET_VENDOR_INVENTORY_REPORT returns them.
+        row: dict[str, Any] = {
+            "startDate": "2026-06-10",
+            "endDate": "2026-06-10",
+            "asin": "B0TEST0001",
+            "sellableOnHandInventory": {"cost": {"amount": 500.0, "currencyCode": "EUR"}, "units": 40},
+            "aged90PlusDaysSellableInventory": {"cost": {"amount": 10.0, "currencyCode": "EUR"}, "units": 1},
+            "sellThroughRate": 0.5,
+            "vendorConfirmationRate": 0.9,
+            "uft": 3,
+        }
+        df = pd.DataFrame([row])
+
+        normalizer = child_asset.normalizer
+        assert isinstance(normalizer, DataFrameNormalizer)
+        normalized = normalizer.normalize(df)
+
+        # The two-level nesting and aged90Plus digit prefix land on schema fields.
+        assert "sellable_on_hand_inventory_cost_amount" in normalized.columns
+        assert "aged_90_plus_days_sellable_inventory_cost_amount" in normalized.columns
+
+        conformer = Representation.of(normalized).conformer
+        conformer.validate(normalized, schemas.VendorInventoryRetailManufacturingStats)  # must not raise


### PR DESCRIPTION
## What

Adds the **Amazon Selling Partner** vendor-analytics source to `interloper-assets`, ported from the `digitlcloud-connectors` reference. Covers the 12 vendor reports that ship with schemas:

- **8 reports-API `_stats`** — `vendor_traffic_stats`, `vendor_sales_{retail,business}_{manufacturing,sourcing}_stats`, `vendor_inventory_retail_{manufacturing,sourcing}_stats`, `vendor_net_pure_product_margin_stats` (time-partitioned on `start_date`).
- **`vendor_forecasting_retail_stats`** — a forward-looking forecast snapshot (unpartitioned).
- **3 Data Kiosk (GraphQL) assets** — `products` (ASIN identifier lookup, Entity), `product_fulfillment_stats`, `geo_sales_stats_by_country` (partitioned on a stamped `date`).

Asset/schema names follow the `AGENTS.md` row-grain convention (`_stats` reports, bare-plural entity). The 4 Amazon Fresh report variants from the reference are intentionally omitted — they ship no schema and are niche.

## How

- **Auth** — `LWATokenAuth` (subclass of `OAuth2RefreshTokenAuth`) carries the LWA token in the `x-amz-access-token` header; SP-API no longer uses SigV4 / the `Authorization` header. `check()` validates credentials via the LWA token exchange.
- **Flows** — async request → poll → gzip-download for the Reports API, and create → poll → download for Data Kiosk, modelled on the `impact` source's poll loop.
- **Normalizer** — a source-level `DataFrameNormalizer` flattens nested camelCase money objects (e.g. `sellableOnHandInventory.cost.amount` → `sellable_on_hand_inventory_cost_amount`) and snake-cases digit groups (`p70ForecastUnits` → `p_70_forecast_units`) onto the flat schema fields.
- **`marketplace` is a region-scoped `FetchField`** backed by a static region→marketplaces map. SP-API has no vendor-accessible endpoint to enumerate marketplaces (`getMarketplaceParticipations` is seller-only and 403s for vendor tokens), so the provider scopes the picker to the connection's region **without an API call**, making a region/marketplace mismatch unselectable. `location` stays on the connection because the region-bound client + auth host are built there.

## Reviewer notes

- **`flatten_max_level` is a concrete int, not `None`.** The DAG-spec serializer uses `exclude_none`, so `None` is dropped and the child pod's normalizer silently reverts to no flattening. `tests/test_amazon_selling_partner.py` pins this through the host→child spec round-trip (mirrors the existing `amazon_ads` normalizer regression test).
- **Live-verified end to end** against a real vendor account: `check()`, the `x-amz-access-token` auth, the report request→poll→gzip-download flow, and the normalize+conform pipeline all pass on real forecasting/traffic/sales reports. Reports take ~1–3 min each to process server-side, so the default 2 h report timeout is appropriately generous.
- All schema fields are nullable, so unexpected/extra API columns are dropped at conform rather than failing.

By Digitl