### PR TITLE
fix(core): make lazy Registry loading thread-safe

### DIFF
--- a/packages/interloper-core/src/interloper/registry/base.py
+++ b/packages/interloper-core/src/interloper/registry/base.py
@@ -9,6 +9,7 @@ who consumes it.
 
 from __future__ import annotations
 
+import threading
 from collections.abc import Callable
 from importlib.metadata import entry_points
 from typing import Any, Generic, TypeVar
@@ -42,6 +43,7 @@ class Registry(Generic[T]):
         self._adopt = adopt
         self._entries: dict[str, T] = {}
         self._loaded = group is None
+        self._load_lock = threading.RLock()
 
     def register(self, name: str, obj: T) -> None:
         """Register *obj* under *name* (first-wins, idempotent)."""
@@ -67,7 +69,14 @@ class Registry(Generic[T]):
         """
         obj = self.get(name)
         if obj is None:
-            raise KeyError(f"'{name}' is not registered (available: {', '.join(self.keys())})")
+            available = ", ".join(self.keys())
+            where = f" in entry-point group '{self._group}'" if self._group else ""
+            hint = (
+                f" (available: {available})"
+                if available
+                else " (no entries discovered — is the package declaring it installed?)"
+            )
+            raise KeyError(f"'{name}' is not registered{where}{hint}")
         return obj
 
     def keys(self) -> tuple[str, ...]:
@@ -106,11 +115,22 @@ class Registry(Generic[T]):
         return self.get(name) is not None
 
     def _load(self) -> None:
-        """Populate from the entry-point group (once)."""
+        """Populate from the entry-point group (once, thread-safely).
+
+        First lookups can race from worker threads (e.g. several assets
+        conforming concurrently), so loading is serialized and ``_loaded``
+        flips only after every entry registered — a concurrent reader either
+        loads itself or waits, never observing a partially-populated registry.
+        A failed load leaves ``_loaded`` unset so the next lookup retries
+        instead of latching the registry empty.
+        """
         if self._loaded or self._group is None:
             return
-        self._loaded = True
-        for entry_point in entry_points(group=self._group):
-            loaded = entry_point.load()
-            name, obj = self._adopt(entry_point.name, loaded) if self._adopt else (entry_point.name, loaded)
-            self.register(name, obj)
+        with self._load_lock:
+            if self._loaded:
+                return
+            for entry_point in entry_points(group=self._group):
+                loaded = entry_point.load()
+                name, obj = self._adopt(entry_point.name, loaded) if self._adopt else (entry_point.name, loaded)
+                self.register(name, obj)
+            self._loaded = True

--- a/packages/interloper-core/tests/registry/test_base.py
+++ b/packages/interloper-core/tests/registry/test_base.py
@@ -1,5 +1,7 @@
 """Tests for ``interloper.registry.base``."""
 
+import threading
+import time
 from unittest import mock
 
 import pytest
@@ -78,3 +80,72 @@ class TestEntryPoints:
             pytest.raises(TypeError, match="bad entry: alpha"),
         ):
             registry.get("alpha")
+
+    def test_failed_load_retries_on_next_lookup(self):
+        # A transient load failure must not latch the registry empty forever.
+        registry: Registry[str] = Registry("test.group")
+        with (
+            mock.patch("interloper.registry.base.entry_points", side_effect=RuntimeError("boom")),
+            pytest.raises(RuntimeError, match="boom"),
+        ):
+            registry.get("alpha")
+        with mock.patch("interloper.registry.base.entry_points", return_value=[self._entry_point("alpha", "A")]):
+            assert registry.get("alpha") == "A"
+
+
+class TestThreadSafety:
+    def test_concurrent_first_lookups_never_see_a_partial_registry(self):
+        # Regression: a reader arriving while another thread was mid-load used
+        # to observe an empty registry (KeyError "'rows' is not registered
+        # (available: )") because _loaded flipped before the entries landed.
+        registry: Registry[str] = Registry("test.group")
+
+        entry = mock.Mock()
+        entry.name = "alpha"
+        entry.load.side_effect = lambda: time.sleep(0.05) or "A"
+
+        results: dict[str, object] = {}
+
+        def lookup(tid: str) -> None:
+            try:
+                results[tid] = registry["alpha"]
+            except KeyError as e:
+                results[tid] = e
+
+        with mock.patch("interloper.registry.base.entry_points", return_value=[entry]):
+            first = threading.Thread(target=lookup, args=("first",))
+            second = threading.Thread(target=lookup, args=("second",))
+            first.start()
+            time.sleep(0.01)  # let the first thread enter the load
+            second.start()
+            first.join()
+            second.join()
+
+        assert results == {"first": "A", "second": "A"}
+
+
+class TestErrorMessage:
+    def test_unknown_name_lists_available(self):
+        registry: Registry[str] = Registry()
+        registry.register("alpha", "A")
+        with pytest.raises(KeyError, match=r"'missing' is not registered \(available: alpha\)"):
+            registry["missing"]
+
+    def test_unknown_name_names_the_entry_point_group(self):
+        registry: Registry[str] = Registry("test.group")
+        entry = mock.Mock()
+        entry.name = "alpha"
+        entry.load.return_value = "A"
+        with (
+            mock.patch("interloper.registry.base.entry_points", return_value=[entry]),
+            pytest.raises(KeyError, match=r"'missing' is not registered in entry-point group 'test.group'"),
+        ):
+            registry["missing"]
+
+    def test_empty_group_hints_at_missing_package(self):
+        registry: Registry[str] = Registry("test.group")
+        with (
+            mock.patch("interloper.registry.base.entry_points", return_value=[]),
+            pytest.raises(KeyError, match=r"no entries discovered — is the package declaring it installed\?"),
+        ):
+            registry["rows"]


### PR DESCRIPTION
## Problem

Prod run `19f8e217` failed with:

```
KeyError: "'rows' is not registered (available: )"
```

even though the image has all entry points correctly installed (verified in the prod pod). The registry was emptied at runtime by a race, not by the build.

## Root cause

`Registry._load` set `_loaded = True` **before** iterating the entry-point group. First lookups can race from worker threads — `_normalize_and_conform` runs via `asyncio.to_thread` with up to 4 assets concurrently, and in run `19f8e217` four Amazon SP report fetches completed within ~60ms of each other. Thread A flipped the flag and began loading; thread B saw `_loaded = True`, skipped loading, and read an empty registry → the exact prod error. Reproduced deterministically with two threads and a slow entry-point load.

Intermittent by nature (needs simultaneous first use), and affects every entry-point registry (kinds, runners, representations) since the Registry refactor in 0.32.0.

## Fix

- Serialize `_load` behind an `RLock` and flip `_loaded` only after every entry is registered — concurrent readers either load themselves or wait, never observing a partially-populated registry.
- A failed load no longer latches the registry permanently empty; the next lookup retries.
- Actionable lookup errors: name the entry-point group and distinguish "wrong name" from "nothing discovered":
  - `'dataframe' is not registered in entry-point group 'interloper.representations' (available: rows)`
  - `'rows' is not registered in entry-point group 'interloper.representations' (no entries discovered — is the package declaring it installed?)`

## Tests

Five new tests: the concurrent first-lookup regression (two threads racing a slow load), retry-after-failed-load, and the three error-message shapes. Full core suite passes (613 tests).

By Digitl