### PR TITLE
feat(assets): time-partition every entity asset

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ Override extras at `make` time: `CORE_EXTRAS`, `ASSETS_EXTRAS` (flavor extras co
 
 Assets in `interloper-assets` are named for **what the asset is**, decided by its actual row grain (not the upstream/vendor report name). Three categories:
 
-- **Entity** — one row per object (a dimension snapshot, e.g. an ad or campaign and its attributes). Name is a **bare plural noun**, `tags=["Entity"]`, unpartitioned. Examples: `ads`, `campaigns`, `advertisers`, `custom_audiences`.
+- **Entity** — one row per object (a dimension snapshot, e.g. an ad or campaign and its attributes). Name is a **bare plural noun**, `tags=["Entity"]`, time-partitioned on a stamped `date` column (`partitioning=il.TimePartitionConfig(column="date")`, rows stamped with `context.partition_date`, schema carries `date: dt.date | None`). Examples: `ads`, `campaigns`, `advertisers`, `custom_audiences`.
 - **Report** — metrics aggregated over a date/dimension grain. Name is **`<base>_stats`**, with any `_by_<dim>` breakdown *after* `stats`; `tags=["Report"]`, time-partitioned. Examples: `ads_stats`, `ads_stats_by_country`, `page_stats`, `performance_stats`.
 - **Event / fact** — one row per event/record (per-row identifiers like `order_id`/`event_date`, no aggregation). Name is a **bare plural noun**, `tags=["Report"]`, time-partitioned. Examples: `orders`, `transactions`, `conversions`, `clicks`, `actions`.
 

--- a/packages/interloper-assets/src/interloper_assets/__init__.py
+++ b/packages/interloper-assets/src/interloper_assets/__init__.py
@@ -1,6 +1,7 @@
 from interloper_assets.adservice.source import Adservice, AdserviceConnection
 from interloper_assets.adup.source import Adup, AdupConnection
-from interloper_assets.amazon_ads.source import AmazonAds, AmazonAdsConnection
+from interloper_assets.amazon_ads.connection import AmazonAdsAPILocation, AmazonAdsConnection
+from interloper_assets.amazon_ads.source import AmazonAds
 from interloper_assets.amazon_selling_partner.source import AmazonSellingPartner, AmazonSellingPartnerConnection
 from interloper_assets.awin.source import Awin, AwinConnection
 from interloper_assets.bing_ads.source import BingAds, BingAdsConnection
@@ -34,6 +35,7 @@ __all__ = [
     "AdupConnection",
     "AmazonAds",
     "AmazonAdsConnection",
+    "AmazonAdsAPILocation",
     "AmazonSellingPartner",
     "AmazonSellingPartnerConnection",
     "Awin",

--- a/packages/interloper-assets/src/interloper_assets/adup/schemas/account.py
+++ b/packages/interloper-assets/src/interloper_assets/adup/schemas/account.py
@@ -5,6 +5,9 @@ from pydantic import Field
 
 
 class Account(Schema):
+    date: dt.date | None = Field(
+        default=None, description="The day the snapshot was taken (stamped from the partition)."
+    )
     username: str | None = Field(default=None, description="The username of the account")
     label: str | None = Field(default=None, description="The label of the account")
     type: str | None = Field(default=None, description="The type of the account")
@@ -14,6 +17,4 @@ class Account(Schema):
     id: int | None = Field(default=None, description="The advertiser account ID")
     advertiser_url: str | None = Field(default=None, description="The advertiser's URL")
     channel_id: int | None = Field(default=None, description="The channel ID")
-    date: dt.date | None = Field(
-        default=None, description="The day the snapshot was taken (stamped from the partition)."
-    )
+

--- a/packages/interloper-assets/src/interloper_assets/adup/schemas/account.py
+++ b/packages/interloper-assets/src/interloper_assets/adup/schemas/account.py
@@ -1,3 +1,5 @@
+import datetime as dt
+
 from interloper.schema import Schema
 from pydantic import Field
 
@@ -12,3 +14,6 @@ class Account(Schema):
     id: int | None = Field(default=None, description="The advertiser account ID")
     advertiser_url: str | None = Field(default=None, description="The advertiser's URL")
     channel_id: int | None = Field(default=None, description="The channel ID")
+    date: dt.date | None = Field(
+        default=None, description="The day the snapshot was taken (stamped from the partition)."
+    )

--- a/packages/interloper-assets/src/interloper_assets/adup/source.py
+++ b/packages/interloper-assets/src/interloper_assets/adup/source.py
@@ -44,14 +44,15 @@ class Adup(il.Source):
     """Adup advertising platform integration."""
 
     @il.asset(
+        partitioning=il.TimePartitionConfig(column="date"),
         tags=["Entity"],
         schema=Account,
     )
-    async def account(self, connection: AdupConnection) -> list[dict[str, Any]]:
+    async def account(self, context: il.ExecutionContext, connection: AdupConnection) -> list[dict[str, Any]]:
         """Advertiser account information."""
         response = await connection.client.get("/advertisers/me")
         response.raise_for_status()
-        return [response.json()]
+        return [{**response.json(), "date": context.partition_date}]
 
     @il.asset(
         partitioning=il.TimePartitionConfig(column="date", allow_window=True),

--- a/packages/interloper-assets/src/interloper_assets/amazon_ads/schemas/profiles.py
+++ b/packages/interloper-assets/src/interloper_assets/amazon_ads/schemas/profiles.py
@@ -5,6 +5,9 @@ from pydantic import Field
 
 
 class Profiles(Schema):
+    date: dt.date | None = Field(
+        default=None, description="The day the snapshot was taken (stamped from the partition)."
+    )
     profile_id: int = Field(..., description="The Amazon Ads profile ID")
     country_code: str = Field(..., description="The account's country code")
     currency_code: str = Field(..., description="The account's currency code")
@@ -14,6 +17,4 @@ class Profiles(Schema):
     account_info_type: str = Field(..., description="Account info type")
     account_info_name: str = Field(..., description="Account info name")
     account_info_valid_payment_method: bool = Field(..., description="Whether account's payment method is valid")
-    date: dt.date | None = Field(
-        default=None, description="The day the snapshot was taken (stamped from the partition)."
-    )
+

--- a/packages/interloper-assets/src/interloper_assets/amazon_ads/schemas/profiles.py
+++ b/packages/interloper-assets/src/interloper_assets/amazon_ads/schemas/profiles.py
@@ -1,3 +1,5 @@
+import datetime as dt
+
 from interloper.schema import Schema
 from pydantic import Field
 
@@ -12,3 +14,6 @@ class Profiles(Schema):
     account_info_type: str = Field(..., description="Account info type")
     account_info_name: str = Field(..., description="Account info name")
     account_info_valid_payment_method: bool = Field(..., description="Whether account's payment method is valid")
+    date: dt.date | None = Field(
+        default=None, description="The day the snapshot was taken (stamped from the partition)."
+    )

--- a/packages/interloper-assets/src/interloper_assets/amazon_ads/source.py
+++ b/packages/interloper-assets/src/interloper_assets/amazon_ads/source.py
@@ -183,12 +183,16 @@ class AmazonAds(il.Source):
         discriminator=True,
     )
 
-    @il.asset(schema=schemas.Profiles, tags=["Entity"])
-    def profiles(self, connection: AmazonAdsConnection) -> list[dict[str, Any]]:
+    @il.asset(
+        schema=schemas.Profiles,
+        partitioning=il.TimePartitionConfig(column="date"),
+        tags=["Entity"],
+    )
+    def profiles(self, context: il.ExecutionContext, connection: AmazonAdsConnection) -> list[dict[str, Any]]:
         """Advertising profiles associated with the account."""
         response = connection.client.get("/v2/profiles")
         response.raise_for_status()
-        return response.json()
+        return [{**row, "date": context.partition_date} for row in response.json()]
 
     # --- Sponsored Products ---
 

--- a/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/schemas/products.py
+++ b/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/schemas/products.py
@@ -10,6 +10,9 @@ class Products(Schema):
     Sourced from the Data Kiosk vendor analytics ``sourcingView`` group-by keys.
     """
 
+    date: dt.date | None = Field(
+        default=None, description="The day the snapshot was taken (stamped from the partition)."
+    )
     asin: str | None = Field(default=None, description="Amazon Standard Identification Number for the product.")
     parent_asin: str | None = Field(
         default=None,
@@ -24,6 +27,4 @@ class Products(Schema):
         default=None,
         description="13-digit International Standard Book Number. Only applicable to products that are books.",
     )
-    date: dt.date | None = Field(
-        default=None, description="The day the snapshot was taken (stamped from the partition)."
-    )
+

--- a/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/schemas/products.py
+++ b/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/schemas/products.py
@@ -1,3 +1,5 @@
+import datetime as dt
+
 from interloper.schema import Schema
 from pydantic import Field
 
@@ -21,4 +23,7 @@ class Products(Schema):
     isbn_13: str | None = Field(
         default=None,
         description="13-digit International Standard Book Number. Only applicable to products that are books.",
+    )
+    date: dt.date | None = Field(
+        default=None, description="The day the snapshot was taken (stamped from the partition)."
     )

--- a/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/source.py
+++ b/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/source.py
@@ -152,9 +152,7 @@ async def _wait_for_query(connection: AmazonSellingPartnerConnection, query_id: 
     while True:
         logger.info(f"Waiting for query {query_id}...")
         try:
-            response = await connection.client.get(
-                f"/dataKiosk/{constants.DATAKIOSK_API_VERSION}/queries/{query_id}"
-            )
+            response = await connection.client.get(f"/dataKiosk/{constants.DATAKIOSK_API_VERSION}/queries/{query_id}")
             response.raise_for_status()
             payload = response.json()
             status = payload["processingStatus"]
@@ -216,9 +214,7 @@ async def _run_query(connection: AmazonSellingPartnerConnection, query: str) -> 
         # DONE with no document => the query produced no rows.
         return []
 
-    response = await connection.client.get(
-        f"/dataKiosk/{constants.DATAKIOSK_API_VERSION}/documents/{document_id}"
-    )
+    response = await connection.client.get(f"/dataKiosk/{constants.DATAKIOSK_API_VERSION}/documents/{document_id}")
     response.raise_for_status()
     document = await _download_json(response.json()["documentUrl"])
     return _extract_metrics(document)
@@ -403,25 +399,33 @@ class AmazonSellingPartner(il.Source):
         )
         return document.get("netPureProductMarginByAsin", []) if document else []
 
-    @il.asset(schema=schemas.VendorForecastingRetailStats, tags=["Report"])
-    async def vendor_forecasting_retail_stats(
-        self, connection: AmazonSellingPartnerConnection
-    ) -> list[_Record]:
-        """Latest forward-looking demand forecast per ASIN (retail, snapshot)."""
-        document = await _get_report(
-            connection,
-            report_type="GET_VENDOR_FORECASTING_REPORT",
-            marketplace=self.marketplace,
-            options={"sellingProgram": "RETAIL"},
-        )
-        return document.get("forecastByAsin", []) if document else []
+    # TODO: disabled for now. Review whether this should be partitioned.
+    # @il.asset(
+    #     schema=schemas.VendorForecastingRetailStats,
+    #     tags=["Report"],
+    # )
+    # async def vendor_forecasting_retail_stats(self, connection: AmazonSellingPartnerConnection) -> list[_Record]:
+    #     """Latest forward-looking demand forecast per ASIN (retail, snapshot)."""
+    #     document = await _get_report(
+    #         connection,
+    #         report_type="GET_VENDOR_FORECASTING_REPORT",
+    #         marketplace=self.marketplace,
+    #         options={"sellingProgram": "RETAIL"},
+    #     )
+    #     return document.get("forecastByAsin", []) if document else []
 
     # --- Vendor Analytics — Data Kiosk (GraphQL) ---
 
-    @il.asset(schema=schemas.Products, tags=["Entity"])
-    async def products(self, connection: AmazonSellingPartnerConnection) -> list[_Record]:
+    @il.asset(
+        schema=schemas.Products,
+        partitioning=il.TimePartitionConfig(column="date"),
+        tags=["Entity"],
+    )
+    async def products(
+        self, context: il.ExecutionContext, connection: AmazonSellingPartnerConnection
+    ) -> list[_Record]:
         """Product identifier lookup (ASIN, parent ASIN, EAN, UPC, ISBN)."""
-        date = dt.date.today() - dt.timedelta(days=1)
+        date = context.partition_date
         query = f"""{{
           {constants.DATAKIOSK_SCHEMA} {{
             sourcingView(aggregateBy: DAY, startDate: "{date:%Y-%m-%d}", endDate: "{date:%Y-%m-%d}") {{
@@ -433,15 +437,18 @@ class AmazonSellingPartner(il.Source):
         }}"""
         metrics = await _run_query(connection, query)
         return [
-            _scalars(
-                {
-                    "asin": _nested(m, "groupByKey", "asin"),
-                    "parent_asin": _nested(m, "groupByKey", "parentAsin"),
-                    "ean": _nested(m, "groupByKey", "ean"),
-                    "upc": _nested(m, "groupByKey", "upc"),
-                    "isbn_13": _nested(m, "groupByKey", "isbn13"),
-                }
-            )
+            {
+                **_scalars(
+                    {
+                        "asin": _nested(m, "groupByKey", "asin"),
+                        "parent_asin": _nested(m, "groupByKey", "parentAsin"),
+                        "ean": _nested(m, "groupByKey", "ean"),
+                        "upc": _nested(m, "groupByKey", "upc"),
+                        "isbn_13": _nested(m, "groupByKey", "isbn13"),
+                    }
+                ),
+                "date": date,
+            }
             for m in metrics
         ]
 

--- a/packages/interloper-assets/src/interloper_assets/campaign_manager_360/schemas/custom_audiences.py
+++ b/packages/interloper-assets/src/interloper_assets/campaign_manager_360/schemas/custom_audiences.py
@@ -7,6 +7,9 @@ from pydantic import Field
 class CustomAudiences(Schema):
     """Remarketing lists (custom audiences) of an advertiser."""
 
+    date: dt.date | None = Field(
+        default=None, description="The day the snapshot was taken (stamped from the partition)."
+    )
     id: str | None = Field(default=None, description="Unique identifier for the audience")
     account_id: str | None = Field(default=None, description="Identifier for the account associated with the audience")
     advertiser_id: str | None = Field(
@@ -40,6 +43,4 @@ class CustomAudiences(Schema):
     list_population_rule_list_population_clauses: str | None = Field(
         default=None, description="Clauses for the list population rule"
     )
-    date: dt.date | None = Field(
-        default=None, description="The day the snapshot was taken (stamped from the partition)."
-    )
+

--- a/packages/interloper-assets/src/interloper_assets/campaign_manager_360/schemas/custom_audiences.py
+++ b/packages/interloper-assets/src/interloper_assets/campaign_manager_360/schemas/custom_audiences.py
@@ -1,3 +1,5 @@
+import datetime as dt
+
 from interloper.schema import Schema
 from pydantic import Field
 
@@ -37,4 +39,7 @@ class CustomAudiences(Schema):
     )
     list_population_rule_list_population_clauses: str | None = Field(
         default=None, description="Clauses for the list population rule"
+    )
+    date: dt.date | None = Field(
+        default=None, description="The day the snapshot was taken (stamped from the partition)."
     )

--- a/packages/interloper-assets/src/interloper_assets/campaign_manager_360/source.py
+++ b/packages/interloper-assets/src/interloper_assets/campaign_manager_360/source.py
@@ -249,8 +249,14 @@ class CampaignManager360(il.Source):
         # The REACH report has no date dimension; stamp the partition day.
         return [{**row, "date": context.partition_date} for row in rows]
 
-    @il.asset(schema=schemas.CustomAudiences, tags=["Entity"])
-    def custom_audiences(self, connection: CampaignManager360Connection) -> list[_Record]:
+    @il.asset(
+        schema=schemas.CustomAudiences,
+        partitioning=il.TimePartitionConfig(column="date"),
+        tags=["Entity"],
+    )
+    def custom_audiences(
+        self, context: il.ExecutionContext, connection: CampaignManager360Connection
+    ) -> list[_Record]:
         """Remarketing lists (custom audiences) of the configured advertiser."""
         if not self.advertiser_id:
             raise ValueError("The custom_audiences asset requires the source's advertiser_id to be set")
@@ -260,4 +266,4 @@ class CampaignManager360(il.Source):
             # Clauses are a nested list; JSON-encode them onto the string column.
             if isinstance(rule, dict) and isinstance(rule.get("listPopulationClauses"), list):
                 rule["listPopulationClauses"] = json.dumps(rule["listPopulationClauses"])
-        return items
+        return [{**item, "date": context.partition_date} for item in items]

--- a/packages/interloper-assets/src/interloper_assets/display_video_360/schemas/audiences.py
+++ b/packages/interloper-assets/src/interloper_assets/display_video_360/schemas/audiences.py
@@ -1,3 +1,5 @@
+import datetime as dt
+
 from interloper.schema import Schema
 from pydantic import Field
 
@@ -21,3 +23,6 @@ class Audiences(Schema):
         default=None, description="The duration, in days, for which a user remains a member of the audience"
     )
     description: str | None = Field(default=None, description="A detailed description of the audience")
+    date: dt.date | None = Field(
+        default=None, description="The day the snapshot was taken (stamped from the partition)."
+    )

--- a/packages/interloper-assets/src/interloper_assets/display_video_360/schemas/audiences.py
+++ b/packages/interloper-assets/src/interloper_assets/display_video_360/schemas/audiences.py
@@ -7,6 +7,9 @@ from pydantic import Field
 class Audiences(Schema):
     """First-party and partner audiences of a partner or advertiser."""
 
+    date: dt.date | None = Field(
+        default=None, description="The day the snapshot was taken (stamped from the partition)."
+    )
     name: str | None = Field(default=None, description="The name of the audience")
     first_party_and_partner_audience_id: str | None = Field(
         default=None, description="The unique identifier for the first or partner audience"
@@ -23,6 +26,4 @@ class Audiences(Schema):
         default=None, description="The duration, in days, for which a user remains a member of the audience"
     )
     description: str | None = Field(default=None, description="A detailed description of the audience")
-    date: dt.date | None = Field(
-        default=None, description="The day the snapshot was taken (stamped from the partition)."
-    )
+

--- a/packages/interloper-assets/src/interloper_assets/display_video_360/schemas/custom_audiences.py
+++ b/packages/interloper-assets/src/interloper_assets/display_video_360/schemas/custom_audiences.py
@@ -7,6 +7,9 @@ from pydantic import Field
 class CustomAudiences(Schema):
     """Detail of a single first-party/partner audience, including per-surface audience sizes."""
 
+    date: dt.date | None = Field(
+        default=None, description="The day the snapshot was taken (stamped from the partition)."
+    )
     name: str | None = Field(default=None, description="The name of the custom audience.")
     first_party_and_partner_audience_id: str | None = Field(
         default=None, description="The unique identifier for the first and partner audience."
@@ -39,6 +42,4 @@ class CustomAudiences(Schema):
         default=None, description="The size of the audience for display campaigns on desktop."
     )
     description: str | None = Field(default=None, description="A description of the custom audience.")
-    date: dt.date | None = Field(
-        default=None, description="The day the snapshot was taken (stamped from the partition)."
-    )
+

--- a/packages/interloper-assets/src/interloper_assets/display_video_360/schemas/custom_audiences.py
+++ b/packages/interloper-assets/src/interloper_assets/display_video_360/schemas/custom_audiences.py
@@ -1,3 +1,5 @@
+import datetime as dt
+
 from interloper.schema import Schema
 from pydantic import Field
 
@@ -37,3 +39,6 @@ class CustomAudiences(Schema):
         default=None, description="The size of the audience for display campaigns on desktop."
     )
     description: str | None = Field(default=None, description="A description of the custom audience.")
+    date: dt.date | None = Field(
+        default=None, description="The day the snapshot was taken (stamped from the partition)."
+    )

--- a/packages/interloper-assets/src/interloper_assets/display_video_360/schemas/partners.py
+++ b/packages/interloper-assets/src/interloper_assets/display_video_360/schemas/partners.py
@@ -7,6 +7,9 @@ from pydantic import Field
 class Partners(Schema):
     """DV360 partners and their configuration."""
 
+    date: dt.date | None = Field(
+        default=None, description="The day the snapshot was taken (stamped from the partition)."
+    )
     name: str | None = Field(default=None, description="The name of the partner")
     partner_id: str | None = Field(default=None, description="The ID of the partner")
     update_time: str | None = Field(default=None, description="The last update time of the partner")
@@ -26,6 +29,4 @@ class Partners(Schema):
     data_access_config_sdf_config_admin_email: str | None = Field(
         default=None, description="Admin email for SDF config"
     )
-    date: dt.date | None = Field(
-        default=None, description="The day the snapshot was taken (stamped from the partition)."
-    )
+

--- a/packages/interloper-assets/src/interloper_assets/display_video_360/schemas/partners.py
+++ b/packages/interloper-assets/src/interloper_assets/display_video_360/schemas/partners.py
@@ -1,3 +1,5 @@
+import datetime as dt
+
 from interloper.schema import Schema
 from pydantic import Field
 
@@ -23,4 +25,7 @@ class Partners(Schema):
     )
     data_access_config_sdf_config_admin_email: str | None = Field(
         default=None, description="Admin email for SDF config"
+    )
+    date: dt.date | None = Field(
+        default=None, description="The day the snapshot was taken (stamped from the partition)."
     )

--- a/packages/interloper-assets/src/interloper_assets/display_video_360/source.py
+++ b/packages/interloper-assets/src/interloper_assets/display_video_360/source.py
@@ -235,8 +235,12 @@ class DisplayVideo360(il.Source):
 
     # --- Entities (Display & Video API) ---
 
-    @il.asset(schema=schemas.Partners, tags=["Entity"])
-    def partners(self, connection: DisplayVideo360Connection) -> list[_Record]:
+    @il.asset(
+        schema=schemas.Partners,
+        partitioning=il.TimePartitionConfig(column="date"),
+        tags=["Entity"],
+    )
+    def partners(self, context: il.ExecutionContext, connection: DisplayVideo360Connection) -> list[_Record]:
         """DV360 partners and their configuration."""
         items = connection._list_partners()
         for item in items:
@@ -244,15 +248,26 @@ class DisplayVideo360(il.Source):
             # Enabled exchanges are a nested list; JSON-encode onto the string column.
             if isinstance(exchange_config, dict) and isinstance(exchange_config.get("enabledExchanges"), list):
                 exchange_config["enabledExchanges"] = json.dumps(exchange_config["enabledExchanges"])
-        return items
+        return [{**item, "date": context.partition_date} for item in items]
 
-    @il.asset(schema=schemas.Audiences, tags=["Entity"])
-    def audiences(self, connection: DisplayVideo360Connection) -> list[_Record]:
+    @il.asset(
+        schema=schemas.Audiences,
+        partitioning=il.TimePartitionConfig(column="date"),
+        tags=["Entity"],
+    )
+    def audiences(self, context: il.ExecutionContext, connection: DisplayVideo360Connection) -> list[_Record]:
         """First-party and partner audiences of the configured partner or advertiser."""
-        return _list_audiences(connection.dv_client, self._audience_scope)
+        rows = _list_audiences(connection.dv_client, self._audience_scope)
+        return [{**row, "date": context.partition_date} for row in rows]
 
-    @il.asset(schema=schemas.CustomAudiences, tags=["Entity"])
-    def custom_audiences(self, connection: DisplayVideo360Connection) -> list[_Record]:
+    @il.asset(
+        schema=schemas.CustomAudiences,
+        partitioning=il.TimePartitionConfig(column="date"),
+        tags=["Entity"],
+    )
+    def custom_audiences(
+        self, context: il.ExecutionContext, connection: DisplayVideo360Connection
+    ) -> list[_Record]:
         """Detail of the configured audience, including per-surface audience sizes."""
         if not self.audience_id:
             raise ValueError("The custom_audiences asset requires the source's audience_id to be set")
@@ -261,4 +276,4 @@ class DisplayVideo360(il.Source):
             .get(**self._audience_scope, firstPartyAndPartnerAudienceId=self.audience_id)
             .execute()
         )
-        return [audience]
+        return [{**audience, "date": context.partition_date}]

--- a/packages/interloper-assets/src/interloper_assets/facebook_ads/schemas/ads.py
+++ b/packages/interloper-assets/src/interloper_assets/facebook_ads/schemas/ads.py
@@ -7,6 +7,9 @@ from pydantic import Field
 class Ads(Schema):
     """Facebook Ads entity snapshot. One row per ad (not time-series). Captures ad configuration, status, and creative details. Join to the ads insights table on id=ad_id. Join to facebook_insights.posts on creative_effective_object_story_id=post_id to resolve paid vs organic split."""
 
+    date: dt.date | None = Field(
+        default=None, description="The day the snapshot was taken (stamped from the partition)."
+    )
     id: str | None = Field(default=None, description="Unique ad identifier. Join key to ads insights table (ad_id).")
     account_id: str | None = Field(default=None, description="Ad account ID.")
     ad_active_time: float | None = Field(default=None, description="Time in seconds the ad has been in an active/running state.")
@@ -36,6 +39,4 @@ class Ads(Schema):
     status: str | None = Field(default=None, description="Ad status as set by the advertiser (mirrors configured_status in most cases).")
     tracking_specs: str | None = Field(default=None, description="JSON array of tracking specification objects defining what events to track for this ad.")
     updated_time: str | None = Field(default=None, description="ISO 8601 timestamp when the ad was last updated.")
-    date: dt.date | None = Field(
-        default=None, description="The day the snapshot was taken (stamped from the partition)."
-    )
+

--- a/packages/interloper-assets/src/interloper_assets/facebook_ads/schemas/ads.py
+++ b/packages/interloper-assets/src/interloper_assets/facebook_ads/schemas/ads.py
@@ -1,3 +1,5 @@
+import datetime as dt
+
 from interloper.schema import Schema
 from pydantic import Field
 
@@ -34,3 +36,6 @@ class Ads(Schema):
     status: str | None = Field(default=None, description="Ad status as set by the advertiser (mirrors configured_status in most cases).")
     tracking_specs: str | None = Field(default=None, description="JSON array of tracking specification objects defining what events to track for this ad.")
     updated_time: str | None = Field(default=None, description="ISO 8601 timestamp when the ad was last updated.")
+    date: dt.date | None = Field(
+        default=None, description="The day the snapshot was taken (stamped from the partition)."
+    )

--- a/packages/interloper-assets/src/interloper_assets/facebook_ads/schemas/campaigns.py
+++ b/packages/interloper-assets/src/interloper_assets/facebook_ads/schemas/campaigns.py
@@ -7,6 +7,9 @@ from pydantic import Field
 class Campaigns(Schema):
     """Facebook Ads campaign entity snapshot. One row per campaign (not time-series). Captures campaign-level configuration, objective, budget, and status. boosted_object_id is the join key to facebook_insights.posts for Boost Post campaigns."""
 
+    date: dt.date | None = Field(
+        default=None, description="The day the snapshot was taken (stamped from the partition)."
+    )
     id: str | None = Field(default=None, description="Unique campaign identifier. Join key to campaign insights table (campaign_id).")
     account_id: str | None = Field(default=None, description="Ad account ID this campaign belongs to.")
     adlabels: str | None = Field(default=None, description="JSON array of ad labels attached to this campaign.")
@@ -42,6 +45,4 @@ class Campaigns(Schema):
     stop_time: str | None = Field(default=None, description="ISO 8601 scheduled stop time. NULL if the campaign has no end date.")
     topline_id: str | None = Field(default=None, description="Topline/IO number for managed accounts. NULL for self-serve accounts.")
     updated_time: str | None = Field(default=None, description="ISO 8601 timestamp when the campaign was last updated.")
-    date: dt.date | None = Field(
-        default=None, description="The day the snapshot was taken (stamped from the partition)."
-    )
+

--- a/packages/interloper-assets/src/interloper_assets/facebook_ads/schemas/campaigns.py
+++ b/packages/interloper-assets/src/interloper_assets/facebook_ads/schemas/campaigns.py
@@ -1,3 +1,5 @@
+import datetime as dt
+
 from interloper.schema import Schema
 from pydantic import Field
 
@@ -40,3 +42,6 @@ class Campaigns(Schema):
     stop_time: str | None = Field(default=None, description="ISO 8601 scheduled stop time. NULL if the campaign has no end date.")
     topline_id: str | None = Field(default=None, description="Topline/IO number for managed accounts. NULL for self-serve accounts.")
     updated_time: str | None = Field(default=None, description="ISO 8601 timestamp when the campaign was last updated.")
+    date: dt.date | None = Field(
+        default=None, description="The day the snapshot was taken (stamped from the partition)."
+    )

--- a/packages/interloper-assets/src/interloper_assets/facebook_ads/schemas/custom_audiences.py
+++ b/packages/interloper-assets/src/interloper_assets/facebook_ads/schemas/custom_audiences.py
@@ -7,12 +7,13 @@ from pydantic import Field
 class CustomAudiences(Schema):
     """The Facebook Custom Audiences report provides information about custom audiences volume for a given account id"""
 
+    date: dt.date | None = Field(
+        default=None, description="The day the snapshot was taken (stamped from the partition)."
+    )
     account_id: str | None = Field(default=None, description="The ID of the Facebook account")
     approximate_count_lower_bound: int | None = Field(default=None, description="The lower bound of the approximate count of custom audiences")
     approximate_count_upper_bound: int | None = Field(default=None, description="The upper bound of the approximate count of custom audiences")
     description: str | None = Field(default=None, description="The description of the custom audience")
     id: str | None = Field(default=None, description="The ID of the custom audience")
     name: str | None = Field(default=None, description="The name of the custom audience")
-    date: dt.date | None = Field(
-        default=None, description="The day the snapshot was taken (stamped from the partition)."
-    )
+

--- a/packages/interloper-assets/src/interloper_assets/facebook_ads/schemas/custom_audiences.py
+++ b/packages/interloper-assets/src/interloper_assets/facebook_ads/schemas/custom_audiences.py
@@ -1,3 +1,5 @@
+import datetime as dt
+
 from interloper.schema import Schema
 from pydantic import Field
 
@@ -11,3 +13,6 @@ class CustomAudiences(Schema):
     description: str | None = Field(default=None, description="The description of the custom audience")
     id: str | None = Field(default=None, description="The ID of the custom audience")
     name: str | None = Field(default=None, description="The name of the custom audience")
+    date: dt.date | None = Field(
+        default=None, description="The day the snapshot was taken (stamped from the partition)."
+    )

--- a/packages/interloper-assets/src/interloper_assets/facebook_ads/source.py
+++ b/packages/interloper-assets/src/interloper_assets/facebook_ads/source.py
@@ -394,9 +394,12 @@ class FacebookAds(il.Source):
 
     @il.asset(
         schema=schemas.CustomAudiences,
+        partitioning=il.TimePartitionConfig(column="date"),
         tags=["Entity"],
     )
-    def custom_audiences(self, connection: FacebookAdsConnection) -> list[dict[str, Any]]:
+    def custom_audiences(
+        self, context: il.ExecutionContext, connection: FacebookAdsConnection
+    ) -> list[dict[str, Any]]:
         """Custom audiences with approximate size bounds for the account."""
         rows = _get_custom_audiences(
             connection,
@@ -404,20 +407,22 @@ class FacebookAds(il.Source):
             fields=constants.CUSTOM_AUDIENCES_FIELDS,
             params={},
         )
-        return rows
+        return [{**row, "date": context.partition_date} for row in rows]
 
     @il.asset(
         schema=schemas.Ads,
+        partitioning=il.TimePartitionConfig(column="date"),
         tags=["Entity"],
     )
-    def ads(self, connection: FacebookAdsConnection) -> list[dict[str, Any]]:
+    def ads(self, context: il.ExecutionContext, connection: FacebookAdsConnection) -> list[dict[str, Any]]:
         """Ad entities including creative, status, and configuration."""
-        return _get_ads(connection, self.account_id)
+        return [{**row, "date": context.partition_date} for row in _get_ads(connection, self.account_id)]
 
     @il.asset(
         schema=schemas.Campaigns,
+        partitioning=il.TimePartitionConfig(column="date"),
         tags=["Entity"],
     )
-    def campaigns(self, connection: FacebookAdsConnection) -> list[dict[str, Any]]:
+    def campaigns(self, context: il.ExecutionContext, connection: FacebookAdsConnection) -> list[dict[str, Any]]:
         """Campaign entities including objective, budget, and status configuration."""
-        return _get_campaigns(connection, self.account_id)
+        return [{**row, "date": context.partition_date} for row in _get_campaigns(connection, self.account_id)]

--- a/packages/interloper-assets/src/interloper_assets/snapchat_ads/schemas/ad_account.py
+++ b/packages/interloper-assets/src/interloper_assets/snapchat_ads/schemas/ad_account.py
@@ -7,6 +7,9 @@ from pydantic import Field
 class AdAccount(Schema):
     """The Ad Account entity provides detailed information about each advertising account, including identifiers, timestamps, names, types, statuses, and various financial and organizational details."""
 
+    date: dt.date | None = Field(
+        default=None, description="The day the snapshot was taken (stamped from the partition)."
+    )
     id: str | None = Field(default=None, description="Unique identifier for the ad account.")
     updated_at: dt.datetime | None = Field(default=None, description="Timestamp of when the ad account was last updated.")
     created_at: dt.datetime | None = Field(default=None, description="Timestamp of when the ad account was created.")
@@ -24,6 +27,4 @@ class AdAccount(Schema):
     lifetime_spend_cap_micro: int | None = Field(default=None, description="Lifetime spend cap for the ad account in micro-units of the currency.")
     agency_representing_client: bool | None = Field(default=None, description="Indicates whether an agency is representing the client.")
     client_paying_invoices: bool | None = Field(default=None, description="Indicates whether the client is paying the invoices.")
-    date: dt.date | None = Field(
-        default=None, description="The day the snapshot was taken (stamped from the partition)."
-    )
+

--- a/packages/interloper-assets/src/interloper_assets/snapchat_ads/schemas/ad_account.py
+++ b/packages/interloper-assets/src/interloper_assets/snapchat_ads/schemas/ad_account.py
@@ -24,3 +24,6 @@ class AdAccount(Schema):
     lifetime_spend_cap_micro: int | None = Field(default=None, description="Lifetime spend cap for the ad account in micro-units of the currency.")
     agency_representing_client: bool | None = Field(default=None, description="Indicates whether an agency is representing the client.")
     client_paying_invoices: bool | None = Field(default=None, description="Indicates whether the client is paying the invoices.")
+    date: dt.date | None = Field(
+        default=None, description="The day the snapshot was taken (stamped from the partition)."
+    )

--- a/packages/interloper-assets/src/interloper_assets/snapchat_ads/schemas/ad_accounts.py
+++ b/packages/interloper-assets/src/interloper_assets/snapchat_ads/schemas/ad_accounts.py
@@ -24,3 +24,6 @@ class AdAccounts(Schema):
     lifetime_spend_cap_micro: int | None = Field(default=None, description="Lifetime spend cap for the ad account in micro-units of the currency.")
     agency_representing_client: bool | None = Field(default=None, description="Indicates whether an agency is representing the client.")
     client_paying_invoices: bool | None = Field(default=None, description="Indicates whether the client is paying the invoices.")
+    date: dt.date | None = Field(
+        default=None, description="The day the snapshot was taken (stamped from the partition)."
+    )

--- a/packages/interloper-assets/src/interloper_assets/snapchat_ads/schemas/ad_accounts.py
+++ b/packages/interloper-assets/src/interloper_assets/snapchat_ads/schemas/ad_accounts.py
@@ -7,6 +7,9 @@ from pydantic import Field
 class AdAccounts(Schema):
     """The Ad Accounts entity provides detailed information about each advertising account, including identifiers, timestamps, names, types, statuses, and various financial and organizational details."""
 
+    date: dt.date | None = Field(
+        default=None, description="The day the snapshot was taken (stamped from the partition)."
+    )
     id: str | None = Field(default=None, description="Unique identifier for the ad account.")
     updated_at: dt.datetime | None = Field(default=None, description="Timestamp of when the ad account was last updated.")
     created_at: dt.datetime | None = Field(default=None, description="Timestamp of when the ad account was created.")
@@ -24,6 +27,4 @@ class AdAccounts(Schema):
     lifetime_spend_cap_micro: int | None = Field(default=None, description="Lifetime spend cap for the ad account in micro-units of the currency.")
     agency_representing_client: bool | None = Field(default=None, description="Indicates whether an agency is representing the client.")
     client_paying_invoices: bool | None = Field(default=None, description="Indicates whether the client is paying the invoices.")
-    date: dt.date | None = Field(
-        default=None, description="The day the snapshot was taken (stamped from the partition)."
-    )
+

--- a/packages/interloper-assets/src/interloper_assets/snapchat_ads/schemas/ad_squads.py
+++ b/packages/interloper-assets/src/interloper_assets/snapchat_ads/schemas/ad_squads.py
@@ -1,3 +1,5 @@
+import datetime as dt
+
 from interloper.schema import Schema
 from pydantic import Field
 
@@ -64,3 +66,6 @@ class AdSquads(Schema):
     ad_scheduling_config_friday_hour_of_day: str | None = Field(default=None, description="Ad scheduling config Friday hour of day")
     targeting_app_install_states: str | None = Field(default=None, description="Targeting app install states")
     ad_scheduling_config_sunday_hour_of_day: str | None = Field(default=None, description="Ad scheduling config sunday hour of day")
+    date: dt.date | None = Field(
+        default=None, description="The day the snapshot was taken (stamped from the partition)."
+    )

--- a/packages/interloper-assets/src/interloper_assets/snapchat_ads/schemas/ad_squads.py
+++ b/packages/interloper-assets/src/interloper_assets/snapchat_ads/schemas/ad_squads.py
@@ -7,6 +7,9 @@ from pydantic import Field
 class AdSquads(Schema):
     """The Ad Squads entity provides insights into the attributes of ads squads in a campaign. It includes key metrics such as ad squad ID, status, placement, bid strategy, budget, targeting details (demographics, interests, geos), scheduling configurations, and delivery constraints."""
 
+    date: dt.date | None = Field(
+        default=None, description="The day the snapshot was taken (stamped from the partition)."
+    )
     id: str | None = Field(default=None, description="The ID of the ad squad")
     updated_at: str | None = Field(default=None, description="The last updated timestamp of the ad squad")
     created_at: str | None = Field(default=None, description="The creation timestamp of the ad squad")
@@ -66,6 +69,4 @@ class AdSquads(Schema):
     ad_scheduling_config_friday_hour_of_day: str | None = Field(default=None, description="Ad scheduling config Friday hour of day")
     targeting_app_install_states: str | None = Field(default=None, description="Targeting app install states")
     ad_scheduling_config_sunday_hour_of_day: str | None = Field(default=None, description="Ad scheduling config sunday hour of day")
-    date: dt.date | None = Field(
-        default=None, description="The day the snapshot was taken (stamped from the partition)."
-    )
+

--- a/packages/interloper-assets/src/interloper_assets/snapchat_ads/schemas/ads.py
+++ b/packages/interloper-assets/src/interloper_assets/snapchat_ads/schemas/ads.py
@@ -1,3 +1,5 @@
+import datetime as dt
+
 from interloper.schema import Schema
 from pydantic import Field
 
@@ -20,3 +22,6 @@ class Ads(Schema):
     delivery_status: str | None = Field(default=None, description="The delivery status of the ad")
     review_status_reasons: str | None = Field(default=None, description="The reasons for the review status of the ad")
     container_chain_ids: str | None = Field(default=None, description="The container chain IDs of the ad")
+    date: dt.date | None = Field(
+        default=None, description="The day the snapshot was taken (stamped from the partition)."
+    )

--- a/packages/interloper-assets/src/interloper_assets/snapchat_ads/schemas/ads.py
+++ b/packages/interloper-assets/src/interloper_assets/snapchat_ads/schemas/ads.py
@@ -7,6 +7,9 @@ from pydantic import Field
 class Ads(Schema):
     """The Ads entity provides insights into the attributes of indivudal ads in a campaign. It includes key metrics such as ad ID, timestamps for creation and last update, ad name, ad squad ID, creative ID, third-party paid impression tracking URLs, third-party on swipe tracking URLs, ad status, ad type, render type, review status, delivery status, reasons for the review status, and container chain IDs."""
 
+    date: dt.date | None = Field(
+        default=None, description="The day the snapshot was taken (stamped from the partition)."
+    )
     id: str | None = Field(default=None, description="The ID of the ad")
     updated_at: str | None = Field(default=None, description="The timestamp when the ad was last updated")
     created_at: str | None = Field(default=None, description="The timestamp when the ad was created")
@@ -22,6 +25,4 @@ class Ads(Schema):
     delivery_status: str | None = Field(default=None, description="The delivery status of the ad")
     review_status_reasons: str | None = Field(default=None, description="The reasons for the review status of the ad")
     container_chain_ids: str | None = Field(default=None, description="The container chain IDs of the ad")
-    date: dt.date | None = Field(
-        default=None, description="The day the snapshot was taken (stamped from the partition)."
-    )
+

--- a/packages/interloper-assets/src/interloper_assets/snapchat_ads/schemas/campaigns.py
+++ b/packages/interloper-assets/src/interloper_assets/snapchat_ads/schemas/campaigns.py
@@ -7,6 +7,9 @@ from pydantic import Field
 class Campaigns(Schema):
     """The Campaigns entity provides insights into the attributes of campaigns. It includes key dimensions such as campaign ID, name, objective, status, start and end times, lifetime spend cap, buy model, delivery status, and creation state."""
 
+    date: dt.date | None = Field(
+        default=None, description="The day the snapshot was taken (stamped from the partition)."
+    )
     id: str | None = Field(default=None, description="The ID of the campaign")
     updated_at: str | None = Field(default=None, description="The last updated timestamp of the campaign")
     created_at: str | None = Field(default=None, description="The creation timestamp of the campaign")
@@ -21,6 +24,4 @@ class Campaigns(Schema):
     delivery_status: str | None = Field(default=None, description="The delivery status of the campaign")
     creation_state: str | None = Field(default=None, description="The creation state of the campaign")
     experiment_id: str | None = Field(default=None, description="The ID of the associated experiment")
-    date: dt.date | None = Field(
-        default=None, description="The day the snapshot was taken (stamped from the partition)."
-    )
+

--- a/packages/interloper-assets/src/interloper_assets/snapchat_ads/schemas/campaigns.py
+++ b/packages/interloper-assets/src/interloper_assets/snapchat_ads/schemas/campaigns.py
@@ -1,3 +1,5 @@
+import datetime as dt
+
 from interloper.schema import Schema
 from pydantic import Field
 
@@ -19,3 +21,6 @@ class Campaigns(Schema):
     delivery_status: str | None = Field(default=None, description="The delivery status of the campaign")
     creation_state: str | None = Field(default=None, description="The creation state of the campaign")
     experiment_id: str | None = Field(default=None, description="The ID of the associated experiment")
+    date: dt.date | None = Field(
+        default=None, description="The day the snapshot was taken (stamped from the partition)."
+    )

--- a/packages/interloper-assets/src/interloper_assets/snapchat_ads/source.py
+++ b/packages/interloper-assets/src/interloper_assets/snapchat_ads/source.py
@@ -176,14 +176,25 @@ class SnapchatAds(il.Source):
 
     # --- Entity assets (flattening normalizer) ---
 
-    @il.asset(schema=AdAccount, tags=["Entity"], normalizer=_ENTITY_NORMALIZER)
-    async def ad_account(self, connection: SnapchatAdsConnection) -> list[_RECORD]:
+    @il.asset(
+        schema=AdAccount,
+        partitioning=il.TimePartitionConfig(column="date"),
+        tags=["Entity"],
+        normalizer=_ENTITY_NORMALIZER,
+    )
+    async def ad_account(self, context: il.ExecutionContext, connection: SnapchatAdsConnection) -> list[_RECORD]:
         """A single ad account with its attributes."""
         path = f"/{constants.API_VERSION}/adaccounts/{self.account_id}"
-        return await _entity_records(connection, path, "adaccounts", "adaccount")
+        rows = await _entity_records(connection, path, "adaccounts", "adaccount")
+        return _with_date(rows, context.partition_date)
 
-    @il.asset(schema=AdAccounts, tags=["Entity"], normalizer=_ENTITY_NORMALIZER)
-    async def ad_accounts(self, connection: SnapchatAdsConnection) -> list[_RECORD]:
+    @il.asset(
+        schema=AdAccounts,
+        partitioning=il.TimePartitionConfig(column="date"),
+        tags=["Entity"],
+        normalizer=_ENTITY_NORMALIZER,
+    )
+    async def ad_accounts(self, context: il.ExecutionContext, connection: SnapchatAdsConnection) -> list[_RECORD]:
         """All ad accounts in the organization owning this account."""
         account_path = f"/{constants.API_VERSION}/adaccounts/{self.account_id}"
         accounts = await _entity_records(connection, account_path, "adaccounts", "adaccount")
@@ -191,22 +202,41 @@ class SnapchatAds(il.Source):
         if organization_id is None:
             return []
         path = f"/{constants.API_VERSION}/organizations/{organization_id}/adaccounts"
-        return await _entity_records(connection, path, "adaccounts", "adaccount")
+        rows = await _entity_records(connection, path, "adaccounts", "adaccount")
+        return _with_date(rows, context.partition_date)
 
-    @il.asset(schema=Ads, tags=["Entity"], normalizer=_ENTITY_NORMALIZER)
-    async def ads(self, connection: SnapchatAdsConnection) -> list[_RECORD]:
+    @il.asset(
+        schema=Ads,
+        partitioning=il.TimePartitionConfig(column="date"),
+        tags=["Entity"],
+        normalizer=_ENTITY_NORMALIZER,
+    )
+    async def ads(self, context: il.ExecutionContext, connection: SnapchatAdsConnection) -> list[_RECORD]:
         """All ads in the ad account with their attributes."""
         path = f"/{constants.API_VERSION}/adaccounts/{self.account_id}/ads"
-        return await _entity_records(connection, path, "ads", "ad")
+        rows = await _entity_records(connection, path, "ads", "ad")
+        return _with_date(rows, context.partition_date)
 
-    @il.asset(schema=AdSquads, tags=["Entity"], normalizer=_ENTITY_NORMALIZER)
-    async def ad_squads(self, connection: SnapchatAdsConnection) -> list[_RECORD]:
+    @il.asset(
+        schema=AdSquads,
+        partitioning=il.TimePartitionConfig(column="date"),
+        tags=["Entity"],
+        normalizer=_ENTITY_NORMALIZER,
+    )
+    async def ad_squads(self, context: il.ExecutionContext, connection: SnapchatAdsConnection) -> list[_RECORD]:
         """All ad squads in the ad account with their attributes."""
         path = f"/{constants.API_VERSION}/adaccounts/{self.account_id}/adsquads"
-        return await _entity_records(connection, path, "adsquads", "adsquad")
+        rows = await _entity_records(connection, path, "adsquads", "adsquad")
+        return _with_date(rows, context.partition_date)
 
-    @il.asset(schema=Campaigns, tags=["Entity"], normalizer=_ENTITY_NORMALIZER)
-    async def campaigns(self, connection: SnapchatAdsConnection) -> list[_RECORD]:
+    @il.asset(
+        schema=Campaigns,
+        partitioning=il.TimePartitionConfig(column="date"),
+        tags=["Entity"],
+        normalizer=_ENTITY_NORMALIZER,
+    )
+    async def campaigns(self, context: il.ExecutionContext, connection: SnapchatAdsConnection) -> list[_RECORD]:
         """All campaigns in the ad account with their attributes."""
         path = f"/{constants.API_VERSION}/adaccounts/{self.account_id}/campaigns"
-        return await _entity_records(connection, path, "campaigns", "campaign")
+        rows = await _entity_records(connection, path, "campaigns", "campaign")
+        return _with_date(rows, context.partition_date)

--- a/packages/interloper-assets/src/interloper_assets/tiktok_ads/schemas/ads.py
+++ b/packages/interloper-assets/src/interloper_assets/tiktok_ads/schemas/ads.py
@@ -63,3 +63,6 @@ class Ads(Schema):
     video_id: str | None = Field(default=None, description="Identifier for the video used in the ad")
     viewability_postbid_partner: str | None = Field(default=None, description="Viewability post-bid partner for the ad")
     viewability_vast_url: str | None = Field(default=None, description="URL for VAST viewability tracking")
+    date: dt.date | None = Field(
+        default=None, description="The day the snapshot was taken (stamped from the partition)."
+    )

--- a/packages/interloper-assets/src/interloper_assets/tiktok_ads/schemas/ads.py
+++ b/packages/interloper-assets/src/interloper_assets/tiktok_ads/schemas/ads.py
@@ -7,6 +7,9 @@ from pydantic import Field
 class Ads(Schema):
     """Tiktok ad entities"""
 
+    date: dt.date | None = Field(
+        default=None, description="The day the snapshot was taken (stamped from the partition)."
+    )
     ad_format: str | None = Field(default=None, description="Format of the ad")
     ad_id: str | None = Field(default=None, description="Unique identifier for the ad")
     ad_name: str | None = Field(default=None, description="Name of the ad")
@@ -63,6 +66,4 @@ class Ads(Schema):
     video_id: str | None = Field(default=None, description="Identifier for the video used in the ad")
     viewability_postbid_partner: str | None = Field(default=None, description="Viewability post-bid partner for the ad")
     viewability_vast_url: str | None = Field(default=None, description="URL for VAST viewability tracking")
-    date: dt.date | None = Field(
-        default=None, description="The day the snapshot was taken (stamped from the partition)."
-    )
+

--- a/packages/interloper-assets/src/interloper_assets/tiktok_ads/schemas/advertisers.py
+++ b/packages/interloper-assets/src/interloper_assets/tiktok_ads/schemas/advertisers.py
@@ -7,6 +7,9 @@ from pydantic import Field
 class Advertisers(Schema):
     """Tiktok advertiser entities"""
 
+    date: dt.date | None = Field(
+        default=None, description="The day the snapshot was taken (stamped from the partition)."
+    )
     address: str | None = Field(default=None, description="Physical address of the advertiser")
     advertiser_id: str | None = Field(default=None, description="Unique identifier for the advertiser")
     balance: float | None = Field(default=None, description="Account balance of the advertiser")
@@ -26,6 +29,4 @@ class Advertisers(Schema):
     role: str | None = Field(default=None, description="Role of the advertiser in the system")
     status: str | None = Field(default=None, description="Current status of the advertiser")
     timezone: str | None = Field(default=None, description="Timezone used by the advertiser")
-    date: dt.date | None = Field(
-        default=None, description="The day the snapshot was taken (stamped from the partition)."
-    )
+

--- a/packages/interloper-assets/src/interloper_assets/tiktok_ads/schemas/advertisers.py
+++ b/packages/interloper-assets/src/interloper_assets/tiktok_ads/schemas/advertisers.py
@@ -1,3 +1,5 @@
+import datetime as dt
+
 from interloper.schema import Schema
 from pydantic import Field
 
@@ -24,3 +26,6 @@ class Advertisers(Schema):
     role: str | None = Field(default=None, description="Role of the advertiser in the system")
     status: str | None = Field(default=None, description="Current status of the advertiser")
     timezone: str | None = Field(default=None, description="Timezone used by the advertiser")
+    date: dt.date | None = Field(
+        default=None, description="The day the snapshot was taken (stamped from the partition)."
+    )

--- a/packages/interloper-assets/src/interloper_assets/tiktok_ads/schemas/campaigns.py
+++ b/packages/interloper-assets/src/interloper_assets/tiktok_ads/schemas/campaigns.py
@@ -7,6 +7,9 @@ from pydantic import Field
 class Campaigns(Schema):
     """Tiktok campaign entities"""
 
+    date: dt.date | None = Field(
+        default=None, description="The day the snapshot was taken (stamped from the partition)."
+    )
     modify_time: dt.datetime | None = Field(default=None, description="Last modification timestamp of the campaign")
     special_industries: str | None = Field(default=None, description="Indicates if the campaign belongs to special industries")
     campaign_id: str | None = Field(default=None, description="Unique identifier for the campaign")
@@ -29,6 +32,4 @@ class Campaigns(Schema):
     secondary_status: str | None = Field(default=None, description="Secondary status of the campaign")
     budget_optimize_on: str | None = Field(default=None, description="Indicates how the budget is optimized")
     rf_campaign_type: str | None = Field(default=None, description="Type of Reach and Frequency campaign")
-    date: dt.date | None = Field(
-        default=None, description="The day the snapshot was taken (stamped from the partition)."
-    )
+

--- a/packages/interloper-assets/src/interloper_assets/tiktok_ads/schemas/campaigns.py
+++ b/packages/interloper-assets/src/interloper_assets/tiktok_ads/schemas/campaigns.py
@@ -29,3 +29,6 @@ class Campaigns(Schema):
     secondary_status: str | None = Field(default=None, description="Secondary status of the campaign")
     budget_optimize_on: str | None = Field(default=None, description="Indicates how the budget is optimized")
     rf_campaign_type: str | None = Field(default=None, description="Type of Reach and Frequency campaign")
+    date: dt.date | None = Field(
+        default=None, description="The day the snapshot was taken (stamped from the partition)."
+    )

--- a/packages/interloper-assets/src/interloper_assets/tiktok_ads/source.py
+++ b/packages/interloper-assets/src/interloper_assets/tiktok_ads/source.py
@@ -210,18 +210,37 @@ class TiktokAds(il.Source):
 
     # --- Entity assets (_ENTITY_NORMALIZER) ---
 
-    @il.asset(schema=Ads, tags=["Entity"], normalizer=_ENTITY_NORMALIZER)
-    async def ads(self, connection: TiktokAdsConnection) -> list[dict[str, Any]]:
+    @il.asset(
+        schema=Ads,
+        partitioning=il.TimePartitionConfig(column="date"),
+        tags=["Entity"],
+        normalizer=_ENTITY_NORMALIZER,
+    )
+    async def ads(self, context: il.ExecutionContext, connection: TiktokAdsConnection) -> list[dict[str, Any]]:
         """All ads in the advertiser account with their attributes."""
-        return await _paginate(connection, "/ad/get/", {"advertiser_id": self.advertiser_id})
+        rows = await _paginate(connection, "/ad/get/", {"advertiser_id": self.advertiser_id})
+        return _with_date(rows, context.partition_date)
 
-    @il.asset(schema=Campaigns, tags=["Entity"], normalizer=_ENTITY_NORMALIZER)
-    async def campaigns(self, connection: TiktokAdsConnection) -> list[dict[str, Any]]:
+    @il.asset(
+        schema=Campaigns,
+        partitioning=il.TimePartitionConfig(column="date"),
+        tags=["Entity"],
+        normalizer=_ENTITY_NORMALIZER,
+    )
+    async def campaigns(self, context: il.ExecutionContext, connection: TiktokAdsConnection) -> list[dict[str, Any]]:
         """All campaigns in the advertiser account with their attributes."""
-        return await _paginate(connection, "/campaign/get/", {"advertiser_id": self.advertiser_id})
+        rows = await _paginate(connection, "/campaign/get/", {"advertiser_id": self.advertiser_id})
+        return _with_date(rows, context.partition_date)
 
-    @il.asset(schema=Advertisers, tags=["Entity"], normalizer=_ENTITY_NORMALIZER)
-    async def advertisers(self, connection: TiktokAdsConnection) -> list[dict[str, Any]]:
+    @il.asset(
+        schema=Advertisers,
+        partitioning=il.TimePartitionConfig(column="date"),
+        tags=["Entity"],
+        normalizer=_ENTITY_NORMALIZER,
+    )
+    async def advertisers(
+        self, context: il.ExecutionContext, connection: TiktokAdsConnection
+    ) -> list[dict[str, Any]]:
         """The advertiser account with its attributes."""
         response = await connection.client.get(
             "/advertiser/info/",
@@ -234,4 +253,4 @@ class TiktokAds(il.Source):
         body = response.json()
         if body.get("code") != 0:
             raise RuntimeError(f"TikTok API error {body.get('code')}: {body.get('message')}")
-        return body["data"]["list"]
+        return _with_date(body["data"]["list"], context.partition_date)

--- a/packages/interloper-assets/tests/test_display_video_360.py
+++ b/packages/interloper-assets/tests/test_display_video_360.py
@@ -69,7 +69,7 @@ class TestAudienceScope:
         src = _source()
         asset = next(a for a in src.assets if type(a).key == "custom_audiences")
         with pytest.raises(ValueError, match="audience_id"):
-            asset.data(connection=object())
+            asset.data(context=object(), connection=object())
 
 
 class TestReports:
@@ -124,8 +124,9 @@ class TestNormalizerMapping:
         assert isinstance(normalizer, DataFrameNormalizer)
         normalized = normalizer.normalize([_PARTNER])
 
+        # `date` is stamped by the asset (partition column), not present in the raw payload.
         fields = set(schemas.Partners.model_fields)
-        assert set(normalized.columns) == fields
+        assert set(normalized.columns) == fields - {"date"}
 
         conformer = Representation.of(normalized).conformer
         df = conformer.reconcile(normalized, schemas.Partners)

--- a/packages/interloper-assets/tests/test_entity_partitioning.py
+++ b/packages/interloper-assets/tests/test_entity_partitioning.py
@@ -1,0 +1,54 @@
+"""Every Entity asset in the catalog must be time-partitioned on a stamped ``date``.
+
+Entity assets are dimension snapshots; partitioning them (even where the
+partition seems redundant) keeps every asset uniformly partitioned for the
+scheduling and destination machinery. The BigQuery destination requires the
+partition column to exist on the schema, so each entity schema must carry the
+stamped ``date`` field.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import inspect
+
+import interloper as il
+from interloper.source.base import Source
+
+import interloper_assets
+
+# The demo source is a test fixture, exempt from asset conventions.
+_EXEMPT_SOURCES = {"DemoSource"}
+
+
+def _catalog_sources() -> list[type[Source]]:
+    sources = []
+    for name in dir(interloper_assets):
+        obj = getattr(interloper_assets, name)
+        if inspect.isclass(obj) and issubclass(obj, Source) and obj is not Source and name not in _EXEMPT_SOURCES:
+            sources.append(obj)
+    return sources
+
+
+def test_every_entity_asset_is_partitioned_on_date():
+    checked = 0
+    for source in _catalog_sources():
+        for asset_type in source.asset_types:
+            if "Entity" not in (asset_type.tags or []):
+                continue
+            checked += 1
+            partitioning = asset_type.partitioning
+            assert isinstance(partitioning, il.TimePartitionConfig), (
+                f"{source.__name__}.{asset_type.key} is an Entity asset without time partitioning"
+            )
+            assert partitioning.column == "date", (
+                f"{source.__name__}.{asset_type.key} must partition on 'date', not {partitioning.column!r}"
+            )
+            schema = asset_type.schema
+            assert schema is not None and "date" in schema.model_fields, (
+                f"{source.__name__}.{asset_type.key}: schema {schema and schema.__name__} lacks the 'date' column"
+            )
+            assert schema.model_fields["date"].annotation == (dt.date | None), (
+                f"{source.__name__}.{asset_type.key}: 'date' must be typed dt.date | None"
+            )
+    assert checked >= 18, f"expected at least 18 entity assets in the catalog, found {checked}"

--- a/packages/interloper-core/src/interloper/asset/base.py
+++ b/packages/interloper-core/src/interloper/asset/base.py
@@ -100,6 +100,7 @@ class Asset(Component):
     schema: ClassVar[type[Schema] | None] = None
     partitioning: ClassVar[PartitionConfig | None] = None
     relation_types: ClassVar[dict[str, RelationDefinition]] = {
+        # TODO: `"resource": RelationDefinition(kinds=["resources"]...` ?
         "resource": RelationDefinition(kinds=["connection", "config", "resource"], field="resources", slotted=True),
         "destination": RelationDefinition(kinds=["destination"], field="destinations"),
         "dependency": RelationDefinition(kinds=["asset"], field="dependencies", slotted=True, inline=False),


### PR DESCRIPTION
## What

Makes **every Entity asset in the catalog time-partitioned** — even where the partition carries no inherent meaning for the entity — so all assets are uniformly partitioned for the scheduling and destination machinery.

Each of the **18 entity assets** gains:
- `partitioning=il.TimePartitionConfig(column="date")`,
- a stamped `date` = `context.partition_date` on its rows,
- the matching nullable `date` field on its schema — required because the BigQuery destination validates that the partition column exists on the schema (and the GCS destination embeds it in the path).

| Source | Entity assets |
|---|---|
| `tiktok_ads` | `ads`, `campaigns`, `advertisers` |
| `adup` | `account` |
| `amazon_ads` | `profiles` |
| `facebook_ads` | `custom_audiences`, `ads`, `campaigns` |
| `snapchat_ads` | `ad_account`, `ad_accounts`, `ads`, `ad_squads`, `campaigns` |
| `campaign_manager_360` | `custom_audiences` |
| `display_video_360` | `partners`, `audiences`, `custom_audiences` |
| `amazon_selling_partner` | `products` — its Data Kiosk query now uses the partition date instead of `today - 1` |

## Guard test

`tests/test_entity_partitioning.py` walks every source exported from `interloper_assets` and asserts each Entity asset is partitioned on `date`, its schema carries the column typed `dt.date | None`, and that at least 18 entities exist — so a future entity can't land unpartitioned.

## Included working-tree changes

Per request, this also carries the changes that were uncommitted on `main`:
- `interloper_assets`: export `AmazonAdsAPILocation`;
- `amazon_selling_partner`: the `vendor_forecasting_retail_stats` **report** disabled with a TODO pending a partitioning review — left as-is since it's a forward-looking snapshot (Report), not an entity; it can be re-enabled partitioned in a follow-up if that's the review's outcome;
- `interloper-core`: a relation-types TODO note.

## Reviewer notes

- **Existing entity tables change shape**: they gain a `date` column and their destination tables become day-partitioned. Existing unpartitioned BQ entity tables will conflict with the new partitioning spec on the next write — they'll need a one-time drop/migration.
- Entity rows are stamped with the *run's* partition date; re-running a past partition writes yesterday's snapshot labels with that past date (snapshots are only meaningful for the day they ran).
- Two DV360 tests were updated for the new `context` parameter and the stamped column; full `interloper-assets` suite (88) + `ruff` + `ty` pass.

By Digitl