### PR TITLE
feat(agent): react-only bulk connection creation from volunteered credentials

### DIFF
--- a/packages/interloper-agent/src/interloper_agent/agent.py
+++ b/packages/interloper-agent/src/interloper_agent/agent.py
@@ -108,6 +108,7 @@ collection_agent = Agent(
     tools=[
         collection.list_components,
         collection.request_connection_setup,
+        collection.create_connections,
         collection.check_connection,
         collection.resolve_source_field_options,
         collection.create_source,

--- a/packages/interloper-agent/src/interloper_agent/prompts.py
+++ b/packages/interloper-agent/src/interloper_agent/prompts.py
@@ -82,6 +82,17 @@ Set up a connection:
    check or something seems off — and whenever a connection misbehaves or a
    source hits auth errors.
 
+The form is the only path you ever propose — never ask for or invite
+credentials in chat. But if the user has *already* pasted credential values
+themselves (any format), they are in the session regardless: don't dead-end
+on a form. Read what they gave, work out which connections it describes
+(one per secret, shared fields repeated, names/regions from their
+instructions), recap with request_confirmation showing names and regions
+only — never the secret values — and on confirmation create them with
+create_connections, then check_connection each. Use the form for anything
+they didn't supply; never ask for a missing secret in chat. Afterwards, note
+once that the secure form keeps credentials out of the chat next time.
+
 Set up sources — one flow for one account or many; the selection decides the
 count, never assume it:
 1. Identify the definition and what it needs (a connection, config fields).

--- a/packages/interloper-agent/src/interloper_agent/tools/collection.py
+++ b/packages/interloper-agent/src/interloper_agent/tools/collection.py
@@ -93,6 +93,74 @@ def list_components(kind: str | None = None, tool_context: ToolContext | None = 
 # -- Connection operations (kind-specific by nature) ------------------------------
 
 
+def create_connections(
+    connection_key: str,
+    instances: list[dict[str, Any]],
+    tool_context: ToolContext | None = None,
+) -> dict[str, Any]:
+    """Create connections directly from credential values the user already gave.
+
+    REACT-ONLY. The secure form (request_connection_setup) is the only path
+    you ever propose or ask for — never invite the user to paste credentials.
+    Use this solely when the user has *already* put the credential values in
+    the conversation unprompted: they are in context regardless, so create
+    what they asked for instead of dead-ending on a form. Recap and get
+    explicit confirmation first, and never repeat a credential value back —
+    not in the recap, not in your reply (identity and location only).
+
+    Each config is validated against the connection definition and stored
+    encrypted. Instances that fail are reported individually; the rest are
+    created. Verify the results with check_connection afterwards.
+
+    Args:
+        connection_key: Catalog key of the connection definition
+            (e.g. 'amazon_selling_partner_connection').
+        instances: One entry per connection, each ``{"name": ...,
+            "config": {<field>: <value>, ...}}`` — config carries the
+            definition's fields (shared ones like client_id/client_secret
+            repeated per instance, plus the per-instance secret).
+    """
+    try:
+        org_id = get_org_id(tool_context)
+        store = get_store()
+        catalog = get_catalog()
+
+        defn = catalog.get(connection_key)
+        if defn is None or defn.get("kind") != "connection":
+            valid = sorted(k for k, d in catalog.items() if d.get("kind") == "connection")
+            return {
+                "status": "error",
+                "error": f"Connection definition '{connection_key}' not found in catalog",
+                "valid_keys": valid,
+            }
+        cleaned: list[tuple[str, dict[str, Any]]] = [
+            (str(i["name"]), i["config"])
+            for i in instances
+            if isinstance(i, dict) and i.get("name") and isinstance(i.get("config"), dict)
+        ]
+        if not cleaned:
+            return {"status": "error", "error": "instances must carry at least one {name, config} entry"}
+
+        created, failed = [], []
+        for name, config in cleaned:
+            try:
+                row = store.create_component(org_id, kind="connection", key=connection_key, name=name, config=config)
+            except (ConfigError, CatalogKeyError) as e:
+                # str(e) may name required fields but never echoes values.
+                failed.append({"name": name, "error": str(e)})
+                continue
+            created.append({"id": serialize(row.id), "name": row.name})
+
+        return {
+            "status": "success" if created else "error",
+            "message": f"{len(created)} connection(s) created" + (f", {len(failed)} failed" if failed else ""),
+            "created": created,
+            "failed": failed,
+        }
+    except Exception as e:
+        return {"status": "error", "error": str(e)}
+
+
 def request_connection_setup(
     connection_key: str,
     name: str | None = None,


### PR DESCRIPTION
## What

"Create Amazon SP connections, one per refresh token" used to dead-end on a single empty form. Now the agent completes it — but only reacting to credentials the user *already* volunteered, never soliciting them.

- **`create_connections(connection_key, instances)`** on CollectionAgent — takes the `{name, config}` instances the agent assembled and writes them encrypted (the connection kind is sensitive; the store encrypts / fails closed). Per-instance failure reporting; result is **identity-only**, never echoing a config value.
- **Instruction (react-only clause):** the secure form stays the *only* path the agent proposes — it never asks for or invites credentials. But if the user has already pasted values (any format), the agent reads them, works out the connections (one per secret, shared fields repeated, names/regions from the user's instructions), recaps with **secret values masked**, creates on confirmation, and runs `check_connection` on each (the form's pre-check is bypassed here). Missing pieces → fall back to the form; never solicit a missing secret. A one-line forward nudge notes the form keeps credentials out of chat next time.

## Why this is the right seam

The "secrets never transit the model" invariant exists to prevent the leak. Once the user volunteers secrets, that already happened for the session — refusing to use them buys nothing but a worse UX. The behavioral guarantee is preserved by **react ≠ solicit**: the agent never advertises or requests the paste, so the unsafe habit is never trained; it just stops wasting the situation. Normal interactions are exactly as safe as before.

## Verification

Live run of the reported scenario in a **non-JSON freeform paste** (`BE -> atzr-be-001`, …), representative 4 across all regions: consult → recap (no token values) → confirm → `create_connections` → `check_connection` ×4. Result verified in the DB: `Amazon SP BE/DE → EU`, `CA → NA`, `JP → FE`, shared client_id, correct per-marketplace tokens stored encrypted. Asserted no token string appeared in the confirmation card. ruff / ty / pytest (979) green; fixtures cleaned by tracked id in a separate process.

## Note

Default-on per the agreed stance. If some orgs want strict "no volunteered secrets ever", `create_connections` is the single choke point to gate behind a deployment flag — noted for a follow-up if wanted.

By Digitl