### PR TITLE
chore(app): update the agent's default suggested prompts

### DIFF
--- a/packages/interloper-app/app/app/components/agent/Panel.vue
+++ b/packages/interloper-app/app/app/components/agent/Panel.vue
@@ -75,9 +75,9 @@ function submit(text: string) {
 }
 
 const SUGGESTIONS = [
+    'Setup a new source',
+    'Setup a new connection',
     'What failed in the last 24 hours?',
-    'Summarize my pipeline health',
-    'Which sources are stale?',
 ]
 </script>
 

--- a/packages/interloper-app/app/app/pages/agent/index.vue
+++ b/packages/interloper-app/app/app/pages/agent/index.vue
@@ -6,10 +6,9 @@ const prompt = ref('')
 const creating = ref(false)
 
 const suggestions = [
-    { label: 'What sources are configured?', icon: 'i-lucide-plug' },
-    { label: 'Show me recent job failures', icon: 'i-lucide-alert-circle' },
-    { label: 'Help me create a new asset', icon: 'i-lucide-file-plus' },
-    { label: 'Explain my DAG dependencies', icon: 'i-lucide-workflow' },
+    { label: 'Setup a new source', icon: 'i-lucide-plug' },
+    { label: 'Setup a new connection', icon: 'i-lucide-key-round' },
+    { label: 'What failed in the last 24 hours?', icon: 'i-lucide-alert-circle' },
 ]
 
 async function onSubmit(e: Event) {


### PR DESCRIPTION
Aligns both fresh-conversation surfaces (agent side panel `SUGGESTIONS` and the full-page `suggestions`) on the same three prompts:

1. Setup a new source
2. Setup a new connection
3. What failed in the last 24 hours?

The first two showcase the setup flows built over the recent PRs (cards, selections, confirmations); the third was already the panel's lead suggestion. Drops stale entries for things the agent doesn't do ("Help me create a new asset") and the panel/page divergence. Icons on the page variant: plug / key-round / alert-circle.

Lint + typecheck green.

By Digitl