### PR TITLE
feat: relation-aware deletion semantics via on_delete vocabulary

### DIFF
--- a/packages/interloper-app/app/app/components/collection/Table.vue
+++ b/packages/interloper-app/app/app/components/collection/Table.vue
@@ -74,14 +74,15 @@ const emit = defineEmits<{
 
 async function deleteSource(sourceId: string) {
     const info = sourceInfoById.value.get(sourceId)
-    const referrers = componentsStore.usedBy(sourceId)
-    if (referrers.length) {
-        toast.add(inUseToastPayload('Source', referrers))
+    const { blocking, detaching } = componentsStore.deleteImpact(sourceId)
+    if (blocking.length) {
+        toast.add(inUseToastPayload('Source', blocking))
         return
     }
+    const detachNote = detaching.length ? ` It will also be removed from: ${usedByNames(detaching)}.` : ''
     const confirmed = await confirm({
         title: 'Delete source?',
-        description: `This will permanently delete "${info?.name ?? 'this source'}" and all its assets.`,
+        description: `This will permanently delete "${info?.name ?? 'this source'}" and all its assets.${detachNote}`,
         confirmLabel: 'Delete',
         confirmColor: 'error',
         icon: 'i-lucide-triangle-alert',

--- a/packages/interloper-app/app/app/components/ui/DataTable.vue
+++ b/packages/interloper-app/app/app/components/ui/DataTable.vue
@@ -15,11 +15,12 @@ const props = defineProps<{
     /** When true, suppresses the built-in actions column and row menus. */
     noActions?: boolean
     /**
-     * Referrers still bound to the given ids (e.g. `componentsStore.usedBy`).
-     * When it returns any, the delete confirmation lists them and disables
-     * the destructive button — the backend guard stays the authority.
+     * Impact preview for deleting the given ids (e.g.
+     * `componentsStore.deleteImpact`). `blocking` referrers disable the
+     * destructive button; `detaching` ones are listed as a heads-up — the
+     * backend guard stays the authority.
      */
-    usedBy?: (ids: string[]) => UsedByRef[]
+    deleteImpact?: (ids: string[]) => { blocking: UsedByRef[], detaching: UsedByRef[] }
 }>()
 
 const emit = defineEmits<{
@@ -51,11 +52,12 @@ function selectedIds(): string[] {
     return tableRef.value?.tableApi?.getFilteredSelectedRowModel().rows.map((row: any) => row.original.id) ?? []
 }
 
-const bulkReferrers = computed<UsedByRef[]>(() =>
-    showDeleteModal.value ? props.usedBy?.(selectedIds()) ?? [] : [],
+const NO_IMPACT = { blocking: [], detaching: [] }
+const bulkImpact = computed(() =>
+    showDeleteModal.value ? props.deleteImpact?.(selectedIds()) ?? NO_IMPACT : NO_IMPACT,
 )
-const oneReferrers = computed<UsedByRef[]>(() =>
-    deleteOneItem.value ? props.usedBy?.([deleteOneItem.value.id]) ?? [] : [],
+const oneImpact = computed(() =>
+    deleteOneItem.value ? props.deleteImpact?.([deleteOneItem.value.id]) ?? NO_IMPACT : NO_IMPACT,
 )
 
 function confirmBulkDelete() {
@@ -170,20 +172,26 @@ const showEmpty = computed(() => hasLoaded.value && props.data.length === 0 && !
 
                     <template #body>
                         <div class="space-y-4">
-                            <template v-if="bulkReferrers.length">
+                            <template v-if="bulkImpact.blocking.length">
                                 <p>Still in use — rebind or delete these first:</p>
-                                <UsedByTable :referrers="bulkReferrers" />
+                                <UsedByTable :referrers="bulkImpact.blocking" />
                             </template>
-                            <p v-else>
-                                This will permanently delete {{ selectedCount }} {{ selectedCount === 1 ? 'item' :
-                                    'items' }}. This action cannot be undone.
-                            </p>
+                            <template v-else>
+                                <p>
+                                    This will permanently delete {{ selectedCount }} {{ selectedCount === 1 ? 'item' :
+                                        'items' }}. This action cannot be undone.
+                                </p>
+                                <template v-if="bulkImpact.detaching.length">
+                                    <p>It will also be removed from:</p>
+                                    <UsedByTable :referrers="bulkImpact.detaching" />
+                                </template>
+                            </template>
                             <div class="flex justify-end gap-2">
                                 <UButton label="Cancel"
                                          @click="showDeleteModal = false" />
                                 <UButton color="error"
                                          label="Delete"
-                                         :disabled="bulkReferrers.length > 0"
+                                         :disabled="bulkImpact.blocking.length > 0"
                                          @click="confirmBulkDelete" />
                             </div>
                         </div>
@@ -235,19 +243,25 @@ const showEmpty = computed(() => hasLoaded.value && props.data.length === 0 && !
             <template #default />
             <template #body>
                 <div class="space-y-4">
-                    <template v-if="oneReferrers.length">
+                    <template v-if="oneImpact.blocking.length">
                         <p>Still in use — rebind or delete these first:</p>
-                        <UsedByTable :referrers="oneReferrers" />
+                        <UsedByTable :referrers="oneImpact.blocking" />
                     </template>
-                    <p v-else>
-                        This will permanently delete this item. This action cannot be undone.
-                    </p>
+                    <template v-else>
+                        <p>
+                            This will permanently delete this item. This action cannot be undone.
+                        </p>
+                        <template v-if="oneImpact.detaching.length">
+                            <p>It will also be removed from:</p>
+                            <UsedByTable :referrers="oneImpact.detaching" />
+                        </template>
+                    </template>
                     <div class="flex justify-end gap-2">
                         <UButton label="Cancel"
                                  @click="showDeleteOneModal = false" />
                         <UButton color="error"
                                  label="Delete"
-                                 :disabled="oneReferrers.length > 0"
+                                 :disabled="oneImpact.blocking.length > 0"
                                  @click="confirmDeleteOne" />
                     </div>
                 </div>

--- a/packages/interloper-app/app/app/pages/destinations.vue
+++ b/packages/interloper-app/app/app/pages/destinations.vue
@@ -103,7 +103,7 @@ function handleSaved() {
             <DataTable :columns="columns"
                        :data="destinations"
                        :loading="componentsStore.loading"
-                       :used-by="componentsStore.usedBy"
+                       :delete-impact="componentsStore.deleteImpact"
                        search-placeholder="Search destinations..."
                        @delete="handleDelete"
                        @edit="handleEdit">

--- a/packages/interloper-app/app/app/pages/graph.vue
+++ b/packages/interloper-app/app/app/pages/graph.vue
@@ -80,9 +80,9 @@ function onCloseAnimationEnd() {
 
 async function onDeleteSource(sourceId: string) {
     const source = componentsStore.byId(sourceId)
-    const referrers = componentsStore.usedBy(sourceId)
-    if (referrers.length) {
-        toast.add(inUseToastPayload('Source', referrers))
+    const { blocking } = componentsStore.deleteImpact(sourceId)
+    if (blocking.length) {
+        toast.add(inUseToastPayload('Source', blocking))
         return
     }
     try {

--- a/packages/interloper-app/app/app/pages/hooks.vue
+++ b/packages/interloper-app/app/app/pages/hooks.vue
@@ -109,7 +109,7 @@ async function handleDelete(ids: string[]) {
             <DataTable :columns="columns"
                        :data="hooks"
                        :loading="componentsStore.loading"
-                       :used-by="componentsStore.usedBy"
+                       :delete-impact="componentsStore.deleteImpact"
                        search-placeholder="Search hooks..."
                        @delete="handleDelete"
                        @edit="handleEdit">

--- a/packages/interloper-app/app/app/pages/jobs.vue
+++ b/packages/interloper-app/app/app/pages/jobs.vue
@@ -130,7 +130,7 @@ async function handleDelete(ids: string[]) {
                        :data="jobs"
                        :loading="componentsStore.loading"
                        :row-actions="rowActions"
-                       :used-by="componentsStore.usedBy"
+                       :delete-impact="componentsStore.deleteImpact"
                        search-placeholder="Search jobs..."
                        @delete="handleDelete"
                        @edit="handleEdit">

--- a/packages/interloper-app/app/app/pages/resources/[kind].vue
+++ b/packages/interloper-app/app/app/pages/resources/[kind].vue
@@ -109,7 +109,7 @@ const emptyCopy = computed(() => EMPTY_COPY[kind.value] ?? {
             <DataTable :columns="columns"
                        :data="resources"
                        :loading="componentsStore.loading"
-                       :used-by="componentsStore.usedBy"
+                       :delete-impact="componentsStore.deleteImpact"
                        :search-placeholder="`Search ${pageTitle.toLowerCase()}...`"
                        @delete="handleDelete"
                        @edit="handleEdit">

--- a/packages/interloper-app/app/app/pages/sources.vue
+++ b/packages/interloper-app/app/app/pages/sources.vue
@@ -159,7 +159,7 @@ async function handleDelete(ids: string[]) {
                        :data="sources"
                        :loading="componentsStore.loading"
                        :row-actions="rowActions"
-                       :used-by="componentsStore.usedBy"
+                       :delete-impact="componentsStore.deleteImpact"
                        search-placeholder="Search sources..."
                        @delete="handleDelete"
                        @edit="handleEdit">

--- a/packages/interloper-app/app/app/stores/components.ts
+++ b/packages/interloper-app/app/app/stores/components.ts
@@ -144,24 +144,53 @@ export const useComponentsStore = defineStore('components', () => {
     }
 
     /**
-     * Components outside `ids` (and their children) that hold relations into
-     * them — the client-side mirror of the API's delete guard, used to preview
-     * "used by" before a delete is attempted. Referrers that are source-owned
-     * assets resolve to their parent source, the unit the user can act on.
+     * Whether a relation detaches (rather than blocks) when its destination
+     * is deleted — the referrer's vocabulary decides: `on_delete: 'detach'`
+     * types (job targets, hook watches) and optional slots detach; anything
+     * unresolvable blocks, matching the backend guard's fail-closed default.
      */
-    function usedBy(ids: string | string[]): ComponentRecord[] {
+    function _relationDetaches(src: ComponentRecord | undefined, r: Relation): boolean {
+        if (!src) return false
+        const catalogStore = useCatalogStore()
+        let vocabulary = catalogStore.catalog[src.key]?.relations
+        if (src.kind === 'asset' && src.parent_id) {
+            const parent = byId(src.parent_id)
+            const assetDefn = parent && catalogStore.getSourceDefinition(parent.key)?.assets?.find(a => a.key === src.key)
+            if (assetDefn) vocabulary = assetDefn.relations
+        }
+        const defn = vocabulary?.[r.type]
+        if (!defn) return false
+        if (defn.on_delete === 'detach') return true
+        const slot = defn.slots?.[r.slot]
+        return !!slot && !slot.required
+    }
+
+    /**
+     * What deleting `ids` does to the components bound to them — the
+     * client-side mirror of the API's delete guard, used to preview the
+     * impact before a delete is attempted. `blocking` referrers make the
+     * backend refuse with 409; `detaching` ones just lose the relation.
+     * Referrers that are source-owned assets resolve to their parent source,
+     * the unit the user can act on; a referrer that blocks through any
+     * relation is only reported as blocking.
+     */
+    function deleteImpact(ids: string | string[]): { blocking: ComponentRecord[], detaching: ComponentRecord[] } {
         const subtree = new Set(Array.isArray(ids) ? ids : [ids])
         for (const id of [...subtree]) {
             for (const child of byId(id)?.children ?? []) subtree.add(child.id)
         }
-        const referrers = new Map<string, ComponentRecord>()
+        const blocking = new Map<string, ComponentRecord>()
+        const detaching = new Map<string, ComponentRecord>()
         for (const r of relations.value) {
             if (!subtree.has(r.dst_id) || subtree.has(r.src_id)) continue
             let src = byId(r.src_id)
+            const detaches = _relationDetaches(src, r)
             if (src?.parent_id && !subtree.has(src.parent_id)) src = byId(src.parent_id) ?? src
-            if (src && !subtree.has(src.id)) referrers.set(src.id, src)
+            if (!src || subtree.has(src.id)) continue
+            ;(detaches ? detaching : blocking).set(src.id, src)
         }
-        return [...referrers.values()]
+        for (const id of blocking.keys()) detaching.delete(id)
+        return { blocking: [...blocking.values()], detaching: [...detaching.values()] }
     }
 
     function search(query: string, kind?: string): ComponentRecord[] {
@@ -245,7 +274,7 @@ export const useComponentsStore = defineStore('components', () => {
         fetchPartitionRowCounts,
         byKind,
         byId,
-        usedBy,
+        deleteImpact,
         search,
         _upsert,
         _remove,

--- a/packages/interloper-app/app/app/types/catalog.ts
+++ b/packages/interloper-app/app/app/types/catalog.ts
@@ -18,6 +18,12 @@ export interface RelationDefinition {
      * `source_key.asset_key`; `required` flag meaningful).
      */
     slots: Record<string, RelationSlot>
+    /**
+     * What deleting the relation's destination does to the referrer:
+     * `block` refuses the deletion, `detach` cascades the relation away
+     * (job targets, hook watches). Optional slots detach regardless.
+     */
+    on_delete: 'block' | 'detach'
 }
 
 export interface ComponentDefinition {

--- a/packages/interloper-core/src/interloper/component/base.py
+++ b/packages/interloper-core/src/interloper/component/base.py
@@ -10,7 +10,7 @@ class — the single per-kind authority every kind-level question reads from.
 from __future__ import annotations
 
 import uuid
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 from pydantic import BaseModel, Field
 from typing_extensions import Self
@@ -75,6 +75,14 @@ class RelationDefinition(BaseModel):
     unslotted ones ``list[...]``. ``inline`` declares what the field carries:
     embedded component instances (the default), or bare instance ids resolved
     at execution time (``inline=False``, e.g. asset dependencies).
+
+    ``on_delete`` declares what deleting the relation's *destination* does to
+    the referrer: ``"block"`` (the default) refuses the deletion while the
+    relation exists — right for consumption relations, whose loss breaks the
+    referrer at its next run; ``"detach"`` lets the relation cascade away —
+    right for orchestration pointers (a job's ``target``, a hook's ``watch``)
+    that merely shrink the referrer's scope. Optional slots
+    (``RelationSlot.required=False``) detach regardless of this default.
     """
 
     kinds: list[str]
@@ -83,6 +91,7 @@ class RelationDefinition(BaseModel):
     inline: bool = True
     keys: list[str] = Field(default_factory=list)
     slots: dict[str, RelationSlot] = Field(default_factory=dict)
+    on_delete: Literal["block", "detach"] = "block"
 
 
 # -- Definitions ---------------------------------------------------------------

--- a/packages/interloper-core/src/interloper/hook/base.py
+++ b/packages/interloper-core/src/interloper/hook/base.py
@@ -64,7 +64,9 @@ class Hook(Component):
 
     icon: ClassVar[str] = "carbon:lightning"
     relation_types: ClassVar[dict[str, RelationDefinition]] = {
-        "watch": RelationDefinition(kinds=["source", "asset", "job"], field="watches"),
+        # A watch is observation, not consumption: a hook with fewer (or no)
+        # watches goes dormant rather than breaking, so it detaches.
+        "watch": RelationDefinition(kinds=["source", "asset", "job"], field="watches", on_delete="detach"),
         "resource": RelationDefinition(kinds=["connection", "config", "resource"], field="resources", slotted=True),
     }
     internal_fields: ClassVar[frozenset[str]] = frozenset({"watches"})

--- a/packages/interloper-core/src/interloper/job/base.py
+++ b/packages/interloper-core/src/interloper/job/base.py
@@ -43,7 +43,9 @@ class Job(Component):
     icon: ClassVar[str] = "carbon:event-schedule"
     runnable: ClassVar[bool] = True
     relation_types: ClassVar[dict[str, RelationDefinition]] = {
-        "target": RelationDefinition(kinds=["source", "asset"], field="targets"),
+        # A target is an orchestration pointer, not an input: deleting it just
+        # shrinks the job's scope, so it detaches rather than blocking.
+        "target": RelationDefinition(kinds=["source", "asset"], field="targets", on_delete="detach"),
         "destination": RelationDefinition(kinds=["destination"], field="destinations"),
         "resource": RelationDefinition(kinds=["connection", "config", "resource"], field="resources", slotted=True),
     }

--- a/packages/interloper-db/src/interloper_db/store/components.py
+++ b/packages/interloper-db/src/interloper_db/store/components.py
@@ -189,11 +189,16 @@ class ComponentMixin(StoreBase):
     def delete_component(self, component_id: UUID) -> None:
         """Delete a component. Children and out-bound relations cascade via FK.
 
+        In-bound relations follow their declared ``on_delete`` semantics:
+        consumption relations (a bound connection, a required dependency)
+        block the deletion; orchestration pointers (a job's ``target``, a
+        hook's ``watch``, optional dependency slots) detach — the relation
+        row cascades away and the referrer keeps working with reduced scope.
+
         Raises:
             NotFoundError: If the component is not found.
-            InUseError: If other components hold relations into this one or
-                its children (a bound connection, a job's target) — those
-                must be unbound or deleted first.
+            InUseError: If other components hold blocking relations into this
+                one or its children — those must be unbound or deleted first.
             ValueError: If the component is source-owned (delete or update
                 the parent source instead).
         """
@@ -203,7 +208,7 @@ class ComponentMixin(StoreBase):
                 raise NotFoundError(f"Component {component_id} not found")
             if db_component.parent_id is not None:
                 raise ValueError("Cannot delete a source-owned asset directly. Delete or update the source instead.")
-            if referrers := self._external_referrers(session, db_component):
+            if referrers := self._blocking_referrers(session, db_component):
                 names = ", ".join(str(r["name"] or r["key"]) for r in referrers)
                 raise InUseError(
                     f"Cannot delete {db_component.kind} '{db_component.name or db_component.key}': "
@@ -213,14 +218,16 @@ class ComponentMixin(StoreBase):
             session.delete(db_component)
             session.commit()
 
-    def _external_referrers(self, session: Session, db_component: Component) -> list[dict[str, str | None]]:
-        """Components outside a component's subtree that hold relations into it.
+    def _blocking_referrers(self, session: Session, db_component: Component) -> list[dict[str, str | None]]:
+        """Components outside a component's subtree whose relations into it block deletion.
 
-        Deleting a relation destination would cascade the binding row and leave
-        the referrer silently broken at its next run, so deletion is refused
-        while such referrers exist. Relations internal to the subtree (a
-        source's own asset dependencies) don't count, and a referrer that is a
-        source-owned asset is reported as its parent source — the unit the
+        Deleting a relation destination cascades the binding row, which would
+        leave a *consuming* referrer silently broken at its next run — those
+        relations refuse the deletion. Relations whose vocabulary declares
+        ``on_delete="detach"`` (and optional slots) are skipped: cascading
+        them is the intended outcome. Relations internal to the subtree (a
+        source's own asset dependencies) don't count, and a referrer that is
+        a source-owned asset is reported as its parent source — the unit the
         user can act on.
         """
         subtree_ids = {db_component.id} | {child.id for child in db_component.children}
@@ -233,7 +240,7 @@ class ComponentMixin(StoreBase):
         referrers: dict[UUID, Component] = {}
         for relation in rows:
             src = session.get(Component, relation.src_id)
-            if src is None:
+            if src is None or self._relation_detaches(session, src, relation):
                 continue
             if src.parent_id is not None and src.parent_id not in subtree_ids:
                 src = session.get(Component, src.parent_id) or src
@@ -242,6 +249,39 @@ class ComponentMixin(StoreBase):
             {"id": str(c.id), "kind": c.kind, "key": c.key, "name": c.name}
             for c in sorted(referrers.values(), key=lambda c: ((c.name or c.key).lower(), str(c.id)))
         ]
+
+    def _relation_detaches(self, session: Session, db_src: Component, relation: ComponentRelation) -> bool:
+        """Whether a relation detaches (rather than blocks) when its destination is deleted.
+
+        Consults the referrer's own vocabulary: a type declared
+        ``on_delete="detach"`` detaches, as does a slot the referrer declares
+        optional (``RelationSlot.required=False`` — an ``optional_requires``
+        dependency). Anything unresolvable — unknown type, drifted key,
+        undeclared slot — blocks, keeping the guard fail-closed.
+        """
+        definition = self._relation_vocabulary(session, db_src).get(relation.type)
+        if definition is None:
+            return False
+        if definition.on_delete == "detach":
+            return True
+        slot = definition.slots.get(relation.slot)
+        return slot is not None and not slot.required
+
+    def _relation_vocabulary(self, session: Session, db_src: Component) -> dict[str, il.RelationDefinition]:
+        """A referrer row's relation vocabulary, slots included.
+
+        Source-owned assets are not top-level catalog entries: their concrete
+        definition (which carries the dependency slots' ``required`` flags)
+        comes from the parent source's definition. Everything else resolves
+        through the catalog with the kind's anchor as drift fallback.
+        """
+        if db_src.kind == "asset" and db_src.parent_id is not None:
+            parent = session.get(Component, db_src.parent_id)
+            parent_definition = self._catalog.get(parent.key) if parent else None
+            for asset_definition in getattr(parent_definition, "assets", []):
+                if asset_definition.key == db_src.key:
+                    return asset_definition.relations
+        return self._catalog.vocabulary(db_src.kind, db_src.key)
 
     # -- Relations -------------------------------------------------------------
 

--- a/packages/interloper-db/tests/store/test_components.py
+++ b/packages/interloper-db/tests/store/test_components.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import ClassVar
 from uuid import uuid4
 
 import interloper as il
@@ -172,13 +173,33 @@ class TestDeleteInUseGuard:
         with pytest.raises(NotFoundError):
             store.get_component(conn.id)
 
-    def test_job_target_blocks_component_delete(self, store: Store):
+    def test_job_target_detaches(self, store: Store):
         asset = store.create_component(_ORG, kind="asset", key="a")
         job = store.create_component(_ORG, kind="job", key="cron_job", name="J", relations={"target": [(asset.id, "")]})
 
-        with pytest.raises(InUseError) as excinfo:
-            store.delete_component(asset.id)
-        assert [r["id"] for r in excinfo.value.referrers] == [str(job.id)]
+        store.delete_component(asset.id)
+        assert store.get_component(job.id).id == job.id
+        assert store.list_relations(_ORG) == []
+
+    def test_hook_watch_detaches(self, store: Store):
+        asset = store.create_component(_ORG, kind="asset", key="a")
+        hook = store.create_component(_ORG, kind="hook", key="webhook", name="H", relations={"watch": [(asset.id, "")]})
+
+        store.delete_component(asset.id)
+        assert store.get_component(hook.id).id == hook.id
+        assert store.list_relations(_ORG) == []
+
+    def test_blocking_relation_wins_over_detaching(self, store: Store):
+        conn = self._connection(store)
+        asset = store.create_component(_ORG, kind="asset", key="a", name="A", relations={"resource": [(conn.id, "c")]})
+        store.create_component(_ORG, kind="job", key="cron_job", relations={"target": [(asset.id, "")]})
+
+        # The asset both consumes the connection (blocks its deletion) and is
+        # a job target (detachable) — deleting the asset succeeds, deleting
+        # the connection does not.
+        with pytest.raises(InUseError):
+            store.delete_component(conn.id)
+        store.delete_component(asset.id)
 
     def test_referrer_through_child_reports_parent(self, store: Store, component_db: Engine):
         conn = self._connection(store)
@@ -208,6 +229,50 @@ class TestDeleteInUseGuard:
         store.delete_component(parent.id)
         with pytest.raises(NotFoundError):
             store.get_component(parent.id)
+
+
+class GuardUpstream(il.Asset):
+    """Upstream asset for the delete-guard dependency tests."""
+
+
+class GuardRequired(il.Asset):
+    """Asset with a required dependency on ``guard_upstream``."""
+
+    requires: ClassVar[dict[str, str]] = {"up": "guard_upstream"}
+
+
+class GuardOptional(il.Asset):
+    """Asset with an optional dependency on ``guard_upstream``."""
+
+    optional_requires: ClassVar[dict[str, str]] = {"up": "guard_upstream"}
+
+
+class TestDependencyDeleteSemantics:
+    """Required dependency slots block deletion; optional slots detach."""
+
+    @pytest.fixture
+    def dep_store(self, component_db: Engine) -> Store:
+        return Store(catalog=il.Catalog.from_assets([GuardUpstream, GuardRequired, GuardOptional]))
+
+    def test_required_dependency_blocks(self, dep_store: Store):
+        up = dep_store.create_component(_ORG, kind="asset", key="guard_upstream", name="Up")
+        down = dep_store.create_component(
+            _ORG, kind="asset", key="guard_required", relations={"dependency": [(up.id, "up")]}
+        )
+
+        with pytest.raises(InUseError) as excinfo:
+            dep_store.delete_component(up.id)
+        assert [r["id"] for r in excinfo.value.referrers] == [str(down.id)]
+
+    def test_optional_dependency_detaches(self, dep_store: Store):
+        up = dep_store.create_component(_ORG, kind="asset", key="guard_upstream", name="Up")
+        down = dep_store.create_component(
+            _ORG, kind="asset", key="guard_optional", relations={"dependency": [(up.id, "up")]}
+        )
+
+        dep_store.delete_component(up.id)
+        assert dep_store.get_component(down.id).id == down.id
+        assert dep_store.list_relations(_ORG) == []
 
 
 class DiscriminatedSource(il.Source):


### PR DESCRIPTION
## What

Follow-up to #157/#167. The delete guard treated every in-bound relation as blocking, but the two relation families have opposite semantics:

- **Consumption relations** — the referrer needs the target to run: a bound connection (unbound slots auto-instantiate → validation/auth errors mid-run), a destination (empty destinations = silent no-op write), a **required** dependency (`data()` called without the param → TypeError). These keep blocking with 409.
- **Orchestration pointers** — the referrer merely acts on the target: a job's `target`, a hook's `watch`. Deleting the target just shrinks the referrer's scope, so these now **detach**: the relation cascades away (as the FK always did) and the deletion proceeds.

## How

- `RelationDefinition` grows `on_delete: 'block' | 'detach'` (default `block`, fail-safe for new relation types). `Job.target` and `Hook.watch` declare `detach`; `TriggerHook.target` stays blocking (a trigger target that vanishes breaks the hook at fire time).
- Optional dependency slots detach regardless: `RelationSlot.required=False` (the existing `optional_requires` contract) already encodes that the referrer runs without the input.
- The store guard consults the *referrer's* vocabulary — parent-source definitions for source-owned assets, kind-anchor fallback on drift — and raises `InUseError` only for blocking referrers. Anything unresolvable (unknown type, drifted key, undeclared slot) blocks.
- A job left with zero targets stays **enabled** and produces empty runs — deliberately no auto-disable; that's a visible, reversible state.
- Client preview mirrors the split: `componentsStore.deleteImpact()` partitions blocking/detaching, the confirm dialogs list detaching referrers under *"It will also be removed from:"* with Delete enabled, blocking referrers keep the disabled button, and the collection/graph pre-flights block only on blocking referrers.

## Verified live

Headless Chrome + API against a seeded dev instance: bound connection still 409s; deleting a job-targeted source succeeds, the job survives with `targets: []`; the sources-page dialog shows the detach heads-up table with Delete enabled and the deletion goes through. Store tests cover job-target/hook-watch detach, required-vs-optional dependency slots, and blocking-wins-over-detaching.

By Digitl