### PR TITLE
feat(app): preview "used by" in delete confirmations

### DIFF
--- a/packages/interloper-app/app/app/components/collection/Table.vue
+++ b/packages/interloper-app/app/app/components/collection/Table.vue
@@ -74,6 +74,11 @@ const emit = defineEmits<{
 
 async function deleteSource(sourceId: string) {
     const info = sourceInfoById.value.get(sourceId)
+    const referrers = componentsStore.usedBy(sourceId)
+    if (referrers.length) {
+        toast.add(inUseToastPayload('Source', referrers))
+        return
+    }
     const confirmed = await confirm({
         title: 'Delete source?',
         description: `This will permanently delete "${info?.name ?? 'this source'}" and all its assets.`,

--- a/packages/interloper-app/app/app/components/ui/DataTable.vue
+++ b/packages/interloper-app/app/app/components/ui/DataTable.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts" generic="TData extends { id: string }, TValue">
 import type { TableColumn, DropdownMenuItem } from '@nuxt/ui'
 import { getPaginationRowModel } from '@tanstack/vue-table'
+import type { UsedByRef } from '~/utils/apiErrors'
 
 const PAGE_SIZE = 20
 
@@ -13,6 +14,12 @@ const props = defineProps<{
     rowActions?: (item: TData) => DropdownMenuItem[][]
     /** When true, suppresses the built-in actions column and row menus. */
     noActions?: boolean
+    /**
+     * Referrers still bound to the given ids (e.g. `componentsStore.usedBy`).
+     * When it returns any, the delete confirmation lists them and disables
+     * the destructive button — the backend guard stays the authority.
+     */
+    usedBy?: (ids: string[]) => UsedByRef[]
 }>()
 
 const emit = defineEmits<{
@@ -43,6 +50,13 @@ const totalCount = computed<number>(() =>
 function selectedIds(): string[] {
     return tableRef.value?.tableApi?.getFilteredSelectedRowModel().rows.map((row: any) => row.original.id) ?? []
 }
+
+const bulkReferrers = computed<UsedByRef[]>(() =>
+    showDeleteModal.value ? props.usedBy?.(selectedIds()) ?? [] : [],
+)
+const oneReferrers = computed<UsedByRef[]>(() =>
+    deleteOneItem.value ? props.usedBy?.([deleteOneItem.value.id]) ?? [] : [],
+)
 
 function confirmBulkDelete() {
     emit('delete', selectedIds())
@@ -156,7 +170,11 @@ const showEmpty = computed(() => hasLoaded.value && props.data.length === 0 && !
 
                     <template #body>
                         <div class="space-y-4">
-                            <p>
+                            <p v-if="bulkReferrers.length">
+                                Still in use by: <span class="font-medium">{{ usedByNames(bulkReferrers) }}</span>.
+                                Rebind or delete those first.
+                            </p>
+                            <p v-else>
                                 This will permanently delete {{ selectedCount }} {{ selectedCount === 1 ? 'item' :
                                     'items' }}. This action cannot be undone.
                             </p>
@@ -165,6 +183,7 @@ const showEmpty = computed(() => hasLoaded.value && props.data.length === 0 && !
                                          @click="showDeleteModal = false" />
                                 <UButton color="error"
                                          label="Delete"
+                                         :disabled="bulkReferrers.length > 0"
                                          @click="confirmBulkDelete" />
                             </div>
                         </div>
@@ -216,7 +235,11 @@ const showEmpty = computed(() => hasLoaded.value && props.data.length === 0 && !
             <template #default />
             <template #body>
                 <div class="space-y-4">
-                    <p>
+                    <p v-if="oneReferrers.length">
+                        Still in use by: <span class="font-medium">{{ usedByNames(oneReferrers) }}</span>.
+                        Rebind or delete those first.
+                    </p>
+                    <p v-else>
                         This will permanently delete this item. This action cannot be undone.
                     </p>
                     <div class="flex justify-end gap-2">
@@ -224,6 +247,7 @@ const showEmpty = computed(() => hasLoaded.value && props.data.length === 0 && !
                                  @click="showDeleteOneModal = false" />
                         <UButton color="error"
                                  label="Delete"
+                                 :disabled="oneReferrers.length > 0"
                                  @click="confirmDeleteOne" />
                     </div>
                 </div>

--- a/packages/interloper-app/app/app/components/ui/DataTable.vue
+++ b/packages/interloper-app/app/app/components/ui/DataTable.vue
@@ -170,10 +170,10 @@ const showEmpty = computed(() => hasLoaded.value && props.data.length === 0 && !
 
                     <template #body>
                         <div class="space-y-4">
-                            <p v-if="bulkReferrers.length">
-                                Still in use by: <span class="font-medium">{{ usedByNames(bulkReferrers) }}</span>.
-                                Rebind or delete those first.
-                            </p>
+                            <template v-if="bulkReferrers.length">
+                                <p>Still in use — rebind or delete these first:</p>
+                                <UsedByTable :referrers="bulkReferrers" />
+                            </template>
                             <p v-else>
                                 This will permanently delete {{ selectedCount }} {{ selectedCount === 1 ? 'item' :
                                     'items' }}. This action cannot be undone.
@@ -235,10 +235,10 @@ const showEmpty = computed(() => hasLoaded.value && props.data.length === 0 && !
             <template #default />
             <template #body>
                 <div class="space-y-4">
-                    <p v-if="oneReferrers.length">
-                        Still in use by: <span class="font-medium">{{ usedByNames(oneReferrers) }}</span>.
-                        Rebind or delete those first.
-                    </p>
+                    <template v-if="oneReferrers.length">
+                        <p>Still in use — rebind or delete these first:</p>
+                        <UsedByTable :referrers="oneReferrers" />
+                    </template>
                     <p v-else>
                         This will permanently delete this item. This action cannot be undone.
                     </p>

--- a/packages/interloper-app/app/app/components/ui/UsedByTable.vue
+++ b/packages/interloper-app/app/app/components/ui/UsedByTable.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import type { UsedByRef } from '~/utils/apiErrors'
+
+defineProps<{ referrers: UsedByRef[] }>()
+</script>
+
+<template>
+    <div class="border border-default rounded-lg divide-y divide-default overflow-hidden">
+        <div v-for="r in referrers"
+             :key="r.id"
+             class="flex items-center gap-2 px-3 py-2 text-sm">
+            <UIcon :name="componentIcon(r.key)"
+                   class="size-4 shrink-0 text-muted" />
+            <span class="font-medium truncate">{{ r.name ?? r.key }}</span>
+            <span class="ml-auto text-xs text-muted capitalize shrink-0">{{ r.kind }}</span>
+        </div>
+    </div>
+</template>

--- a/packages/interloper-app/app/app/pages/collection.vue
+++ b/packages/interloper-app/app/app/pages/collection.vue
@@ -63,13 +63,13 @@ function onCloseAnimationEnd() {
 // Fired in setup so `loading` flags are set before the first render
 // (gates the empty placeholder without a flash).
 componentsStore.fetchAll()
-componentsStore.fetchRelations('dependency')
+componentsStore.fetchRelations()
 runsStore.fetch()
 if (!catalogStore.loaded) catalogStore.fetchCatalog()
 
 function handleSaved() {
     componentsStore.fetchAll()
-    componentsStore.fetchRelations('dependency')
+    componentsStore.fetchRelations()
     drawerOpen.value = false
 }
 

--- a/packages/interloper-app/app/app/pages/destinations.vue
+++ b/packages/interloper-app/app/app/pages/destinations.vue
@@ -27,7 +27,8 @@ const {
 } = useWizardDrawer<ComponentRecord>()
 
 // Resource kinds too — the Connection column resolves resource names by id.
-componentsStore.fetchAll(['destination', ...catalogStore.resourceKinds])
+componentsStore.fetchAll()
+componentsStore.fetchRelations()
 
 function typeIcon(key: string): string {
     return componentIcon(key, 'i-lucide-hard-drive')
@@ -102,6 +103,7 @@ function handleSaved() {
             <DataTable :columns="columns"
                        :data="destinations"
                        :loading="componentsStore.loading"
+                       :used-by="componentsStore.usedBy"
                        search-placeholder="Search destinations..."
                        @delete="handleDelete"
                        @edit="handleEdit">

--- a/packages/interloper-app/app/app/pages/graph.vue
+++ b/packages/interloper-app/app/app/pages/graph.vue
@@ -37,7 +37,7 @@ const statusCounts = computed<Record<StatusFilter, number>>(() => {
 onMounted(() => {
     if (!componentsStore.loading) {
         componentsStore.fetchAll()
-        componentsStore.fetchRelations('dependency')
+        componentsStore.fetchRelations()
     }
 })
 
@@ -48,7 +48,7 @@ function onEditSource(sourceId: string) {
 
 function handleSaved() {
     componentsStore.fetchAll()
-    componentsStore.fetchRelations('dependency')
+    componentsStore.fetchRelations()
     sourceDrawerOpen.value = false
 }
 
@@ -80,6 +80,11 @@ function onCloseAnimationEnd() {
 
 async function onDeleteSource(sourceId: string) {
     const source = componentsStore.byId(sourceId)
+    const referrers = componentsStore.usedBy(sourceId)
+    if (referrers.length) {
+        toast.add(inUseToastPayload('Source', referrers))
+        return
+    }
     try {
         await componentsStore.remove(sourceId)
         toast.add({ title: `Source "${source?.name ?? 'Source'}" deleted`, color: 'success' })

--- a/packages/interloper-app/app/app/pages/hooks.vue
+++ b/packages/interloper-app/app/app/pages/hooks.vue
@@ -25,7 +25,8 @@ const {
     openEdit: handleEdit,
 } = useWizardDrawer<ComponentRecord>()
 
-componentsStore.fetchAll(['hook', 'source', 'asset', 'job'])
+componentsStore.fetchAll()
+componentsStore.fetchRelations()
 
 const columns = computed<TableColumn<ComponentRecord>[]>(() => [
     { accessorKey: 'select' as any, header: '' },
@@ -108,6 +109,7 @@ async function handleDelete(ids: string[]) {
             <DataTable :columns="columns"
                        :data="hooks"
                        :loading="componentsStore.loading"
+                       :used-by="componentsStore.usedBy"
                        search-placeholder="Search hooks..."
                        @delete="handleDelete"
                        @edit="handleEdit">

--- a/packages/interloper-app/app/app/pages/jobs.vue
+++ b/packages/interloper-app/app/app/pages/jobs.vue
@@ -27,7 +27,8 @@ const {
 const runModalOpen = ref(false)
 const runModalJob = ref<ComponentRecord | null>(null)
 
-componentsStore.fetchAll(['job', 'source'])
+componentsStore.fetchAll()
+componentsStore.fetchRelations()
 
 function cronLabel(cron: string): string {
     try {
@@ -129,6 +130,7 @@ async function handleDelete(ids: string[]) {
                        :data="jobs"
                        :loading="componentsStore.loading"
                        :row-actions="rowActions"
+                       :used-by="componentsStore.usedBy"
                        search-placeholder="Search jobs..."
                        @delete="handleDelete"
                        @edit="handleEdit">

--- a/packages/interloper-app/app/app/pages/resources/[kind].vue
+++ b/packages/interloper-app/app/app/pages/resources/[kind].vue
@@ -38,8 +38,11 @@ const {
     openEdit: handleEdit,
 } = useWizardDrawer<ComponentRecord>()
 
-// Re-fetch when kind changes
-watch(kind, () => componentsStore.fetchAll([kind.value]), { immediate: true })
+// Everything once — the delete preview needs referrer records and relations
+// of every kind — then a per-kind refresh when switching resource kinds.
+componentsStore.fetchAll()
+componentsStore.fetchRelations()
+watch(kind, () => componentsStore.fetchAll([kind.value]))
 
 const columns: TableColumn<ComponentRecord>[] = [
     { accessorKey: 'select' as any, header: '' },
@@ -106,6 +109,7 @@ const emptyCopy = computed(() => EMPTY_COPY[kind.value] ?? {
             <DataTable :columns="columns"
                        :data="resources"
                        :loading="componentsStore.loading"
+                       :used-by="componentsStore.usedBy"
                        :search-placeholder="`Search ${pageTitle.toLowerCase()}...`"
                        @delete="handleDelete"
                        @edit="handleEdit">

--- a/packages/interloper-app/app/app/pages/sources.vue
+++ b/packages/interloper-app/app/app/pages/sources.vue
@@ -32,7 +32,8 @@ const {
     openEdit: handleEdit,
 } = useWizardDrawer<ComponentRecord>()
 
-componentsStore.fetchAll(['source', 'destination'])
+componentsStore.fetchAll()
+componentsStore.fetchRelations()
 
 // ── Run now ─────────────────────────────────────────────────────
 
@@ -158,6 +159,7 @@ async function handleDelete(ids: string[]) {
                        :data="sources"
                        :loading="componentsStore.loading"
                        :row-actions="rowActions"
+                       :used-by="componentsStore.usedBy"
                        search-placeholder="Search sources..."
                        @delete="handleDelete"
                        @edit="handleEdit">

--- a/packages/interloper-app/app/app/stores/components.ts
+++ b/packages/interloper-app/app/app/stores/components.ts
@@ -143,6 +143,27 @@ export const useComponentsStore = defineStore('components', () => {
         return components.value.find(c => c.id === id)
     }
 
+    /**
+     * Components outside `ids` (and their children) that hold relations into
+     * them — the client-side mirror of the API's delete guard, used to preview
+     * "used by" before a delete is attempted. Referrers that are source-owned
+     * assets resolve to their parent source, the unit the user can act on.
+     */
+    function usedBy(ids: string | string[]): ComponentRecord[] {
+        const subtree = new Set(Array.isArray(ids) ? ids : [ids])
+        for (const id of [...subtree]) {
+            for (const child of byId(id)?.children ?? []) subtree.add(child.id)
+        }
+        const referrers = new Map<string, ComponentRecord>()
+        for (const r of relations.value) {
+            if (!subtree.has(r.dst_id) || subtree.has(r.src_id)) continue
+            let src = byId(r.src_id)
+            if (src?.parent_id && !subtree.has(src.parent_id)) src = byId(src.parent_id) ?? src
+            if (src && !subtree.has(src.id)) referrers.set(src.id, src)
+        }
+        return [...referrers.values()]
+    }
+
     function search(query: string, kind?: string): ComponentRecord[] {
         const base = kind ? byKind(kind) : components.value
         if (!query) return base
@@ -224,6 +245,7 @@ export const useComponentsStore = defineStore('components', () => {
         fetchPartitionRowCounts,
         byKind,
         byId,
+        usedBy,
         search,
         _upsert,
         _remove,

--- a/packages/interloper-app/app/app/utils/apiErrors.ts
+++ b/packages/interloper-app/app/app/utils/apiErrors.ts
@@ -21,16 +21,20 @@ export function usedByNames(refs: UsedByRef[]): string {
     return refs.map(r => r.name ?? r.key).join(', ')
 }
 
+/** Toast payload naming an entity's referrers (pre-flight checks and 409 handling share the copy). */
+export function inUseToastPayload(entity: string, refs: UsedByRef[]): { title: string, description: string, color: 'error' } {
+    return {
+        title: `${entity} is in use`,
+        description: `Used by: ${usedByNames(refs)}. Rebind or delete those first.`,
+        color: 'error',
+    }
+}
+
 /**
  * Toast payload for a 409 in-use delete failure, or `null` for any other
  * error (callers fall back to their generic failure toast).
  */
 export function inUseToast(e: unknown, entity: string): { title: string, description: string, color: 'error' } | null {
     const usedBy = usedByFromError(e)
-    if (!usedBy) return null
-    return {
-        title: `${entity} is in use`,
-        description: `Used by: ${usedByNames(usedBy)}. Rebind or delete those first.`,
-        color: 'error',
-    }
+    return usedBy ? inUseToastPayload(entity, usedBy) : null
 }


### PR DESCRIPTION
## What

Follow-up to #157. The delete confirmations still promised *"this will permanently delete"* even when the backend would refuse with 409. The referrer preview now happens **before** the attempt:

- `componentsStore.usedBy(ids)` — client-side mirror of the API's delete guard (in-bound relations into the ids and their children, intra-subtree edges excluded, source-owned referrers resolved to their parent source).
- `DataTable`'s single and bulk delete modals take an optional `used-by` callback: when it returns referrers, the modal shows *"Still in use by: X, Y. Rebind or delete those first."* and **disables** the destructive button. Wired on the sources, destinations, jobs, hooks, and resources pages.
- The collection table and graph delete flows (which use `confirm()`) short-circuit to the in-use toast instead of offering a doomed confirmation.
- Delete-surface pages now fetch all components + relations up front — the preview needs referrer records of every kind (a connections page that never loaded sources couldn't name them). Realtime subscriptions keep both fresh afterwards.

The backend 409 remains the authority; the preview is UX only and race-safe.

## Verified live

Headless Chrome against a seeded dev instance: bound connection → dialog lists the source and Delete is disabled; unbound connection → normal destructive dialog; job-targeted source → dialog lists the job. Fixtures cleaned up.

By Digitl