### PR TITLE
feat(assets): add The Trade Desk source

### DIFF
--- a/packages/interloper-assets/src/interloper_assets/thetradedesk/connection.py
+++ b/packages/interloper-assets/src/interloper_assets/thetradedesk/connection.py
@@ -17,7 +17,6 @@ class TheTradeDeskConnection(il.Connection):
     model_config = SettingsConfigDict(env_prefix="thetradedesk_")
 
     api_key: str = il.SecretField(title="API Key", description="The Trade Desk API key")
-    partner_id: str = il.InputField(title="Partner ID", description="The Trade Desk partner ID", discriminator=True)
 
     @cached_property
     def client(self) -> il.AsyncRESTClient:
@@ -25,4 +24,27 @@ class TheTradeDeskConnection(il.Connection):
         return il.AsyncRESTClient(
             BASE_URL,
             headers={"TTD-Auth": self.api_key},
+            timeout=60,
         )
+
+    @il.fetch_field_provider
+    async def partners(self) -> list[dict[str, str]]:
+        """Fetch the partners accessible to the API key."""
+        response = await self.client.post("/partner/query", json={"PageStartIndex": 0, "PageSize": 100})
+        response.raise_for_status()
+        return [
+            {
+                "partner_id": p["PartnerId"],
+                "name": f"{p.get('PartnerName', p['PartnerId'])} ({p['PartnerId']})",
+            }
+            for p in response.json().get("Result", [])
+        ]
+
+    async def check(self) -> bool:
+        """Prove the credentials work by running the ``partners`` lookup.
+
+        Returns:
+            True — any credential failure raises out of the lookup.
+        """
+        await self.partners()
+        return True

--- a/packages/interloper-assets/src/interloper_assets/thetradedesk/constants.py
+++ b/packages/interloper-assets/src/interloper_assets/thetradedesk/constants.py
@@ -1,1 +1,5 @@
 BASE_URL = "https://api.thetradedesk.com/v3"
+
+# MyReports system template "Global Standard Adgroup" — the ad_groups_stats
+# schema is bound to this template's columns.
+ADGROUPS_REPORT_TEMPLATE_ID = "168005"

--- a/packages/interloper-assets/src/interloper_assets/thetradedesk/schemas/__init__.py
+++ b/packages/interloper-assets/src/interloper_assets/thetradedesk/schemas/__init__.py
@@ -1,0 +1,5 @@
+from .ad_groups_stats import AdGroupsStats
+
+__all__ = [
+    "AdGroupsStats",
+]

--- a/packages/interloper-assets/src/interloper_assets/thetradedesk/schemas/ad_groups_stats.py
+++ b/packages/interloper-assets/src/interloper_assets/thetradedesk/schemas/ad_groups_stats.py
@@ -1,0 +1,229 @@
+import datetime as dt
+
+from interloper.schema import Schema
+from pydantic import Field
+
+
+class AdGroupsStats(Schema):
+    """Ad-group performance metrics per day (MyReports Global Standard Adgroup template)."""
+
+    date: dt.date | None = Field(default=None, description="The date of the record")
+    partner_id: str | None = Field(default=None, description="Unique identifier for the partner")
+    advertiser_id: str | None = Field(default=None, description="Unique identifier for the advertiser")
+    campaign_id: str | None = Field(default=None, description="Unique identifier for the campaign")
+    ad_group_id: str | None = Field(default=None, description="Unique identifier for the ad group")
+    ad_format: str | None = Field(default=None, description="Format of the advertisement")
+    creative_id: str | None = Field(default=None, description="Unique identifier for the creative")
+    frequency: int | None = Field(default=None, description="Number of times the ad was shown")
+    advertiser: str | None = Field(default=None, description="Name of the advertiser")
+    campaign: str | None = Field(default=None, description="Name of the campaign")
+    ad_group: str | None = Field(default=None, description="Name of the ad group")
+    ad_group_budget_in_impressions: int | None = Field(
+        default=None, description="Budget of the ad group in impressions"
+    )
+    ad_group_daily_cap_in_impressions: int | None = Field(
+        default=None, description="Daily cap of the ad group in impressions"
+    )
+    ad_group_daily_target_in_impressions: int | None = Field(
+        default=None, description="Daily target of the ad group in impressions"
+    )
+    ad_group_base_bid_cpm_adv_currency: float | None = Field(
+        default=None, description="Base bid CPM in advertiser's currency"
+    )
+    ad_group_budget_adv_currency: float | None = Field(
+        default=None, description="Budget of the ad group in advertiser's currency"
+    )
+    ad_group_daily_cap_adv_currency: float | None = Field(
+        default=None, description="Daily cap of the ad group in advertiser's currency"
+    )
+    ad_group_daily_target_adv_currency: float | None = Field(
+        default=None, description="Daily target of the ad group in advertiser's currency"
+    )
+    advertiser_currency_code: str | None = Field(default=None, description="Currency code of the advertiser")
+    partner_currency_code: str | None = Field(default=None, description="Currency code of the partner")
+    creative: str | None = Field(default=None, description="Name of the creative")
+    click_conversion_currency_01: float | None = Field(
+        default=None, description="Conversion value for click in currency 01"
+    )
+    view_through_conversion_currency_01: float | None = Field(
+        default=None, description="Conversion value for view-through in currency 01"
+    )
+    click_conversion_currency_02: float | None = Field(
+        default=None, description="Conversion value for click in currency 02"
+    )
+    view_through_conversion_currency_02: float | None = Field(
+        default=None, description="Conversion value for view-through in currency 02"
+    )
+    click_conversion_currency_03: float | None = Field(
+        default=None, description="Conversion value for click in currency 03"
+    )
+    view_through_conversion_currency_03: float | None = Field(
+        default=None, description="Conversion value for view-through in currency 03"
+    )
+    click_conversion_currency_04: float | None = Field(
+        default=None, description="Conversion value for click in currency 04"
+    )
+    view_through_conversion_currency_04: float | None = Field(
+        default=None, description="Conversion value for view-through in currency 04"
+    )
+    click_conversion_currency_05: float | None = Field(
+        default=None, description="Conversion value for click in currency 05"
+    )
+    view_through_conversion_currency_05: float | None = Field(
+        default=None, description="Conversion value for view-through in currency 05"
+    )
+    click_conversion_currency_06: float | None = Field(
+        default=None, description="Conversion value for click in currency 06"
+    )
+    view_through_conversion_currency_06: float | None = Field(
+        default=None, description="Conversion value for view-through in currency 06"
+    )
+    deal_id: str | None = Field(default=None, description="Unique identifier for the deal")
+    ad_server_name: str | None = Field(default=None, description="Name of the ad server")
+    ad_server_creative_placement_id: str | None = Field(
+        default=None, description="Unique identifier for the ad server creative placement"
+    )
+    bids: int | None = Field(default=None, description="Number of bids")
+    total_bid_amount_adv_currency: float | None = Field(
+        default=None, description="Total bid amount in advertiser's currency"
+    )
+    total_bid_amount_partner_currency: float | None = Field(
+        default=None, description="Total bid amount in partner's currency"
+    )
+    total_bid_amount_usd: float | None = Field(default=None, description="Total bid amount in USD")
+    impressions: int | None = Field(default=None, description="Number of impressions")
+    clicks: int | None = Field(default=None, description="Number of clicks")
+    ttd_cost_adv_currency: float | None = Field(default=None, description="TTD cost in advertiser's currency")
+    ttd_cost_partner_currency: float | None = Field(default=None, description="TTD cost in partner's currency")
+    ttd_cost_usd: float | None = Field(default=None, description="TTD cost in USD")
+    partner_cost_adv_currency: float | None = Field(default=None, description="Partner cost in advertiser's currency")
+    partner_cost_partner_currency: float | None = Field(default=None, description="Partner cost in partner's currency")
+    partner_cost_usd: float | None = Field(default=None, description="Partner cost in USD")
+    advertiser_cost_adv_currency: float | None = Field(
+        default=None, description="Advertiser cost in advertiser's currency"
+    )
+    advertiser_cost_partner_currency: float | None = Field(
+        default=None, description="Advertiser cost in partner's currency"
+    )
+    advertiser_cost_usd: float | None = Field(default=None, description="Advertiser cost in USD")
+    player_views: int | None = Field(default=None, description="Number of player views")
+    player_starts: int | None = Field(default=None, description="Number of player starts")
+    player_25pct_complete: int | None = Field(
+        default=None, description="Number of times the player reached 25% completion"
+    )
+    player_50pct_complete: int | None = Field(
+        default=None, description="Number of times the player reached 50% completion"
+    )
+    player_75pct_complete: int | None = Field(
+        default=None, description="Number of times the player reached 75% completion"
+    )
+    player_completed_views: int | None = Field(default=None, description="Number of completed views")
+    player_mute: int | None = Field(default=None, description="Indicates if the player is muted")
+    player_unmute: int | None = Field(default=None, description="Indicates if the player is unmuted")
+    player_pause: int | None = Field(default=None, description="Indicates if the player is paused")
+    player_resume: int | None = Field(default=None, description="Indicates if the player is resumed")
+    player_full_screen: int | None = Field(default=None, description="Indicates if the player is in full screen mode")
+    player_errors: str | None = Field(default=None, description="Details of any errors encountered by the player")
+    player_skip: int | None = Field(default=None, description="Indicates if the player skipped content")
+    player_engaged_views: int | None = Field(default=None, description="Number of engaged views by the player")
+    player_rewind: int | None = Field(default=None, description="Indicates if the player rewound content")
+    player_expansion: int | None = Field(default=None, description="Indicates if the player expanded")
+    player_collapse: int | None = Field(default=None, description="Indicates if the player collapsed")
+    player_invitation_accept: int | None = Field(
+        default=None, description="Indicates if the player accepted an invitation"
+    )
+    player_close: int | None = Field(default=None, description="Indicates if the player was closed")
+    sampled_tracked_impressions: int | None = Field(default=None, description="Number of sampled tracked impressions")
+    sampled_viewed_impressions: int | None = Field(default=None, description="Number of sampled viewed impressions")
+    conversion_touch_01: int | None = Field(default=None, description="Number of first conversion touches")
+    conversion_touch_revenue_01: float | None = Field(default=None, description="Revenue from first conversion touches")
+    click_conversion_01: int | None = Field(default=None, description="Number of first click conversions")
+    click_conversion_revenue_01: float | None = Field(default=None, description="Revenue from first click conversions")
+    view_through_conversion_01: int | None = Field(default=None, description="Number of first view-through conversions")
+    view_through_conversion_revenue_01: float | None = Field(
+        default=None, description="Revenue from first view-through conversions"
+    )
+    time_weighted_decay_conversion_01: int | None = Field(
+        default=None, description="Number of first time-weighted decay conversions"
+    )
+    time_weighted_decay_conversion_revenue_01: float | None = Field(
+        default=None, description="Revenue from first time-weighted decay conversions"
+    )
+    time_weighted_decay_conversion_02: int | None = Field(
+        default=None, description="Number of second time-weighted decay conversions"
+    )
+    time_weighted_decay_conversion_revenue_02: float | None = Field(
+        default=None, description="Revenue from second time-weighted decay conversions"
+    )
+    view_through_conversion_02: int | None = Field(
+        default=None, description="Number of second view-through conversions"
+    )
+    view_through_conversion_revenue_02: float | None = Field(
+        default=None, description="Revenue from second view-through conversions"
+    )
+    click_conversion_02: int | None = Field(default=None, description="Number of second click conversions")
+    click_conversion_revenue_02: float | None = Field(default=None, description="Revenue from second click conversions")
+    conversion_touch_02: int | None = Field(default=None, description="Number of second conversion touches")
+    conversion_touch_revenue_02: float | None = Field(
+        default=None, description="Revenue from second conversion touches"
+    )
+    conversion_touch_03: int | None = Field(default=None, description="Number of third conversion touches")
+    conversion_touch_revenue_03: float | None = Field(default=None, description="Revenue from third conversion touches")
+    click_conversion_03: int | None = Field(default=None, description="Number of third click conversions")
+    click_conversion_revenue_03: float | None = Field(default=None, description="Revenue from third click conversions")
+    view_through_conversion_03: int | None = Field(default=None, description="Number of third view-through conversions")
+    view_through_conversion_revenue_03: float | None = Field(
+        default=None, description="Revenue from third view-through conversions"
+    )
+    time_weighted_decay_conversion_03: int | None = Field(
+        default=None, description="Number of third time-weighted decay conversions"
+    )
+    time_weighted_decay_conversion_revenue_03: float | None = Field(
+        default=None, description="Revenue from third time-weighted decay conversions"
+    )
+    time_weighted_decay_conversion_04: int | None = Field(
+        default=None, description="Number of fourth time-weighted decay conversions"
+    )
+    time_weighted_decay_conversion_revenue_04: float | None = Field(
+        default=None, description="Revenue from fourth time-weighted decay conversions"
+    )
+    view_through_conversion_04: int | None = Field(
+        default=None, description="Number of fourth view-through conversions"
+    )
+    view_through_conversion_revenue_04: float | None = Field(
+        default=None, description="Revenue from fourth view-through conversions"
+    )
+    click_conversion_04: int | None = Field(default=None, description="Number of fourth click conversions")
+    click_conversion_revenue_04: float | None = Field(default=None, description="Revenue from fourth click conversions")
+    conversion_touch_04: int | None = Field(default=None, description="Number of fourth conversion touches")
+    conversion_touch_revenue_04: float | None = Field(
+        default=None, description="Revenue from fourth conversion touches"
+    )
+    conversion_touch_05: int | None = Field(default=None, description="Number of fifth conversion touches")
+    conversion_touch_revenue_05: float | None = Field(default=None, description="Revenue from fifth conversion touches")
+    click_conversion_05: int | None = Field(default=None, description="Number of fifth click conversions")
+    click_conversion_revenue_05: float | None = Field(default=None, description="Revenue from fifth click conversions")
+    view_through_conversion_05: int | None = Field(default=None, description="Number of fifth view-through conversions")
+    view_through_conversion_revenue_05: float | None = Field(
+        default=None, description="Revenue from fifth view-through conversions"
+    )
+    time_weighted_decay_conversion_05: int | None = Field(
+        default=None, description="Number of fifth time-weighted decay conversions"
+    )
+    time_weighted_decay_conversion_revenue_05: float | None = Field(
+        default=None, description="Revenue from fifth time-weighted decay conversions"
+    )
+    time_weighted_decay_conversion_06: int | None = Field(
+        default=None, description="Number of sixth time-weighted decay conversions"
+    )
+    time_weighted_decay_conversion_revenue_06: float | None = Field(
+        default=None, description="Revenue from sixth time-weighted decay conversions"
+    )
+    conversion_touch_06: int | None = Field(default=None, description="Number of sixth conversion touches")
+    conversion_touch_revenue_06: float | None = Field(default=None, description="Revenue from sixth conversion touches")
+    click_conversion_06: int | None = Field(default=None, description="Number of sixth click conversions")
+    click_conversion_revenue_06: float | None = Field(default=None, description="Revenue from sixth click conversions")
+    view_through_conversion_06: int | None = Field(default=None, description="Number of sixth view-through conversions")
+    view_through_conversion_revenue_06: float | None = Field(
+        default=None, description="Revenue from sixth view-through conversions"
+    )

--- a/packages/interloper-assets/src/interloper_assets/thetradedesk/source.py
+++ b/packages/interloper-assets/src/interloper_assets/thetradedesk/source.py
@@ -1,19 +1,182 @@
+import asyncio
+import csv
+import datetime as dt
+import logging
+from typing import Any
 
 import interloper as il
+import pandas as pd
+from interloper_pandas import DataFrameNormalizer
 
+from interloper_assets.thetradedesk import constants, schemas
 from interloper_assets.thetradedesk.connection import TheTradeDeskConnection
 
+logger = logging.getLogger(__name__)
+
+_Record = dict[str, Any]
+
+# Report executions queue server-side; poll with backoff until complete.
+_POLL_START_INTERVAL = 60.0
+_POLL_MAX_INTERVAL = 300.0
+_REPORT_TIMEOUT = 3 * 60 * 60  # 3 hours
+
+
+# -- NORMALIZER ----------------------------------------------------------------
+def _decimal_comma_to_float(value: Any) -> Any:
+    """Convert a decimal-comma numeric string ("1,5") to a float; pass the rest through."""
+    if isinstance(value, str) and "," in value:
+        try:
+            return float(value.replace(",", "."))
+        except ValueError:
+            return value
+    return value
+
+
+class TheTradeDeskNormalizer(DataFrameNormalizer):
+    """Reshape MyReports CSV rows onto the schema columns.
+
+    Reports are requested in "International" format, so metric values carry
+    decimal commas ("1,5") and the date column is DD/MM/YYYY — convert both so
+    the generic numeric/date casts succeed. Headers also spell quartiles with
+    ``%`` ("Player 25% Complete" → ``player_25pct_complete``), which the generic
+    snake-casing would drop.
+    """
+
+    def column_name(self, name: str) -> str:
+        return super().column_name(name.replace("%", "pct"))
+
+    def normalize(self, data: Any) -> pd.DataFrame:
+        df = super().normalize(data)
+        if df.empty:
+            return df
+        object_columns = df.select_dtypes(include="object").columns
+        df[object_columns] = df[object_columns].map(_decimal_comma_to_float)
+        if "date" in df.columns:
+            df["date"] = pd.to_datetime(df["date"], format="%d/%m/%Y").dt.date
+        return df
+
+
+# -- HELPERS -------------------------------------------------------------------
+async def _create_report_schedule(
+    connection: TheTradeDeskConnection, template_id: str, partner_id: str, date: dt.date
+) -> str:
+    """Create a one-time report schedule and return its id."""
+    response = await connection.client.post(
+        "/myreports/reportschedule",
+        json={
+            "RequestedByUserName": "interloper",
+            "IncludeHeaders": True,
+            "PartnerFilters": [partner_id],
+            "ReportDateFormat": "International",
+            "ReportDateRange": "Custom",
+            "ReportStartDateInclusive": date.isoformat(),
+            "ReportEndDateExclusive": (date + dt.timedelta(days=1)).isoformat(),
+            "ReportFileFormat": "CSV",
+            "ReportFrequency": "Once",
+            "ReportNumericFormat": "International",
+            "ReportScheduleName": f"interloper_{template_id}_{date.isoformat()}",
+            "ReportTemplateId": template_id,
+            "TimeZone": "UTC",
+        },
+    )
+    response.raise_for_status()
+    return str(response.json()["ReportScheduleId"])
+
+
+async def _wait_for_execution(connection: TheTradeDeskConnection, partner_id: str, schedule_id: str) -> dict:
+    """Poll the schedule's execution until it completes; return the execution."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + _REPORT_TIMEOUT
+    interval = _POLL_START_INTERVAL
+    while True:
+        logger.info(f"Waiting for report schedule {schedule_id}...")
+        response = await connection.client.post(
+            "/myreports/reportexecution/query/partners",
+            json={
+                "PageStartIndex": 0,
+                "PageSize": 100,
+                "PartnerIds": [partner_id],
+                "ReportScheduleIds": [schedule_id],
+            },
+        )
+        response.raise_for_status()
+        executions = response.json().get("Result") or []
+
+        if executions:
+            if len(executions) > 1:
+                logger.warning(f"Schedule {schedule_id} has multiple executions; using the first")
+            execution = executions[0]
+            state = execution["ReportExecutionState"]
+            if state == "Complete":
+                return execution
+            if state in ("Failed", "Error"):
+                raise RuntimeError(f"Report schedule {schedule_id} failed with state {state}")
+
+        if loop.time() >= deadline:
+            raise RuntimeError(f"Report schedule {schedule_id} did not complete within {_REPORT_TIMEOUT:.0f}s")
+        await asyncio.sleep(interval)
+        interval = min(interval * 2, _POLL_MAX_INTERVAL)
+
+
+async def _download_report(connection: TheTradeDeskConnection, url: str) -> list[_Record]:
+    """Download a report delivery and parse its CSV rows (values stay strings)."""
+    response = await connection.client.get(url, follow_redirects=True)
+    response.raise_for_status()
+    return list(csv.DictReader(response.text.splitlines()))
+
+
+async def _get_report(
+    connection: TheTradeDeskConnection, template_id: str, partner_id: str, date: dt.date
+) -> list[_Record]:
+    """Schedule, wait for, and download a one-time report, deleting the schedule after."""
+    schedule_id = await _create_report_schedule(connection, template_id, partner_id, date)
+    logger.info(f"Report schedule id: {schedule_id} (template {template_id})")
+    try:
+        execution = await _wait_for_execution(connection, partner_id, schedule_id)
+        deliveries = execution["ReportDeliveries"]
+        if len(deliveries) > 1:
+            logger.warning(f"Schedule {schedule_id} has multiple deliveries; using the first")
+        return await _download_report(connection, deliveries[0]["DownloadURL"])
+    finally:
+        # One-shot schedules; clean up best-effort so they don't pile up.
+        try:
+            response = await connection.client.delete(f"/myreports/reportschedule/{schedule_id}")
+            response.raise_for_status()
+        except Exception as exc:
+            logger.warning(f"Failed to delete report schedule {schedule_id}: {exc}")
+
+
 # -- SOURCE --------------------------------------------------------------------
-
-
 @il.source(
     resources={"connection": TheTradeDeskConnection},
     tags=["Advertising"],
     icon="icon:thetradedesk",
+    normalizer=TheTradeDeskNormalizer(replace_empty_strings=True),
 )
 class TheTradeDesk(il.Source):
     """The Trade Desk programmatic advertising platform integration."""
 
-    report_template_id: str = il.InputField(
-        description="Report template ID for the MyReports schedule",
+    partner_id: str = il.FetchField(
+        title="Partner ID",
+        description="The Trade Desk partner",
+        provider="connection.partners",
+        label_key="name",
+        value_key="partner_id",
+        discriminator=True,
     )
+
+    @il.asset(
+        schema=schemas.AdGroupsStats,
+        partitioning=il.TimePartitionConfig(column="date"),
+        tags=["Report"],
+    )
+    async def ad_groups_stats(
+        self, context: il.ExecutionContext, connection: TheTradeDeskConnection
+    ) -> list[_Record]:
+        """Ad-group performance metrics per day, including video-player and conversion metrics."""
+        return await _get_report(
+            connection,
+            template_id=constants.ADGROUPS_REPORT_TEMPLATE_ID,
+            partner_id=self.partner_id,
+            date=context.partition_date,
+        )

--- a/packages/interloper-assets/tests/test_thetradedesk.py
+++ b/packages/interloper-assets/tests/test_thetradedesk.py
@@ -1,0 +1,98 @@
+"""Regression tests for the TheTradeDesk source.
+
+MyReports are requested in "International" format: metric values carry decimal
+commas ("12,34"), the date column is DD/MM/YYYY, and quartile headers spell
+``%`` ("Player 25% Complete" → ``player_25pct_complete``). The custom
+normalizer must convert all three so the generic casts succeed — and survive
+the host→child DAG-spec round-trip.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any
+
+from interloper.dag import DAGSpec
+from interloper.dag.base import DAG
+from interloper.representation import Representation
+
+from interloper_assets.thetradedesk import schemas
+from interloper_assets.thetradedesk.source import TheTradeDesk, TheTradeDeskNormalizer
+
+_ASSET_KEY = "ad_groups_stats"
+
+# A CSV row as csv.DictReader yields it: every value a string, international format.
+_ROW = {
+    "Date": "10/07/2026",
+    "Partner ID": "qz94j5z",
+    "Ad Group": "AG, One",
+    "Impressions": "1000",
+    "TTD Cost (USD)": "12,34",
+    "Player 25% Complete": "7",
+    "Player 50% Complete": "4",
+    "Sampled Tracked Impressions": "",
+}
+
+
+def _source() -> Any:
+    return TheTradeDesk(id="src-1", partner_id="qz94j5z")  # ty: ignore[unknown-argument]
+
+
+def _normalizer() -> TheTradeDeskNormalizer:
+    return TheTradeDeskNormalizer(replace_empty_strings=True)
+
+
+class TestNormalizer:
+    """International-format values and % headers land on the schema columns."""
+
+    def test_percent_headers(self):
+        normalizer = _normalizer()
+        assert normalizer.column_name("Player 25% Complete") == "player_25pct_complete"
+        assert normalizer.column_name("TTD Cost (USD)") == "ttd_cost_usd"
+        assert normalizer.column_name("Ad Group Base Bid CPM (Adv Currency)") == (
+            "ad_group_base_bid_cpm_adv_currency"
+        )
+
+    def test_decimal_commas_and_day_first_dates(self):
+        df = _normalizer().normalize([_ROW])
+        record = df.to_dict("records")[0]
+        assert record["date"] == dt.date(2026, 7, 10)  # day-first, not October 7
+        assert record["ttd_cost_usd"] == 12.34
+        # Strings containing commas that are not numbers pass through untouched.
+        assert record["ad_group"] == "AG, One"
+
+    def test_row_conforms_to_schema(self):
+        df = _normalizer().normalize([_ROW])
+        assert set(df.columns) <= set(schemas.AdGroupsStats.model_fields)
+        conformer = Representation.of(df).conformer
+        conformed = conformer.reconcile(df, schemas.AdGroupsStats)
+        conformer.validate(conformed, schemas.AdGroupsStats)  # must not raise
+        record = conformed.to_dict("records")[0]
+        assert record["impressions"] == 1000
+        assert record["player_25pct_complete"] == 7
+        assert record["sampled_tracked_impressions"] is None  # "" -> None -> NA
+
+    def test_all_assets_inherit_the_normalizer(self):
+        src = _source()
+        assert len(src.assets) == 1
+        for asset in src.assets:
+            assert isinstance(asset.normalizer, TheTradeDeskNormalizer), type(asset).key
+
+
+class TestSpecRoundtrip:
+    """The host→child spec round-trip must preserve the normalizer subclass."""
+
+    def test_child_asset_keeps_custom_normalizer(self):
+        src = _source()
+        asset = next(a for a in src.assets if type(a).key == _ASSET_KEY)
+        spec_json = DAG(src).mini_dag(asset.id).to_spec().model_dump(mode="json")
+        child_dag = DAGSpec(**spec_json).reconstruct()
+        child_asset = next(a for a in child_dag.assets if type(a).key == _ASSET_KEY)
+
+        normalizer = child_asset.normalizer
+        assert isinstance(normalizer, TheTradeDeskNormalizer)
+        assert normalizer.replace_empty_strings is True
+        # International-format handling must survive in the child pod.
+        record = normalizer.normalize([_ROW]).to_dict("records")[0]
+        assert record["date"] == dt.date(2026, 7, 10)
+        assert record["ttd_cost_usd"] == 12.34


### PR DESCRIPTION
## What

Adds **The Trade Desk** source to `interloper-assets`, ported from the `digitlcloud-connectors` reference. One report asset — the only one the reference ships a schema for:

| Asset | Type | Notes |
|---|---|---|
| `ad_groups_stats` (120 cols) | Report, partitioned `date` | MyReports "Global Standard Adgroup" system template; includes video-player and conversion metrics |

## How

- **MyReports flow**: create a one-time report schedule (template `168005`, kept as a **constant** since the schema is bound to its columns) → poll `reportexecution/query/partners` until `Complete` (60s→5min backoff, 3h cap) → download the CSV delivery (`follow_redirects=True` — the signed URL redirects to storage) → `csv.DictReader`. The schedule is **deleted in `finally`** — the reference never deleted them, letting one-time schedules pile up.
- **`TheTradeDeskNormalizer`** handles the "International" report format (reports are requested with `ReportDateFormat`/`ReportNumericFormat: International`), which the generic conformer casts would otherwise choke on:
  - decimal-comma metrics: `"12,34"` → `12.34` (strings with non-numeric commas, e.g. an ad-group name `"AG, One"`, pass through untouched);
  - the `date` column parsed **strictly as `DD/MM/YYYY`** — the generic `pd.to_datetime` would silently misparse day-first dates (`10/07/2026` as October 7);
  - `%` headers spelled out as `pct` with **no separator**: `"Player 25% Complete"` → `player_25pct_complete` (note: unlike CM360's `_pct_` variant — this matches the reference sanitize exactly).
- **`partner_id` moves from the connection to the source** as a FetchField fed by a new `connection.partners` provider (`POST /partner/query`), which also backs `check()` — the credential-on-connection / entity-on-source idiom. Auth stays the `TTD-Auth` header. The scaffold's free-form `report_template_id` source field is dropped in favor of the constant.

## Tests

`tests/test_thetradedesk.py` (5 tests): `%`/header mapping, decimal-comma + day-first-date conversion (including the comma-containing-string pass-through), a realistic all-strings DictReader row conforming to the schema, normalizer inheritance, and the host→child DAG-spec round-trip re-verifying the international handling in the child pod. Full `interloper-assets` suite (87) passes; `ruff` + `ty` clean.

## Reviewer notes — needs verification

**Not live-tested**: no The Trade Desk credentials were available. CSV header names are reconstructed from the reference pipeline + schema, not from a live report — a smoke run against a real partner before relying on it would be prudent. The reference's partner/advertiser lookup endpoints ship no schemas and are deliberately not assets; `partners` serves as the fetch provider instead.

By Digitl