### PR TITLE
fix: keep declared field order when a field shadows a Serializable ClassVar

### DIFF
--- a/packages/interloper-core/src/interloper/schema/base.py
+++ b/packages/interloper-core/src/interloper/schema/base.py
@@ -108,20 +108,18 @@ class Schema(Serializable):
 
         Fields declared by :class:`Schema` itself (framework plumbing, if
         any) are excluded — only the subclass's data columns count.  Fields
-        are returned in the subclass's declaration order: pydantic positions
-        a field that shadows a parent attribute at the *parent's* annotation
-        slot, so ``model_fields`` order alone would scramble the author's
-        column order.
+        come out in declaration order: :class:`Serializable` normalizes
+        ``model_fields`` so a column shadowing a parent ClassVar (``name``,
+        ``key``) is not hoisted out of place.
 
         Returns:
             One :class:`FieldSpec` per declared data field, in declaration order.
         """
         data_fields = cls._data_fields()
-        names = [n for n in cls.model_fields if n in data_fields]
-        own_order = [n for n in cls.__dict__.get("__annotations__", {}) if n in data_fields]
-        ordered = own_order + [n for n in names if n not in own_order]
         return [
-            _field_spec(name, cls.model_fields[name].annotation, cls.model_fields[name].description) for name in ordered
+            _field_spec(name, info.annotation, info.description)
+            for name, info in cls.model_fields.items()
+            if name in data_fields
         ]
 
     @classmethod
@@ -129,9 +127,8 @@ class Schema(Serializable):
         """JSON Schema for this schema's data fields only.
 
         Like :meth:`pydantic.BaseModel.model_json_schema` but restricted to
-        the subclass's data columns, and orders ``properties`` by declaration
-        order (see :meth:`field_specs`) so the column order matches the
-        author's intent rather than pydantic's parent-first layout.
+        the subclass's data columns, in declaration order (see
+        :meth:`field_specs`).
 
         Returns:
             A JSON Schema dict whose ``properties`` are the data columns.

--- a/packages/interloper-core/src/interloper/serializable/base.py
+++ b/packages/interloper-core/src/interloper/serializable/base.py
@@ -207,6 +207,37 @@ class Serializable(BaseModel):
         if "key" not in cls.__dict__:
             cls.key = to_snake_case(cls.__name__)
 
+    @classmethod
+    def __pydantic_init_subclass__(cls, **kwargs: Any) -> None:
+        """Restore declaration order for fields that shadow a parent ClassVar.
+
+        Pydantic merges annotations across the MRO with dict-update
+        semantics, so a subclass field whose name is also *annotated* on a
+        parent — e.g. a schema column named ``name``, which every
+        Serializable declares as a ClassVar — is hoisted to the parent's
+        annotation slot, landing first in ``model_fields`` regardless of
+        where the subclass declares it. Rebuild the order from each class's
+        own annotations, counting only occurrences that are actual fields
+        on that class, so a ClassVar annotation no longer pins a position.
+        """
+        super().__pydantic_init_subclass__(**kwargs)
+        fields = cls.__pydantic_fields__
+        order: dict[str, None] = {}
+        for klass in reversed(cls.__mro__):
+            klass_fields = getattr(klass, "__pydantic_fields__", {})
+            for field_name in klass.__dict__.get("__annotations__", {}):
+                if field_name in fields and field_name in klass_fields:
+                    order.setdefault(field_name, None)
+        reordered = {field_name: fields[field_name] for field_name in order}
+        reordered.update({field_name: info for field_name, info in fields.items() if field_name not in reordered})
+        if list(reordered) == list(fields):
+            return
+        cls.__pydantic_fields__ = reordered
+        # With unresolved forward refs the core schema is built lazily and
+        # picks up the reordered dict; rebuilding now would fail resolution.
+        if cls.__pydantic_fields_complete__:
+            cls.model_rebuild(force=True)
+
     def __init__(self, /, **data: Any) -> None:
         """Validate kwargs strictly against the model's fields.
 

--- a/packages/interloper-core/tests/schema/test_base.py
+++ b/packages/interloper-core/tests/schema/test_base.py
@@ -100,6 +100,23 @@ class TestFieldSpecs:
     def test_declaration_order_preserved_with_shadowing_names(self):
         assert [s.name for s in ShadowingSchema.field_specs()] == ["id", "cost", "name", "day"]
 
+    def test_model_fields_in_declaration_order(self):
+        assert list(ShadowingSchema.model_fields) == ["id", "cost", "name", "day"]
+
+    def test_subclass_keeps_parent_order_and_appends(self):
+        class Extended(ShadowingSchema):
+            extra: str | None = Field(...)
+
+        assert [s.name for s in Extended.field_specs()] == ["id", "cost", "name", "day", "extra"]
+
+    def test_inferred_schema_keeps_key_order_with_shadowing_name(self):
+        inferred = Schema.infer([{"a": 1, "name": "x", "b": 2}])
+        assert [s.name for s in inferred.field_specs()] == ["a", "name", "b"]
+
+    def test_reconciled_rows_in_declaration_order(self):
+        rows = ShadowingSchema.reconcile([{"name": "x", "id": 1, "cost": 2.0, "day": "mon"}])
+        assert list(rows[0]) == ["id", "cost", "name", "day"]
+
     def test_inferred_schema_has_specs(self):
         inferred = Schema.infer([{"a": 1, "b": "x"}, {"a": None, "b": "y"}])
         specs = {s.name: s for s in inferred.field_specs()}

--- a/packages/interloper-core/tests/serializable/test_base.py
+++ b/packages/interloper-core/tests/serializable/test_base.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import Any
 
 import pytest
@@ -25,6 +26,17 @@ class FakeOtherSerializable(Serializable):
     """Second class, used to exercise type-mismatch scenarios."""
 
     value: str = ""
+
+
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", message=r'Field name "name" in "ShadowingSerializable" shadows an attribute')
+
+    class ShadowingSerializable(Serializable):
+        """Declares a ``name`` data field that shadows the parent ClassVar."""
+
+        alpha: str | None = None
+        name: str | None = None
+        beta: str | None = None
 
 
 # -- The Spec envelope ---------------------------------------------------------
@@ -108,6 +120,32 @@ class TestSubclassScopedConstruction:
         instance = FakeSerializable.from_spec_file(file)
         assert isinstance(instance, FakeSerializable)
         assert instance.text == "abc"
+
+
+class TestFieldOrdering:
+    """A field shadowing a parent ClassVar keeps its declaration position."""
+
+    def test_model_fields_keep_declaration_order(self):
+        assert list(ShadowingSerializable.model_fields) == ["alpha", "name", "beta"]
+
+    def test_dump_order_matches_declaration(self):
+        assert list(ShadowingSerializable(name="x").model_dump()) == ["alpha", "name", "beta"]
+
+    def test_subclass_appends_new_fields_after_inherited(self):
+        class Extended(ShadowingSerializable):
+            gamma: str | None = None
+
+        assert list(Extended.model_fields) == ["alpha", "name", "beta", "gamma"]
+
+    def test_classvars_untouched_by_shadowing_field(self):
+        assert ShadowingSerializable.key == "shadowing_serializable"
+        assert ShadowingSerializable(name="x").name == "x"
+
+    def test_spec_roundtrip_with_shadowing_field(self):
+        rebuilt = ShadowingSerializable.from_spec(ShadowingSerializable(name="x").to_spec())
+        assert type(rebuilt) is ShadowingSerializable
+        assert rebuilt.name == "x"
+        assert type(rebuilt).key == "shadowing_serializable"
 
 
 class TestStrictInit:


### PR DESCRIPTION
## Problem

Pydantic v2 collects fields by merging `__annotations__` across the MRO with dict-update semantics: a key that already exists keeps its **first** insertion position. Since `Serializable` annotates `name: ClassVar[str]` (likewise `key`, `internal_fields`), any `Schema` subclass declaring a `name` *data field* had it hoisted into the parent's annotation slot — first in `model_fields`, regardless of declaration position:

```python
class Repro(Schema):
    alpha: str | None = None
    name: str | None = None
    beta: str | None = None

list(Repro.model_fields)  # ['name', 'alpha', 'beta']
```

This scrambled the declared column order of 13+ asset schemas in interloper-assets (facebook_ads `Ads`/`Campaigns`, snapchat_ads, display_video_360 `Partners`/`Audiences`, …). A consumer-side reordering workaround in `Schema.field_specs()`/`json_schema()` patched destination column order, but only covered the immediate class's annotations, and `model_dump` order (which drives `Schema.reconcile()` row dicts) stayed scrambled.

## Fix

Normalize field order at model build time in `Serializable.__pydantic_init_subclass__`: rebuild the order by walking the MRO base-first through each class's *own* annotations, counting only occurrences that are real fields on that class — so a ClassVar annotation no longer pins a position, while genuine field overrides keep pydantic's parent-slot semantics. When the order changed, `__pydantic_fields__` is reassigned and the core schema rebuilt, so `model_dump` and `model_json_schema` order follow. With unresolved forward refs the rebuild is deferred to pydantic's lazy build, which picks up the reordered dict.

Fixing at the `Serializable` root (rather than `Schema`) covers every consumer and is generic over all ClassVars, including future ones. The now-redundant `own_order` workaround in `Schema.field_specs()` is removed.

Alternatives considered: renaming the ClassVar (huge blast radius — Source/Asset/Connection, API, frontend all rely on `name`/`key`) and hiding the annotations behind `TYPE_CHECKING` (works, but silently regresses with every future ClassVar).

## Verification

- New `TestFieldOrdering` regression tests at both levels: mid-class `name` keeps declaration order in `model_fields`/`model_dump`, multi-level inheritance appends after inherited fields, `Schema.infer` with a `name` column, `reconcile()` row order, ClassVars untouched, and spec round-trip of a shadowing class.
- All 96 asset schemas in interloper-assets scripted-checked: `model_fields` == declaration order, 0 mismatches (previously 13+ scrambled).
- DAG-spec round-trip verified (`DemoSource`/`Asset` `to_spec()` → `from_spec()`); `name`/`key` ClassVar behavior unchanged.
- Full suite: 1025 passed; ruff + ty clean.

By Digitl