### PR TITLE
feat(app): polish the source wizard asset list

### DIFF
--- a/packages/interloper-app/app/app/components/sources/AssetSelect.vue
+++ b/packages/interloper-app/app/app/components/sources/AssetSelect.vue
@@ -178,14 +178,24 @@ function depSelectionKey(assetKey: string, paramName: string): string {
                         <span class="text-sm font-medium">{{ asset.name || asset.key }}</span>
                         <span v-if="asset.description"
                               class="text-xs text-muted truncate">{{ asset.description }}</span>
+                        <div v-if="asset.tags.length"
+                             class="flex flex-wrap gap-1 mt-1.5">
+                            <UBadge v-for="tag in asset.tags"
+                                    :key="tag"
+                                    :color="tagColor(tag)"
+                                    variant="subtle"
+                                    size="sm">
+                                {{ tag }}
+                            </UBadge>
+                        </div>
                     </div>
                     <div class="ml-auto flex items-center gap-2">
-                        <UBadge v-if="asset.partitioning"
-                                color="neutral"
-                                variant="subtle"
-                                size="sm">
-                            Partitioned
-                        </UBadge>
+                        <UTooltip v-if="asset.partitioning"
+                                  text="This asset is partitioned"
+                                  :delay-duration="0">
+                            <UIcon name="i-lucide-layers"
+                                   class="size-4 text-muted shrink-0" />
+                        </UTooltip>
                         <UBadge v-if="depsByAsset.get(asset.key)?.length"
                                 color="info"
                                 variant="subtle"

--- a/packages/interloper-app/app/app/components/sources/Stepper.vue
+++ b/packages/interloper-app/app/app/components/sources/Stepper.vue
@@ -229,7 +229,7 @@ watch(derivedName, (val, old) => {
 watch(selectedSourceKey, (key) => {
     if (key && sourceDefn.value && !isEditMode.value) {
         sourceName.value = derivedName.value
-        selectedAssetKeys.value = sourceDefn.value.assets.map(a => a.key)
+        selectedAssetKeys.value = []
         resourceSelections.value = {}
         configData.value = {}
         nextStep()

--- a/packages/interloper-app/app/app/utils/tags.ts
+++ b/packages/interloper-app/app/app/utils/tags.ts
@@ -1,0 +1,10 @@
+import type { BadgeProps } from '@nuxt/ui'
+
+const TAG_COLORS: NonNullable<BadgeProps['color']>[] = ['primary', 'secondary', 'info', 'success', 'warning', 'error']
+
+/** Deterministic badge color for a tag — the same value always gets the same color. */
+export function tagColor(tag: string): NonNullable<BadgeProps['color']> {
+    let hash = 0
+    for (let i = 0; i < tag.length; i++) hash = (hash * 31 + tag.charCodeAt(i)) | 0
+    return TAG_COLORS[Math.abs(hash) % TAG_COLORS.length]!
+}


### PR DESCRIPTION
Three changes to the asset selection step of the source wizard:

- **Asset tags** — each asset's catalog tags (`Entity`, `Report`, …) render as badges under the name/description, colored deterministically per tag value via a new shared `tagColor` util (same value → same color everywhere it's used).
- **Partitioned indicator** — the `Partitioned` badge becomes a muted layers icon with a zero-delay tooltip reading "This asset is partitioned", keeping the right side of the row light.
- **Deselected by default** — picking a source type no longer pre-selects all assets. The step's existing guard already requires at least one selected asset to advance, and "Select all" restores the old behavior in one click. Edit mode is unchanged (initializes from the source's actual children).

The collection table's tag chips are still neutral; they can adopt `tagColor` in a follow-up if we want app-wide tag coloring.

By Digitl