### PR TITLE
fix(app): instant info tooltip with hover effect

### DIFF
--- a/packages/interloper-app/app/app/components/ui/SchemaForm.vue
+++ b/packages/interloper-app/app/app/components/ui/SchemaForm.vue
@@ -563,9 +563,10 @@ defineExpose({ setErrors })
             <template v-if="field.info"
                       #hint>
                 <UTooltip :text="field.info"
+                          :delay-duration="0"
                           :ui="{ content: 'max-w-72 h-auto py-2', text: 'whitespace-normal' }">
                     <UIcon name="i-lucide-info"
-                           class="size-4 text-dimmed" />
+                           class="size-4 text-dimmed transition-colors hover:text-highlighted" />
                 </UTooltip>
             </template>
 


### PR DESCRIPTION
Follow-up polish on the field info tooltips (#192): `delay-duration=0` so the tooltip opens immediately, plus a hover color transition on the ⓘ icon.

By Digitl