### PR TITLE
feat(app): show the app version in the sidebar footer

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -146,6 +146,8 @@ COPY packages/interloper-app/app/package.json packages/interloper-app/app/pnpm-l
 COPY packages/interloper-app/app/patches/ patches/
 RUN pnpm install --frozen-lockfile --ignore-scripts
 COPY packages/interloper-app/app/ ./
+# One level up from the app dir: nuxt.config reads the workspace version from it.
+COPY packages/interloper-app/pyproject.toml /pyproject.toml
 RUN pnpm exec nuxt prepare && NUXT_PRESET=static pnpm build
 
 

--- a/packages/interloper-app/app/app/layouts/default.vue
+++ b/packages/interloper-app/app/app/layouts/default.vue
@@ -7,6 +7,7 @@ const catalogStore = useCatalogStore()
 const userStore = useUserStore()
 const { open: commandPaletteOpen, groups: commandPaletteGroups } = useCommandPalette()
 const { open: agentOpen, width: agentWidth, dragging: agentDragging } = useAgentPanel()
+const appVersion = useRuntimeConfig().public.version
 
 /** Design page header rendered by the layout, declared via definePageMeta({ pageHeader }). */
 interface PageHeaderMeta {
@@ -162,6 +163,10 @@ const items = computed<NavigationMenuItem[]>(() => {
                         <div class="flex flex-col gap-1 w-full">
                             <NavOrganisation :collapsed="collapsed" />
                             <NavUser :collapsed="collapsed" />
+                            <span v-if="!collapsed && appVersion"
+                                  class="px-2.5 text-[10px] text-dimmed">
+                                v{{ appVersion }}
+                            </span>
                         </div>
                     </template>
                 </UDashboardSidebar>

--- a/packages/interloper-app/app/nuxt.config.ts
+++ b/packages/interloper-app/app/nuxt.config.ts
@@ -1,3 +1,14 @@
+import { readFileSync } from 'node:fs'
+
+// The enclosing python package carries the single PSR-bumped workspace
+// version; absent (standalone SPA builds), the version label simply hides.
+let appVersion = ''
+try {
+    appVersion = readFileSync(new URL('../pyproject.toml', import.meta.url), 'utf8')
+        .match(/^version = "([^"]+)"/m)?.[1] ?? ''
+}
+catch { /* noop */ }
+
 export default defineNuxtConfig({
     compatibilityDate: '2025-07-15',
     components: [
@@ -61,6 +72,7 @@ export default defineNuxtConfig({
     runtimeConfig: {
         public: {
             devApiPort: process.env.INTERLOPER_API_PORT || '',
+            version: appVersion,
         },
     },
     ssr: false,


### PR DESCRIPTION
A tiny dimmed `v0.x.y` label under the username in the sidebar footer.

- The version is stamped at build time: `nuxt.config.ts` reads it from `packages/interloper-app/pyproject.toml` — the single `python-semantic-release`-bumped workspace version, and the exact package the built SPA ships inside — into `runtimeConfig.public.version` (runtime-overridable via `NUXT_PUBLIC_VERSION` if ever needed).
- The docker `build-spa` stage only copies the `app/` directory, so it gains a one-line `COPY` of that pyproject; without it the read fails gracefully and the label simply hides (standalone SPA builds keep working).
- Hidden when the sidebar is collapsed.

By Digitl