### PR TITLE
feat(core): fail partition-less runs of partitioned assets at preflight

### DIFF
--- a/packages/interloper-core/src/interloper/runner/base.py
+++ b/packages/interloper-core/src/interloper/runner/base.py
@@ -190,8 +190,22 @@ class Runner(Serializable):
         """Run preflight validations before execution begins.
 
         Raises:
-            PartitionError: If any partitioned asset does not support windowed execution.
+            PartitionError: If partitioned assets are run without a partition,
+                or a windowed run includes assets that do not support windows.
         """
+        if partition_or_window is None:
+            partitioned = sorted(
+                type(asset).key
+                for asset in dag.assets
+                if asset.materializable and asset.partitioning is not None
+            )
+            if partitioned:
+                raise PartitionError(
+                    "This run requires a partition or partition window. "
+                    f"Partitioned assets: {partitioned}."
+                )
+            return
+
         if not isinstance(partition_or_window, PartitionWindow):
             return
 

--- a/packages/interloper-core/tests/runner/test_base.py
+++ b/packages/interloper-core/tests/runner/test_base.py
@@ -3,15 +3,18 @@
 from __future__ import annotations
 
 import asyncio
+import datetime as dt
 from typing import Any
 
 import pytest
 
 import interloper as il
-from interloper.errors import ConfigError
+from interloper.errors import ConfigError, PartitionError
 from interloper.events import Event
+from interloper.partitioning.time import TimePartition, TimePartitionConfig
 from interloper.runner.async_runner import AsyncRunner
 from interloper.runner.base import RUNNERS
+from interloper.runner.results import ExecutionStatus
 from interloper.runner.serial import SerialRunner
 from interloper.settings import RunnerSettings
 
@@ -123,3 +126,55 @@ class TestOnEventScoping:
         run_ids = {e.metadata.get("run_id") for e in events}
         assert len(run_ids) == 1
         assert None not in run_ids
+
+
+class TestPreflightValidation:
+    """DAG-wide partition validation, raised before any asset executes."""
+
+    async def test_partitioned_assets_require_a_partition(self):
+        il.MemoryDestination.clear()
+        calls: list[str] = []
+
+        @il.asset(partitioning=TimePartitionConfig(column="date"))
+        def daily() -> list[dict[str, Any]]:
+            calls.append("daily")
+            return [{"date": "2026-01-01"}]
+
+        @il.asset()
+        def static() -> list[dict[str, Any]]:
+            calls.append("static")
+            return [{"x": 1}]
+
+        dag = il.DAG(
+            daily(id="daily", destinations=[il.MemoryDestination()]),
+            static(id="static", destinations=[il.MemoryDestination()]),
+        )
+        with pytest.raises(PartitionError, match=r"requires a partition.*daily"):
+            await AsyncRunner().run(dag)
+
+        # The run fails as a whole: not even the non-partitioned asset ran.
+        assert calls == []
+
+    async def test_partition_satisfies_the_preflight(self):
+        il.MemoryDestination.clear()
+
+        @il.asset(partitioning=TimePartitionConfig(column="date"))
+        def daily() -> list[dict[str, Any]]:
+            return [{"date": "2026-01-01"}]
+
+        dag = il.DAG(daily(id="daily", destinations=[il.MemoryDestination()]))
+        result = await AsyncRunner().run(dag, TimePartition(dt.date(2026, 1, 1)))
+
+        assert result.status is ExecutionStatus.COMPLETED
+
+    def test_non_materializable_partitioned_assets_are_exempt(self):
+        # Upstream dependencies are hydrated read-only (materializable=False);
+        # they must not force a partition onto an otherwise unpartitioned run.
+        @il.asset(partitioning=TimePartitionConfig(column="date"))
+        def upstream() -> list[dict[str, Any]]:
+            return [{"date": "2026-01-01"}]
+
+        asset = upstream(id="upstream", destinations=[il.MemoryDestination()])
+        asset.materializable = False
+
+        AsyncRunner()._preflight_validation(il.DAG(asset), None)


### PR DESCRIPTION
## Problem

When a partitioned job/source/asset is run without a partition (e.g. prod run `2463c424`, see #182), the failure happens **per asset, mid-walk**:

- each partitioned asset raises `PartitionError` only when the DAG walk reaches it, producing N asset-level failures/cancellations with tracebacks;
- non-partitioned assets scheduled earlier in the same run **complete and materialize**, leaving partial output behind on a doomed run.

## Change

Extend `Runner._preflight_validation` — which already gates `allow_window` for windowed runs DAG-wide — with the symmetric missing-partition check: if no partition/window is provided and the DAG contains materializable partitioned assets, raise a single run-level `PartitionError` **before any asset executes**, listing the offending asset keys:

```
PartitionError: This run requires a partition or partition window. Partitioned assets: ['vendor_traffic_stats', ...].
```

- Runs all-or-nothing: nothing materializes, one clear error instead of asset-level noise.
- The scheduler's executor already catches exceptions from `runner.run` and emits `RUN_FAILED` + marks the run failed — no executor changes needed.
- Covers every entry point: all runners subclass `AsyncRunner`/`SyncRunner`, which share `_init_run` → `_preflight_validation`.
- Non-materializable assets are exempt (read-only upstream deps, already-succeeded assets in `scope=failed` retries), matching the existing window check.
- The asset-level check in `Asset._validate_partitioning` stays, guarding direct `asset.run()` usage.

## Behavior change

A partition-less run of a mixed DAG previously materialized its non-partitioned assets before failing; it now fails upfront and materializes nothing.

## Tests

Three new tests in `tests/runner/test_base.py`: preflight failure (asserting nothing executed, not even non-partitioned assets), partition satisfies the preflight, and the non-materializable exemption. Full core + scheduler suites pass (636 tests).

Complements #182 (UI fix that stops dropping the date); this makes any future partition-less run fail cleanly at run level.

By Digitl