### PR TITLE
feat(core): destination-level materialization strategy

### DIFF
--- a/packages/interloper-core/src/interloper/destination/database.py
+++ b/packages/interloper-core/src/interloper/destination/database.py
@@ -11,6 +11,7 @@ from typing import Any, ClassVar
 
 from interloper.destination.context import IOContext
 from interloper.destination.partitioned import PartitionedDestination
+from interloper.normalizer import MaterializationStrategy
 from interloper.partitioning.base import Partition, PartitionWindow
 from interloper.representation import REPRESENTATIONS, Representation
 from interloper.utils.data import is_empty
@@ -51,6 +52,7 @@ class DatabaseDestination(PartitionedDestination):
     # appear in the destination's config schema (the UI form) or its specs.
     write_disposition: ClassVar[WriteDisposition] = WriteDisposition.REPLACE
     read_representation: ClassVar[str] = "rows"
+    materialization_strategy: ClassVar[MaterializationStrategy] = MaterializationStrategy.AUTO
 
     # -- Transaction hook ------------------------------------------------------
 
@@ -158,6 +160,8 @@ class DatabaseDestination(PartitionedDestination):
         if is_empty(data):
             return
 
+        data = self._apply_materialization_strategy(data, context)
+
         if context.partition_or_window is not None and context.asset.partitioning is not None:
             col = context.asset.partitioning.column
             columns = Representation.of(data).columns(data)
@@ -192,6 +196,29 @@ class DatabaseDestination(PartitionedDestination):
                     self._delete_partition(table, schema, col, context.partition_or_window.id)
 
             self._insert_data(table, schema, data, context)
+
+    def _apply_materialization_strategy(self, data: Any, context: IOContext) -> Any:
+        """Enforce this backend's write-time schema strategy.
+
+        A backend declares how strictly its physical types demand
+        schema-shaped data: ``AUTO`` trusts the conformed data as-is,
+        ``STRICT`` validates it against the effective schema (failing
+        loudly), and ``RECONCILE`` aligns columns and coerces values — for
+        backends whose typed load path rejects representations that lax
+        validation lets through (e.g. ISO date strings against a DATE
+        column). No-op when no effective schema was resolved.
+
+        Returns:
+            The data to write, coerced under ``RECONCILE``.
+        """
+        strategy = self.materialization_strategy
+        if strategy is MaterializationStrategy.AUTO or context.schema is None:
+            return data
+        conformer = Representation.of(data).conformer
+        if strategy is MaterializationStrategy.RECONCILE:
+            return conformer.reconcile(data, context.schema)
+        conformer.validate(data, context.schema, strict=True)
+        return data
 
     def _read_scope(self, context: IOContext, partition: Partition | None) -> Any:
         """Load one scope from the database table.

--- a/packages/interloper-core/src/interloper/destination/decorator.py
+++ b/packages/interloper-core/src/interloper/destination/decorator.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from typing import Any, TypeVar, overload
 
 from interloper.destination.base import Destination
+from interloper.normalizer import MaterializationStrategy
 from interloper.resource import Resource
 
 # Bounded TypeVar so that classes already extending Destination preserve their
@@ -28,6 +29,7 @@ def destination(
     name: str = ...,
     icon: str = ...,
     read_representation: str = ...,
+    materialization_strategy: MaterializationStrategy = ...,
 ) -> Callable[[type[DestinationT]], type[DestinationT]]: ...
 def destination(
     cls: type | None = None,
@@ -39,6 +41,7 @@ def destination(
     name: str | None = None,
     icon: str | None = None,
     read_representation: str | None = None,
+    materialization_strategy: MaterializationStrategy | None = None,
 ) -> type[Destination] | Callable[[type], type[Destination]]:
     """Create a Destination subclass from a decorated class.
 
@@ -70,6 +73,8 @@ def destination(
         classvars["resource_types"] = resources
     if read_representation is not None:
         classvars["read_representation"] = read_representation
+    if materialization_strategy is not None:
+        classvars["materialization_strategy"] = materialization_strategy
     if tags is not None:
         classvars["tags"] = tags
     if key is not None:

--- a/packages/interloper-core/tests/destination/test_database.py
+++ b/packages/interloper-core/tests/destination/test_database.py
@@ -210,3 +210,59 @@ class TestRecordsConversion:
         out = DataFrameReadDB(id="db")._from_rows([{"a": 1}])
         assert isinstance(out, pd.DataFrame)
         assert RecordingDB(id="db")._from_rows([{"a": 1}]) == [{"a": 1}]
+
+
+class DateSchema(il.Schema):
+    """Schema with a date field, mirroring API rows that carry ISO strings."""
+
+    name: str | None = None
+    day: datetime.date | None = None
+
+
+class TestMaterializationStrategy:
+    """Write-time schema enforcement declared as a backend trait."""
+
+    def test_auto_trusts_conformed_data(self):
+        dest = RecordingDB(id="db")
+        rows = [{"name": "a", "day": "2026-07-13"}]
+        dest.write(make_ctx(plain_asset(), schema=DateSchema), rows)
+        assert dest.calls[-1][1][2] == rows
+
+    def test_reconcile_coerces_rows_to_the_effective_schema(self):
+        class ReconcilingDB(RecordingDB):
+            materialization_strategy = il.MaterializationStrategy.RECONCILE
+
+        dest = ReconcilingDB(id="db")
+        dest.write(make_ctx(plain_asset(), schema=DateSchema), [{"name": "a", "day": "2026-07-13"}])
+        inserted = dest.calls[-1][1][2]
+        assert inserted == [{"name": "a", "day": datetime.date(2026, 7, 13)}]
+
+    def test_reconcile_coerces_dataframes(self):
+        pd = pytest.importorskip("pandas")
+
+        class ReconcilingDB(RecordingDB):
+            materialization_strategy = il.MaterializationStrategy.RECONCILE
+
+        dest = ReconcilingDB(id="db")
+        dest.write(make_ctx(plain_asset(), schema=DateSchema), pd.DataFrame([{"name": "a", "day": "2026-07-13"}]))
+        inserted = dest.calls[-1][1][2]
+        assert inserted[0]["day"] == datetime.date(2026, 7, 13)
+
+    def test_reconcile_without_schema_is_a_noop(self):
+        class ReconcilingDB(RecordingDB):
+            materialization_strategy = il.MaterializationStrategy.RECONCILE
+
+        dest = ReconcilingDB(id="db")
+        rows = [{"name": "a", "day": "2026-07-13"}]
+        dest.write(make_ctx(plain_asset()), rows)
+        assert dest.calls[-1][1][2] == rows
+
+    def test_decorator_sets_the_trait(self):
+        from interloper.destination import destination
+
+        @destination(materialization_strategy=il.MaterializationStrategy.RECONCILE)
+        class DecoratedDB(RecordingDB):
+            pass
+
+        assert DecoratedDB.materialization_strategy is il.MaterializationStrategy.RECONCILE
+        assert RecordingDB.materialization_strategy is il.MaterializationStrategy.AUTO

--- a/packages/interloper-google-cloud/src/interloper_google_cloud/bigquery/destination.py
+++ b/packages/interloper-google-cloud/src/interloper_google_cloud/bigquery/destination.py
@@ -19,6 +19,7 @@ from google.oauth2 import service_account
 from interloper.destination import IOContext, destination
 from interloper.destination.database import DatabaseDestination
 from interloper.errors import ConfigError, DataNotFoundError
+from interloper.normalizer import MaterializationStrategy
 from interloper.partitioning import PartitionConfig, TimePartitionConfig
 from interloper.representation import Representation
 from interloper.resource.fields import FetchField, InputField, SelectField
@@ -34,6 +35,10 @@ from interloper_google_cloud.serialization import json_default, replace_non_fini
     icon="icon:bigquery",
     tags=["Cloud"],
     read_representation="dataframe",
+    # The DataFrame write path is a typed parquet load: values that pass lax
+    # schema validation but don't match the physical column type (e.g. ISO
+    # date strings against DATE) fail the load, so coerce at the boundary.
+    materialization_strategy=MaterializationStrategy.RECONCILE,
 )
 class BigQueryDestination(DatabaseDestination):
     """BigQuery destination."""

--- a/packages/interloper-google-cloud/tests/test_bigquery.py
+++ b/packages/interloper-google-cloud/tests/test_bigquery.py
@@ -632,3 +632,15 @@ class TestDefinition:
             "label_key": "name",
             "value_key": "project_id",
         }
+
+
+class TestMaterializationStrategy:
+    """BigQuery's parquet load path requires schema-typed data."""
+
+    def test_bigquery_reconciles_on_write(self):
+        # Regression pin: the DataFrame write path is a typed parquet load, so
+        # lax-validated values (ISO date strings against DATE) must be coerced
+        # at the write boundary — the trait must stay RECONCILE.
+        from interloper_google_cloud.bigquery.destination import BigQueryDestination
+
+        assert BigQueryDestination.materialization_strategy is il.MaterializationStrategy.RECONCILE


### PR DESCRIPTION
## Problem

BigQuery's DataFrame write path is a typed parquet load: values that pass lax schema validation but don't match the physical column type fail the load —

```
pyarrow.lib.ArrowTypeError: Error converting Pandas column with name: "start_date" and datatype: "object" ...
```

(first hit: Amazon SP vendor reports for Swarovski BE, prod run `f6733c25`; the JSON rows path coerces the same ISO date strings happily). #188 fixed this per source with `materialization_strategy=RECONCILE`, but that spreads a **backend** concern across every integration — each ported source would need the same ceremony.

## Change

Declare the strategy as a **backend trait on `DatabaseDestination`** — same DX as sources/assets (attribute or decorator kwarg), same plumbing as the existing `write_disposition`/`read_representation` traits (ClassVar: never in config UIs or serialized specs, deterministic in worker pods):

```python
@destination(..., materialization_strategy=MaterializationStrategy.RECONCILE)
class BigQueryDestination(DatabaseDestination): ...
```

At write time (`DatabaseDestination.write`, before the partition checks and inserts):
- **AUTO** (default) — trust the conformed data as-is; unchanged behavior for every existing destination.
- **RECONCILE** — align columns and coerce values via `Representation.of(data).conformer.reconcile(...)`; works for rows and DataFrames with the existing tested cast machinery.
- **STRICT** — validate strictly against the effective schema and fail loudly.

No-op when no effective schema was resolved. BigQuery opts into RECONCILE — every source writing date/datetime/numeric schemas through the parquet load is fixed at once, with zero per-source configuration.

This mirrors the legacy stack, where `reconcile_schema` lived in the dagster BigQuery IO manager, not in connectors.

## Behavior notes

- Asset-level `materialization_strategy` keeps its meaning as the user-facing contract knob (applies to all destination types, including files); the destination trait is a mechanical guarantee for database backends.
- With multiple destinations, a file destination still receives the conformed-but-uncoerced data; only database backends declaring RECONCILE coerce. Extra columns are dropped by reconcile at those backends.

## Tests

Five new core tests (AUTO passthrough, RECONCILE coercion for rows and DataFrames, schema-less no-op, decorator sets the trait without leaking to the parent class) + a regression pin that `BigQueryDestination` stays RECONCILE. Full core + assets suites pass (706 tests).

Supersedes #188 (will close it).

By Digitl