### PR TITLE
fix(db): stop the ORM orphaning child assets on source deletion

### DIFF
--- a/packages/interloper-db/src/interloper_db/models.py
+++ b/packages/interloper-db/src/interloper_db/models.py
@@ -183,9 +183,13 @@ class Component(SQLModel, table=True):
         back_populates="children",
         sa_relationship_kwargs={"remote_side": "Component.id"},
     )
+    # Deletion is owned by the DB (parent_id is ON DELETE CASCADE). "all" —
+    # not True — because True still nulls parent_id on children that happen
+    # to be loaded in the deleting session, detaching them from the cascade
+    # and leaving orphaned asset rows.
     children: list["Component"] = Relationship(
         back_populates="parent",
-        sa_relationship_kwargs={"passive_deletes": True},
+        sa_relationship_kwargs={"passive_deletes": "all"},
     )
     out_relations: list["ComponentRelation"] = Relationship(
         sa_relationship_kwargs={

--- a/packages/interloper-db/src/interloper_db/store/components.py
+++ b/packages/interloper-db/src/interloper_db/store/components.py
@@ -230,7 +230,11 @@ class ComponentMixin(StoreBase):
         a source-owned asset is reported as its parent source — the unit the
         user can act on.
         """
-        subtree_ids = {db_component.id} | {child.id for child in db_component.children}
+        # Child ids via a bare SELECT, not the ORM relationship: loading the
+        # children into the session that is about to delete their parent
+        # invites the unit of work to manage them.
+        child_ids = session.exec(select(Component.id).where(Component.parent_id == db_component.id)).all()
+        subtree_ids = {db_component.id} | set(child_ids)
         rows = session.exec(
             select(ComponentRelation).where(
                 col(ComponentRelation.dst_id).in_(subtree_ids),

--- a/packages/interloper-db/tests/store/test_components.py
+++ b/packages/interloper-db/tests/store/test_components.py
@@ -125,6 +125,20 @@ class TestCrud:
         with pytest.raises(ValueError):
             store.delete_component(child_id)
 
+    def test_delete_source_removes_child_rows(self, component_db: Engine):
+        from interloper_assets.demo.source import DemoSource
+
+        store = Store(catalog=il.Catalog.from_assets([DemoSource]))
+        source = store.create_component(_ORG, kind="source", key="demo_source")
+        assert source.children
+
+        store.delete_component(source.id)
+
+        # The DB cascade must delete the children — a regression here leaves
+        # them behind as orphaned parentless asset rows instead.
+        with Session(component_db) as session:
+            assert session.exec(select(Component).where(Component.kind == "asset")).all() == []
+
     def test_delete_cascades_outbound_relations(self, store: Store):
         job = store.create_component(_ORG, kind="job", key="cron_job", name="J")
         asset = store.create_component(_ORG, kind="asset", key="a")


### PR DESCRIPTION
## What

Since the in-use delete guard (#157), deleting a source leaves its child assets behind as orphaned, parentless rows instead of cascading them — they show up as floating asset nodes on the graph.

**Not a schema problem.** `components.parent_id` is `ON DELETE CASCADE` and always was. The guard loads `db_component.children` inside the deleting session, and with `passive_deletes=True` SQLAlchemy still nulls the `parent_id` of *loaded* children before deleting the parent (`True` only skips loading unloaded collections; `'all'` is the full delegation). The `UPDATE … SET parent_id = NULL` detaches the children from the cascade, so Postgres never gets to delete them.

## Fix

- `passive_deletes="all"` on the children relationship — the ORM never touches child foreign keys; the database's cascade is the single owner of deletion behavior.
- The guard computes subtree child ids with a bare `SELECT` instead of the ORM relationship, so child objects never enter the delete session at all.
- Regression test: delete a source, assert the child *rows* are gone (existing tests only checked relation cascade). Verified red on the previous code, green with the fix.

## Verified live

Against a Postgres dev instance: creating a `facebook_ads` source materializes 8 children; deleting it now removes all 8 with zero parentless rows added (previously each deletion leaked 8).

Existing orphans are not migrated — they're local-DB debris; clean with
`delete from components where kind='asset' and parent_id is null` (minus any legitimately standalone catalog assets, e.g. `demo_asset`).

By Digitl