### PR TITLE
feat(app): split the events table asset column into source and asset

### DIFF
--- a/packages/interloper-app/app/app/components/chart/ExecutionTimeline.vue
+++ b/packages/interloper-app/app/app/components/chart/ExecutionTimeline.vue
@@ -111,7 +111,7 @@ const parsed = computed<Parsed[]>(() => {
 })
 
 function parseExecution(record: AssetExecution): Parsed {
-    const displayName = record.asset_id ? assetDisplayName.value.get(record.asset_id) : undefined
+    const displayName = record.asset_id ? assetDisplayName.value.get(record.asset_id)?.label : undefined
     return {
         id: record.asset_id,
         name: displayName ?? record.asset_key,

--- a/packages/interloper-app/app/app/components/executions/EventsTable.vue
+++ b/packages/interloper-app/app/app/components/executions/EventsTable.vue
@@ -69,12 +69,22 @@ const columns: TableColumn<RunEvent>[] = [
         cell: ({ row }) => h('span', { class: 'font-mono text-xs text-muted' }, formatTimestamp(row.getValue<string>('timestamp'))),
     },
     {
+        id: 'source',
+        header: 'Source',
+        cell: ({ row }) => {
+            const event = row.original as RunEvent
+            const names = event.asset_id ? assetDisplayName.value.get(event.asset_id) : null
+            if (!names) return h('span', { class: 'text-muted' }, '—')
+            return h(EntityBadge, { icon: names.sourceIcon, label: names.sourceName })
+        },
+    },
+    {
         accessorKey: 'asset_key',
         header: 'Asset',
         cell: ({ row }) => {
             const event = row.original as RunEvent
-            const displayName = event.asset_id ? assetDisplayName.value.get(event.asset_id) : null
-            const label = displayName ?? event.asset_key
+            const names = event.asset_id ? assetDisplayName.value.get(event.asset_id) : null
+            const label = names?.assetName ?? event.asset_key
             if (!label) return h('span', { class: 'text-muted' }, '—')
             return h(EntityBadge, { label })
         },

--- a/packages/interloper-app/app/app/composables/assetDisplayName.ts
+++ b/packages/interloper-app/app/app/composables/assetDisplayName.ts
@@ -1,17 +1,30 @@
-/** asset_id → "Source Name → Asset Name" */
+export interface AssetNames {
+    sourceName: string
+    sourceIcon: string
+    assetName: string
+    /** Combined "Source Name → Asset Name" label. */
+    label: string
+}
+
+/** asset_id → display names of the asset and its source */
 export function useAssetDisplayName() {
     const componentsStore = useComponentsStore()
     const catalogStore = useCatalogStore()
 
     const assetDisplayName = computed(() => {
-        const map = new Map<string, string>()
+        const map = new Map<string, AssetNames>()
         for (const source of componentsStore.byKind('source')) {
             const sourceDefn = catalogStore.getSourceDefinition(source.key)
             const sourceName = source.name ?? sourceDefn?.name ?? source.key
             for (const asset of source.children) {
                 const assetDefn = sourceDefn?.assets?.find(a => a.key === asset.key)
                 const assetName = assetDefn?.name ?? asset.key
-                map.set(asset.id, `${sourceName} → ${assetName}`)
+                map.set(asset.id, {
+                    sourceName,
+                    sourceIcon: componentIcon(source.key),
+                    assetName,
+                    label: `${sourceName} → ${assetName}`,
+                })
             }
         }
         return map


### PR DESCRIPTION
The events table's Asset column rendered a combined "Source → Asset" badge. It's now two columns:

- **Source** — entity badge with the source's catalog icon and name; `—` for run-level events with no asset.
- **Asset** — entity badge with the asset name, still falling back to the raw `asset_key` when the asset can't be resolved (e.g. deleted).

`useAssetDisplayName` now maps `asset_id → { sourceName, sourceIcon, assetName, label }` instead of only the joined string, so the parts are reusable; the execution timeline (its other consumer) keeps using the combined `label`, unchanged.

By Digitl