### PR TITLE
feat(assets): add Campaign Manager 360 source

### DIFF
--- a/packages/interloper-assets/src/interloper_assets/campaign_manager_360/connection.py
+++ b/packages/interloper-assets/src/interloper_assets/campaign_manager_360/connection.py
@@ -1,8 +1,12 @@
+import asyncio
+import json
 from functools import cached_property
 from typing import Any
 
 import interloper as il
 from pydantic_settings import SettingsConfigDict
+
+from interloper_assets.campaign_manager_360 import constants
 
 
 @il.connection(
@@ -21,17 +25,38 @@ class CampaignManager360Connection(il.Connection):
     @cached_property
     def client(self) -> Any:
         """Build the Campaign Manager 360 (DFA Reporting) API service client."""
-        import json
-
         from google.oauth2 import service_account
         from googleapiclient.discovery import build
 
-        key_data = json.loads(self.service_account_key)
-        scopes = [
-            "https://www.googleapis.com/auth/dfareporting",
-            "https://www.googleapis.com/auth/dfatrafficking",
-            "https://www.googleapis.com/auth/cloud-platform",
-        ]
-        credentials = service_account.Credentials.from_service_account_info(key_data, scopes=scopes)
+        credentials = service_account.Credentials.from_service_account_info(
+            json.loads(self.service_account_key),
+            scopes=constants.SCOPES,
+        )
+        return build(constants.API_SERVICE, constants.API_VERSION, credentials=credentials)
 
-        return build("dfareporting", "v4", credentials=credentials)
+    @il.fetch_field_provider
+    async def profiles(self) -> list[dict[str, str]]:
+        """Fetch the CM360 user profiles the service account has access to.
+
+        Each profile carries both the profile id and its account id/name, so the
+        same lookup feeds the source's ``profile_id`` and ``account_id`` fields.
+        """
+        response = await asyncio.to_thread(lambda: self.client.userProfiles().list().execute())
+        return [
+            {
+                "profile_id": str(p["profileId"]),
+                "account_id": str(p["accountId"]),
+                "name": f"{p.get('userName', p['profileId'])} ({p.get('accountName', p['accountId'])})",
+                "account_name": f"{p.get('accountName', p['accountId'])} ({p['accountId']})",
+            }
+            for p in response.get("items", [])
+        ]
+
+    async def check(self) -> bool:
+        """Prove the credentials work by running the ``profiles`` lookup.
+
+        Returns:
+            True — any credential failure raises out of the lookup.
+        """
+        await self.profiles()
+        return True

--- a/packages/interloper-assets/src/interloper_assets/campaign_manager_360/constants.py
+++ b/packages/interloper-assets/src/interloper_assets/campaign_manager_360/constants.py
@@ -1,3 +1,11 @@
+API_SERVICE = "dfareporting"
+API_VERSION = "v5"
+
+SCOPES = [
+    "https://www.googleapis.com/auth/dfareporting",
+    "https://www.googleapis.com/auth/dfatrafficking",
+]
+
 CAMPAIGN_DIMENSIONS = [
     "date",
     "campaignStartDate",

--- a/packages/interloper-assets/src/interloper_assets/campaign_manager_360/schemas/__init__.py
+++ b/packages/interloper-assets/src/interloper_assets/campaign_manager_360/schemas/__init__.py
@@ -1,0 +1,11 @@
+from .ads_stats import AdsStats
+from .campaigns_stats import CampaignsStats
+from .custom_audiences import CustomAudiences
+from .reach_stats import ReachStats
+
+__all__ = [
+    "AdsStats",
+    "CampaignsStats",
+    "CustomAudiences",
+    "ReachStats",
+]

--- a/packages/interloper-assets/src/interloper_assets/campaign_manager_360/schemas/ads_stats.py
+++ b/packages/interloper-assets/src/interloper_assets/campaign_manager_360/schemas/ads_stats.py
@@ -1,0 +1,86 @@
+import datetime as dt
+
+from interloper.schema import Schema
+from pydantic import Field
+
+
+class AdsStats(Schema):
+    """Ad performance metrics per day (CM360 STANDARD report at ad/placement/creative grain)."""
+
+    active_view_average_viewable_time_seconds: float | None = Field(
+        default=None, description="Active View Average Viewable Time (Seconds)"
+    )
+    active_view_measurable_impressions: int | None = Field(
+        default=None, description="Active View Measurable Impressions"
+    )
+    active_view_pct_viewable_impressions: float | None = Field(
+        default=None, description="Active View Percentage of Viewable Impressions"
+    )
+    active_view_pct_visible_at_completion: float | None = Field(
+        default=None, description="Active View Percentage Visible at Completion"
+    )
+    active_view_viewable_impressions: int | None = Field(default=None, description="Active View Viewable Impressions")
+    activity: str | None = Field(default=None, description="Activity")
+    activity_id: str | None = Field(default=None, description="Activity ID")
+    ad: str | None = Field(default=None, description="Ad")
+    ad_id: str | None = Field(default=None, description="Ad ID")
+    ad_status: str | None = Field(default=None, description="Ad Status")
+    advertiser: str | None = Field(default=None, description="Name of the advertiser")
+    advertiser_id: str | None = Field(default=None, description="ID of the advertiser")
+    booked_activities: float | None = Field(default=None, description="Booked Activities")
+    booked_clicks: float | None = Field(default=None, description="Booked Clicks")
+    booked_impressions: float | None = Field(default=None, description="Booked Impressions")
+    booked_viewable_impressions: float | None = Field(default=None, description="Booked Viewable Impressions")
+    campaign: str | None = Field(default=None, description="Name of the campaign")
+    campaign_end_date: dt.date | None = Field(default=None, description="End date of the campaign")
+    campaign_id: str | None = Field(default=None, description="ID of the campaign")
+    campaign_start_date: dt.date | None = Field(default=None, description="Start date of the campaign")
+    click_rate: float | None = Field(default=None, description="Click Rate")
+    click_through_conversions: float | None = Field(default=None, description="Click-Through Conversions")
+    click_through_revenue: float | None = Field(default=None, description="Click-Through Revenue")
+    clicks: int | None = Field(default=None, description="Clicks")
+    companion_clicks: int | None = Field(default=None, description="Companion Clicks")
+    companion_views: int | None = Field(default=None, description="Companion Views")
+    creative: str | None = Field(default=None, description="Creative")
+    creative_id: str | None = Field(default=None, description="Creative ID")
+    creative_pixel_size: str | None = Field(default=None, description="Pixel size of the placement")
+    creative_type: str | None = Field(default=None, description="Creative Type")
+    date: dt.date | None = Field(default=None, description="Date of the ad")
+    dv_360_cost_account_currency: float | None = Field(default=None, description="DV 360 Cost (Account Currency)")
+    dv_360_cost_usd: float | None = Field(default=None, description="DV 360 Cost (USD)")
+    dynamic_profile: str | None = Field(default=None, description="Dynamic Profile")
+    dynamic_profile_id: str | None = Field(default=None, description="Dynamic Profile ID")
+    effective_cpm: float | None = Field(default=None, description="Effective CPM")
+    impressions: int | None = Field(default=None, description="Impressions")
+    media_cost: float | None = Field(default=None, description="Media Cost")
+    package_roadblock: str | None = Field(default=None, description="Name of the package roadblock")
+    package_roadblock_id: str | None = Field(default=None, description="ID of the package roadblock")
+    package_roadblock_total_booked_units: str | None = Field(
+        default=None, description="Package Roadblock Total Booked Units"
+    )
+    placement: str | None = Field(default=None, description="Name of the placement")
+    placement_cost_structure: str | None = Field(default=None, description="Placement Cost Structure")
+    placement_id: str | None = Field(default=None, description="ID of the placement")
+    placement_pixel_size: str | None = Field(default=None, description="Pixel size of the placement")
+    placement_rate: str | None = Field(default=None, description="Placement Rate")
+    placement_total_booked_units: str | None = Field(default=None, description="Placement Total Booked Units")
+    placement_total_planned_media_cost: str | None = Field(
+        default=None, description="Placement Total Planned Media Cost"
+    )
+    planned_media_cost: float | None = Field(default=None, description="Planned Media Cost")
+    platform_type: str | None = Field(default=None, description="Platform Type")
+    site_cm_360: str | None = Field(default=None, description="Name of the site in Campaign Manager 360")
+    site_id_cm_360: str | None = Field(default=None, description="ID of the site in Campaign Manager 360")
+    total_conversions: float | None = Field(default=None, description="Total Conversions")
+    total_revenue: float | None = Field(default=None, description="Total Revenue")
+    true_view_views: int | None = Field(default=None, description="True View Views")
+    video_average_view_time: float | None = Field(default=None, description="Video Average View Time")
+    video_companion_clicks: int | None = Field(default=None, description="Video Companion Clicks")
+    video_completions: int | None = Field(default=None, description="Video Completions")
+    video_first_quartile_completions: int | None = Field(default=None, description="Video First Quartile Completions")
+    video_midpoints: int | None = Field(default=None, description="Video Midpoints")
+    video_plays: int | None = Field(default=None, description="Video Plays")
+    video_third_quartile_completions: int | None = Field(default=None, description="Video Third Quartile Completions")
+    video_views: int | None = Field(default=None, description="Video Views")
+    view_through_conversions: float | None = Field(default=None, description="View-Through Conversions")
+    view_through_revenue: float | None = Field(default=None, description="View-Through Revenue")

--- a/packages/interloper-assets/src/interloper_assets/campaign_manager_360/schemas/campaigns_stats.py
+++ b/packages/interloper-assets/src/interloper_assets/campaign_manager_360/schemas/campaigns_stats.py
@@ -1,0 +1,71 @@
+import datetime as dt
+
+from interloper.schema import Schema
+from pydantic import Field
+
+
+class CampaignsStats(Schema):
+    """Campaign performance metrics per day (CM360 STANDARD report at campaign/activity grain)."""
+
+    active_view_average_viewable_time_seconds: float | None = Field(
+        default=None, description="The average viewable time in seconds"
+    )
+    active_view_measurable_impressions: int | None = Field(
+        default=None, description="The number of active view measurable impressions"
+    )
+    active_view_pct_viewable_impressions: float | None = Field(
+        default=None, description="The percentage of active view viewable impressions"
+    )
+    active_view_pct_visible_at_completion: float | None = Field(
+        default=None, description="The percentage of visible impressions at completion"
+    )
+    active_view_viewable_impressions: int | None = Field(
+        default=None, description="The number of active view viewable impressions"
+    )
+    activity: str | None = Field(default=None, description="The name of the activity")
+    activity_id: str | None = Field(default=None, description="The ID of the activity")
+    advertiser: str | None = Field(default=None, description="The name of the advertiser")
+    advertiser_id: str | None = Field(default=None, description="The ID of the advertiser")
+    booked_activities: float | None = Field(default=None, description="The number of booked activities")
+    booked_clicks: float | None = Field(default=None, description="The number of booked clicks")
+    booked_impressions: float | None = Field(default=None, description="The number of booked impressions")
+    booked_viewable_impressions: float | None = Field(
+        default=None, description="The number of booked viewable impressions"
+    )
+    campaign: str | None = Field(default=None, description="The name of the campaign")
+    campaign_end_date: dt.date | None = Field(default=None, description="The end date of the campaign")
+    campaign_id: str | None = Field(default=None, description="The ID of the campaign")
+    campaign_start_date: dt.date | None = Field(default=None, description="The start date of the campaign")
+    click_rate: float | None = Field(default=None, description="The click rate")
+    click_through_conversions: float | None = Field(default=None, description="The number of click-through conversions")
+    click_through_revenue: float | None = Field(default=None, description="The click-through revenue")
+    clicks: int | None = Field(default=None, description="The number of clicks")
+    companion_clicks: int | None = Field(default=None, description="The number of companion clicks")
+    companion_views: int | None = Field(default=None, description="The number of companion views")
+    date: dt.date | None = Field(default=None, description="The date of the campaign")
+    dv_360_cost_account_currency: float | None = Field(default=None, description="The DV 360 cost in account currency")
+    dv_360_cost_usd: float | None = Field(default=None, description="The DV 360 cost in USD")
+    dynamic_profile: str | None = Field(default=None, description="The dynamic profile")
+    dynamic_profile_id: str | None = Field(default=None, description="The ID of the dynamic profile")
+    effective_cpm: float | None = Field(default=None, description="The effective CPM")
+    impressions: int | None = Field(default=None, description="The number of impressions")
+    media_cost: float | None = Field(default=None, description="The media cost")
+    planned_media_cost: float | None = Field(default=None, description="The planned media cost")
+    platform_type: str | None = Field(default=None, description="The platform type")
+    total_conversions: float | None = Field(default=None, description="The total number of conversions")
+    total_revenue: float | None = Field(default=None, description="The total revenue")
+    true_view_views: int | None = Field(default=None, description="The number of TrueView views")
+    video_average_view_time: float | None = Field(default=None, description="The average view time for videos")
+    video_companion_clicks: int | None = Field(default=None, description="The number of video companion clicks")
+    video_completions: int | None = Field(default=None, description="The number of video completions")
+    video_first_quartile_completions: int | None = Field(
+        default=None, description="The number of video first quartile completions"
+    )
+    video_midpoints: int | None = Field(default=None, description="The number of video midpoints")
+    video_plays: int | None = Field(default=None, description="The number of video plays")
+    video_third_quartile_completions: int | None = Field(
+        default=None, description="The number of video third quartile completions"
+    )
+    video_views: int | None = Field(default=None, description="The number of video views")
+    view_through_conversions: float | None = Field(default=None, description="The number of view-through conversions")
+    view_through_revenue: float | None = Field(default=None, description="The view-through revenue")

--- a/packages/interloper-assets/src/interloper_assets/campaign_manager_360/schemas/custom_audiences.py
+++ b/packages/interloper-assets/src/interloper_assets/campaign_manager_360/schemas/custom_audiences.py
@@ -1,0 +1,40 @@
+from interloper.schema import Schema
+from pydantic import Field
+
+
+class CustomAudiences(Schema):
+    """Remarketing lists (custom audiences) of an advertiser."""
+
+    id: str | None = Field(default=None, description="Unique identifier for the audience")
+    account_id: str | None = Field(default=None, description="Identifier for the account associated with the audience")
+    advertiser_id: str | None = Field(
+        default=None, description="Identifier for the advertiser associated with the audience"
+    )
+    name: str | None = Field(default=None, description="Name of the audience")
+    description: str | None = Field(default=None, description="Description of the audience")
+    active: bool | None = Field(default=None, description="Indicates whether the audience is active")
+    list_size: str | None = Field(default=None, description="Size of the audience list")
+    life_span: str | None = Field(default=None, description="Lifespan of the audience")
+    list_source: str | None = Field(default=None, description="Source of the audience list")
+    kind: str | None = Field(default=None, description="Type or category of the audience")
+    advertiser_id_dimension_value_dimension_name: str | None = Field(
+        default=None, description="Dimension name for the advertiser ID"
+    )
+    advertiser_id_dimension_value_value: str | None = Field(
+        default=None, description="Value of the advertiser ID dimension"
+    )
+    advertiser_id_dimension_value_kind: str | None = Field(
+        default=None, description="Kind of the advertiser ID dimension value"
+    )
+    advertiser_id_dimension_value_etag: str | None = Field(
+        default=None, description="ETag for the advertiser ID dimension value"
+    )
+    list_population_rule_floodlight_activity_id: str | None = Field(
+        default=None, description="Floodlight activity ID for the list population rule"
+    )
+    list_population_rule_floodlight_activity_name: str | None = Field(
+        default=None, description="Floodlight activity name for the list population rule"
+    )
+    list_population_rule_list_population_clauses: str | None = Field(
+        default=None, description="Clauses for the list population rule"
+    )

--- a/packages/interloper-assets/src/interloper_assets/campaign_manager_360/schemas/reach_stats.py
+++ b/packages/interloper-assets/src/interloper_assets/campaign_manager_360/schemas/reach_stats.py
@@ -1,0 +1,44 @@
+import datetime as dt
+
+from interloper.schema import Schema
+from pydantic import Field
+
+
+class ReachStats(Schema):
+    """Unique-reach metrics per campaign and country (CM360 REACH report)."""
+
+    date: dt.date | None = Field(
+        default=None, description="The day the report was run for (stamped from the partition)."
+    )
+    active_view_measurable_impressions: float | None = Field(
+        default=None, description="Number of measurable impressions"
+    )
+    active_view_viewable_impressions: float | None = Field(default=None, description="Number of viewable impressions")
+    advertiser: str | None = Field(default=None, description="Name of the advertiser")
+    advertiser_id: str | None = Field(default=None, description="ID of the advertiser")
+    campaign: str | None = Field(default=None, description="Name of the campaign")
+    campaign_end_date: str | None = Field(default=None, description="End date of the campaign")
+    campaign_id: str | None = Field(default=None, description="ID of the campaign")
+    campaign_start_date: str | None = Field(default=None, description="Start date of the campaign")
+    country: str | None = Field(default=None, description="Country of the campaign")
+    impressions: float | None = Field(default=None, description="Number of impressions")
+    unique_reach_duplicate_impression_reach: str | None = Field(
+        default=None, description="Duplicate impression reach for unique users"
+    )
+    unique_reach_exclusive_impression_reach: str | None = Field(
+        default=None, description="Exclusive impression reach for unique users"
+    )
+    unique_reach_impression_reach: str | None = Field(default=None, description="Impression reach for unique users")
+    unique_reach_incremental_impression_reach: str | None = Field(
+        default=None, description="Incremental impression reach for unique users"
+    )
+    unique_reach_incremental_total_reach: str | None = Field(
+        default=None, description="Incremental total reach for unique users"
+    )
+    unique_reach_incremental_viewable_impression_reach: str | None = Field(
+        default=None, description="Incremental viewable impression reach for unique users"
+    )
+    unique_reach_total_reach: str | None = Field(default=None, description="Total reach for unique users")
+    unique_reach_viewable_impression_reach: str | None = Field(
+        default=None, description="Viewable impression reach for unique users"
+    )

--- a/packages/interloper-assets/src/interloper_assets/campaign_manager_360/source.py
+++ b/packages/interloper-assets/src/interloper_assets/campaign_manager_360/source.py
@@ -1,9 +1,160 @@
+import datetime as dt
+import json
+import logging
+import time
+from io import BytesIO
+from typing import Any
 
 import interloper as il
+import pandas as pd
+from interloper_pandas import DataFrameNormalizer
 
+from interloper_assets.campaign_manager_360 import constants, schemas
 from interloper_assets.campaign_manager_360.connection import CampaignManager360Connection
 
+logger = logging.getLogger(__name__)
 
+_Record = dict[str, Any]
+
+# Report files queue server-side; poll with backoff until available.
+_REPORT_TIMEOUT = 3 * 60 * 60  # 3 hours
+
+
+# -- NORMALIZER ----------------------------------------------------------------
+class CampaignManager360Normalizer(DataFrameNormalizer):
+    """Snake-case CM360's CSV report headers onto the schema columns.
+
+    Headers are human-readable ("Active View: % Viewable Impressions",
+    "Site (CM360)", "DV360 Cost (USD)"). The generic pass drops ``%`` outright,
+    which would collide "% Viewable Impressions" with "Viewable Impressions" —
+    so spell it out as ``pct`` first, then defer to snake-casing with digit
+    splitting (CM360 → cm_360).
+    """
+
+    def column_name(self, name: str) -> str:
+        return super().column_name(name.replace("%", "pct"))
+
+
+# -- HELPERS — report definitions ------------------------------------------------
+def _standard_report_body(
+    account_id: str, start_date: dt.date, end_date: dt.date, dimensions: list[str], metrics: list[str]
+) -> dict:
+    return {
+        "accountId": account_id,
+        "name": f"report_standard_{start_date.isoformat()}_{end_date.isoformat()}",
+        "type": "STANDARD",
+        "criteria": {
+            "dateRange": {"startDate": start_date.isoformat(), "endDate": end_date.isoformat()},
+            "dimensions": [{"name": dimension} for dimension in dimensions],
+            "metricNames": metrics,
+        },
+    }
+
+
+def _reach_report_body(
+    account_id: str, start_date: dt.date, end_date: dt.date, dimensions: list[str], metrics: list[str]
+) -> dict:
+    return {
+        "accountId": account_id,
+        "name": f"report_reach_{start_date.isoformat()}_{end_date.isoformat()}",
+        "type": "REACH",
+        "reachCriteria": {
+            "dateRange": {"startDate": start_date.isoformat(), "endDate": end_date.isoformat()},
+            "dimensions": [{"name": dimension} for dimension in dimensions],
+            "metricNames": metrics,
+        },
+    }
+
+
+# -- HELPERS — report execution --------------------------------------------------
+def _wait_for_file(service: Any, profile_id: str, report_id: int, file_id: int) -> None:
+    """Poll a report file until it is available, raising on failure or timeout."""
+    deadline = time.monotonic() + _REPORT_TIMEOUT
+    interval = float(constants.MIN_RETRY_INTERVAL)
+    while True:
+        logger.info(f"Waiting for report {report_id} (file {file_id})...")
+        status = (
+            service.reports().files().get(profileId=profile_id, reportId=report_id, fileId=file_id).execute()
+        )["status"]
+
+        if status == "REPORT_AVAILABLE":
+            return
+        if status in ("FAILED", "CANCELLED"):
+            raise RuntimeError(f"Report {report_id} failed with status {status}")
+
+        if time.monotonic() >= deadline:
+            raise RuntimeError(f"Report {report_id} did not complete within {_REPORT_TIMEOUT}s")
+        time.sleep(interval)
+        interval = min(interval * 2, constants.MAX_RETRY_INTERVAL)
+
+
+def _download_file(service: Any, report_id: int, file_id: int) -> BytesIO:
+    """Download a report file into memory."""
+    from googleapiclient.http import MediaIoBaseDownload
+
+    buffer = BytesIO()
+    downloader = MediaIoBaseDownload(buffer, service.files().get_media(reportId=report_id, fileId=file_id))
+    done = False
+    while not done:
+        status, done = downloader.next_chunk()
+        logger.info(f"Downloading report {report_id}: {int(status.progress() * 100)}%")
+    buffer.seek(0)
+    return buffer
+
+
+def _parse_report_csv(file: BytesIO) -> list[_Record]:
+    """Parse a CM360 report file: skip the preamble, drop the trailing totals.
+
+    The file opens with a metadata preamble ending at a "Report Fields" line,
+    then the CSV proper, closed by a "Grand Total:" summary row.
+    """
+    for line in file:
+        if b"Report Fields" in line:
+            break
+    df = pd.read_csv(file, na_values=["-"])
+    if df.empty:
+        return []
+    totals = df[df.iloc[:, 0].astype("string").str.contains("Grand Total:", na=False)].index
+    if len(totals):
+        df = df.iloc[: totals[-1]]
+    return df.to_dict("records")
+
+
+def _get_report(connection: CampaignManager360Connection, profile_id: str, report_body: dict) -> list[_Record]:
+    """Insert, run, download, and parse a report, deleting its definition after."""
+    service = connection.client
+    report_id = int(service.reports().insert(profileId=profile_id, body=report_body).execute()["id"])
+    logger.info(f"Report id: {report_id} ({report_body['type']})")
+    try:
+        file_id = int(service.reports().run(profileId=profile_id, reportId=report_id).execute()["id"])
+        _wait_for_file(service, profile_id, report_id, file_id)
+        return _parse_report_csv(_download_file(service, report_id, file_id))
+    finally:
+        # One-shot report definitions; clean up best-effort so they don't pile up.
+        try:
+            service.reports().delete(profileId=profile_id, reportId=report_id).execute()
+        except Exception as exc:
+            logger.warning(f"Failed to delete report {report_id}: {exc}")
+
+
+def _list_remarketing_lists(service: Any, profile_id: str, advertiser_id: str) -> list[_Record]:
+    """Page through the remarketing lists of an advertiser."""
+    items: list[_Record] = []
+    page_token: str | None = None
+    while True:
+        response = (
+            service.remarketingLists()
+            .list(profileId=profile_id, advertiserId=advertiser_id, pageToken=page_token)
+            .execute()
+        )
+        items.extend(response.get("remarketingLists") or [])
+        page_token = response.get("nextPageToken")
+        if not page_token:
+            break
+    return items
+
+
+# -- SOURCE --------------------------------------------------------------------
 @il.source(
     key="campaign_manager_360",
     resources={
@@ -11,9 +162,102 @@ from interloper_assets.campaign_manager_360.connection import CampaignManager360
     },
     tags=["Advertising"],
     icon="icon:cm360",
+    normalizer=CampaignManager360Normalizer(snake_case_digits=True, flatten_max_level=2),
 )
 class CampaignManager360(il.Source):
     """Campaign Manager 360 advertising platform integration."""
 
-    profile_id: str = il.InputField(description="CM360 user profile ID")
-    account_id: str = il.InputField(description="CM360 account ID", discriminator=True)
+    profile_id: str = il.FetchField(
+        title="Profile ID",
+        description="CM360 user profile",
+        provider="connection.profiles",
+        label_key="name",
+        value_key="profile_id",
+    )
+    account_id: str = il.FetchField(
+        title="Account ID",
+        description="CM360 account",
+        provider="connection.profiles",
+        label_key="account_name",
+        value_key="account_id",
+        discriminator=True,
+    )
+    advertiser_id: str = il.InputField(
+        default="",
+        title="Advertiser ID",
+        description="CM360 advertiser ID (only required for the custom_audiences asset)",
+    )
+
+    @il.asset(
+        schema=schemas.CampaignsStats,
+        partitioning=il.TimePartitionConfig(column="date"),
+        tags=["Report"],
+    )
+    def campaigns_stats(
+        self, context: il.ExecutionContext, connection: CampaignManager360Connection
+    ) -> list[_Record]:
+        """Campaign performance metrics per day."""
+        return _get_report(
+            connection,
+            self.profile_id,
+            _standard_report_body(
+                self.account_id,
+                context.partition_date,
+                context.partition_date,
+                dimensions=constants.CAMPAIGN_DIMENSIONS,
+                metrics=constants.CAMPAIGN_METRICS,
+            ),
+        )
+
+    @il.asset(
+        schema=schemas.AdsStats,
+        partitioning=il.TimePartitionConfig(column="date"),
+        tags=["Report"],
+    )
+    def ads_stats(self, context: il.ExecutionContext, connection: CampaignManager360Connection) -> list[_Record]:
+        """Ad performance metrics per day at placement/creative grain."""
+        return _get_report(
+            connection,
+            self.profile_id,
+            _standard_report_body(
+                self.account_id,
+                context.partition_date,
+                context.partition_date,
+                dimensions=constants.AD_DIMENSIONS,
+                metrics=constants.AD_METRICS,
+            ),
+        )
+
+    @il.asset(
+        schema=schemas.ReachStats,
+        partitioning=il.TimePartitionConfig(column="date"),
+        tags=["Report"],
+    )
+    def reach_stats(self, context: il.ExecutionContext, connection: CampaignManager360Connection) -> list[_Record]:
+        """Unique-reach metrics per campaign and country."""
+        rows = _get_report(
+            connection,
+            self.profile_id,
+            _reach_report_body(
+                self.account_id,
+                context.partition_date,
+                context.partition_date,
+                dimensions=constants.UNIQUE_REACH_DIMENSIONS,
+                metrics=constants.UNIQUE_REACH_METRICS,
+            ),
+        )
+        # The REACH report has no date dimension; stamp the partition day.
+        return [{**row, "date": context.partition_date} for row in rows]
+
+    @il.asset(schema=schemas.CustomAudiences, tags=["Entity"])
+    def custom_audiences(self, connection: CampaignManager360Connection) -> list[_Record]:
+        """Remarketing lists (custom audiences) of the configured advertiser."""
+        if not self.advertiser_id:
+            raise ValueError("The custom_audiences asset requires the source's advertiser_id to be set")
+        items = _list_remarketing_lists(connection.client, self.profile_id, self.advertiser_id)
+        for item in items:
+            rule = item.get("listPopulationRule")
+            # Clauses are a nested list; JSON-encode them onto the string column.
+            if isinstance(rule, dict) and isinstance(rule.get("listPopulationClauses"), list):
+                rule["listPopulationClauses"] = json.dumps(rule["listPopulationClauses"])
+        return items

--- a/packages/interloper-assets/tests/test_campaign_manager_360.py
+++ b/packages/interloper-assets/tests/test_campaign_manager_360.py
@@ -1,0 +1,123 @@
+"""Regression tests for the CampaignManager360 source.
+
+CM360 report downloads are CSV files with a metadata preamble (ending at a
+"Report Fields" line), human-readable headers, and a trailing "Grand Total:"
+summary row. The custom normalizer must map those headers onto the schema
+columns — notably spelling ``%`` out as ``pct`` so "% Viewable Impressions"
+does not collide with "Viewable Impressions" — and survive the host→child
+DAG-spec round-trip.
+"""
+
+from __future__ import annotations
+
+import math
+from io import BytesIO
+from typing import Any
+
+from interloper.dag import DAGSpec
+from interloper.dag.base import DAG
+from interloper.representation import Representation
+
+from interloper_assets.campaign_manager_360 import schemas
+from interloper_assets.campaign_manager_360.source import (
+    CampaignManager360,
+    CampaignManager360Normalizer,
+    _parse_report_csv,
+)
+
+_ASSET_KEY = "campaigns_stats"
+
+_REPORT_FILE = b"""Report Name,report_standard_2026-07-10_2026-07-10
+Date Range,2026-07-10 - 2026-07-10
+
+Report Fields
+Date,Advertiser ID,Campaign,Active View: Viewable Impressions,Active View: % Viewable Impressions,Impressions,Clicks
+2026-07-10,123,Campaign A,90,85.5,100,5
+2026-07-10,123,Campaign B,-,-,200,10
+Grand Total:,,,90,85.5,300,15
+"""
+
+
+def _source() -> Any:
+    return CampaignManager360(id="src-1", profile_id="111", account_id="222")  # ty: ignore[unknown-argument]
+
+
+def _normalizer() -> CampaignManager360Normalizer:
+    return CampaignManager360Normalizer(snake_case_digits=True, flatten_max_level=2)
+
+
+class TestCsvParsing:
+    """The preamble is skipped and the trailing totals row dropped."""
+
+    def test_parse_report_csv(self):
+        rows = _parse_report_csv(BytesIO(_REPORT_FILE))
+        assert len(rows) == 2
+        assert rows[0]["Date"] == "2026-07-10"
+        assert rows[0]["Impressions"] == 100
+        assert rows[1]["Campaign"] == "Campaign B"
+
+    def test_dash_reads_as_missing(self):
+        rows = _parse_report_csv(BytesIO(_REPORT_FILE))
+        assert math.isnan(rows[1]["Active View: Viewable Impressions"])
+
+    def test_report_without_totals_keeps_all_rows(self):
+        content = _REPORT_FILE.replace(b"Grand Total:,,,90,85.5,300,15\n", b"")
+        assert len(_parse_report_csv(BytesIO(content))) == 2
+
+
+class TestHeaderNormalization:
+    """CSV headers land on schema columns; ``%`` becomes ``pct``, digits split."""
+
+    def test_percent_headers_do_not_collide(self):
+        normalizer = _normalizer()
+        assert normalizer.column_name("Active View: % Viewable Impressions") == (
+            "active_view_pct_viewable_impressions"
+        )
+        assert normalizer.column_name("Active View: Viewable Impressions") == "active_view_viewable_impressions"
+
+    def test_digit_and_symbol_headers(self):
+        normalizer = _normalizer()
+        assert normalizer.column_name("Site (CM360)") == "site_cm_360"
+        assert normalizer.column_name("DV360 Cost (USD)") == "dv_360_cost_usd"
+        assert normalizer.column_name("Package/Roadblock ID") == "package_roadblock_id"
+        assert normalizer.column_name("TrueView: Views") == "true_view_views"
+
+    def test_parsed_report_conforms_to_schema(self):
+        rows = _parse_report_csv(BytesIO(_REPORT_FILE))
+        normalized = _normalizer().normalize(rows)
+        conformer = Representation.of(normalized).conformer
+        df = conformer.reconcile(normalized, schemas.CampaignsStats)
+        conformer.validate(df, schemas.CampaignsStats)  # must not raise
+        record = df.to_dict("records")[0]
+        assert record["active_view_pct_viewable_impressions"] == 85.5
+        assert record["active_view_viewable_impressions"] == 90
+
+
+class TestSourceNormalizer:
+    """The decorator-configured normalizer must reach every asset instance."""
+
+    def test_all_assets_inherit_the_normalizer(self):
+        src = _source()
+        assert len(src.assets) == 4
+        for asset in src.assets:
+            assert isinstance(asset.normalizer, CampaignManager360Normalizer), type(asset).key
+
+
+class TestSpecRoundtrip:
+    """The host→child spec round-trip must preserve the normalizer subclass."""
+
+    def test_child_asset_keeps_custom_normalizer(self):
+        src = _source()
+        asset = next(a for a in src.assets if type(a).key == _ASSET_KEY)
+        spec_json = DAG(src).mini_dag(asset.id).to_spec().model_dump(mode="json")
+        child_dag = DAGSpec(**spec_json).reconstruct()
+        child_asset = next(a for a in child_dag.assets if type(a).key == _ASSET_KEY)
+
+        normalizer = child_asset.normalizer
+        assert isinstance(normalizer, CampaignManager360Normalizer)
+        assert normalizer.snake_case_digits is True
+        assert normalizer.flatten_max_level == 2
+        # The % -> pct behavior must survive in the child pod.
+        assert normalizer.column_name("Active View: % Viewable Impressions") == (
+            "active_view_pct_viewable_impressions"
+        )


### PR DESCRIPTION
## What

Adds the **Campaign Manager 360** (`dfareporting` v5) source to `interloper-assets`, ported from the `digitlcloud-connectors` reference — the first fully implemented Google-discovery source in the repo (DV360/DBM/SA360/google_ads/search_console are still stubs).

| Asset | Type | Notes |
|---|---|---|
| `campaigns_stats` | Report, partitioned `date` | STANDARD report, campaign/activity grain (46 fields) |
| `ads_stats` | Report, partitioned `date` | STANDARD report, ad/placement/creative grain (65 fields) |
| `reach_stats` | Report, partitioned `date` | REACH report — has **no date dimension**, so the partition date is stamped onto rows (awin-style) |
| `custom_audiences` | Entity, unpartitioned | `remarketingLists.list`, paginated; `listPopulationClauses` JSON-encoded onto its string column |

## How

- **Sync assets, lazy imports** — the Google client is blocking, so assets are plain `def` (the `amazon_ads` idiom); all `googleapiclient` imports stay inside functions since `google-api-python-client` is an optional extra (`google`) of `interloper-assets`.
- **Report flow** — insert → run → poll `reports.files.get` (60s→20min backoff, 3h cap) → in-memory `MediaIoBaseDownload` → CSV parse: skip the metadata preamble (up to the "Report Fields" line), read `-` as NA, drop the trailing "Grand Total:" summary row. The one-shot report definition is **deleted in a `finally`** so definitions don't pile up server-side (the reference only deleted on success).
- **`CampaignManager360Normalizer`** — CM360 CSV headers are human-readable, and generic snake-casing *drops* `%`, which would collide "Active View: % Viewable Impressions" with "Active View: Viewable Impressions". The subclass spells `%` out as `pct` first (matching the reference's sanitize), and `snake_case_digits=True` maps `Site (CM360)` → `site_cm_360`, `DV360 Cost (USD)` → `dv_360_cost_usd`.
- **`profile_id` / `account_id` are FetchFields** fed by a single `connection.profiles` provider — `userProfiles.list` returns both ids, so one lookup populates both pickers. `check()` reuses it. Blocking calls run via `asyncio.to_thread`.
- `advertiser_id` is an optional source field used only by `custom_audiences` (clear error if unset).

## Deliberate deviations from the reference

- **API v5** (the reference's pin; the earlier scaffold had v4).
- **Dropped the `cloud-platform` scope** — least privilege; `dfareporting` + `dfatrafficking` cover reports and remarketing lists. (`cloud-platform` served the reference's impersonation flow, which this connection doesn't use.)
- Reports deleted even on failure (see above).

## Tests

`tests/test_campaign_manager_360.py` (8 tests): CSV preamble/totals/`-`-as-NA parsing, the `%`-collision guard, digit/symbol header mapping, full parse→normalize→conform against the schema, and the host→child DAG-spec round-trip preserving the normalizer subclass **and** its `pct` behavior. `ruff` + `ty` + `pytest` all pass.

## Reviewer notes — needs verification

**Not live-tested**: no CM360 credentials were available. The header→schema mapping is verified against a reconstruction of the reference's sanitize pipeline (22 realistic headers checked), not against real report CSVs — and the `userProfiles.list` FetchField provider is likewise untested. A smoke run against a real profile before relying on it would be prudent.

By Digitl