### PR TITLE
feat(core): label/description/info field presentation with info tooltips

### DIFF
--- a/packages/interloper-app/app/app/components/ui/SchemaForm.vue
+++ b/packages/interloper-app/app/app/components/ui/SchemaForm.vue
@@ -40,6 +40,7 @@ interface JsonSchemaProperty {
     'x-options-from'?: string
     'x-fetch'?: FetchMeta
     'x-discriminator'?: boolean
+    'x-info'?: string
     minimum?: number
     maximum?: number
     minLength?: number
@@ -408,6 +409,7 @@ const fields = computed(() => {
             key,
             label: prop.title ?? key,
             description: prop.description,
+            info: prop['x-info'],
             widget: resolveWidget(prop),
             required: required.has(key),
             default: prop.default,
@@ -554,6 +556,16 @@ defineExpose({ setErrors })
                     :label="field.label"
                     :description="field.description"
                     :required="field.required">
+            <!-- Info tooltip next to the label (long explanatory text) -->
+            <template v-if="field.info"
+                      #hint>
+                <UTooltip :text="field.info"
+                          :ui="{ content: 'max-w-72 h-auto py-2', text: 'whitespace-normal' }">
+                    <UIcon name="i-lucide-info"
+                           class="size-4 text-dimmed" />
+                </UTooltip>
+            </template>
+
             <!-- Password with visibility toggle -->
             <UInput v-if="field.widget === 'password'"
                     v-model="data[field.key]"

--- a/packages/interloper-assets/src/interloper_assets/adservice/connection.py
+++ b/packages/interloper-assets/src/interloper_assets/adservice/connection.py
@@ -15,7 +15,7 @@ class AdserviceConnection(il.Connection):
 
     model_config = SettingsConfigDict(env_prefix="adservice_")
 
-    api_key: str = il.SecretField(title="API Key", description="Adservice API key")
+    api_key: str = il.SecretField(label="API Key", description="Adservice API key")
 
     @cached_property
     def client(self) -> il.AsyncRESTClient:

--- a/packages/interloper-assets/src/interloper_assets/adup/connection.py
+++ b/packages/interloper-assets/src/interloper_assets/adup/connection.py
@@ -16,7 +16,7 @@ class AdupConnection(il.Connection):
 
     model_config = SettingsConfigDict(env_prefix="adup_")
 
-    client_id: str = il.InputField(title="Client ID", description="OAuth2 client ID")
+    client_id: str = il.InputField(label="Client ID", description="OAuth2 client ID")
     client_secret: str = il.SecretField(description="OAuth2 client secret")
 
     @cached_property

--- a/packages/interloper-assets/src/interloper_assets/amazon_ads/source.py
+++ b/packages/interloper-assets/src/interloper_assets/amazon_ads/source.py
@@ -175,7 +175,7 @@ class AmazonAds(il.Source):
     connection: AmazonAdsConnection
 
     profile_id: str = il.FetchField(
-        title="Profile ID",
+        label="Profile ID",
         description="Amazon Ads profile",
         provider="connection.profiles",
         label_key="name",

--- a/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/connection.py
+++ b/packages/interloper-assets/src/interloper_assets/amazon_selling_partner/connection.py
@@ -106,9 +106,9 @@ class AmazonSellingPartnerConnection(il.Connection):
         description="API region",
         discriminator=True,
     )
-    client_id: str = il.InputField(title="Client ID", description="LWA client ID")
-    client_secret: str = il.SecretField(title="Client Secret", description="LWA client secret")
-    refresh_token: str = il.SecretField(title="Refresh Token", description="LWA refresh token")
+    client_id: str = il.InputField(label="Client ID", description="LWA client ID")
+    client_secret: str = il.SecretField(label="Client Secret", description="LWA client secret")
+    refresh_token: str = il.SecretField(label="Refresh Token", description="LWA refresh token")
 
     @cached_property
     def api_location(self) -> AmazonSellingPartnerLocation:

--- a/packages/interloper-assets/src/interloper_assets/awin/connection.py
+++ b/packages/interloper-assets/src/interloper_assets/awin/connection.py
@@ -16,7 +16,7 @@ class AwinConnection(il.Connection):
 
     model_config = SettingsConfigDict(env_prefix="awin_")
 
-    access_token: str = il.SecretField(title="Access Token", description="Awin API access token")
+    access_token: str = il.SecretField(label="Access Token", description="Awin API access token")
 
     @cached_property
     def client(self) -> il.AsyncRESTClient:

--- a/packages/interloper-assets/src/interloper_assets/bing_ads/source.py
+++ b/packages/interloper-assets/src/interloper_assets/bing_ads/source.py
@@ -170,7 +170,7 @@ class BingAds(il.Source):
     """Bing Ads (Microsoft Advertising) platform integration."""
 
     account_id: str = il.FetchField(
-        title="Account ID",
+        label="Account ID",
         description="Bing Ads account",
         provider="connection.accounts",
         label_key="name",

--- a/packages/interloper-assets/src/interloper_assets/brandwatch/connection.py
+++ b/packages/interloper-assets/src/interloper_assets/brandwatch/connection.py
@@ -16,7 +16,7 @@ class BrandwatchConnection(il.Connection):
 
     model_config = SettingsConfigDict(env_prefix="brandwatch_")
 
-    api_key: str = il.SecretField(title="API Key", description="Brandwatch (Falcon.io) Measure API key")
+    api_key: str = il.SecretField(label="API Key", description="Brandwatch (Falcon.io) Measure API key")
 
     @cached_property
     def client(self) -> il.AsyncRESTClient:

--- a/packages/interloper-assets/src/interloper_assets/brandwatch/source.py
+++ b/packages/interloper-assets/src/interloper_assets/brandwatch/source.py
@@ -126,7 +126,7 @@ class Brandwatch(il.Source):
     """Brandwatch (Falcon.io) social media analytics integration."""
 
     channel_id: str = il.InputField(
-        title="Channel ID",
+        label="Channel ID",
         description="Falcon.io channel id (a connected social profile)",
         discriminator=True,
     )

--- a/packages/interloper-assets/src/interloper_assets/campaign_manager_360/source.py
+++ b/packages/interloper-assets/src/interloper_assets/campaign_manager_360/source.py
@@ -168,14 +168,14 @@ class CampaignManager360(il.Source):
     """Campaign Manager 360 advertising platform integration."""
 
     profile_id: str = il.FetchField(
-        title="Profile ID",
+        label="Profile ID",
         description="CM360 user profile",
         provider="connection.profiles",
         label_key="name",
         value_key="profile_id",
     )
     account_id: str = il.FetchField(
-        title="Account ID",
+        label="Account ID",
         description="CM360 account",
         provider="connection.profiles",
         label_key="account_name",
@@ -184,7 +184,7 @@ class CampaignManager360(il.Source):
     )
     advertiser_id: str = il.InputField(
         default="",
-        title="Advertiser ID",
+        label="Advertiser ID",
         description="CM360 advertiser ID (only required for the custom_audiences asset)",
     )
 

--- a/packages/interloper-assets/src/interloper_assets/display_video_360/source.py
+++ b/packages/interloper-assets/src/interloper_assets/display_video_360/source.py
@@ -159,7 +159,7 @@ class DisplayVideo360(il.Source):
     """Display & Video 360 advertising platform integration."""
 
     partner_id: str = il.FetchField(
-        title="Partner ID",
+        label="Partner ID",
         description="DV360 partner",
         provider="connection.partners",
         label_key="name",
@@ -168,7 +168,7 @@ class DisplayVideo360(il.Source):
     )
     advertiser_id: str = il.InputField(
         default="",
-        title="Advertiser ID",
+        label="Advertiser ID",
         description=(
             "DV360 advertiser ID — narrows report assets to one advertiser and "
             "scopes audience assets by advertiser instead of partner"
@@ -176,7 +176,7 @@ class DisplayVideo360(il.Source):
     )
     audience_id: str = il.InputField(
         default="",
-        title="Audience ID",
+        label="Audience ID",
         description="Audience ID (only required for the custom_audiences asset)",
     )
 

--- a/packages/interloper-assets/src/interloper_assets/facebook_ads/connection.py
+++ b/packages/interloper-assets/src/interloper_assets/facebook_ads/connection.py
@@ -35,7 +35,7 @@ class FacebookAdsConnection(il.OAuthConnection):
     model_config = SettingsConfigDict(env_prefix="facebook_ads_")
 
     access_token: str = il.SecretField(description="Facebook access token")
-    app_id: str = il.InputField(title="App ID", description="Facebook App ID")
+    app_id: str = il.InputField(label="App ID", description="Facebook App ID")
     app_secret: str = il.SecretField(description="Facebook App secret")
 
     @model_validator(mode="before")

--- a/packages/interloper-assets/src/interloper_assets/impact/connection.py
+++ b/packages/interloper-assets/src/interloper_assets/impact/connection.py
@@ -17,7 +17,7 @@ class ImpactConnection(il.Connection):
 
     model_config = SettingsConfigDict(env_prefix="impact_")
 
-    account_sid: str = il.InputField(title="Account SID", description="Impact account SID", discriminator=True)
+    account_sid: str = il.InputField(label="Account SID", description="Impact account SID", discriminator=True)
     auth_token: str = il.SecretField(description="Impact auth token")
 
     @cached_property

--- a/packages/interloper-assets/src/interloper_assets/teads/connection.py
+++ b/packages/interloper-assets/src/interloper_assets/teads/connection.py
@@ -16,7 +16,7 @@ class TeadsConnection(il.Connection):
 
     model_config = SettingsConfigDict(env_prefix="teads_")
 
-    api_key: str = il.SecretField(title="API Key", description="Teads API key")
+    api_key: str = il.SecretField(label="API Key", description="Teads API key")
 
     @cached_property
     def client(self) -> il.AsyncRESTClient:

--- a/packages/interloper-assets/src/interloper_assets/thetradedesk/connection.py
+++ b/packages/interloper-assets/src/interloper_assets/thetradedesk/connection.py
@@ -16,7 +16,7 @@ class TheTradeDeskConnection(il.Connection):
 
     model_config = SettingsConfigDict(env_prefix="thetradedesk_")
 
-    api_key: str = il.SecretField(title="API Key", description="The Trade Desk API key")
+    api_key: str = il.SecretField(label="API Key", description="The Trade Desk API key")
 
     @cached_property
     def client(self) -> il.AsyncRESTClient:

--- a/packages/interloper-assets/src/interloper_assets/thetradedesk/source.py
+++ b/packages/interloper-assets/src/interloper_assets/thetradedesk/source.py
@@ -157,7 +157,7 @@ class TheTradeDesk(il.Source):
     """The Trade Desk programmatic advertising platform integration."""
 
     partner_id: str = il.FetchField(
-        title="Partner ID",
+        label="Partner ID",
         description="The Trade Desk partner",
         provider="connection.partners",
         label_key="name",

--- a/packages/interloper-assets/src/interloper_assets/usercentrics/connection.py
+++ b/packages/interloper-assets/src/interloper_assets/usercentrics/connection.py
@@ -16,8 +16,8 @@ class UsercentricsConnection(il.Connection):
 
     model_config = SettingsConfigDict(env_prefix="usercentrics_")
 
-    api_key: str = il.SecretField(title="API Key", description="Usercentrics API key")
-    analytics_id: str = il.InputField(title="Analytics ID", description="Usercentrics analytics ID", discriminator=True)
+    api_key: str = il.SecretField(label="API Key", description="Usercentrics API key")
+    analytics_id: str = il.InputField(label="Analytics ID", description="Usercentrics analytics ID", discriminator=True)
 
     @cached_property
     def client(self) -> il.AsyncRESTClient:

--- a/packages/interloper-core/src/interloper/asset/base.py
+++ b/packages/interloper-core/src/interloper/asset/base.py
@@ -21,6 +21,7 @@ from interloper.normalizer import MaterializationStrategy, Normalizer
 from interloper.partitioning import Partition, PartitionConfig, PartitionWindow
 from interloper.representation import Representation
 from interloper.resource import Resource
+from interloper.resource.fields import SelectField
 from interloper.schema import Schema
 from interloper.utils import concurrency
 from interloper.utils.concurrency import invoke
@@ -118,13 +119,14 @@ class Asset(Component):
     dataset: str = Field(default="")
     default_destination_key: str = Field(default="")
     materializable: bool = Field(default=True)
-    materialization_strategy: MaterializationStrategy = Field(
+    materialization_strategy: MaterializationStrategy = SelectField(
         default=MaterializationStrategy.AUTO,
-        title="Materialization Strategy",
-        description=(
-            "How this asset's data is checked against its schema: 'auto' "
-            "validates (or infers a schema when none is declared), 'strict' "
-            "fails on any mismatch, 'reconcile' coerces values to the schema."
+        label="Materialization Strategy",
+        description="How this asset's data is checked against its schema.",
+        info=(
+            "'Auto' validates data against the schema (or infers a schema "
+            "when none is declared), 'Strict' fails on any mismatch, "
+            "'Reconcile' coerces values to the schema."
         ),
     )
     normalizer: Normalizer | None = Field(default=None)

--- a/packages/interloper-core/src/interloper/destination/database.py
+++ b/packages/interloper-core/src/interloper/destination/database.py
@@ -9,13 +9,12 @@ from contextlib import contextmanager
 from enum import Enum
 from typing import Any, ClassVar
 
-from pydantic import Field
-
 from interloper.destination.context import IOContext
 from interloper.destination.partitioned import PartitionedDestination
 from interloper.normalizer import MaterializationStrategy
 from interloper.partitioning.base import Partition, PartitionWindow
 from interloper.representation import REPRESENTATIONS, Representation
+from interloper.resource.fields import SelectField
 from interloper.utils.data import is_empty
 
 
@@ -57,13 +56,13 @@ class DatabaseDestination(PartitionedDestination):
 
     # Instance configuration: backends set a default via the @destination
     # decorator; users can override it per configured destination in the UI.
-    materialization_strategy: MaterializationStrategy = Field(
+    materialization_strategy: MaterializationStrategy = SelectField(
         default=MaterializationStrategy.AUTO,
-        title="Materialization Strategy",
-        description=(
-            "How strictly written data must match the effective schema: "
-            "'auto' trusts the conformed data as-is, 'strict' validates it "
-            "and fails on mismatch, 'reconcile' aligns columns and coerces "
+        label="Materialization Strategy",
+        description="How strictly written data must match the effective schema.",
+        info=(
+            "'Auto' trusts the conformed data as-is, 'Strict' validates it "
+            "and fails on mismatch, 'Reconcile' aligns columns and coerces "
             "values to the schema before writing."
         ),
     )

--- a/packages/interloper-core/src/interloper/resource/fields.py
+++ b/packages/interloper-core/src/interloper/resource/fields.py
@@ -147,17 +147,30 @@ def strip_internal_fields(schema: dict[str, Any], extra: Iterable[str] = ()) -> 
 def _extra(kwargs: dict[str, Any], widget: str) -> dict[str, Any]:
     """Pop json_schema_extra from kwargs and inject the widget hint.
 
-    Also lifts the ``discriminator=True`` marker (accepted by every field
-    factory) into ``x-discriminator``: it marks the config field whose value
-    distinguishes instances of a component, driving the derived display name
-    (:meth:`Component.instance_name`) and — for sources — the per-instance
-    asset table names (:meth:`Source.asset_table`).
+    Also lifts the presentation kwargs every field factory accepts:
+
+    - ``label`` becomes the JSON-schema-standard ``title`` (the form label;
+      ``title=`` keeps working as a plain pydantic passthrough).
+    - ``info`` becomes ``x-info`` — long explanatory text the UI renders in
+      an info tooltip next to the label, keeping the inline ``description``
+      short.
+    - ``discriminator=True`` becomes ``x-discriminator``: it marks the config
+      field whose value distinguishes instances of a component, driving the
+      derived display name (:meth:`Component.instance_name`) and — for
+      sources — the per-instance asset table names (:meth:`Source.asset_table`).
 
     Returns:
-        The extra dict with ``x-widget`` (and possibly ``x-discriminator``) set.
+        The extra dict with ``x-widget`` (and possibly ``x-info`` /
+        ``x-discriminator``) set.
     """
     extra = kwargs.pop("json_schema_extra", {})
     extra["x-widget"] = widget
+    label = kwargs.pop("label", None)
+    if label is not None:
+        kwargs["title"] = label
+    info = kwargs.pop("info", None)
+    if info is not None:
+        extra["x-info"] = info
     if kwargs.pop("discriminator", False):
         extra["x-discriminator"] = True
     return extra

--- a/packages/interloper-core/src/interloper/source/base.py
+++ b/packages/interloper-core/src/interloper/source/base.py
@@ -105,14 +105,15 @@ class Source(Component):
     # State
     destinations: list[Destination] = Field(default_factory=list)
     normalizer: Normalizer | None = Field(default=None)
-    materialization_strategy: MaterializationStrategy | None = Field(
+    materialization_strategy: MaterializationStrategy | None = SelectField(
         default=None,
-        title="Materialization Strategy",
-        description=(
-            "Default strategy for this source's assets: 'auto' validates "
-            "against the schema, 'strict' fails on any mismatch, 'reconcile' "
-            "coerces values to the schema. Assets declaring their own "
-            "strategy keep it; leave empty to use each asset's default."
+        label="Materialization Strategy",
+        description="Default strategy for this source's assets.",
+        info=(
+            "'Auto' validates data against the schema, 'Strict' fails on any "
+            "mismatch, 'Reconcile' coerces values to the schema. Assets "
+            "declaring their own strategy keep it; leave empty to use each "
+            "asset's default."
         ),
     )
     assets: list[Asset] = Field(default_factory=list)

--- a/packages/interloper-core/src/interloper/source/base.py
+++ b/packages/interloper-core/src/interloper/source/base.py
@@ -136,7 +136,7 @@ class Source(Component):
     # Exposed fields
     dataset: str = InputField(default="", description="Defaults to the source key when left empty")
     default_destination_key: str = SelectField(
-        title="Default Destination",
+        label="Default Destination",
         default="",
         options_from="destinations",
         description="When an asset has multiple destinations, downstream assets use this to know where to read from",

--- a/packages/interloper-core/tests/destination/test_database.py
+++ b/packages/interloper-core/tests/destination/test_database.py
@@ -278,3 +278,7 @@ class TestMaterializationStrategy:
         ref = prop.get("$ref") or prop.get("allOf", [{}])[0].get("$ref", "")
         enum_def = schema["$defs"][ref.split("/")[-1]]
         assert set(enum_def["enum"]) == {"auto", "strict", "reconcile"}
+        # Short inline description; the long per-value text lives in the tooltip.
+        assert prop["title"] == "Materialization Strategy"
+        assert prop["description"] == "How strictly written data must match the effective schema."
+        assert "'Reconcile' aligns columns" in prop["x-info"]

--- a/packages/interloper-core/tests/resource/test_fields.py
+++ b/packages/interloper-core/tests/resource/test_fields.py
@@ -25,6 +25,42 @@ class TestFetchProvider:
         assert not is_fetch_field_provider(Conn.not_a_provider)
 
 
+class TestPresentationKwargs:
+    """``label`` / ``info`` presentation kwargs accepted by every factory."""
+
+    def test_label_becomes_schema_title(self):
+        class FakeLabeledSource(il.Source):
+            account_id: str = il.InputField(default="", label="Account ID")
+
+        prop = FakeLabeledSource.definition().config_schema["properties"]["account_id"]
+        assert prop["title"] == "Account ID"
+
+    def test_info_becomes_x_info(self):
+        class FakeInfoSource(il.Source):
+            account_id: str = il.InputField(default="", info="Where to find this in the vendor console.")
+
+        prop = FakeInfoSource.definition().config_schema["properties"]["account_id"]
+        assert prop["x-info"] == "Where to find this in the vendor console."
+
+    def test_presentation_kwargs_compose_across_factories(self):
+        class FakeComposedSource(il.Source):
+            region: str = il.SelectField(
+                default="eu",
+                options=[{"label": "EU", "value": "eu"}],
+                label="Region",
+                description="API region.",
+                info="Pick the region the account was created in.",
+                discriminator=True,
+            )
+
+        prop = FakeComposedSource.definition().config_schema["properties"]["region"]
+        assert prop["title"] == "Region"
+        assert prop["description"] == "API region."
+        assert prop["x-info"] == "Pick the region the account was created in."
+        assert prop["x-discriminator"] is True
+        assert prop["x-widget"] == "select"
+
+
 class TestDiscriminatorMarker:
     def test_marker_serialized_as_x_discriminator(self):
         class FakeMarkedSource(il.Source):


### PR DESCRIPTION
Follow-up to #191 (planned there, split out after its merge).

## Change

Config fields gain a three-attribute presentation model, named consistently from Python declaration to rendered form:

- **`label`** — display name. New kwarg on every field factory, mapped to the JSON-schema-standard `title` (so the wire format is unchanged and `title=` keeps working as a plain pydantic passthrough).
- **`description`** — short helper text, still rendered inline under the label.
- **`info`** — long explanatory text, serialized as `x-info` and rendered by SchemaForm as an ⓘ icon next to the label (UFormField's `hint` slot) with a wrapping `UTooltip` (`ui.content`/`ui.text` overrides — the default tooltip is single-line and would truncate).

Both kwargs are lifted in the shared `_extra()` funnel in `resource/fields.py`, same pattern as `discriminator` → `x-discriminator`, so InputField/SecretField/TextField/JsonField/SelectField/FetchField all accept them.

The three `materialization_strategy` declarations (destination/source/asset) migrate to `SelectField(label=…, description=<short>, info=<long>)` as the first users — their long per-value explanations move out of the form body into the tooltip.

## Migration sweep

Every existing field-factory `title=` is migrated to `label=` — 24 sites across 16 asset connections/sources plus the core source's default-destination picker. Serialized schemas are byte-identical (`label` maps to `title`), verified against the Amazon SP connection definition. The only remaining `title=` usages are not fields (FastAPI's app title, DV360's report titles).

## Still out of scope

Moving other sources' long descriptions into `info` — a content follow-up.

## Tests

New `TestPresentationKwargs` in `tests/resource/test_fields.py` (label→title, info→x-info, composition with discriminator across factories); the destination config-schema test pins title/short description/x-info. Core + assets suites pass (711 tests); ESLint + `nuxt typecheck` clean on SchemaForm.

By Digitl