### PR TITLE
fix(assets): reconcile Amazon Selling Partner report data

### DIFF
--- a/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/source.py
+++ b/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/source.py
@@ -233,6 +233,10 @@ async def _run_query(connection: AmazonSellingPartnerConnection, query: str) -> 
     # normalizer to no flattening. Data Kiosk assets already return flat
     # snake_case rows, so this is a no-op for them.
     normalizer=DataFrameNormalizer(flatten_max_level=3, snake_case_digits=True),
+    # Reports carry ISO date strings; RECONCILE casts them to the schemas'
+    # date fields — validation alone would pass the strings through to a
+    # DATE-typed BigQuery parquet load, which rejects them.
+    materialization_strategy=il.MaterializationStrategy.RECONCILE,
 )
 class AmazonSellingPartner(il.Source):
     """Amazon Selling Partner integration for vendor and seller reporting."""


### PR DESCRIPTION
## Problem

The first live runs of the Amazon SP source (Swarovski, Belgium marketplace) failed at the BigQuery write (prod run `f6733c25`, partition 2026-07-13):

```
pyarrow.lib.ArrowTypeError: Error converting Pandas column with name: "start_date" and datatype: "object" ...
    object of type <class 'str'> cannot be converted to int
```

## Root cause

Vendor reports return ISO date **strings** (`"startDate": "2026-07-13"`). Under the default AUTO strategy, conform only *validates* — pydantic's lax mode accepts a date string for a `dt.date` field and discards the coercion — so `start_date`/`end_date` reach the destination as object-dtype strings. The DataFrame write path is a parquet load with an explicit `DATE` field, and pyarrow cannot cast str → `date32` (int-backed, hence the cryptic message).

Reproduced end-to-end against the live `GET_VENDOR_SALES_REPORT` (RETAIL/SOURCING, marketplace `AMEN7PMS3EDWL`, partition 2026-07-13): raw `startDate` is `str`, survives normalize + conform unchanged, arrow `date32` conversion throws the exact prod error.

## Fix

`materialization_strategy=il.MaterializationStrategy.RECONCILE` on the source — `DataFrameConformer.reconcile` already does the right vectorized casts (`str → datetime.date` included); AUTO just never invokes it. Verified the same frame converts cleanly to arrow `date32` after reconcile, and that the source-level strategy propagates to all 12 bound assets (each declares a schema, as RECONCILE requires).

This restores parity with the legacy pipeline: digitlcloud-dagster's `AmazonSellingPartnerAsset` hardwired `reconcile_schema: True` and force-cast every column to the BQ schema before loading — that default was lost in the port.

## Note

Other sources ported from digitlcloud-connectors that relied on the always-on `reconcile_schema` may have the same latent gap; worth a sweep.

## Tests

interloper-assets + interloper-pandas suites pass (121 tests).

By Digitl