### PR TITLE
feat(assets): add Display & Video 360 source

### DIFF
--- a/packages/interloper-assets/src/interloper_assets/display_video_360/connection.py
+++ b/packages/interloper-assets/src/interloper_assets/display_video_360/connection.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from functools import cached_property
 from typing import Any
@@ -37,3 +38,36 @@ class DisplayVideo360Connection(il.Connection):
             constants.DISPLAY_VIDEO_API_VERSION,
             credentials=credentials,
         )
+
+    def _list_partners(self) -> list[dict[str, Any]]:
+        """Page through the partners accessible to the service account."""
+        partners: list[dict[str, Any]] = []
+        page_token: str | None = None
+        while True:
+            response = self.client.partners().list(pageToken=page_token).execute()
+            partners.extend(response.get("partners") or [])
+            page_token = response.get("nextPageToken")
+            if not page_token:
+                break
+        return partners
+
+    @il.fetch_field_provider
+    async def partners(self) -> list[dict[str, str]]:
+        """Fetch the DV360 partners the service account has access to."""
+        partners = await asyncio.to_thread(self._list_partners)
+        return [
+            {
+                "partner_id": str(p["partnerId"]),
+                "name": f"{p.get('displayName', p['partnerId'])} ({p['partnerId']})",
+            }
+            for p in partners
+        ]
+
+    async def check(self) -> bool:
+        """Prove the credentials work by running the ``partners`` lookup.
+
+        Returns:
+            True — any credential failure raises out of the lookup.
+        """
+        await self.partners()
+        return True

--- a/packages/interloper-assets/src/interloper_assets/display_video_360/schemas/__init__.py
+++ b/packages/interloper-assets/src/interloper_assets/display_video_360/schemas/__init__.py
@@ -1,0 +1,9 @@
+from .audiences import Audiences
+from .custom_audiences import CustomAudiences
+from .partners import Partners
+
+__all__ = [
+    "Audiences",
+    "CustomAudiences",
+    "Partners",
+]

--- a/packages/interloper-assets/src/interloper_assets/display_video_360/schemas/audiences.py
+++ b/packages/interloper-assets/src/interloper_assets/display_video_360/schemas/audiences.py
@@ -1,0 +1,23 @@
+from interloper.schema import Schema
+from pydantic import Field
+
+
+class Audiences(Schema):
+    """First-party and partner audiences of a partner or advertiser."""
+
+    name: str | None = Field(default=None, description="The name of the audience")
+    first_party_and_partner_audience_id: str | None = Field(
+        default=None, description="The unique identifier for the first or partner audience"
+    )
+    display_name: str | None = Field(default=None, description="The display name of the audience")
+    first_party_and_partner_audience_type: str | None = Field(
+        default=None, description="The type of audience, indicating whether it is first-party or partner"
+    )
+    audience_type: str | None = Field(
+        default=None, description="The classification of the audience based on its purpose or characteristics"
+    )
+    audience_source: str | None = Field(default=None, description="The source from which the audience data is derived")
+    membership_duration_days: str | None = Field(
+        default=None, description="The duration, in days, for which a user remains a member of the audience"
+    )
+    description: str | None = Field(default=None, description="A detailed description of the audience")

--- a/packages/interloper-assets/src/interloper_assets/display_video_360/schemas/custom_audiences.py
+++ b/packages/interloper-assets/src/interloper_assets/display_video_360/schemas/custom_audiences.py
@@ -1,0 +1,39 @@
+from interloper.schema import Schema
+from pydantic import Field
+
+
+class CustomAudiences(Schema):
+    """Detail of a single first-party/partner audience, including per-surface audience sizes."""
+
+    name: str | None = Field(default=None, description="The name of the custom audience.")
+    first_party_and_partner_audience_id: str | None = Field(
+        default=None, description="The unique identifier for the first and partner audience."
+    )
+    display_name: str | None = Field(default=None, description="The display name of the custom audience.")
+    first_party_and_partner_audience_type: str | None = Field(
+        default=None, description="The type of the first and partner audience."
+    )
+    audience_type: str | None = Field(default=None, description="The type of audience, such as custom or predefined.")
+    audience_source: str | None = Field(
+        default=None, description="The source of the audience data, such as first-party or third-party."
+    )
+    membership_duration_days: str | None = Field(
+        default=None, description="The duration in days for which a user remains a member of the audience."
+    )
+    display_audience_size: str | None = Field(
+        default=None, description="The total size of the audience for display campaigns."
+    )
+    active_display_audience_size: str | None = Field(
+        default=None, description="The size of the active audience for display campaigns."
+    )
+    youtube_audience_size: str | None = Field(
+        default=None, description="The size of the audience for YouTube campaigns."
+    )
+    gmail_audience_size: str | None = Field(default=None, description="The size of the audience for Gmail campaigns.")
+    display_mobile_web_audience_size: str | None = Field(
+        default=None, description="The size of the audience for display campaigns on mobile web."
+    )
+    display_desktop_audience_size: str | None = Field(
+        default=None, description="The size of the audience for display campaigns on desktop."
+    )
+    description: str | None = Field(default=None, description="A description of the custom audience.")

--- a/packages/interloper-assets/src/interloper_assets/display_video_360/schemas/partners.py
+++ b/packages/interloper-assets/src/interloper_assets/display_video_360/schemas/partners.py
@@ -1,0 +1,26 @@
+from interloper.schema import Schema
+from pydantic import Field
+
+
+class Partners(Schema):
+    """DV360 partners and their configuration."""
+
+    name: str | None = Field(default=None, description="The name of the partner")
+    partner_id: str | None = Field(default=None, description="The ID of the partner")
+    update_time: str | None = Field(default=None, description="The last update time of the partner")
+    display_name: str | None = Field(default=None, description="The display name of the partner")
+    entity_status: str | None = Field(default=None, description="The status of the entity")
+    general_config_time_zone: str | None = Field(default=None, description="The time zone of the partner")
+    general_config_currency_code: str | None = Field(default=None, description="Currency of the partner")
+    data_access_config_sdf_config_version: str | None = Field(default=None, description="SDF config version")
+    exchange_config_enabled_exchanges: str | None = Field(default=None, description="Enabled exchanges")
+    billing_config_billing_profile_id: str | None = Field(default=None, description="The ID of the billing profile")
+    ad_server_config_measurement_config_dv_360_to_cm_cost_reporting_enabled: bool | None = Field(
+        default=None, description="Flag indicating if cost reporting is enabled from DV360 to CM"
+    )
+    ad_server_config_measurement_config_dv_360_to_cm_data_sharing_enabled: bool | None = Field(
+        default=None, description="Flag indicating if data sharing is enabled from DV360 to CM"
+    )
+    data_access_config_sdf_config_admin_email: str | None = Field(
+        default=None, description="Admin email for SDF config"
+    )

--- a/packages/interloper-assets/src/interloper_assets/display_video_360/source.py
+++ b/packages/interloper-assets/src/interloper_assets/display_video_360/source.py
@@ -1,11 +1,33 @@
+import json
+import logging
+from typing import Any
 
 import interloper as il
+from interloper_pandas import DataFrameNormalizer
 
+from interloper_assets.display_video_360 import schemas
 from interloper_assets.display_video_360.connection import DisplayVideo360Connection
 
+logger = logging.getLogger(__name__)
+
+_Record = dict[str, Any]
+
+
+# -- HELPERS -------------------------------------------------------------------
+def _list_audiences(service: Any, scope: dict[str, str]) -> list[_Record]:
+    """Page through the first-party/partner audiences of a partner or advertiser."""
+    audiences: list[_Record] = []
+    page_token: str | None = None
+    while True:
+        response = service.firstPartyAndPartnerAudiences().list(**scope, pageToken=page_token).execute()
+        audiences.extend(response.get("firstPartyAndPartnerAudiences") or [])
+        page_token = response.get("nextPageToken")
+        if not page_token:
+            break
+    return audiences
+
+
 # -- SOURCE --------------------------------------------------------------------
-
-
 @il.source(
     key="display_video_360",
     resources={
@@ -13,9 +35,63 @@ from interloper_assets.display_video_360.connection import DisplayVideo360Connec
     },
     tags=["Advertising"],
     icon="icon:dv360",
+    # Partner objects nest config two levels deep (dataAccessConfig.sdfConfig.*);
+    # digit splitting maps dv360ToCm... -> dv_360_to_cm_... onto the schema fields.
+    normalizer=DataFrameNormalizer(snake_case_digits=True, flatten_max_level=2),
 )
 class DisplayVideo360(il.Source):
     """Display & Video 360 advertising platform integration."""
 
-    partner_id: str = il.InputField(description="DV360 partner ID", discriminator=True)
-    advertiser_id: str = il.InputField(description="DV360 advertiser ID (optional, used for audience queries)")
+    partner_id: str = il.FetchField(
+        title="Partner ID",
+        description="DV360 partner",
+        provider="connection.partners",
+        label_key="name",
+        value_key="partner_id",
+        discriminator=True,
+    )
+    advertiser_id: str = il.InputField(
+        default="",
+        title="Advertiser ID",
+        description="DV360 advertiser ID — set to scope audience assets by advertiser instead of partner",
+    )
+    audience_id: str = il.InputField(
+        default="",
+        title="Audience ID",
+        description="Audience ID (only required for the custom_audiences asset)",
+    )
+
+    @property
+    def _audience_scope(self) -> dict[str, str]:
+        """Audience calls take a partner XOR advertiser scope; advertiser wins when set."""
+        if self.advertiser_id:
+            return {"advertiserId": self.advertiser_id}
+        return {"partnerId": self.partner_id}
+
+    @il.asset(schema=schemas.Partners, tags=["Entity"])
+    def partners(self, connection: DisplayVideo360Connection) -> list[_Record]:
+        """DV360 partners and their configuration."""
+        items = connection._list_partners()
+        for item in items:
+            exchange_config = item.get("exchangeConfig")
+            # Enabled exchanges are a nested list; JSON-encode onto the string column.
+            if isinstance(exchange_config, dict) and isinstance(exchange_config.get("enabledExchanges"), list):
+                exchange_config["enabledExchanges"] = json.dumps(exchange_config["enabledExchanges"])
+        return items
+
+    @il.asset(schema=schemas.Audiences, tags=["Entity"])
+    def audiences(self, connection: DisplayVideo360Connection) -> list[_Record]:
+        """First-party and partner audiences of the configured partner or advertiser."""
+        return _list_audiences(connection.client, self._audience_scope)
+
+    @il.asset(schema=schemas.CustomAudiences, tags=["Entity"])
+    def custom_audiences(self, connection: DisplayVideo360Connection) -> list[_Record]:
+        """Detail of the configured audience, including per-surface audience sizes."""
+        if not self.audience_id:
+            raise ValueError("The custom_audiences asset requires the source's audience_id to be set")
+        audience = (
+            connection.client.firstPartyAndPartnerAudiences()
+            .get(**self._audience_scope, firstPartyAndPartnerAudienceId=self.audience_id)
+            .execute()
+        )
+        return [audience]

--- a/packages/interloper-assets/tests/test_display_video_360.py
+++ b/packages/interloper-assets/tests/test_display_video_360.py
@@ -1,0 +1,101 @@
+"""Regression tests for the DisplayVideo360 source.
+
+Partner objects nest configuration two levels deep (``dataAccessConfig.sdfConfig.*``,
+``adServerConfig.measurementConfig.dv360ToCm*``). The source-level normalizer must
+flatten them and split digit groups (``dv360ToCm`` → ``dv_360_to_cm``) onto the
+schema columns — and survive the host→child DAG-spec round-trip.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from interloper.dag import DAGSpec
+from interloper.dag.base import DAG
+from interloper.representation import Representation
+from interloper_pandas import DataFrameNormalizer
+
+from interloper_assets.display_video_360 import schemas
+from interloper_assets.display_video_360.source import DisplayVideo360
+
+_ASSET_KEY = "partners"
+
+_PARTNER = {
+    "name": "partners/123",
+    "partnerId": "123",
+    "updateTime": "2026-01-01T00:00:00Z",
+    "displayName": "Digitl",
+    "entityStatus": "ENTITY_STATUS_ACTIVE",
+    "generalConfig": {"timeZone": "Europe/Berlin", "currencyCode": "EUR"},
+    "adServerConfig": {
+        "measurementConfig": {"dv360ToCmCostReportingEnabled": True, "dv360ToCmDataSharingEnabled": False}
+    },
+    "dataAccessConfig": {"sdfConfig": {"version": "SDF_VERSION_8", "adminEmail": "admin@digitl.com"}},
+    "exchangeConfig": {"enabledExchanges": json.dumps([{"exchange": "EXCHANGE_GOOGLE_AD_MANAGER"}])},
+    "billingConfig": {"billingProfileId": "77"},
+}
+
+
+def _source(**overrides: str) -> Any:
+    fields: dict[str, Any] = {"partner_id": "123", **overrides}
+    return DisplayVideo360(id="src-1", **fields)
+
+
+class TestAudienceScope:
+    """Audience calls scope by partner XOR advertiser; advertiser wins when set."""
+
+    def test_partner_scope_by_default(self):
+        assert _source()._audience_scope == {"partnerId": "123"}
+
+    def test_advertiser_scope_when_set(self):
+        assert _source(advertiser_id="9")._audience_scope == {"advertiserId": "9"}
+
+    def test_custom_audiences_requires_audience_id(self):
+        src = _source()
+        asset = next(a for a in src.assets if type(a).key == "custom_audiences")
+        with pytest.raises(ValueError, match="audience_id"):
+            asset.data(connection=object())
+
+
+class TestNormalizerMapping:
+    """A realistic partner payload flattens exactly onto the Partners schema."""
+
+    def test_partner_payload_maps_onto_schema(self):
+        src = _source()
+        normalizer = src.normalizer
+        assert isinstance(normalizer, DataFrameNormalizer)
+        normalized = normalizer.normalize([_PARTNER])
+
+        fields = set(schemas.Partners.model_fields)
+        assert set(normalized.columns) == fields
+
+        conformer = Representation.of(normalized).conformer
+        df = conformer.reconcile(normalized, schemas.Partners)
+        conformer.validate(df, schemas.Partners)  # must not raise
+        record = df.to_dict("records")[0]
+        assert record["ad_server_config_measurement_config_dv_360_to_cm_cost_reporting_enabled"] is True
+        assert record["data_access_config_sdf_config_admin_email"] == "admin@digitl.com"
+
+    def test_all_assets_inherit_the_normalizer(self):
+        src = _source()
+        assert len(src.assets) == 3
+        for asset in src.assets:
+            assert isinstance(asset.normalizer, DataFrameNormalizer), type(asset).key
+
+
+class TestSpecRoundtrip:
+    """The host→child spec round-trip must preserve the normalizer config."""
+
+    def test_child_asset_keeps_dataframe_normalizer(self):
+        src = _source()
+        asset = next(a for a in src.assets if type(a).key == _ASSET_KEY)
+        spec_json = DAG(src).mini_dag(asset.id).to_spec().model_dump(mode="json")
+        child_dag = DAGSpec(**spec_json).reconstruct()
+        child_asset = next(a for a in child_dag.assets if type(a).key == _ASSET_KEY)
+
+        normalizer = child_asset.normalizer
+        assert isinstance(normalizer, DataFrameNormalizer)
+        assert normalizer.snake_case_digits is True
+        assert normalizer.flatten_max_level == 2


### PR DESCRIPTION
## What

Adds the **Display & Video 360** (`displayvideo` v4) source to `interloper-assets`, ported from the `digitlcloud-connectors` reference. An **entity-only** source — the reference exposes no reports (DV360 reporting lives in the DoubleClick Bid Manager API, still a stub):

| Asset | Source | Notes |
|---|---|---|
| `partners` | `partners.list` | Paginated; nested config flattened two levels (`dataAccessConfig.sdfConfig.*`); the `enabledExchanges` list is JSON-encoded onto its string column |
| `audiences` | `firstPartyAndPartnerAudiences.list` | Scoped by **partner XOR advertiser** — the optional `advertiser_id` source field wins when set |
| `custom_audiences` | `firstPartyAndPartnerAudiences.get` | Single-audience detail incl. per-surface sizes, gated on the optional `audience_id` field |

## How

- Follows the Google-discovery idioms established in the Campaign Manager 360 PR (#168): **sync assets** (the client is blocking) and **lazy `googleapiclient` imports** (`google-api-python-client` is an optional `google` extra of `interloper-assets`).
- **`partner_id` is a FetchField** fed by a `connection.partners` provider (paginated `partners.list` via `asyncio.to_thread`); `check()` reuses the same lookup. `advertiser_id` / `audience_id` are optional fields consumed by the audience assets.
- Source-level `DataFrameNormalizer(snake_case_digits=True, flatten_max_level=2)` maps the nested partner payload onto the schema — `adServerConfig.measurementConfig.dv360ToCmCostReportingEnabled` → `ad_server_config_measurement_config_dv_360_to_cm_cost_reporting_enabled`.
- `custom_audiences` deliberately ports the reference's **single-audience-by-id** semantics rather than fanning out a `get()` per listed audience — a partner can have thousands of audiences, and only the `get` endpoint returns size fields.

## Tests

`tests/test_display_video_360.py` (6 tests): XOR scope resolution, the `audience_id` guard, a realistic partner payload flattening **exactly** onto the `Partners` schema (bidirectional: no extra columns, no missing fields) + conform, normalizer inheritance across assets, and the host→child DAG-spec round-trip. `ruff` + `ty` + `pytest` all pass.

## Reviewer notes — needs verification

**Not live-tested**: no DV360 credentials were available. Payload shapes are validated against the reference handler's `json_normalize(max_level=2)` + sanitize pipeline and the v4 API structure, not against live responses — the `partners` FetchField provider is likewise untested. A smoke run against a real partner before relying on it would be prudent.

By Digitl