### PR TITLE
fix(app): cap the agent composer at six rows

### DIFF
--- a/packages/interloper-app/app/app/components/agent/Panel.vue
+++ b/packages/interloper-app/app/app/components/agent/Panel.vue
@@ -180,6 +180,7 @@ const SUGGESTIONS = [
             <UChatPrompt v-model="input"
                          variant="outline"
                          placeholder="Ask about your workspace…"
+                         :maxrows="6"
                          :disabled="streaming || sessionError"
                          :ui="{ base: 'px-1.5 text-[13.5px]/5', body: 'items-center' }"
                          @submit="onSubmit">


### PR DESCRIPTION
The agent panel's prompt textarea autoresizes without bound, so a long draft can swallow the whole panel. This passes `:maxrows="6"` to `UChatPrompt` — Nuxt UI caps the autoresize there and the textarea scrolls natively beyond it.

Follow-up to #163.

By Digitl