### PR TITLE
fix(toolkit): keep JSON-Schema $refs out of LLM tool responses

### DIFF
--- a/.github/workflows/lint_pr.yaml
+++ b/.github/workflows/lint_pr.yaml
@@ -30,6 +30,8 @@ jobs:
             docs
             google-cloud
             k8s
+            mcp
             pandas
             scheduler
+            toolkit
           requireScope: false

--- a/chart/interloper/README.md
+++ b/chart/interloper/README.md
@@ -125,6 +125,24 @@ Either `ingress.enabled: true` or `httpRoute.enabled: true`.  The
 HTTPRoute uses `gateway.networking.k8s.io/v1` and requires the Gateway
 API CRDs installed in your cluster.
 
+### Streaming endpoints and proxy timeouts
+
+The API serves long-lived SSE streams (agent chat), so any proxy in
+front of it with a *total response* timeout must allow the longest
+expected turn.  The chart stays cloud-agnostic — configure the timeout
+where your ingress implementation expects it:
+
+- **ingress-nginx** — via `ingress.annotations`:
+  `nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"`.
+- **GKE Gateway API** (`httpRoute`) — deploy a `GCPBackendPolicy`
+  alongside the release, with `spec.default.timeoutSec` and a
+  `targetRef` at the chart's API Service
+  (`<release>-interloper-api`).  GKE's default is 30 s, which cuts
+  streams mid-response.
+- **GKE Ingress** — deploy a `BackendConfig` with `spec.timeoutSec`
+  and bind it via `api.service.annotations`:
+  `cloud.google.com/backend-config: '{"default": "<name>"}'`.
+
 ### RBAC (Kubernetes launcher)
 
 `rbac.create: true` (the default) creates a ServiceAccount + Role +

--- a/chart/interloper/templates/api-deployment.yaml
+++ b/chart/interloper/templates/api-deployment.yaml
@@ -96,6 +96,10 @@ metadata:
   name: {{ include "interloper.fullname" . }}-api
   labels:
     {{- include "interloper.componentLabels" (dict "root" . "component" "api") | nindent 4 }}
+  {{- with .Values.api.service.annotations }}
+  annotations:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.api.service.type }}
   ports:

--- a/chart/interloper/templates/frontend-deployment.yaml
+++ b/chart/interloper/templates/frontend-deployment.yaml
@@ -65,6 +65,10 @@ metadata:
   name: {{ include "interloper.fullname" . }}-frontend
   labels:
     {{- include "interloper.componentLabels" (dict "root" . "component" "frontend") | nindent 4 }}
+  {{- with .Values.frontend.service.annotations }}
+  annotations:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.frontend.service.type }}
   ports:

--- a/chart/interloper/values.yaml
+++ b/chart/interloper/values.yaml
@@ -70,6 +70,11 @@ api:
   service:
     type: ClusterIP
     port: 3000
+    # Annotations on the API Service — the hook for cloud-specific backend
+    # tuning. The agent chat endpoint streams SSE, so proxies with a total
+    # response timeout must be raised above the longest expected turn (see
+    # the README's "Streaming endpoints and proxy timeouts").
+    annotations: {}
   # IPs uvicorn trusts for X-Forwarded-* headers. The API runs behind the
   # chart's ingress/HTTPRoute (TLS terminated upstream), so it must trust the
   # proxy to emit correct https redirects (e.g. the /api/catalog -> /api/catalog/
@@ -101,6 +106,7 @@ frontend:
   service:
     type: ClusterIP
     port: 80
+    annotations: {}
   nodeSelector: {}
   tolerations: []
   affinity: {}

--- a/packages/interloper-toolkit/src/interloper_toolkit/catalog.py
+++ b/packages/interloper-toolkit/src/interloper_toolkit/catalog.py
@@ -26,6 +26,29 @@ from interloper_toolkit.models import (
 )
 
 
+def _inline_refs(node: Any, defs: dict[str, Any] | None = None, _stack: frozenset[str] = frozenset()) -> Any:
+    """Resolve local ``#/$defs/*`` references in-place and drop ``$defs``.
+
+    Gemini rejects tool responses containing JSON-Schema ``$ref`` pointers
+    (400 INVALID_ARGUMENT), so every schema leaving the toolkit is inlined:
+    a ``$ref`` is replaced by its definition (ref siblings win on conflict);
+    cyclic or unresolvable refs are dropped, keeping the siblings.
+    """
+    if isinstance(node, list):
+        return [_inline_refs(item, defs, _stack) for item in node]
+    if not isinstance(node, dict):
+        return node
+    if isinstance(node.get("$defs"), dict):
+        defs = {**(defs or {}), **node["$defs"]}
+    ref = node.get("$ref")
+    if isinstance(ref, str) and ref.startswith("#/$defs/"):
+        name = ref.rsplit("/", 1)[-1]
+        if defs and name in defs and name not in _stack:
+            siblings = {k: v for k, v in node.items() if k not in ("$ref", "$defs")}
+            return _inline_refs({**defs[name], **siblings}, defs, _stack | {name})
+    return {k: _inline_refs(v, defs, _stack) for k, v in node.items() if k not in ("$defs", "$ref")}
+
+
 def list_definitions(
     ctx: ToolkitContext, kind: str | None = None
 ) -> DefinitionCounts | DefinitionList | ToolError:
@@ -112,7 +135,7 @@ def get_definition(ctx: ToolkitContext, key: str) -> DefinitionDetail | ToolErro
         defn = ctx.catalog.get(key)
         if defn is None:
             return ToolError(error=f"Definition '{key}' not found in catalog")
-        return DefinitionDetail(definition=defn)
+        return DefinitionDetail(definition=_inline_refs(defn))
     except Exception as e:
         return ToolError(error=str(e))
 
@@ -139,6 +162,7 @@ def get_asset_schema(ctx: ToolkitContext, source_key: str, asset_key: str) -> As
 
         for asset_def in defn.get("assets", []):
             if asset_def.get("key") == asset_key or asset_def.get("qualified_key") == f"{source_key}.{asset_key}":
+                asset_def = _inline_refs(asset_def)
                 return AssetSchemaResult(
                     source_key=source_key,
                     asset_key=asset_key,
@@ -275,5 +299,5 @@ def _get_schema_properties(ctx: ToolkitContext, source_key: str, asset_key: str)
             schema = asset_def.get("asset_schema")
             if not schema or "properties" not in schema:
                 return ToolError(error=f"Asset '{source_key}.{asset_key}' has no schema")
-            return schema["properties"]
+            return _inline_refs(schema)["properties"]
     return ToolError(error=f"Asset '{asset_key}' not found in source '{source_key}'")

--- a/packages/interloper-toolkit/tests/test_toolkit.py
+++ b/packages/interloper-toolkit/tests/test_toolkit.py
@@ -8,6 +8,7 @@ and the pure logic (lineage traversal, coverage math, schema search).
 from __future__ import annotations
 
 import datetime
+import json
 from collections.abc import Iterator
 from typing import Any
 from uuid import uuid4
@@ -31,6 +32,14 @@ CATALOG_DUMP: dict[str, Any] = {
     "facebook_ads": {
         "kind": "source",
         "name": "Facebook Ads",
+        "config_schema": {
+            "$defs": {
+                "MaterializationStrategy": {"enum": ["auto", "strict", "reconcile"], "type": "string"},
+            },
+            "properties": {
+                "materialization_strategy": {"$ref": "#/$defs/MaterializationStrategy", "default": "auto"},
+            },
+        },
         "assets": [
             {
                 "key": "ads",
@@ -159,6 +168,28 @@ class TestCatalog:
         result = catalog_tools.get_definition(ctx, "nope")
 
         assert result.status == "error"
+
+    def test_get_definition_inlines_schema_refs(self, ctx: ToolkitContext):
+        result = catalog_tools.get_definition(ctx, "facebook_ads")
+
+        assert result.status == "success"
+        strategy = result.definition["config_schema"]["properties"]["materialization_strategy"]
+        assert strategy["enum"] == ["auto", "strict", "reconcile"]
+        assert strategy["default"] == "auto"
+        serialized = json.dumps(result.definition)
+        assert "$ref" not in serialized
+        assert "$defs" not in serialized
+
+    def test_inline_refs_survives_cyclic_definitions(self):
+        schema = {
+            "$defs": {"Node": {"properties": {"next": {"$ref": "#/$defs/Node"}}, "type": "object"}},
+            "properties": {"root": {"$ref": "#/$defs/Node"}},
+        }
+
+        result = catalog_tools._inline_refs(schema)
+
+        assert result["properties"]["root"]["type"] == "object"
+        assert "$ref" not in json.dumps(result)
 
 
 class TestAnalytics:


### PR DESCRIPTION
## What

Fixes agent chat streams dying mid-response in prod (`ERR_QUIC_PROTOCOL_ERROR 200 (OK)` in the browser, "Something went wrong — try again." in the UI). Two commits:

- **fix(toolkit):** inline local `#/$defs/*` references (and drop the `$defs` blocks) in every schema leaving the toolkit — `get_definition`, `get_asset_schema`, and the properties helper behind `search_fields`/`compare_schemas`.
- **feat(chart):** `api.service.annotations` / `frontend.service.annotations` hooks (rendered through `tpl`) plus a README section documenting per-ingress-flavor streaming-timeout configuration.

## Why

The prod API pod logs showed the stream aborting on a Gemini 400 mid-turn:

```
google.genai.errors.ClientError: 400 INVALID_ARGUMENT
'The referenced name `#/$defs/MaterializationStrategy` in function_response.response
 does not match to a display_name in the function_response.parts.'
```

Catalog definitions embed raw pydantic `model_json_schema()` output, where enums like `MaterializationStrategy` live in `$defs` and are referenced by `$ref`. Gemini rejects `$ref` pointers inside tool responses, the exception fires inside the SSE generator after the 200 is committed, and the connection reset surfaces in the browser as a QUIC protocol error.

The same browser symptom also occurs when the L7 LB's 30 s default total-response timeout cuts a long agent turn — that half is fixed operationally by a `GCPBackendPolicy` in the deploy repo (prod uses Gateway API); the chart commit adds the annotation hook the GKE-*Ingress* path would need and documents the recipe for all flavors.

## Notes for review

- The sanitizer lives in `interloper-toolkit`, not core: the `$ref` allergy is purely an LLM-surface constraint, both LLM consumers (ADK agent, MCP server) route through the toolkit, and the app's SchemaForm keeps consuming the untouched `config_schema`.
- Ref-site siblings (`default`, `description`, `x-widget`, …) win over the definition's keys on merge; cyclic refs degrade to their siblings instead of recursing.
- Verified end-to-end: `_inline_refs(Asset.config_schema())` yields a fully inlined enum with zero `$ref`/`$defs` remaining.
- Not in this PR: hardening the chat SSE endpoint to emit a structured error event instead of dropping the connection (so failures like this render as a readable UI message, not a protocol error). Follow-up candidate.

By Digitl