### PR TITLE
feat(core): materialization strategy as user-facing config with enum selects

### DIFF
--- a/packages/interloper-app/app/app/components/ui/SchemaForm.vue
+++ b/packages/interloper-app/app/app/components/ui/SchemaForm.vue
@@ -32,6 +32,9 @@ interface JsonSchemaProperty {
     description?: string
     default?: unknown
     enum?: unknown[]
+    '$ref'?: string
+    'allOf'?: JsonSchemaProperty[]
+    'anyOf'?: JsonSchemaProperty[]
     'x-widget'?: string
     'x-options'?: { label: string, value: string }[]
     'x-options-from'?: string
@@ -46,6 +49,7 @@ interface JsonSchemaProperty {
 interface JsonSchema {
     properties?: Record<string, JsonSchemaProperty>
     required?: string[]
+    '$defs'?: Record<string, JsonSchemaProperty>
     'x-oauth'?: OAuthFieldMeta
 }
 
@@ -321,6 +325,47 @@ watch(
     { deep: true, immediate: true },
 )
 
+// ── Property resolution ($ref / allOf / anyOf) ───────────────────
+
+/**
+ * Inline `$ref` / `allOf` / `anyOf` composition against the schema's `$defs`,
+ * so enum-typed Pydantic fields (which render as refs into `$defs`) behave
+ * like plain properties. Sibling keys (default, description, x-*) win over
+ * the referenced definition's; `anyOf` resolves to its first non-null branch
+ * (Pydantic's encoding of `Optional[...]` fields).
+ */
+function resolveProperty(prop: JsonSchemaProperty): JsonSchemaProperty {
+    const defs = props.schema?.$defs ?? {}
+    const deref = (p: JsonSchemaProperty): JsonSchemaProperty => {
+        if (!p.$ref) return p
+        const { $ref, ...siblings } = p
+        return { ...(defs[$ref.split('/').pop() ?? ''] ?? {}), ...siblings }
+    }
+    let resolved = deref(prop)
+    if (resolved.allOf) {
+        const { allOf, ...siblings } = resolved
+        resolved = { ...allOf.map(deref).reduce((acc, part) => ({ ...acc, ...part }), {}), ...siblings }
+    }
+    if (resolved.anyOf) {
+        const { anyOf, ...siblings } = resolved
+        const branch = anyOf.find(b => b.type !== 'null') ?? anyOf[0] ?? {}
+        resolved = { ...deref(branch), ...siblings }
+    }
+    return resolved
+}
+
+/** Schema properties with refs and compositions inlined. */
+const resolvedProperties = computed<Record<string, JsonSchemaProperty>>(() => {
+    return Object.fromEntries(
+        Object.entries(props.schema?.properties ?? {}).map(([key, prop]) => [key, resolveProperty(prop)]),
+    )
+})
+
+/** Human label for a raw enum value: "reconcile" → "Reconcile". */
+function enumLabel(value: unknown): string {
+    return String(value).replaceAll(/[_-]/g, ' ').replace(/\b\w/g, c => c.toUpperCase())
+}
+
 /** Resolve which widget to render for a given field. */
 function resolveWidget(prop: JsonSchemaProperty): string {
     if (prop['x-widget']) return prop['x-widget']
@@ -339,12 +384,12 @@ function resolveOptions(prop: JsonSchemaProperty): unknown[] | undefined {
     if (prop['x-options-from'] && props.optionsContext) {
         return props.optionsContext[prop['x-options-from']]
     }
-    return prop.enum
+    return prop.enum?.map(value => ({ label: enumLabel(value), value }))
 }
 
 /** Compute field descriptors from the schema. */
 const fields = computed(() => {
-    const properties = props.schema?.properties ?? {}
+    const properties = resolvedProperties.value
     const required = new Set(props.schema?.required ?? [])
     const excluded = new Set(props.exclude ?? ['id'])
 
@@ -385,8 +430,7 @@ const fields = computed(() => {
 const discriminatorLabel = defineModel<string | null>('discriminatorLabel', { default: null })
 
 const discriminatorKey = computed<string | null>(() => {
-    const properties = props.schema?.properties ?? {}
-    return Object.entries(properties).find(([, prop]) => prop['x-discriminator'])?.[0] ?? null
+    return Object.entries(resolvedProperties.value).find(([, prop]) => prop['x-discriminator'])?.[0] ?? null
 })
 
 watch(
@@ -398,7 +442,7 @@ watch(
             discriminatorLabel.value = null
             return
         }
-        const prop = props.schema?.properties?.[key]
+        const prop = resolvedProperties.value[key]
         const options = prop?.['x-fetch'] ? fetchState.value[key]?.options : resolveOptions(prop!)
         const match = (options ?? []).find(
             o => typeof o === 'object' && o !== null && String((o as { value: unknown }).value) === String(value),
@@ -453,8 +497,7 @@ watch(
     () => props.optionsContext,
     (ctx) => {
         if (!ctx) return
-        const properties = props.schema?.properties ?? {}
-        for (const [key, prop] of Object.entries(properties)) {
+        for (const [key, prop] of Object.entries(resolvedProperties.value)) {
             const entity = prop['x-options-from']
             if (!entity) continue
             const options = ctx[entity]

--- a/packages/interloper-core/src/interloper/asset/base.py
+++ b/packages/interloper-core/src/interloper/asset/base.py
@@ -105,9 +105,7 @@ class Asset(Component):
         "destination": RelationDefinition(kinds=["destination"], field="destinations"),
         "dependency": RelationDefinition(kinds=["asset"], field="dependencies", slotted=True, inline=False),
     }
-    internal_fields: ClassVar[frozenset[str]] = frozenset(
-        {"destinations", "normalizer", "materialization_strategy", "dependencies"}
-    )
+    internal_fields: ClassVar[frozenset[str]] = frozenset({"destinations", "normalizer", "dependencies"})
     requires: ClassVar[dict[str, str]] = {}
     optional_requires: ClassVar[dict[str, str]] = {}
     tags: ClassVar[list[str]] = []
@@ -120,7 +118,15 @@ class Asset(Component):
     dataset: str = Field(default="")
     default_destination_key: str = Field(default="")
     materializable: bool = Field(default=True)
-    materialization_strategy: MaterializationStrategy = Field(default=MaterializationStrategy.AUTO)
+    materialization_strategy: MaterializationStrategy = Field(
+        default=MaterializationStrategy.AUTO,
+        title="Materialization Strategy",
+        description=(
+            "How this asset's data is checked against its schema: 'auto' "
+            "validates (or infers a schema when none is declared), 'strict' "
+            "fails on any mismatch, 'reconcile' coerces values to the schema."
+        ),
+    )
     normalizer: Normalizer | None = Field(default=None)
     dependencies: dict[str, str] = Field(default_factory=dict)
 

--- a/packages/interloper-core/src/interloper/destination/database.py
+++ b/packages/interloper-core/src/interloper/destination/database.py
@@ -9,6 +9,8 @@ from contextlib import contextmanager
 from enum import Enum
 from typing import Any, ClassVar
 
+from pydantic import Field
+
 from interloper.destination.context import IOContext
 from interloper.destination.partitioned import PartitionedDestination
 from interloper.normalizer import MaterializationStrategy
@@ -52,7 +54,19 @@ class DatabaseDestination(PartitionedDestination):
     # appear in the destination's config schema (the UI form) or its specs.
     write_disposition: ClassVar[WriteDisposition] = WriteDisposition.REPLACE
     read_representation: ClassVar[str] = "rows"
-    materialization_strategy: ClassVar[MaterializationStrategy] = MaterializationStrategy.AUTO
+
+    # Instance configuration: backends set a default via the @destination
+    # decorator; users can override it per configured destination in the UI.
+    materialization_strategy: MaterializationStrategy = Field(
+        default=MaterializationStrategy.AUTO,
+        title="Materialization Strategy",
+        description=(
+            "How strictly written data must match the effective schema: "
+            "'auto' trusts the conformed data as-is, 'strict' validates it "
+            "and fails on mismatch, 'reconcile' aligns columns and coerces "
+            "values to the schema before writing."
+        ),
+    )
 
     # -- Transaction hook ------------------------------------------------------
 

--- a/packages/interloper-core/src/interloper/destination/decorator.py
+++ b/packages/interloper-core/src/interloper/destination/decorator.py
@@ -73,8 +73,10 @@ def destination(
         classvars["resource_types"] = resources
     if read_representation is not None:
         classvars["read_representation"] = read_representation
+
+    fields: dict[str, Any] = {}
     if materialization_strategy is not None:
-        classvars["materialization_strategy"] = materialization_strategy
+        fields["materialization_strategy"] = materialization_strategy
     if tags is not None:
         classvars["tags"] = tags
     if key is not None:
@@ -85,9 +87,9 @@ def destination(
         classvars["icon"] = icon
 
     if cls is not None:
-        return Destination.build_class(cls, classvars=classvars)
+        return Destination.build_class(cls, classvars=classvars, fields=fields)
 
     def wrapper(cls: type) -> type[Destination]:
-        return Destination.build_class(cls, classvars=classvars)
+        return Destination.build_class(cls, classvars=classvars, fields=fields)
 
     return wrapper

--- a/packages/interloper-core/src/interloper/serializable/base.py
+++ b/packages/interloper-core/src/interloper/serializable/base.py
@@ -296,11 +296,15 @@ class Serializable(BaseModel):
         """
         from pydantic import create_model
 
-        for field_name in fields or {}:
-            if field_name not in cls.model_fields:
-                raise TypeError(f"Decorator field '{field_name}' is not a field of {cls.__name__}.")
-
         already_subclass = any(isinstance(b, type) and issubclass(b, cls) for b in decorated.__bases__)
+
+        # A decorated subclass may carry fields the receiving class doesn't
+        # declare (e.g. DatabaseDestination traits behind @destination), so
+        # validate against the class whose definitions the overrides target.
+        target = cast("type[Self]", decorated) if already_subclass else cls
+        for field_name in fields or {}:
+            if field_name not in target.model_fields:
+                raise TypeError(f"Decorator field '{field_name}' is not a field of {target.__name__}.")
 
         if already_subclass:
             result_cls = cast("type[Self]", decorated)

--- a/packages/interloper-core/src/interloper/source/base.py
+++ b/packages/interloper-core/src/interloper/source/base.py
@@ -100,14 +100,21 @@ class Source(Component):
         "resource": RelationDefinition(kinds=["connection", "config", "resource"], field="resources", slotted=True),
         "destination": RelationDefinition(kinds=["destination"], field="destinations"),
     }
-    internal_fields: ClassVar[frozenset[str]] = frozenset(
-        {"assets", "destinations", "normalizer", "materialization_strategy", "select"}
-    )
+    internal_fields: ClassVar[frozenset[str]] = frozenset({"assets", "destinations", "normalizer", "select"})
 
     # State
     destinations: list[Destination] = Field(default_factory=list)
     normalizer: Normalizer | None = Field(default=None)
-    materialization_strategy: MaterializationStrategy | None = Field(default=None)
+    materialization_strategy: MaterializationStrategy | None = Field(
+        default=None,
+        title="Materialization Strategy",
+        description=(
+            "Default strategy for this source's assets: 'auto' validates "
+            "against the schema, 'strict' fails on any mismatch, 'reconcile' "
+            "coerces values to the schema. Assets declaring their own "
+            "strategy keep it; leave empty to use each asset's default."
+        ),
+    )
     assets: list[Asset] = Field(default_factory=list)
     select: list[str] | None = Field(
         default=None, description="Asset keys to materialize; others stay as read-only dependencies"

--- a/packages/interloper-core/tests/destination/test_database.py
+++ b/packages/interloper-core/tests/destination/test_database.py
@@ -230,7 +230,7 @@ class TestMaterializationStrategy:
 
     def test_reconcile_coerces_rows_to_the_effective_schema(self):
         class ReconcilingDB(RecordingDB):
-            materialization_strategy = il.MaterializationStrategy.RECONCILE
+            materialization_strategy: il.MaterializationStrategy = il.MaterializationStrategy.RECONCILE
 
         dest = ReconcilingDB(id="db")
         dest.write(make_ctx(plain_asset(), schema=DateSchema), [{"name": "a", "day": "2026-07-13"}])
@@ -241,7 +241,7 @@ class TestMaterializationStrategy:
         pd = pytest.importorskip("pandas")
 
         class ReconcilingDB(RecordingDB):
-            materialization_strategy = il.MaterializationStrategy.RECONCILE
+            materialization_strategy: il.MaterializationStrategy = il.MaterializationStrategy.RECONCILE
 
         dest = ReconcilingDB(id="db")
         dest.write(make_ctx(plain_asset(), schema=DateSchema), pd.DataFrame([{"name": "a", "day": "2026-07-13"}]))
@@ -250,19 +250,31 @@ class TestMaterializationStrategy:
 
     def test_reconcile_without_schema_is_a_noop(self):
         class ReconcilingDB(RecordingDB):
-            materialization_strategy = il.MaterializationStrategy.RECONCILE
+            materialization_strategy: il.MaterializationStrategy = il.MaterializationStrategy.RECONCILE
 
         dest = ReconcilingDB(id="db")
         rows = [{"name": "a", "day": "2026-07-13"}]
         dest.write(make_ctx(plain_asset()), rows)
         assert dest.calls[-1][1][2] == rows
 
-    def test_decorator_sets_the_trait(self):
+    def test_decorator_sets_the_field_default(self):
         from interloper.destination import destination
 
         @destination(materialization_strategy=il.MaterializationStrategy.RECONCILE)
         class DecoratedDB(RecordingDB):
             pass
 
-        assert DecoratedDB.materialization_strategy is il.MaterializationStrategy.RECONCILE
-        assert RecordingDB.materialization_strategy is il.MaterializationStrategy.AUTO
+        assert DecoratedDB(id="db").materialization_strategy is il.MaterializationStrategy.RECONCILE
+        assert RecordingDB(id="db").materialization_strategy is il.MaterializationStrategy.AUTO
+
+    def test_instance_override_beats_the_class_default(self):
+        dest = RecordingDB(id="db", materialization_strategy=il.MaterializationStrategy.RECONCILE)
+        dest.write(make_ctx(plain_asset(), schema=DateSchema), [{"name": "a", "day": "2026-07-13"}])
+        assert dest.calls[-1][1][2] == [{"name": "a", "day": datetime.date(2026, 7, 13)}]
+
+    def test_strategy_renders_in_the_config_schema(self):
+        schema = RecordingDB.config_schema()
+        prop = schema["properties"]["materialization_strategy"]
+        ref = prop.get("$ref") or prop.get("allOf", [{}])[0].get("$ref", "")
+        enum_def = schema["$defs"][ref.split("/")[-1]]
+        assert set(enum_def["enum"]) == {"auto", "strict", "reconcile"}

--- a/packages/interloper-google-cloud/tests/test_bigquery.py
+++ b/packages/interloper-google-cloud/tests/test_bigquery.py
@@ -640,7 +640,8 @@ class TestMaterializationStrategy:
     def test_bigquery_reconciles_on_write(self):
         # Regression pin: the DataFrame write path is a typed parquet load, so
         # lax-validated values (ISO date strings against DATE) must be coerced
-        # at the write boundary — the trait must stay RECONCILE.
+        # at the write boundary — the default must stay RECONCILE.
         from interloper_google_cloud.bigquery.destination import BigQueryDestination
 
-        assert BigQueryDestination.materialization_strategy is il.MaterializationStrategy.RECONCILE
+        default = BigQueryDestination.model_fields["materialization_strategy"].default
+        assert default is il.MaterializationStrategy.RECONCILE


### PR DESCRIPTION
Follow-up to #190: expose `materialization_strategy` in the UI at all three levels, with generic enum→select rendering support in the app.

## Backend

- **Destination**: the trait becomes a per-instance pydantic field (default `auto`, title + description for the form). Backends still set their default via the `@destination` decorator — the kwarg now routes through `build_class` **field overrides** instead of ClassVars, so BigQuery's `reconcile` default is a real field default users can override per configured destination.
- **`build_class`**: decorator field overrides are validated against the *decorated subclass* when it already extends the receiver — `DatabaseDestination` declares fields the `Destination` base doesn't.
- **Source & asset**: their existing `materialization_strategy` fields are removed from `internal_fields`, so they render in the wizard/config forms (they already persisted and serialized; they were only hidden). Both gain titles and descriptions; the source description documents the precedence (assets declaring their own strategy keep it).
- Existing DB rows need no migration — missing keys hydrate to the defaults, preserving current behavior (`auto` everywhere, `reconcile` on BigQuery).

## Frontend — enum rendering support

Pydantic serializes enum-typed fields as `$ref` into `$defs` (and `Optional[Enum]` as `anyOf`), which SchemaForm previously ignored — such fields silently didn't render. SchemaForm now resolves `$ref`/`allOf`/`anyOf` composition against `$defs` (sibling keys win, `anyOf` picks the non-null branch), and plain `enum` properties render as selects with title-cased labels (`reconcile` → "Reconcile"). `x-options` keeps precedence for fields that declare explicit labels. This benefits every future enum-typed config field, not just this one.

## Tests

Core destination tests updated for the field semantics (decorator default, instance override beats class default, config-schema rendering with `$defs`), BigQuery default pinned via `model_fields`. Full backend suite passes (1032 tests); SchemaForm lints and typechecks clean (the two pre-existing typecheck errors in agent chat files are untouched).

## Note for review

This deliberately converts the destination strategy from a fixed backend guarantee into a user-visible knob — a user can now set a BigQuery destination back to `auto` and reintroduce the parquet `ArrowTypeError` for string dates. The field description spells out the semantics; flagging in case we'd rather render it read-only or grouped as advanced.

By Digitl