### PR TITLE
feat(assets): add Brandwatch source

### DIFF
--- a/packages/interloper-assets/src/interloper_assets/brandwatch/connection.py
+++ b/packages/interloper-assets/src/interloper_assets/brandwatch/connection.py
@@ -9,30 +9,19 @@ from interloper_assets.brandwatch import constants
 @il.connection(
     name="Brandwatch",
     icon="fluent:connector-24-filled",
-    tags=["Social"],
+    tags=["Social Media"],
 )
 class BrandwatchConnection(il.Connection):
-    """Brandwatch (Falcon.io) API connection with API key auth."""
+    """Brandwatch (Falcon.io) Measure API connection with API-key auth."""
 
     model_config = SettingsConfigDict(env_prefix="brandwatch_")
 
-    api_key: str = il.SecretField(title="API Key", description="Brandwatch API key")
-    channel_id: str = il.InputField(
-        title="Channel ID",
-        description="Channel ID to fetch insights for",
-        discriminator=True,
-    )
-    network: str = il.SelectField(
-        options=[
-            {"label": "Facebook", "value": "facebook"},
-            {"label": "Instagram", "value": "instagram"},
-            {"label": "LinkedIn", "value": "linkedin"},
-            {"label": "Twitter", "value": "twitter"},
-            {"label": "YouTube", "value": "youtube"},
-        ],
-        description="Social network to fetch insights for",
-    )
+    api_key: str = il.SecretField(title="API Key", description="Brandwatch (Falcon.io) Measure API key")
 
     @cached_property
     def client(self) -> il.AsyncRESTClient:
-        return il.AsyncRESTClient(constants.BASE_URL, params={"param_key": self.api_key})
+        # Falcon.io authenticates the Measure API with the key as a query
+        # parameter applied to every request. NOTE: the parameter name
+        # (`param_key`) is carried over unverified from the reference connector
+        # and may need to be `apikey` — confirm against a live key.
+        return il.AsyncRESTClient(constants.BASE_URL, params={"param_key": self.api_key}, timeout=60)

--- a/packages/interloper-assets/src/interloper_assets/brandwatch/schemas/__init__.py
+++ b/packages/interloper-assets/src/interloper_assets/brandwatch/schemas/__init__.py
@@ -1,0 +1,13 @@
+from .facebook_stats import FacebookStats
+from .instagram_stats import InstagramStats
+from .linkedin_stats import LinkedinStats
+from .twitter_stats import TwitterStats
+from .youtube_stats import YoutubeStats
+
+__all__ = [
+    "FacebookStats",
+    "InstagramStats",
+    "LinkedinStats",
+    "TwitterStats",
+    "YoutubeStats",
+]

--- a/packages/interloper-assets/src/interloper_assets/brandwatch/schemas/facebook_stats.py
+++ b/packages/interloper-assets/src/interloper_assets/brandwatch/schemas/facebook_stats.py
@@ -1,0 +1,75 @@
+import datetime as dt
+
+from interloper.schema import Schema
+from pydantic import Field
+
+
+class FacebookStats(Schema):
+    """Facebook channel performance metrics per day (Brandwatch/Falcon.io Measure)."""
+
+    date: dt.date | None = Field(default=None, description="The date the metrics correspond to.")
+    channel_id: str | None = Field(default=None, description="Unique identifier for the Facebook Page.")
+    engagements: int | None = Field(
+        default=None, description="Total number of post engagements (Reactions, Comments, Shares, Clicks)."
+    )
+    engaged_users: int | None = Field(default=None, description="The number of unique people who engaged with content.")
+    engagement_rate: float | None = Field(
+        default=None, description="Overall engagement rate (e.g., Engagements / Impressions or Reach)."
+    )
+    engagement_rate_reach: float | None = Field(default=None, description="Engagement rate calculated using reach.")
+    interaction_rate: float | None = Field(
+        default=None, description="Rate of interactions (engagement divided by impressions or reach)."
+    )
+    likes: int | None = Field(default=None, description="Total number of reactions of type 'Like' on posts.")
+    comments: int | None = Field(default=None, description="Total number of comments on posts.")
+    shares: int | None = Field(default=None, description="Total number of shares of posts.")
+    reactions: int | None = Field(
+        default=None, description="Total number of Reactions (sum of Like, Love, Wow, Haha, Sad, Angry) on posts."
+    )
+    clicks: int | None = Field(default=None, description="Total clicks on a post (Link, Photo, Other).")
+    fans: int | None = Field(default=None, description="Total number of Page Likes/Fans.")
+    followers: int | None = Field(default=None, description="Total number of people who follow the account/Page.")
+    net_fans: int | None = Field(default=None, description="Net change in Fans (New Fans - Unfans).")
+    net_followers: int | None = Field(default=None, description="Net change in Followers.")
+    negative_fans: int | None = Field(default=None, description="Number of Unfans/Unfollows.")
+    likes_total: int | None = Field(default=None, description="Cumulative Likes for the account/page.")
+    net_likes_total: int | None = Field(default=None, description="Net change in total likes.")
+    impressions: int | None = Field(
+        default=None, description="Total number of times content entered a person's screen (non-unique)."
+    )
+    impressions_organic: int | None = Field(default=None, description="Number of organic impressions.")
+    impressions_paid: int | None = Field(default=None, description="Number of paid impressions.")
+    reach: int | None = Field(default=None, description="Total number of unique people reached.")
+    reach_organic: int | None = Field(default=None, description="Number of unique people reached organically.")
+    reach_paid: int | None = Field(default=None, description="Number of unique people reached via paid advertising.")
+    reach_viral: int | None = Field(
+        default=None, description="Unique people reached due to viral activity (friend interaction)."
+    )
+    reach_nonviral: int | None = Field(
+        default=None, description="Unique people reached not attributed to viral activity."
+    )
+    viral_amplification: float | None = Field(
+        default=None, description="Measure of how much content is spread virally."
+    )
+    video_views: int | None = Field(
+        default=None, description="Total number of video views (e.g., 3-second view count)."
+    )
+    video_views_10s: int | None = Field(default=None, description="Total number of video views of at least 10 seconds.")
+    video_views_30s: int | None = Field(default=None, description="Total number of video views of at least 30 seconds.")
+    video_views_organic: int | None = Field(default=None, description="Number of organic video views.")
+    video_views_paid: int | None = Field(default=None, description="Number of paid video views.")
+    video_plays: int | None = Field(default=None, description="Number of times videos started playing.")
+    video_repeat_views: int | None = Field(
+        default=None, description="Number of times videos were played again by the same user."
+    )
+    video_view_time: float | None = Field(default=None, description="Total accumulated video view time in seconds.")
+    video_viewers: int | None = Field(default=None, description="Number of unique video viewers.")
+    views: int | None = Field(default=None, description="Total number of Page/Profile Views.")
+    views_by_logged_in_out_logged_in: int | None = Field(default=None, description="Views from logged-in users.")
+    views_by_logged_in_out_logged_out: int | None = Field(default=None, description="Views from logged-out users.")
+    new_dm_conversations: int | None = Field(
+        default=None, description="Number of new direct message conversations started."
+    )
+    blocked_dm_conversations: int | None = Field(
+        default=None, description="Number of blocked direct message conversations."
+    )

--- a/packages/interloper-assets/src/interloper_assets/brandwatch/schemas/instagram_stats.py
+++ b/packages/interloper-assets/src/interloper_assets/brandwatch/schemas/instagram_stats.py
@@ -1,0 +1,118 @@
+import datetime as dt
+
+from interloper.schema import Schema
+from pydantic import Field
+
+
+class InstagramStats(Schema):
+    """Instagram channel performance metrics per day (Brandwatch/Falcon.io Measure)."""
+
+    date: dt.date | None = Field(default=None, description="The date the metrics correspond to.")
+    channel_id: str | None = Field(default=None, description="Unique identifier for the Facebook Page.")
+    fans: int | None = Field(default=None, description="Total number of account followers (Fans).")
+    followers: int | None = Field(default=None, description="Total number of people following the account.")
+    net_fans: int | None = Field(default=None, description="Net change in total fans (New - Lost).")
+    net_followers: int | None = Field(default=None, description="Net change in total followers.")
+    impressions: int | None = Field(default=None, description="Total number of times content was seen (non-unique).")
+    reach: int | None = Field(default=None, description="Total number of unique users reached.")
+    reach_organic: int | None = Field(default=None, description="Reach from unpaid sources.")
+    reach_paid: int | None = Field(default=None, description="Reach from paid/promoted sources.")
+    reach_follower: int | None = Field(default=None, description="Reach among current followers.")
+    reach_non_follower: int | None = Field(default=None, description="Reach among non-followers.")
+    frequency: float | None = Field(
+        default=None, description="The average number of times a unique user saw the content (Impressions / Reach)."
+    )
+    reach_post: int | None = Field(default=None, description="Reach of feed posts.")
+    reach_reel: int | None = Field(default=None, description="Reach of Reels.")
+    reach_story: int | None = Field(default=None, description="Reach of Stories.")
+    reach_igtv: int | None = Field(default=None, description="Reach of IGTV/Long-form videos.")
+    reach_carousel: int | None = Field(default=None, description="Reach of carousel posts.")
+    reach_ad: int | None = Field(default=None, description="Reach of paid advertisements.")
+    reach_profile_pic: int | None = Field(default=None, description="Reach of profile picture views.")
+    engagements: int | None = Field(
+        default=None, description="Total engagement actions (Likes, Comments, Saves, Shares, and other interactions)."
+    )
+    engaged_users: int | None = Field(default=None, description="Total number of unique users who engaged.")
+    interactions: int | None = Field(default=None, description="A general count of interactions.")
+    engagement_rate: float | None = Field(default=None, description="Overall engagement rate.")
+    engagement_rate_reach: float | None = Field(
+        default=None, description="Overall engagement rate calculated based on reach."
+    )
+    engaged_users_rate: float | None = Field(
+        default=None, description="Rate of unique engaged users (Engaged Users / Reach)."
+    )
+    interaction_rate: float | None = Field(default=None, description="Overall interaction rate.")
+    interaction_rate_reach: float | None = Field(
+        default=None, description="Interaction rate calculated based on reach."
+    )
+    engagement_rate_reach_post: float | None = Field(
+        default=None, description="Engagement rate of posts based on reach."
+    )
+    engagement_rate_reach_reel: float | None = Field(
+        default=None, description="Engagement rate of Reels based on reach."
+    )
+    engagement_rate_reach_story: float | None = Field(
+        default=None, description="Engagement rate of Stories based on reach."
+    )
+    engagement_rate_reach_igtv: float | None = Field(
+        default=None, description="Engagement rate of IGTV based on reach."
+    )
+    engagement_rate_reach_ad: float | None = Field(default=None, description="Engagement rate of Ads based on reach.")
+    likes: int | None = Field(default=None, description="Total number of likes across all content.")
+    comments: int | None = Field(default=None, description="Total number of comments across all content.")
+    shares: int | None = Field(default=None, description="Total number of shares across all content.")
+    saves: int | None = Field(default=None, description="Total number of saves across all content.")
+    reactions: int | None = Field(
+        default=None, description="Total reactions (often includes likes/emojis, but can be a custom metric)."
+    )
+    engagements_post: int | None = Field(default=None, description="Engagements on posts.")
+    engagements_reel: int | None = Field(default=None, description="Engagements on Reels.")
+    engagements_story: int | None = Field(default=None, description="Engagements on Stories.")
+    engagements_igtv: int | None = Field(default=None, description="Engagements on IGTV.")
+    engagements_live: int | None = Field(default=None, description="Engagements on Live videos.")
+    engagements_ad: int | None = Field(default=None, description="Engagements on Ads.")
+    likes_post: int | None = Field(default=None, description="Likes on posts.")
+    likes_reel: int | None = Field(default=None, description="Likes on Reels.")
+    likes_story: int | None = Field(default=None, description="Likes on Stories.")
+    likes_igtv: int | None = Field(default=None, description="Likes on IGTV.")
+    likes_carousel: int | None = Field(default=None, description="Likes on carousel posts.")
+    likes_ad: int | None = Field(default=None, description="Likes on Ads.")
+    comments_post: int | None = Field(default=None, description="Comments on posts.")
+    comments_reel: int | None = Field(default=None, description="Comments on Reels.")
+    comments_story: int | None = Field(default=None, description="Comments on Stories.")
+    comments_igtv: int | None = Field(default=None, description="Comments on IGTV.")
+    comments_live: int | None = Field(default=None, description="Comments on Live videos.")
+    comments_ad: int | None = Field(default=None, description="Comments on Ads.")
+    shares_post: int | None = Field(default=None, description="Shares of posts.")
+    shares_reel: int | None = Field(default=None, description="Shares of Reels.")
+    shares_story: int | None = Field(default=None, description="Shares of Stories.")
+    shares_igtv: int | None = Field(default=None, description="Shares of IGTV.")
+    shares_carousel: int | None = Field(default=None, description="Shares of carousel posts.")
+    shares_ad: int | None = Field(default=None, description="Shares of Ads.")
+    saves_post: int | None = Field(default=None, description="Saves of posts.")
+    saves_reel: int | None = Field(default=None, description="Saves of Reels.")
+    saves_igtv: int | None = Field(default=None, description="Saves of IGTV.")
+    saves_ad: int | None = Field(default=None, description="Saves of Ads.")
+    cta_clicks: int | None = Field(default=None, description="Total clicks on call-to-action buttons.")
+    website_clicks: int | None = Field(default=None, description="Clicks to the external website link.")
+    directions_clicks: int | None = Field(default=None, description="Clicks on the 'Get Directions' button.")
+    phone_call_clicks: int | None = Field(default=None, description="Clicks on the 'Call' button.")
+    text_message_clicks: int | None = Field(default=None, description="Clicks on the 'Text' button.")
+    profile_links_taps_book_now: int | None = Field(default=None, description="Taps on the 'Book Now' profile link.")
+    profile_links_taps_call: int | None = Field(default=None, description="Taps on the 'Call' profile link.")
+    profile_links_taps_direction: int | None = Field(default=None, description="Taps on the 'Direction' profile link.")
+    profile_links_taps_email: int | None = Field(default=None, description="Taps on the 'Email' profile link.")
+    profile_links_taps_instant_experience: int | None = Field(
+        default=None, description="Taps on 'Instant Experience' links (from ads)."
+    )
+    profile_links_taps_text: int | None = Field(default=None, description="Taps on the 'Text' profile link.")
+    direct_messages: int | None = Field(default=None, description="Total number of direct messages received/sent.")
+    incoming_private_messages: int | None = Field(default=None, description="Number of direct messages received.")
+    stories: int | None = Field(default=None, description="Total number of stories published.")
+    story_replies: int | None = Field(default=None, description="Number of replies received on stories.")
+    story_mentions: int | None = Field(
+        default=None, description="Number of times the account was mentioned in stories."
+    )
+    views: int | None = Field(
+        default=None, description="General views count (often associated with Stories or Profile views)."
+    )

--- a/packages/interloper-assets/src/interloper_assets/brandwatch/schemas/linkedin_stats.py
+++ b/packages/interloper-assets/src/interloper_assets/brandwatch/schemas/linkedin_stats.py
@@ -1,0 +1,67 @@
+import datetime as dt
+
+from interloper.schema import Schema
+from pydantic import Field
+
+
+class LinkedinStats(Schema):
+    """LinkedIn channel performance metrics per day (Brandwatch/Falcon.io Measure)."""
+
+    date: dt.date | None = Field(default=None, description="The date the metrics correspond to.")
+    channel_id: str | None = Field(default=None, description="Unique identifier for the Facebook Page.")
+    fans: int | None = Field(default=None, description="Total number of unique followers (Fans) for the page.")
+    followers: int | None = Field(
+        default=None, description="Total number of people following the page (synonym for fans)."
+    )
+    net_fans: int | None = Field(default=None, description="Net change in total fans (New - Lost).")
+    net_followers: int | None = Field(default=None, description="Net change in total followers.")
+    organic_net_fans: int | None = Field(default=None, description="Net change in fans from organic sources.")
+    paid_net_fans: int | None = Field(default=None, description="Net change in fans from paid/sponsored sources.")
+    fans_by_association_total: int | None = Field(
+        default=None, description="Total fans acquired broken down by how they followed the page."
+    )
+    fans_by_association_employee: int | None = Field(
+        default=None, description="Fans acquired who followed the page via an employee's profile/share."
+    )
+    fans_by_association_non_employee: int | None = Field(
+        default=None, description="Fans acquired who followed the page via non-employee sources."
+    )
+    organic_fans_by_association_total: int | None = Field(
+        default=None, description="Organic fans acquired broken down by source."
+    )
+    organic_fans_by_association_employee: int | None = Field(
+        default=None, description="Organic fans acquired via an employee's profile/share."
+    )
+    organic_fans_by_association_non_employee: int | None = Field(
+        default=None, description="Organic fans acquired via non-employee sources."
+    )
+    paid_fans_by_association_total: int | None = Field(
+        default=None, description="Paid fans acquired broken down by source."
+    )
+    paid_fans_by_association_employee: int | None = Field(
+        default=None, description="Paid fans acquired via an employee's profile/share."
+    )
+    paid_fans_by_association_non_employee: int | None = Field(
+        default=None, description="Paid fans acquired via non-employee sources."
+    )
+    impressions: int | None = Field(default=None, description="Total number of times posts were seen (non-unique).")
+    reach: int | None = Field(default=None, description="Total number of unique users who saw the content.")
+    frequency: float | None = Field(
+        default=None, description="The average number of times a unique user saw the content (Impressions / Reach)."
+    )
+    engagements: int | None = Field(
+        default=None, description="Total engagement actions (Reactions, Comments, Shares, Clicks)."
+    )
+    interactions: int | None = Field(default=None, description="A general count of interactions.")
+    comments: int | None = Field(default=None, description="Total number of comments on posts.")
+    shares: int | None = Field(default=None, description="Total number of shares of posts.")
+    reactions: int | None = Field(
+        default=None, description="Total number of reactions (e.g., Like, Celebrate, Love, Insightful, etc.)."
+    )
+    clicks: int | None = Field(default=None, description="Total clicks on a post.")
+    interaction_rate: float | None = Field(default=None, description="Overall interaction rate.")
+    engagement_rate: float | None = Field(default=None, description="Overall engagement rate.")
+    interaction_rate_reach: float | None = Field(
+        default=None, description="Interaction rate calculated based on reach."
+    )
+    engagement_rate_reach: float | None = Field(default=None, description="Engagement rate calculated based on reach.")

--- a/packages/interloper-assets/src/interloper_assets/brandwatch/schemas/twitter_stats.py
+++ b/packages/interloper-assets/src/interloper_assets/brandwatch/schemas/twitter_stats.py
@@ -1,0 +1,28 @@
+import datetime as dt
+
+from interloper.schema import Schema
+from pydantic import Field
+
+
+class TwitterStats(Schema):
+    """X (Twitter) channel performance metrics per day (Brandwatch/Falcon.io Measure)."""
+
+    date: dt.date | None = Field(default=None, description="The date the metrics correspond to.")
+    channel_id: str | None = Field(default=None, description="Unique identifier for the Facebook Page.")
+    fans: int | None = Field(
+        default=None, description="Total number of account followers (synonymous with 'followers')."
+    )
+    followers: int | None = Field(default=None, description="Total number of people following the account.")
+    friends_count: int | None = Field(default=None, description="Total number of accounts the user is following.")
+    net_fans: int | None = Field(default=None, description="Net change in fans/followers (New - Lost).")
+    net_followers: int | None = Field(default=None, description="Net change in followers.")
+    listed_count: int | None = Field(
+        default=None, description="Total number of public lists this account is a member of."
+    )
+    listed_net: int | None = Field(
+        default=None, description="Net change in the number of lists the account is added to."
+    )
+    statuses_count: int | None = Field(
+        default=None, description="Total number of tweets (posts) published by the account."
+    )
+    statuses_net: int | None = Field(default=None, description="Net change in the number of tweets (posts) published.")

--- a/packages/interloper-assets/src/interloper_assets/brandwatch/schemas/youtube_stats.py
+++ b/packages/interloper-assets/src/interloper_assets/brandwatch/schemas/youtube_stats.py
@@ -1,0 +1,35 @@
+import datetime as dt
+
+from interloper.schema import Schema
+from pydantic import Field
+
+
+class YoutubeStats(Schema):
+    """YouTube channel performance metrics per day (Brandwatch/Falcon.io Measure)."""
+
+    date: dt.date | None = Field(default=None, description="The date the metrics correspond to.")
+    channel_id: str | None = Field(default=None, description="Unique identifier for the Facebook Page.")
+    fans: int | None = Field(default=None, description="Total number of subscribers (synonymous with 'followers').")
+    followers: int | None = Field(default=None, description="Total number of channel subscribers.")
+    net_fans: int | None = Field(default=None, description="Net change in fans/subscribers (New - Lost).")
+    net_followers: int | None = Field(default=None, description="Net change in channel subscribers.")
+    video_views: int | None = Field(default=None, description="Total number of times videos were viewed.")
+    video_view_time: float | None = Field(
+        default=None, description="Total accumulated video view time, typically in minutes or seconds."
+    )
+    engagements: int | None = Field(
+        default=None, description="Total number of all engagement actions (e.g., likes, dislikes, comments, shares)."
+    )
+    interactions: int | None = Field(default=None, description="A general count of interactions.")
+    comments: int | None = Field(default=None, description="Total number of comments on videos.")
+    likes: int | None = Field(default=None, description="Total number of 'Likes' on videos (Thumbs Up).")
+    shares: int | None = Field(default=None, description="Total number of times videos were shared.")
+    reactions: int | None = Field(
+        default=None, description="Total count of all reactions (usually likes/dislikes/emojis)."
+    )
+    reactions_by_type_anger: int | None = Field(default=None, description="Number of 'Anger' reactions/emojis.")
+    reactions_by_type_haha: int | None = Field(default=None, description="Number of 'Haha' reactions/emojis.")
+    reactions_by_type_like: int | None = Field(default=None, description="Number of 'Like' reactions/emojis.")
+    reactions_by_type_love: int | None = Field(default=None, description="Number of 'Love' reactions/emojis.")
+    reactions_by_type_sorry: int | None = Field(default=None, description="Number of 'Sorry/Sad' reactions/emojis.")
+    reactions_by_type_wow: int | None = Field(default=None, description="Number of 'Wow' reactions/emojis.")

--- a/packages/interloper-assets/src/interloper_assets/brandwatch/source.py
+++ b/packages/interloper-assets/src/interloper_assets/brandwatch/source.py
@@ -1,15 +1,185 @@
+import asyncio
+import datetime as dt
+import logging
+from typing import Any
 
 import interloper as il
+from interloper_pandas import DataFrameNormalizer
 
+from interloper_assets.brandwatch import constants, schemas
 from interloper_assets.brandwatch.connection import BrandwatchConnection
 
+logger = logging.getLogger(__name__)
+
+_Record = dict[str, Any]
+
+# Insights reports queue server-side; poll until READY.
+_POLL_INTERVAL = 3.0  # seconds between status polls
+_POLL_TIMEOUT = 600.0  # 10 minutes
+
+
+# -- HELPERS -------------------------------------------------------------------
+def _clean_metric(metric_id: str) -> str:
+    """Map a Measure metric id to its schema column.
+
+    ``channel/reactions_by_type/anger/day`` -> ``reactions_by_type_anger``.
+    """
+    return metric_id.removeprefix("channel/").removesuffix("/day").replace("/", "_")
+
+
+async def _request_insights(
+    client: il.AsyncRESTClient, channel_id: str, metric_ids: list[str], start: dt.date, end: dt.date
+) -> str:
+    """Request a channel-insights report and return its request id."""
+    response = await client.post(
+        "/channel",
+        json={
+            "since": start.isoformat(),
+            "until": end.isoformat(),
+            "channelIds": [channel_id],
+            "metricIds": metric_ids,
+        },
+    )
+    response.raise_for_status()
+    return response.json()["insightsRequestId"]
+
+
+async def _wait_until_ready(client: il.AsyncRESTClient, request_id: str) -> None:
+    """Poll a report until it is READY, raising on failure or timeout."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + _POLL_TIMEOUT
+    while True:
+        response = await client.get(f"/{request_id}")
+        response.raise_for_status()
+        status = response.json().get("status")
+
+        if status == "READY":
+            return
+        if status and status != "IN_PROGRESS":
+            raise RuntimeError(f"Insights request {request_id} failed with status {status}")
+
+        if loop.time() >= deadline:
+            raise RuntimeError(f"Insights request {request_id} not ready within {_POLL_TIMEOUT:.0f}s")
+        await asyncio.sleep(_POLL_INTERVAL)
+
+
+async def _fetch_insights_data(client: il.AsyncRESTClient, request_id: str) -> dict[str, list]:
+    """Page through a ready report, merging each metric's daily points."""
+    merged: dict[str, list] = {}
+    page = 1
+    while True:
+        response = await client.get(f"/{request_id}", params={"page": page})
+        response.raise_for_status()
+        data = response.json()["data"]
+        for metric_id, points in (data.get("insights") or {}).items():
+            merged.setdefault(metric_id, []).extend(points or [])
+        next_page = (data.get("paging") or {}).get("nextPage")
+        if not next_page:
+            break
+        page = next_page
+    return merged
+
+
+async def _get_channel_insights(
+    connection: BrandwatchConnection, channel_id: str, network: str, start: dt.date, end: dt.date
+) -> dict[str, list]:
+    """Fetch all of a network's metrics for a channel, batched by the per-request cap."""
+    metric_ids = constants.NETWORK_METRICS[network]
+    merged: dict[str, list] = {}
+    for i in range(0, len(metric_ids), constants.MAX_METRICS_PER_REQUEST):
+        batch = metric_ids[i : i + constants.MAX_METRICS_PER_REQUEST]
+        logger.info(f"Requesting {network} insights for channel {channel_id} ({len(batch)} metrics)")
+        request_id = await _request_insights(connection.client, channel_id, batch, start, end)
+        await _wait_until_ready(connection.client, request_id)
+        for metric_id, points in (await _fetch_insights_data(connection.client, request_id)).items():
+            merged.setdefault(metric_id, []).extend(points)
+    return merged
+
+
+def _reshape(insights: dict[str, list], channel_id: str, fallback_date: dt.date) -> list[_Record]:
+    """Pivot metric→daily-points into one row per day keyed by the schema columns.
+
+    Each Measure point is ``{"value", "date", "channelId"}``; collect them into a
+    row per date, filling ``date``/``channel_id`` once and each metric's value
+    under its cleaned column name.
+    """
+    rows: dict[Any, _Record] = {}
+    for metric_id, points in insights.items():
+        column = _clean_metric(metric_id)
+        for point in points or []:
+            if not isinstance(point, dict):
+                continue
+            day = point.get("date") or fallback_date
+            row = rows.setdefault(day, {"channel_id": channel_id, "date": day})
+            row[column] = point.get("value")
+    return list(rows.values())
+
+
 # -- SOURCE --------------------------------------------------------------------
-
-
 @il.source(
     resources={"connection": BrandwatchConnection},
     tags=["Social Media"],
     icon="fluent:connector-24-filled",
+    normalizer=DataFrameNormalizer(),
 )
 class Brandwatch(il.Source):
     """Brandwatch (Falcon.io) social media analytics integration."""
+
+    channel_id: str = il.InputField(
+        title="Channel ID",
+        description="Falcon.io channel id (a connected social profile)",
+        discriminator=True,
+    )
+
+    async def _network_stats(
+        self, context: il.ExecutionContext, connection: BrandwatchConnection, network: str
+    ) -> list[_Record]:
+        insights = await _get_channel_insights(
+            connection, self.channel_id, network, context.partition_date, context.partition_date
+        )
+        return _reshape(insights, self.channel_id, context.partition_date)
+
+    @il.asset(
+        schema=schemas.FacebookStats,
+        partitioning=il.TimePartitionConfig(column="date"),
+        tags=["Report"],
+    )
+    async def facebook_stats(self, context: il.ExecutionContext, connection: BrandwatchConnection) -> list[_Record]:
+        """Facebook channel performance metrics per day."""
+        return await self._network_stats(context, connection, "facebook")
+
+    @il.asset(
+        schema=schemas.InstagramStats,
+        partitioning=il.TimePartitionConfig(column="date"),
+        tags=["Report"],
+    )
+    async def instagram_stats(self, context: il.ExecutionContext, connection: BrandwatchConnection) -> list[_Record]:
+        """Instagram channel performance metrics per day."""
+        return await self._network_stats(context, connection, "instagram")
+
+    @il.asset(
+        schema=schemas.LinkedinStats,
+        partitioning=il.TimePartitionConfig(column="date"),
+        tags=["Report"],
+    )
+    async def linkedin_stats(self, context: il.ExecutionContext, connection: BrandwatchConnection) -> list[_Record]:
+        """LinkedIn channel performance metrics per day."""
+        return await self._network_stats(context, connection, "linkedin")
+
+    @il.asset(
+        schema=schemas.TwitterStats,
+        partitioning=il.TimePartitionConfig(column="date"),
+        tags=["Report"],
+    )
+    async def twitter_stats(self, context: il.ExecutionContext, connection: BrandwatchConnection) -> list[_Record]:
+        """X (Twitter) channel performance metrics per day."""
+        return await self._network_stats(context, connection, "twitter")
+
+    @il.asset(
+        schema=schemas.YoutubeStats,
+        partitioning=il.TimePartitionConfig(column="date"),
+        tags=["Report"],
+    )
+    async def youtube_stats(self, context: il.ExecutionContext, connection: BrandwatchConnection) -> list[_Record]:
+        """YouTube channel performance metrics per day."""
+        return await self._network_stats(context, connection, "youtube")

--- a/packages/interloper-assets/tests/test_brandwatch.py
+++ b/packages/interloper-assets/tests/test_brandwatch.py
@@ -1,0 +1,108 @@
+"""Regression tests for the Brandwatch (Falcon.io) source.
+
+The Measure API returns metrics keyed like ``channel/reactions_by_type/anger/day``
+with daily ``{value, date, channelId}`` points. The source cleans each metric id
+to its schema column and pivots the points into one row per day, then the
+source-level ``DataFrameNormalizer`` conforms it — a chain that must survive the
+host→child DAG-spec round-trip.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any
+
+from interloper.dag import DAGSpec
+from interloper.dag.base import DAG
+from interloper.representation import Representation
+from interloper_pandas import DataFrameNormalizer
+
+from interloper_assets.brandwatch import constants, schemas
+from interloper_assets.brandwatch.source import Brandwatch, _clean_metric, _reshape
+
+_ASSET_KEY = "facebook_stats"
+
+_NETWORK_SCHEMA = {
+    "facebook": schemas.FacebookStats,
+    "instagram": schemas.InstagramStats,
+    "linkedin": schemas.LinkedinStats,
+    "twitter": schemas.TwitterStats,
+    "youtube": schemas.YoutubeStats,
+}
+
+
+def _source() -> Any:
+    return Brandwatch(id="src-1", channel_id="chan-1")  # ty: ignore[unknown-argument]
+
+
+class TestMetricSchemaCoverage:
+    """Every configured metric id must map to a column on its network schema."""
+
+    def test_cleaned_metrics_are_schema_fields(self):
+        for network, metric_ids in constants.NETWORK_METRICS.items():
+            fields = set(_NETWORK_SCHEMA[network].model_fields)
+            cleaned = [_clean_metric(m) for m in metric_ids]
+            assert len(cleaned) == len(set(cleaned)), f"{network}: duplicate cleaned metric names"
+            missing = [c for c in cleaned if c not in fields]
+            assert not missing, f"{network}: metrics with no schema field: {missing}"
+
+    def test_clean_metric_handles_nested_paths(self):
+        assert _clean_metric("channel/fans/day") == "fans"
+        assert _clean_metric("channel/reactions_by_type/anger/day") == "reactions_by_type_anger"
+        assert _clean_metric("channel/views_by_logged_in_out/logged_in/day") == "views_by_logged_in_out_logged_in"
+
+
+class TestReshape:
+    """Daily points pivot into one row per day keyed by schema columns."""
+
+    def test_reshape_pivots_and_conforms(self):
+        insights = {
+            "channel/fans/day": [{"value": 1000, "date": "2026-07-10", "channelId": "chan-1"}],
+            "channel/views_by_logged_in_out/logged_in/day": [
+                {"value": 42, "date": "2026-07-10", "channelId": "chan-1"}
+            ],
+            "channel/engagement_rate/day": [{"value": 0.12, "date": "2026-07-10", "channelId": "chan-1"}],
+        }
+        rows = _reshape(insights, "chan-1", dt.date(2026, 7, 10))
+        assert len(rows) == 1
+        assert rows[0]["channel_id"] == "chan-1"
+        assert rows[0]["fans"] == 1000
+        assert rows[0]["views_by_logged_in_out_logged_in"] == 42
+
+        normalized = DataFrameNormalizer().normalize(rows)
+        conformer = Representation.of(normalized).conformer
+        df = conformer.reconcile(normalized, schemas.FacebookStats)
+        conformer.validate(df, schemas.FacebookStats)  # must not raise
+        record = df.to_dict("records")[0]
+        assert record["date"] == dt.date(2026, 7, 10)
+        assert record["engagement_rate"] == 0.12
+
+    def test_reshape_falls_back_to_partition_date(self):
+        insights = {"channel/fans/day": [{"value": 5, "channelId": "chan-1"}]}
+        rows = _reshape(insights, "chan-1", dt.date(2026, 7, 10))
+        assert rows[0]["date"] == dt.date(2026, 7, 10)
+
+
+class TestSourceNormalizer:
+    """The decorator-configured normalizer must reach every asset instance."""
+
+    def test_source_instance_has_dataframe_normalizer(self):
+        assert isinstance(_source().normalizer, DataFrameNormalizer)
+
+    def test_all_assets_inherit_the_normalizer(self):
+        src = _source()
+        assert len(src.assets) == 5
+        for asset in src.assets:
+            assert isinstance(asset.normalizer, DataFrameNormalizer), type(asset).key
+
+
+class TestSpecRoundtrip:
+    """The host→child spec round-trip must preserve the normalizer subclass."""
+
+    def test_child_asset_keeps_dataframe_normalizer(self):
+        src = _source()
+        asset = next(a for a in src.assets if type(a).key == _ASSET_KEY)
+        spec_json = DAG(src).mini_dag(asset.id).to_spec().model_dump(mode="json")
+        child_dag = DAGSpec(**spec_json).reconstruct()
+        child_asset = next(a for a in child_dag.assets if type(a).key == _ASSET_KEY)
+        assert isinstance(child_asset.normalizer, DataFrameNormalizer)


### PR DESCRIPTION
## What

Adds the **Brandwatch (Falcon.io) Measure API** source to `interloper-assets`, ported from the `digitlcloud-connectors` reference. Modelled as **five per-network report assets**, each with its own schema, time-partitioned on `date`:

- `facebook_stats` (42 fields), `instagram_stats` (83), `linkedin_stats` (30), `twitter_stats` (11), `youtube_stats` (20).

Per-network assets (rather than one discriminated asset) mirror how `amazon_ads` splits report types, since each network has a distinct metric set / schema.

## How

- **`api_key` on the connection; `channel_id` as a source discriminator** — the credential-on-connection / entity-on-source idiom used by `amazon_ads`, `awin`, and `impact`. (This restructures the earlier scaffold, which had `channel_id` + `network` on the connection — unworkable once each network needs its own schema.)
- **Async flow per network**, batched by the API's 20-metrics-per-request cap: request insights → poll `/{requestId}` until `READY` → paginate `/{requestId}?page=N`, merging each metric's daily points.
- **Metric-id cleanup + pivot** — `channel/reactions_by_type/anger/day` → `reactions_by_type_anger`; the daily `{value, date, channelId}` points are pivoted into one row per day keyed by the schema columns.
- **Schemas** generated from the reference JSON field sets (all nullable).

## Tests

`tests/test_brandwatch.py` (7 tests): a coverage guard that **every configured metric id cleans to a real schema field** (checked across all 5 networks — no gaps, no dupes), the reshape/pivot + conform, the partition-date fallback, and the host→child DAG-spec normalizer round-trip. `ruff` + `ty` + `pytest` all pass.

## Reviewer notes — needs verification

- **The API-key query-parameter name (`param_key`) is unverified.** It's carried over verbatim from the reference connector and looks like a placeholder — Falcon likely expects `apikey`. I couldn't confirm: the Falcon Apiary docs are JS-rendered (unfetchable) and there are **no Brandwatch credentials available**, so the source is **not yet live-tested**. It's flagged in a code comment in `connection.py`. Please confirm the param name (and ideally smoke-test) with a live key before relying on this.
- All schema fields are nullable, so metrics absent for a given channel/day simply come back null rather than failing conform.

By Digitl