### PR TITLE
feat(app): unify delete confirmations on the shared ConfirmModal

### DIFF
--- a/packages/interloper-app/app/app/components/collection/Table.vue
+++ b/packages/interloper-app/app/app/components/collection/Table.vue
@@ -77,7 +77,8 @@ async function deleteSource(sourceId: string) {
     const { blocking, detaching } = componentsStore.deleteImpact(sourceId)
     const confirmed = await confirm({
         title: 'Delete source?',
-        description: `This will permanently delete "${info?.name ?? 'this source'}" and all its assets.`,
+        description: 'This will permanently delete {subject} and all its assets.',
+        subject: { name: info?.name ?? 'this source', icon: info?.icon },
         confirmLabel: 'Delete',
         confirmColor: 'error',
         icon: 'i-lucide-triangle-alert',

--- a/packages/interloper-app/app/app/components/collection/Table.vue
+++ b/packages/interloper-app/app/app/components/collection/Table.vue
@@ -75,17 +75,14 @@ const emit = defineEmits<{
 async function deleteSource(sourceId: string) {
     const info = sourceInfoById.value.get(sourceId)
     const { blocking, detaching } = componentsStore.deleteImpact(sourceId)
-    if (blocking.length) {
-        toast.add(inUseToastPayload('Source', blocking))
-        return
-    }
-    const detachNote = detaching.length ? ` It will also be removed from: ${usedByNames(detaching)}.` : ''
     const confirmed = await confirm({
         title: 'Delete source?',
-        description: `This will permanently delete "${info?.name ?? 'this source'}" and all its assets.${detachNote}`,
+        description: `This will permanently delete "${info?.name ?? 'this source'}" and all its assets.`,
         confirmLabel: 'Delete',
         confirmColor: 'error',
         icon: 'i-lucide-triangle-alert',
+        blocking,
+        detaching,
     })
     if (!confirmed) return
     try {

--- a/packages/interloper-app/app/app/components/graph/SourceNode.vue
+++ b/packages/interloper-app/app/app/components/graph/SourceNode.vue
@@ -129,7 +129,8 @@ const contextMenuItems = computed<ContextMenuItem[][]>(() => [
                 const { blocking, detaching } = componentsStore.deleteImpact(props.source.id)
                 const confirmed = await confirm({
                     title: 'Delete source',
-                    description: `This will permanently delete "${props.source.name}" and all its assets. This action cannot be undone.`,
+                    description: 'This will permanently delete {subject} and all its assets. This action cannot be undone.',
+                    subject: { name: props.source.name ?? props.source.key, icon: componentIcon(props.source.key) },
                     blocking,
                     detaching,
                 })

--- a/packages/interloper-app/app/app/components/graph/SourceNode.vue
+++ b/packages/interloper-app/app/app/components/graph/SourceNode.vue
@@ -91,6 +91,7 @@ const isCompatible = computed(() => isValidTarget.value || isValidSource.value)
 const shouldFade = computed(() => !container.value && isDragging.value && !isCompatible.value)
 
 const { confirm } = useConfirm()
+const componentsStore = useComponentsStore()
 const { getWarnings } = useAssetWarnings()
 const { getBadgeForSource } = useDestinationBadge()
 const { getSourceSchedule } = useSchedule()
@@ -125,9 +126,12 @@ const contextMenuItems = computed<ContextMenuItem[][]>(() => [
             icon: 'i-lucide-trash',
             color: 'error' as const,
             onSelect: async () => {
+                const { blocking, detaching } = componentsStore.deleteImpact(props.source.id)
                 const confirmed = await confirm({
                     title: 'Delete source',
                     description: `This will permanently delete "${props.source.name}" and all its assets. This action cannot be undone.`,
+                    blocking,
+                    detaching,
                 })
                 if (confirmed) emit('delete', props.source.id)
             },

--- a/packages/interloper-app/app/app/components/ui/ConfirmModal.vue
+++ b/packages/interloper-app/app/app/components/ui/ConfirmModal.vue
@@ -3,11 +3,14 @@ import type { UsedByRef } from '~/utils/apiErrors'
 
 const props = withDefaults(defineProps<{
     title?: string
+    /** Body text. A ``{subject}`` token is replaced by a badge of ``subject``. */
     description?: string
     confirmLabel?: string
     cancelLabel?: string
     confirmColor?: 'error' | 'primary' | 'neutral'
     icon?: string
+    /** The entity the action targets, rendered as an inline badge at ``{subject}``. */
+    subject?: { name: string, icon?: string }
     /** Referrers that block the action — listed, and the confirm button disabled. */
     blocking?: UsedByRef[]
     /** Referrers the target will be detached from — listed as a heads-up. */
@@ -19,6 +22,7 @@ const props = withDefaults(defineProps<{
     cancelLabel: 'Cancel',
     confirmColor: 'error',
     icon: 'i-lucide-triangle-alert',
+    subject: undefined,
     blocking: () => [],
     detaching: () => [],
 })
@@ -26,6 +30,12 @@ const props = withDefaults(defineProps<{
 const emit = defineEmits<{
     close: [confirmed: boolean]
 }>()
+
+// Text segments around the {subject} token; the badge slots between them.
+// Without a subject (or token), this is just the whole description, no badge.
+const descriptionParts = computed(() =>
+    props.subject ? props.description.split('{subject}') : [props.description],
+)
 </script>
 
 <template>
@@ -44,7 +54,13 @@ const emit = defineEmits<{
                         <UsedByTable :referrers="props.blocking" />
                     </template>
                     <template v-else>
-                        <p>{{ props.description }}</p>
+                        <p>
+                            <template v-for="(part, i) in descriptionParts"
+                                      :key="i">{{ part }}<EntityBadge v-if="props.subject && i < descriptionParts.length - 1"
+                                            :label="props.subject.name"
+                                            :icon="props.subject.icon"
+                                            class="mx-0.5 align-middle" /></template>
+                        </p>
                         <template v-if="props.detaching.length">
                             <p>It will also be removed from:</p>
                             <UsedByTable :referrers="props.detaching" />

--- a/packages/interloper-app/app/app/components/ui/ConfirmModal.vue
+++ b/packages/interloper-app/app/app/components/ui/ConfirmModal.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import type { UsedByRef } from '~/utils/apiErrors'
+
 const props = withDefaults(defineProps<{
     title?: string
     description?: string
@@ -6,6 +8,10 @@ const props = withDefaults(defineProps<{
     cancelLabel?: string
     confirmColor?: 'error' | 'primary' | 'neutral'
     icon?: string
+    /** Referrers that block the action — listed, and the confirm button disabled. */
+    blocking?: UsedByRef[]
+    /** Referrers the target will be detached from — listed as a heads-up. */
+    detaching?: UsedByRef[]
 }>(), {
     title: 'Are you sure?',
     description: 'This action cannot be undone.',
@@ -13,6 +19,8 @@ const props = withDefaults(defineProps<{
     cancelLabel: 'Cancel',
     confirmColor: 'error',
     icon: 'i-lucide-triangle-alert',
+    blocking: () => [],
+    detaching: () => [],
 })
 
 const emit = defineEmits<{
@@ -30,9 +38,19 @@ const emit = defineEmits<{
                     <UIcon :name="props.icon"
                            class="size-5 text-error" />
                 </div>
-                <p class="text-sm text-muted">
-                    {{ props.description }}
-                </p>
+                <div class="flex-1 space-y-3 text-sm text-muted">
+                    <template v-if="props.blocking.length">
+                        <p>Still in use — rebind or delete these first:</p>
+                        <UsedByTable :referrers="props.blocking" />
+                    </template>
+                    <template v-else>
+                        <p>{{ props.description }}</p>
+                        <template v-if="props.detaching.length">
+                            <p>It will also be removed from:</p>
+                            <UsedByTable :referrers="props.detaching" />
+                        </template>
+                    </template>
+                </div>
             </div>
         </template>
 
@@ -43,6 +61,7 @@ const emit = defineEmits<{
                      @click="emit('close', false)" />
             <UButton :label="props.confirmLabel"
                      :color="props.confirmColor"
+                     :disabled="props.blocking.length > 0"
                      @click="emit('close', true)" />
         </template>
     </UModal>

--- a/packages/interloper-app/app/app/components/ui/DataTable.vue
+++ b/packages/interloper-app/app/app/components/ui/DataTable.vue
@@ -28,10 +28,9 @@ const emit = defineEmits<{
     edit: [item: TData]
 }>()
 
+const { confirm } = useConfirm()
+
 const globalFilter = ref('')
-const showDeleteModal = ref(false)
-const showDeleteOneModal = ref(false)
-const deleteOneItem = ref<TData | null>(null)
 const tableRef = useTemplateRef<{ tableApi: any }>('table')
 
 const pagination = ref({ pageIndex: 0, pageSize: PAGE_SIZE })
@@ -53,25 +52,20 @@ function selectedIds(): string[] {
 }
 
 const NO_IMPACT = { blocking: [], detaching: [] }
-const bulkImpact = computed(() =>
-    showDeleteModal.value ? props.deleteImpact?.(selectedIds()) ?? NO_IMPACT : NO_IMPACT,
-)
-const oneImpact = computed(() =>
-    deleteOneItem.value ? props.deleteImpact?.([deleteOneItem.value.id]) ?? NO_IMPACT : NO_IMPACT,
-)
 
-function confirmBulkDelete() {
-    emit('delete', selectedIds())
-    tableRef.value?.tableApi?.toggleAllRowsSelected(false)
-    showDeleteModal.value = false
+/** Confirm (via the shared modal) and, when accepted, emit the delete. */
+async function requestDelete(ids: string[], description: string) {
+    const { blocking, detaching } = props.deleteImpact?.(ids) ?? NO_IMPACT
+    const confirmed = await confirm({ title: 'Confirm Deletion', description, blocking, detaching })
+    if (confirmed) emit('delete', ids)
+    return confirmed
 }
 
-function confirmDeleteOne() {
-    if (deleteOneItem.value) {
-        emit('delete', [deleteOneItem.value.id])
-    }
-    deleteOneItem.value = null
-    showDeleteOneModal.value = false
+async function requestBulkDelete() {
+    const ids = selectedIds()
+    const noun = ids.length === 1 ? 'item' : 'items'
+    const confirmed = await requestDelete(ids, `This will permanently delete ${ids.length} ${noun}. This action cannot be undone.`)
+    if (confirmed) tableRef.value?.tableApi?.toggleAllRowsSelected(false)
 }
 
 // ── Row action menus ──
@@ -92,10 +86,7 @@ function buildRowActions(item: TData): DropdownMenuItem[][] {
                 label: 'Delete',
                 icon: 'i-lucide-trash-2',
                 color: 'error' as const,
-                onSelect: () => {
-                    deleteOneItem.value = item
-                    showDeleteOneModal.value = true
-                },
+                onSelect: () => requestDelete([item.id], 'This will permanently delete this item. This action cannot be undone.'),
             },
         ],
     ]
@@ -163,40 +154,11 @@ const showEmpty = computed(() => hasLoaded.value && props.data.length === 0 && !
             <div class="ml-auto flex items-center gap-2">
                 <slot name="toolbar" />
 
-                <UModal v-if="selectedCount > 0"
-                        v-model:open="showDeleteModal"
-                        title="Confirm Deletion">
-                    <UButton color="error"
-                             icon="i-lucide-trash-2"
-                             :label="`Delete (${selectedCount})`" />
-
-                    <template #body>
-                        <div class="space-y-4">
-                            <template v-if="bulkImpact.blocking.length">
-                                <p>Still in use — rebind or delete these first:</p>
-                                <UsedByTable :referrers="bulkImpact.blocking" />
-                            </template>
-                            <template v-else>
-                                <p>
-                                    This will permanently delete {{ selectedCount }} {{ selectedCount === 1 ? 'item' :
-                                        'items' }}. This action cannot be undone.
-                                </p>
-                                <template v-if="bulkImpact.detaching.length">
-                                    <p>It will also be removed from:</p>
-                                    <UsedByTable :referrers="bulkImpact.detaching" />
-                                </template>
-                            </template>
-                            <div class="flex justify-end gap-2">
-                                <UButton label="Cancel"
-                                         @click="showDeleteModal = false" />
-                                <UButton color="error"
-                                         label="Delete"
-                                         :disabled="bulkImpact.blocking.length > 0"
-                                         @click="confirmBulkDelete" />
-                            </div>
-                        </div>
-                    </template>
-                </UModal>
+                <UButton v-if="selectedCount > 0"
+                         color="error"
+                         icon="i-lucide-trash-2"
+                         :label="`Delete (${selectedCount})`"
+                         @click="requestBulkDelete" />
             </div>
         </div>
 
@@ -236,37 +198,6 @@ const showEmpty = computed(() => hasLoaded.value && props.data.length === 0 && !
                        :content="{ reference: ctxMenuVirtual, side: 'bottom', align: 'start', sideOffset: 4 }">
             <div class="hidden" />
         </UDropdownMenu>
-
-        <!-- Single-item delete confirmation -->
-        <UModal v-model:open="showDeleteOneModal"
-                title="Confirm Deletion">
-            <template #default />
-            <template #body>
-                <div class="space-y-4">
-                    <template v-if="oneImpact.blocking.length">
-                        <p>Still in use — rebind or delete these first:</p>
-                        <UsedByTable :referrers="oneImpact.blocking" />
-                    </template>
-                    <template v-else>
-                        <p>
-                            This will permanently delete this item. This action cannot be undone.
-                        </p>
-                        <template v-if="oneImpact.detaching.length">
-                            <p>It will also be removed from:</p>
-                            <UsedByTable :referrers="oneImpact.detaching" />
-                        </template>
-                    </template>
-                    <div class="flex justify-end gap-2">
-                        <UButton label="Cancel"
-                                 @click="showDeleteOneModal = false" />
-                        <UButton color="error"
-                                 label="Delete"
-                                 :disabled="oneImpact.blocking.length > 0"
-                                 @click="confirmDeleteOne" />
-                    </div>
-                </div>
-            </template>
-        </UModal>
 
         <TableFooter v-if="!showEmpty"
                      :page="pagination.pageIndex + 1"

--- a/packages/interloper-app/app/app/composables/confirm.ts
+++ b/packages/interloper-app/app/app/composables/confirm.ts
@@ -8,6 +8,8 @@ interface ConfirmOptions {
     cancelLabel?: string
     confirmColor?: 'error' | 'primary' | 'neutral'
     icon?: string
+    /** Entity the action targets, rendered as a badge at ``{subject}`` in the description. */
+    subject?: { name: string, icon?: string }
     /** Referrers that block the action — listed, confirm disabled. */
     blocking?: UsedByRef[]
     /** Referrers the target will be detached from — listed as a heads-up. */

--- a/packages/interloper-app/app/app/composables/confirm.ts
+++ b/packages/interloper-app/app/app/composables/confirm.ts
@@ -1,4 +1,5 @@
 import { LazyConfirmModal } from '#components'
+import type { UsedByRef } from '~/utils/apiErrors'
 
 interface ConfirmOptions {
     title?: string
@@ -7,6 +8,10 @@ interface ConfirmOptions {
     cancelLabel?: string
     confirmColor?: 'error' | 'primary' | 'neutral'
     icon?: string
+    /** Referrers that block the action — listed, confirm disabled. */
+    blocking?: UsedByRef[]
+    /** Referrers the target will be detached from — listed as a heads-up. */
+    detaching?: UsedByRef[]
 }
 
 export function useConfirm() {

--- a/packages/interloper-app/app/app/pages/graph.vue
+++ b/packages/interloper-app/app/app/pages/graph.vue
@@ -79,12 +79,9 @@ function onCloseAnimationEnd() {
 }
 
 async function onDeleteSource(sourceId: string) {
+    // Confirmation (and the in-use guard preview) happens in SourceNode before
+    // this fires; the backend 409 remains the authority for races.
     const source = componentsStore.byId(sourceId)
-    const { blocking } = componentsStore.deleteImpact(sourceId)
-    if (blocking.length) {
-        toast.add(inUseToastPayload('Source', blocking))
-        return
-    }
     try {
         await componentsStore.remove(sourceId)
         toast.add({ title: `Source "${source?.name ?? 'Source'}" deleted`, color: 'success' })


### PR DESCRIPTION
## What

Two problems with the delete confirmations:

1. **The graph's source-delete modal never showed the impact preview.** Deleting a job-targeted source from the graph (where sources naturally live as nodes) opened a modal that said only "permanently delete … and all its assets" — no mention that the job would be detached. The `deleteImpact` preview only reached the table-based surfaces.
2. **Inconsistent look.** `DataTable` used two hand-rolled `UModal`s (larger body text, action buttons *inside* the body), while every other confirmation goes through `ConfirmModal` via `useConfirm()` (icon + small muted body + footer actions).

## How

`ConfirmModal` becomes the single confirmation component and gains optional `blocking` / `detaching` referrer lists, rendered through the same `UsedByTable`: blocking referrers disable the confirm button, detaching ones show as an "It will also be removed from:" heads-up. `useConfirm()` carries the two lists.

- `DataTable` drops its bespoke modals and routes both single and bulk deletes through `useConfirm()`.
- The graph's `SourceNode` and the collection table pass their `deleteImpact` through to the same modal.
- `graph.vue`'s now-redundant pre-emptive blocking toast is removed (the modal handles it).

Net: **−102/+55 lines**, one confirmation component everywhere.

## Verified live

Headless Chrome against a seeded instance:
- Graph modal for the job-targeted "Demo Data" now shows *"It will also be removed from: Demo Daily (Job)"* — pixel-consistent with the sources-page modal.
- Blocking still works: a connection bound to a source shows *"Still in use — rebind or delete these first"* with the Delete button disabled.
- No orphaned rows left behind by any delete path.

By Digitl