### PR TITLE
fix(app): align agent panel header and composer with the app chrome

### DIFF
--- a/packages/interloper-app/app/app/components/agent/Panel.vue
+++ b/packages/interloper-app/app/app/components/agent/Panel.vue
@@ -92,7 +92,7 @@ const SUGGESTIONS = [
                                 @dblclick="resetWidth" />
 
         <!-- Header -->
-        <div class="flex items-center gap-3 px-[18px] py-3.5 border-b border-default shrink-0">
+        <div class="flex items-center gap-3 px-[18px] h-(--ui-header-height) border-b border-default shrink-0">
             <div class="size-8 rounded-[9px] bg-primary text-inverted flex items-center justify-center">
                 <UIcon name="i-lucide-sparkles"
                        class="size-4" />
@@ -181,7 +181,7 @@ const SUGGESTIONS = [
                          variant="outline"
                          placeholder="Ask about your workspace…"
                          :disabled="streaming || sessionError"
-                         :ui="{ base: 'px-1.5' }"
+                         :ui="{ base: 'px-1.5 text-[13.5px]/5', body: 'items-center' }"
                          @submit="onSubmit">
                 <UChatPromptSubmit :status="status"
                                    size="sm" />


### PR DESCRIPTION
Two visual glitches in the docked agent panel:

- **Header height** — the panel header sized itself with `py-3.5`, landing a few pixels off the app navbar's `--ui-header-height` (4rem), so the two bottom borders didn't line up. It now uses `h-(--ui-header-height)` directly.
- **Composer** — the prompt textarea inherited the app-wide `lg` textarea default (16px `text-base`), and ChatPrompt's `body` slot top-aligns the submit button. The prompt now uses `text-[13.5px]/5` (the chat message font size) with `items-center`.

Verified on a live dev instance: navbar and panel header both measure exactly 64px, the textarea computes to 13.5px, and the textarea/submit-button vertical centers coincide.

By Digitl