### PR TITLE
feat(app): agent panel UX polish

### DIFF
--- a/packages/interloper-app/app/app/components/agent/ConfirmCard.vue
+++ b/packages/interloper-app/app/app/components/agent/ConfirmCard.vue
@@ -42,7 +42,7 @@ function decide(confirmed: boolean) {
 </script>
 
 <template>
-    <div class="border border-default rounded-[13px] p-4 my-2 w-full min-w-72 max-w-md flex flex-col gap-3">
+    <div class="border border-default rounded-[13px] p-4 my-2 w-full min-w-80 max-w-md flex flex-col gap-3">
         <span class="text-[13px] font-semibold text-highlighted">{{ request.title }}</span>
 
         <WizardRecap :rows="rows" />

--- a/packages/interloper-app/app/app/components/agent/ConnectCard.vue
+++ b/packages/interloper-app/app/app/components/agent/ConnectCard.vue
@@ -135,7 +135,7 @@ async function submit() {
 </script>
 
 <template>
-    <div class="border border-default rounded-[13px] p-4 my-2 w-full min-w-72 max-w-md">
+    <div class="border border-default rounded-[13px] p-4 my-2 w-full min-w-80 max-w-md">
         <!-- Unknown type: the catalog may not carry this key anymore -->
         <div v-if="!defn"
              class="flex items-center gap-2 text-[13px] text-muted">

--- a/packages/interloper-app/app/app/components/agent/Panel.vue
+++ b/packages/interloper-app/app/app/components/agent/Panel.vue
@@ -75,9 +75,9 @@ function submit(text: string) {
 }
 
 const SUGGESTIONS = [
-    'Setup a new source',
-    'Setup a new connection',
     'What failed in the last 24 hours?',
+    'Summarize my pipeline health',
+    'Which sources are stale?',
 ]
 </script>
 
@@ -110,7 +110,9 @@ const SUGGESTIONS = [
                      @click="open = false" />
         </div>
 
-        <!-- Messages -->
+        <!-- Messages. The relative wrapper (not the scroll container itself) anchors
+             the floating scroll-to-bottom button to the visible area. -->
+        <div class="relative flex-1 min-h-0 flex flex-col">
         <div class="flex-1 min-h-0 overflow-y-auto p-[18px]">
             <div v-if="sessionError"
                  class="flex flex-col items-center gap-2 py-10 text-center">
@@ -126,7 +128,8 @@ const SUGGESTIONS = [
                                should-auto-scroll
                                :assistant="{ icon: 'i-lucide-sparkles', ui: { body: 'flex-1', content: 'text-[13.5px]', leadingIcon: 'text-primary' } }"
                                :user="{ ui: { content: 'text-[13.5px]' } }"
-                               :auto-scroll="{ size: 'xs', color: 'neutral', variant: 'outline' }"
+                               :auto-scroll="{ size: 'md', color: 'neutral', variant: 'outline' }"
+                               :ui="{ viewport: 'top-auto bottom-3' }"
                                class="pb-2">
                     <template #content="{ message }">
                         <AgentConnectCard v-if="(message as any).connectionSetup"
@@ -138,14 +141,10 @@ const SUGGESTIONS = [
                         <AgentConfirmCard v-else-if="(message as any).confirmation"
                                           :request="(message as any).confirmation"
                                           @decided="onDecision" />
-                        <MDC v-else-if="message.role === 'assistant'"
+                        <MDC v-else
                              :value="message.text"
                              :cache-key="message.id"
-                             class="*:first:mt-0 *:last:mb-0 [&_code]:text-[12px]" />
-                        <p v-else
-                           class="whitespace-pre-wrap">
-                            {{ message.text }}
-                        </p>
+                             :class="['*:first:mt-0 *:last:mb-0 [&_code]:text-[12px]', message.role === 'user' ? '[&_p]:whitespace-pre-wrap' : '']" />
                     </template>
                 </UChatMessages>
 
@@ -173,6 +172,7 @@ const SUGGESTIONS = [
                     </button>
                 </div>
             </template>
+        </div>
         </div>
 
         <!-- Composer -->

--- a/packages/interloper-app/app/app/components/agent/SelectCard.vue
+++ b/packages/interloper-app/app/app/components/agent/SelectCard.vue
@@ -49,7 +49,7 @@ function confirm() {
 </script>
 
 <template>
-    <div class="border border-default rounded-[13px] p-4 my-2 w-full min-w-72 max-w-md flex flex-col gap-3">
+    <div class="border border-default rounded-[13px] p-4 my-2 w-full min-w-80 max-w-md flex flex-col gap-3">
         <div class="flex items-center justify-between gap-2">
             <span class="text-[13px] font-semibold text-highlighted">{{ request.prompt }}</span>
             <UButton v-if="request.multi && request.options.length > 3 && !submitted"

--- a/packages/interloper-app/app/app/layouts/default.vue
+++ b/packages/interloper-app/app/app/layouts/default.vue
@@ -129,13 +129,6 @@ const items = computed<NavigationMenuItem[]>(() => {
                     </NuxtLink>
                 </template>
 
-                <template #right>
-                    <UButton v-if="userStore.agentAvailable"
-                             icon="i-lucide-sparkles"
-                             label="Agent"
-                             size="md"
-                             @click="agentOpen = !agentOpen" />
-                </template>
             </UDashboardNavbar>
 
             <div class="flex flex-1 min-h-0 overflow-hidden">
@@ -211,6 +204,16 @@ const items = computed<NavigationMenuItem[]>(() => {
                     </template>
                 </UModal>
             </div>
+
+            <!-- Floating agent launcher. Positioned inside the dashboard group so it
+                 slides left with the layout when the panel opens, instead of hiding
+                 under the panel. -->
+            <UButton v-if="userStore.agentAvailable"
+                     icon="i-lucide-sparkles"
+                     size="xl"
+                     aria-label="Toggle agent panel"
+                     class="absolute bottom-6 right-6 z-30 rounded-full shadow-lg"
+                     @click="agentOpen = !agentOpen" />
         </UDashboardGroup>
 
         <AgentPanel v-if="userStore.agentAvailable" />


### PR DESCRIPTION
Four UX improvements to the docked agent panel:

- **Floating launcher** — the navbar Agent button becomes a round floating button at the bottom right, in typical AI-bot fashion. It lives inside the dashboard group (whose right offset animates with the panel), so opening the panel slides it left as a visible toggle instead of burying it under the panel.
- **User messages render Markdown** — same MDC pipeline as assistant messages. User paragraphs additionally get `whitespace-pre-wrap` so their single line breaks survive (matching the old plain-text behavior); assistant prose is unchanged.
- **Scroll-to-bottom button** — previously anchored to the panel itself at `top-[86%]`, floating mid-panel; now anchored to the visible messages area (relative wrapper around the scroll container, deliberately not the scroll container itself), sitting 12px above the composer, bumped from `xs` to `md` (32px).
- **Agent cards** (connect / select / confirm) — `min-w-72` → `min-w-80` so forms stay usable when the panel is dragged toward its 320px minimum.

All verified on a live dev instance (screenshots + measured geometry: FAB 24px from the corner closed, 424px when open; scroll button 32×32 at 12px above the composer; user bubble renders real `<strong>`/`<code>`/`<ul>`).

By Digitl