### PR TITLE
feat(agent): add component editing via update_component tool

### DIFF
--- a/packages/interloper-agent/src/interloper_agent/agent.py
+++ b/packages/interloper-agent/src/interloper_agent/agent.py
@@ -101,8 +101,9 @@ collection_agent = Agent(
     description=(
         "The organisation's collection of component instances: lists their sources, connections, and "
         "destinations, checks connection health, sets up new connections via the app's secure form "
-        "(never collecting credentials in chat), and creates sources conversationally — resolving "
-        "provider-backed options like the account to use through an existing connection."
+        "(never collecting credentials in chat), creates sources conversationally — resolving "
+        "provider-backed options like the account to use through an existing connection — and edits "
+        "existing components (rename, config changes, a source's enabled assets)."
     ),
     instruction=with_current_time(COLLECTION_INSTRUCTION),
     tools=[
@@ -113,6 +114,7 @@ collection_agent = Agent(
         collection.resolve_source_field_options,
         collection.create_source,
         collection.create_sources,
+        collection.update_component,
         collection.create_job,
         interaction.request_user_selection,
         interaction.request_confirmation,
@@ -140,7 +142,7 @@ scheduling_agent = Agent(
     description=(
         "Monitors run health, recent failures, job schedules, and backfill progress; "
         "triggers runs, starts backfills, toggles jobs or assets on/off, and creates "
-        "cron jobs over the collection's sources."
+        "or edits cron jobs over the collection's sources."
     ),
     instruction=with_current_time(SCHEDULING_INSTRUCTION),
     tools=[
@@ -156,6 +158,7 @@ scheduling_agent = Agent(
         scheduling.toggle_asset,
         collection.list_components,
         collection.create_job,
+        collection.update_component,
         interaction.request_confirmation,
     ],
 )

--- a/packages/interloper-agent/src/interloper_agent/prompts.py
+++ b/packages/interloper-agent/src/interloper_agent/prompts.py
@@ -32,13 +32,16 @@ Interloper distinguishes two spaces; use these words consistently:
   field?", "Compare Facebook and TikTok schemas"
 - **CollectionAgent** — the collection: "What sources/connections do we
   have?", "Connect Facebook Ads", "Set up the Facebook Ads source", "Is the
-  TikTok connection healthy?"
+  TikTok connection healthy?", "Rename the TikTok source", "Point the
+  Facebook source at a different account", "Disable the reach asset on
+  Google Ads"
 - **LineageAgent** — "What depends on X?", "What's upstream of Y?", "If
   Google Ads breaks, what's affected?", "Show cross-source dependencies"
 - **SchedulingAgent** — "Did last night's runs succeed?", "Which assets
   failed?", "What's the cron schedule?", "Show backfill progress", "Re-run
   the Facebook job for yesterday", "Backfill March 1-15", "Disable the
-  campaign_matcher job", "Run my Facebook sources daily at 6am"
+  campaign_matcher job", "Run my Facebook sources daily at 6am", "Move the
+  daily job to 7am"
 - **AnalyticsAgent** — "How often do runs fail?", "Any partition gaps?",
   "When did each job last succeed?"
 
@@ -48,7 +51,7 @@ Be concise.
 COLLECTION_INSTRUCTION = """\
 You are the Collection specialist for Interloper — the organisation's
 set-up component instances: sources, connections, and destinations. You
-list them, check connection health, and create them. The catalog of what
+list them, check connection health, create them, and edit them. The catalog of what
 *could* be added is the Catalog specialist's domain: consult it via
 consult_catalog for mid-task reasoning (which source fits a need, a
 definition's assets or schemas), but not for facts your own tools return
@@ -64,8 +67,8 @@ Rules that hold throughout:
   recap.
 - When the user must choose from known options, use request_user_selection,
   never a text list.
-- Create nothing without a request_confirmation recap the user then confirms
-  — an answer to an earlier question is not that confirmation.
+- Create or edit nothing without a request_confirmation recap the user then
+  confirms — an answer to an earlier question is not that confirmation.
 - A failed options fetch or connection check warns, it does not block: if the
   user supplies the value and confirms anyway, proceed and note the concern.
 
@@ -113,6 +116,14 @@ count, never assume it:
 
 Use create_source (singular) only for definitions with no account field, or
 one-off config this flow doesn't cover.
+
+Edit a component with update_component: fetch its current state with
+list_components first, recap old → new, and act only on confirmation.
+Config updates are partial (only the fields you pass change); a source's
+asset selection is replaced exactly, so recap the full resulting set, not
+just the delta. Connection credentials are never edited in chat — offer a
+rename, or point the user to the app (or a fresh connection via the secure
+form) for credential changes.
 """ + PRESENTATION
 
 CATALOG_CONSULT_INSTRUCTION = """\
@@ -157,7 +168,7 @@ between assets — which feed which, cross-source edges, and impact analysis.
 SCHEDULING_INSTRUCTION = """\
 You are the Scheduling specialist for Interloper. You explain run health,
 failures, job schedules, and backfill progress, and you act: trigger runs,
-start backfills, toggle jobs or assets, and create cron jobs.
+start backfills, toggle jobs or assets, and create or edit cron jobs.
 
 Reporting:
 - Failures: include the event error message, name the asset that failed, and
@@ -171,6 +182,9 @@ Acting — never execute or create anything without explicit confirmation:
   on the user's next-message confirmation — never in the same turn as the recap.
 - To create a cron job, first find its target sources with list_components
   (kind 'source').
+- To edit a job (schedule, backfill window, name), use update_component —
+  config updates are partial, so pass only the fields that change and recap
+  old → new values in the confirmation.
 - After acting, report the result, including any created run/backfill/job id.
 """ + PRESENTATION
 

--- a/packages/interloper-agent/src/interloper_agent/tools/collection.py
+++ b/packages/interloper-agent/src/interloper_agent/tools/collection.py
@@ -1,9 +1,9 @@
 """Collection tools — the component instances persisted for the organisation.
 
 Generic over component kinds, mirroring the framework's component
-architecture: one lister for any kind (sensitive kinds project
-identity-only, driven by ``KINDS``), plus the connection and source
-operations that are irreducibly kind-specific. Credentials never transit
+architecture: one lister and one editor for any kind (sensitive kinds
+project identity-only and refuse config edits, driven by ``KINDS``), plus
+the connection and source operations that are irreducibly kind-specific. Credentials never transit
 the model: ``request_connection_setup`` only signals the app to present a
 secure setup form, and the browser submits credentials to the API
 directly; source setup is conversational because its inputs (accounts,
@@ -19,6 +19,7 @@ from uuid import UUID
 
 import httpx
 from google.adk.tools.tool_context import ToolContext
+from interloper import KINDS
 from interloper.connection.base import Connection
 from interloper.errors import CatalogKeyError, ComponentDriftError, ConfigError, ConnectionCheckError, HydrationError
 from interloper.oauth import is_provider_configured
@@ -47,6 +48,100 @@ def list_components(kind: str | None = None, tool_context: ToolContext | None = 
 
 
 list_components.__doc__ = toolkit_collection.list_components.__doc__
+
+
+def update_component(
+    component_id: str,
+    name: str | None = None,
+    config_updates: dict[str, Any] | None = None,
+    asset_keys: list[str] | None = None,
+    tool_context: ToolContext | None = None,
+) -> dict[str, Any]:
+    """Edit an existing component in the organisation's collection.
+
+    Works on any kind: rename it, change config values, or change which of a
+    source's assets are enabled. Recap exactly what changes (old → new) and
+    get the user's explicit confirmation BEFORE calling this.
+
+    Config updates are partial — only the fields passed change, the rest of
+    the stored config is kept; pass null to reset a field to its default.
+    Connection configs hold credentials and are never edited here: the user
+    changes those in the app (renaming a connection is fine). Rebinding
+    relations (a source's connection, a job's targets) also happens in the
+    app, not through config.
+
+    Args:
+        component_id: UUID of the component, from list_components.
+        name: New display name; omit to keep the current one.
+        config_updates: Config fields to change, merged over the stored
+            config — e.g. ``{"cron": "0 7 * * *"}`` on a job, or
+            ``{"account_id": ...}`` on a source.
+        asset_keys: Sources only — the child asset keys to enable, replacing
+            the current selection exactly. Omit to leave it unchanged.
+    """
+    try:
+        org_id = get_org_id(tool_context)
+        store = get_store()
+
+        component = store.get_component(UUID(component_id))
+        if component.org_id != org_id:
+            return {"status": "error", "error": f"Component '{component_id}' not found"}
+        if name is None and config_updates is None and not asset_keys:
+            return {"status": "error", "error": "Nothing to update — pass name, config_updates, or asset_keys"}
+        if config_updates and KINDS[component.kind].sensitive:
+            return {
+                "status": "error",
+                "error": (
+                    f"The config of a {component.kind} holds credentials and cannot be edited in chat — "
+                    "the user changes it in the app, or sets up a new one via the secure form. "
+                    "Renaming is allowed."
+                ),
+            }
+
+        config = None
+        if config_updates:
+            # Sensitive kinds were refused above, so the plain config column
+            # is the full stored payload.
+            config = dict(component.config or {})
+            for field, value in config_updates.items():
+                if value is None:
+                    config.pop(field, None)
+                else:
+                    config[field] = value
+
+        children = None
+        defn = get_catalog().get(component.key)
+        if asset_keys:
+            if component.kind != "source":
+                return {"status": "error", "error": f"Components of kind '{component.kind}' have no assets"}
+            if defn is None:
+                return {
+                    "status": "error",
+                    "error": f"'{component.key}' is no longer in the catalog — its asset selection cannot change",
+                }
+            children, error = _normalized_asset_keys(defn, component.key, asset_keys)
+            if error:
+                return error
+
+        try:
+            row = store.update_component(component.id, name=name, config=config, children=children)
+        except (ConfigError, CatalogKeyError) as e:
+            return {"status": "error", "error": str(e)}
+
+        result: dict[str, Any] = {
+            "status": "success",
+            "message": f"{component.kind.capitalize()} '{row.name or row.key}' updated",
+            "component": {"id": serialize(row.id), "kind": row.kind, "key": row.key, "name": row.name},
+        }
+        if config_updates:
+            result["changed_fields"] = sorted(config_updates)
+        if children is not None:
+            result["component"]["asset_count"] = len(row.children)
+            if defn is not None:
+                result["unresolved_requirements"] = _unresolved_requirements(defn, row)
+        return result
+    except Exception as e:
+        return {"status": "error", "error": str(e)}
 
 
 # -- Connection operations (kind-specific by nature) ------------------------------

--- a/packages/interloper-agent/tests/tools/test_collection.py
+++ b/packages/interloper-agent/tests/tools/test_collection.py
@@ -1,0 +1,144 @@
+"""Tests for interloper_agent.tools.collection."""
+
+from types import SimpleNamespace
+from typing import Any, cast
+from uuid import uuid4
+
+import pytest
+from google.adk.tools.tool_context import ToolContext
+
+from interloper_agent import context
+from interloper_agent.tools import collection
+
+ORG_ID = uuid4()
+
+CATALOG = {
+    "facebook_ads": {
+        "kind": "source",
+        "assets": [
+            {"key": "ads"},
+            {"key": "ads_stats", "requires": {"campaigns": "facebook_ads.campaigns"}},
+        ],
+    },
+    "facebook_ads_connection": {"kind": "connection"},
+}
+
+
+class FakeStore:
+    """Captures update_component calls; get_component returns the one row."""
+
+    def __init__(self, component: Any):
+        self.component = component
+        self.update_kwargs: dict[str, Any] | None = None
+
+    def get_component(self, component_id: Any, *, kind: str | None = None) -> Any:
+        return self.component
+
+    def update_component(self, component_id: Any, **kwargs: Any) -> Any:
+        self.update_kwargs = kwargs
+        if kwargs.get("name") is not None:
+            self.component.name = kwargs["name"]
+        if kwargs.get("config") is not None:
+            self.component.config = kwargs["config"]
+        if kwargs.get("children") is not None:
+            self.component.children = [SimpleNamespace(key=k) for k in kwargs["children"]]
+        return self.component
+
+
+def _component(**overrides: Any) -> Any:
+    defaults: dict[str, Any] = {
+        "id": uuid4(),
+        "org_id": ORG_ID,
+        "kind": "source",
+        "key": "facebook_ads",
+        "name": "FB",
+        "config": {"account_id": "1", "dataset": "raw"},
+        "children": [SimpleNamespace(key="ads"), SimpleNamespace(key="ads_stats")],
+    }
+    return SimpleNamespace(**{**defaults, **overrides})
+
+
+@pytest.fixture
+def ctx() -> ToolContext:
+    return cast(ToolContext, SimpleNamespace(state={"org_id": str(ORG_ID)}))
+
+
+@pytest.fixture
+def store(monkeypatch: pytest.MonkeyPatch) -> FakeStore:
+    fake = FakeStore(_component())
+    monkeypatch.setattr(context, "_store", fake)
+    monkeypatch.setattr(context, "_catalog", SimpleNamespace(dump=lambda: CATALOG))
+    return fake
+
+
+def test_update_component_merges_partial_config(store: FakeStore, ctx: ToolContext):
+    result = collection.update_component(
+        str(store.component.id), config_updates={"dataset": "clean", "account_id": None}, tool_context=ctx
+    )
+    assert result["status"] == "success"
+    assert result["changed_fields"] == ["account_id", "dataset"]
+    assert store.update_kwargs is not None
+    assert store.update_kwargs["config"] == {"dataset": "clean"}
+
+
+def test_update_component_renames_without_touching_config(store: FakeStore, ctx: ToolContext):
+    result = collection.update_component(str(store.component.id), name="Meta Ads", tool_context=ctx)
+    assert result["status"] == "success"
+    assert result["component"]["name"] == "Meta Ads"
+    assert store.update_kwargs is not None
+    assert store.update_kwargs["config"] is None
+
+
+def test_update_component_replaces_asset_selection(store: FakeStore, ctx: ToolContext):
+    result = collection.update_component(str(store.component.id), asset_keys=["ads_stats"], tool_context=ctx)
+    assert result["status"] == "success"
+    assert store.update_kwargs is not None
+    assert store.update_kwargs["children"] == ["ads_stats"]
+    assert result["component"]["asset_count"] == 1
+    assert result["unresolved_requirements"] == ["ads_stats: campaigns"]
+
+
+def test_update_component_rejects_unknown_asset_keys(store: FakeStore, ctx: ToolContext):
+    result = collection.update_component(str(store.component.id), asset_keys=["nope"], tool_context=ctx)
+    assert result["status"] == "error"
+    assert result["valid_asset_keys"] == ["ads", "ads_stats"]
+    assert store.update_kwargs is None
+
+
+def test_update_component_rejects_assets_on_non_source(store: FakeStore, ctx: ToolContext):
+    store.component = _component(kind="job", key="cron_job", config={"cron": "0 6 * * *"})
+    result = collection.update_component(str(store.component.id), asset_keys=["ads"], tool_context=ctx)
+    assert result["status"] == "error"
+    assert "have no assets" in result["error"]
+
+
+def test_update_component_refuses_connection_config(store: FakeStore, ctx: ToolContext):
+    store.component = _component(kind="connection", key="facebook_ads_connection", config=None)
+    result = collection.update_component(
+        str(store.component.id), config_updates={"access_token": "x"}, tool_context=ctx
+    )
+    assert result["status"] == "error"
+    assert "credentials" in result["error"]
+    assert store.update_kwargs is None
+
+
+def test_update_component_allows_connection_rename(store: FakeStore, ctx: ToolContext):
+    store.component = _component(kind="connection", key="facebook_ads_connection", config=None)
+    result = collection.update_component(str(store.component.id), name="Meta main", tool_context=ctx)
+    assert result["status"] == "success"
+    assert store.update_kwargs is not None
+    assert store.update_kwargs["config"] is None
+
+
+def test_update_component_hides_other_orgs_components(store: FakeStore, ctx: ToolContext):
+    store.component = _component(org_id=uuid4())
+    result = collection.update_component(str(store.component.id), name="Hijack", tool_context=ctx)
+    assert result["status"] == "error"
+    assert "not found" in result["error"]
+    assert store.update_kwargs is None
+
+
+def test_update_component_requires_a_change(store: FakeStore, ctx: ToolContext):
+    result = collection.update_component(str(store.component.id), tool_context=ctx)
+    assert result["status"] == "error"
+    assert store.update_kwargs is None


### PR DESCRIPTION
## What

Adds a kind-generic `update_component` tool to the agent's collection toolkit, closing the gap where the agent could create components and flip two booleans (`toggle_job`, `toggle_asset`) but not edit anything else.

- **Rename** any component (sources, connections, jobs, destinations, assets).
- **Partial config edits** — only the fields passed change, merged over the stored config; an explicit `null` resets a field to its default. Covers job cron changes, source account/dataset changes, etc.
- **Replace a source's asset selection** — `asset_keys` swaps the enabled child set exactly, validated against the catalog definition, reporting unresolved cross-source requirements like `create_source` does.

Registered on the collection agent and — for job schedule edits — the scheduling agent; root routing examples and both specialist instructions updated with the same recap-old→new-then-confirm rule the create flows use.

## Why

Users asking the agent to "change the schedule on this job" or "point this source at a different account" previously dead-ended: no tool could fulfil it.

## Reviewer notes

- **Credentials never transit the chat**: config edits on sensitive kinds are refused (keyed off `KINDS[kind].sensitive`, not a hardcoded kind list); renaming a connection stays allowed. This mirrors the existing secure-form policy.
- Cross-org rows return "not found", matching the other tools; `ConfigError`/`CatalogKeyError` surface as tool-result errors, same depth of validation as the API's `PUT /components/{id}`.
- Deliberately out of scope (the docstring points the model to the app): deleting components and rebinding relations (a source's connection, a job's targets).
- New `tests/tools/test_collection.py` with 9 cases over a fake store: merge semantics, null-reset, connection refusal + rename allowance, asset validation, org isolation, no-op rejection.

By Digitl