### PR TITLE
fix(app): pass the partition date when running a job from the UI

### DIFF
--- a/packages/interloper-app/app/app/components/executions/RunModal.vue
+++ b/packages/interloper-app/app/app/components/executions/RunModal.vue
@@ -13,11 +13,15 @@ import { jobPartitioned } from '~/types/component'
 
 const open = defineModel<boolean>('open', { default: false })
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
     target: ComponentRecord
     /** Whether the target takes a partition date. Defaults to the job's config for jobs. */
     partitioned?: boolean
-}>()
+}>(), {
+    // Vue casts an absent Boolean prop to false; default it to undefined so the
+    // ?? fallback to the job's config below can actually kick in.
+    partitioned: undefined,
+})
 
 const runsStore = useRunsStore()
 const backfillsStore = useBackfillsStore()


### PR DESCRIPTION
## Problem

Triggering a single-day run of a partitioned job from the UI queued the run without a `partition_date`, so it failed with:

```
interloper.errors.PartitionError: Asset '...' is partitioned, but no partition/partition_window provided
```

(prod runs `2463c424` and `6b13bbf7`, job "Amazon SP").

## Root cause

Vue casts an absent Boolean prop to `false`, not `undefined`. RunModal's

```ts
const partitioned = computed(() => props.partitioned ?? (isJob.value && jobPartitioned(props.target)))
```

therefore never reached the `??` fallback for jobs (the jobs page doesn't pass the prop), and the picked date was silently dropped — while the modal still displayed "This will queue a single run for {date}".

Regressed in 86afe7b (shipped in 0.32.0) when the jobs-only modal was generalized to run any component. Scheduled cron runs, backfills, and source/asset triggers were unaffected.

## Fix

Default the prop to `undefined` via `withDefaults`, which opts out of Vue's Boolean casting: absence now falls through to the job's config, while explicit `true`/`false` from the sources page and asset panel still override.

By Digitl