### PR TITLE
fix(app): surface backend error detail in failure toasts

### DIFF
--- a/packages/interloper-app/app/app/components/agent/ConnectCard.vue
+++ b/packages/interloper-app/app/app/components/agent/ConnectCard.vue
@@ -98,12 +98,12 @@ async function submit() {
             body: { component_key: props.request.connectionKey, config: formData.value },
         })
     }
-    catch (e: any) {
+    catch (e) {
         check = {
             ok: false,
             live: false,
             category: 'error',
-            message: e?.data?.detail ?? 'The connection check could not be run.',
+            message: errorDetail(e) ?? 'The connection check could not be run.',
             errors: [],
         }
     }
@@ -127,8 +127,8 @@ async function submit() {
         toast.add({ title: `Connection "${createdName.value}" created`, color: 'success' })
         emit('created', createdName.value, check.live)
     }
-    catch {
-        toast.add({ title: 'Failed to create connection', color: 'error' })
+    catch (e) {
+        toast.add(errorToast(e, 'Failed to create connection'))
         state.value = 'idle'
     }
 }

--- a/packages/interloper-app/app/app/components/collection/Table.vue
+++ b/packages/interloper-app/app/app/components/collection/Table.vue
@@ -91,7 +91,7 @@ async function deleteSource(sourceId: string) {
         toast.add({ title: `Source "${info?.name ?? 'Source'}" deleted`, color: 'success' })
     }
     catch (e) {
-        toast.add(inUseToast(e, 'Source') ?? { title: 'Failed to delete source', color: 'error' })
+        toast.add(inUseToast(e, 'Source') ?? errorToast(e, 'Failed to delete source'))
     }
 }
 

--- a/packages/interloper-app/app/app/components/destinations/Stepper.vue
+++ b/packages/interloper-app/app/app/components/destinations/Stepper.vue
@@ -251,8 +251,8 @@ async function submit() {
             emit('created')
         }
     }
-    catch {
-        toast.add({ title: `Failed to ${isEditMode.value ? 'update' : 'create'} destination`, color: 'error' })
+    catch (e) {
+        toast.add(errorToast(e, `Failed to ${isEditMode.value ? 'update' : 'create'} destination`))
     }
     finally {
         submitting.value = false

--- a/packages/interloper-app/app/app/components/drift/Banner.vue
+++ b/packages/interloper-app/app/app/components/drift/Banner.vue
@@ -47,7 +47,7 @@ async function handleCleanup() {
         toast.add({ title: 'Catalog drift cleaned up', color: 'success' })
     }
     catch (e) {
-        toast.add(inUseToast(e, 'Source') ?? { title: 'Failed to clean up drift', color: 'error' })
+        toast.add(inUseToast(e, 'Source') ?? errorToast(e, 'Failed to clean up drift'))
     }
     finally {
         cleaningUp.value = false

--- a/packages/interloper-app/app/app/components/executions/RunModal.vue
+++ b/packages/interloper-app/app/app/components/executions/RunModal.vue
@@ -155,8 +155,8 @@ async function onSubmit() {
         }
         open.value = false
     }
-    catch {
-        toast.add({ title: `Failed to queue ${isRange.value ? 'backfill' : 'run'}`, color: 'error' })
+    catch (e) {
+        toast.add(errorToast(e, `Failed to queue ${isRange.value ? 'backfill' : 'run'}`))
     }
     finally {
         submitting.value = false

--- a/packages/interloper-app/app/app/components/graph/AssetPanel.vue
+++ b/packages/interloper-app/app/app/components/graph/AssetPanel.vue
@@ -64,7 +64,7 @@ async function fetchPartitionCounts() {
             partitionNotMaterialized.value = true
         }
         else {
-            partitionError.value = e?.data?.detail ?? e?.message ?? 'Failed to load partition data'
+            partitionError.value = errorDetail(e) ?? 'Failed to load partition data'
         }
         partitionData.value = []
     }
@@ -165,8 +165,8 @@ async function saveConfig() {
         if (props.asset.parent_id) await componentsStore.fetchOne(props.asset.parent_id)
         toast.add({ title: 'Asset config saved', color: 'success' })
     }
-    catch {
-        toast.add({ title: 'Failed to save asset config', color: 'error' })
+    catch (e) {
+        toast.add(errorToast(e, 'Failed to save asset config'))
     }
     finally {
         configSaving.value = false
@@ -252,8 +252,8 @@ async function runNow() {
         const runId = await runsStore.createRun(props.asset.id)
         toast.add({ title: `Run queued (${runId.slice(0, 8)})`, color: 'success' })
     }
-    catch {
-        toast.add({ title: 'Failed to queue run', color: 'error' })
+    catch (e) {
+        toast.add(errorToast(e, 'Failed to queue run'))
     }
     finally {
         runSubmitting.value = false

--- a/packages/interloper-app/app/app/components/hooks/Stepper.vue
+++ b/packages/interloper-app/app/app/components/hooks/Stepper.vue
@@ -178,8 +178,8 @@ async function submit() {
             emit('created')
         }
     }
-    catch {
-        toast.add({ title: `Failed to ${isEditing.value ? 'update' : 'create'} hook`, color: 'error' })
+    catch (e) {
+        toast.add(errorToast(e, `Failed to ${isEditing.value ? 'update' : 'create'} hook`))
     }
     finally {
         submitting.value = false

--- a/packages/interloper-app/app/app/components/jobs/Stepper.vue
+++ b/packages/interloper-app/app/app/components/jobs/Stepper.vue
@@ -190,8 +190,8 @@ async function submit() {
             emit('created')
         }
     }
-    catch {
-        toast.add({ title: `Failed to ${isEditing.value ? 'update' : 'create'} job`, color: 'error' })
+    catch (e) {
+        toast.add(errorToast(e, `Failed to ${isEditing.value ? 'update' : 'create'} job`))
     }
     finally {
         submitting.value = false

--- a/packages/interloper-app/app/app/components/organization/InviteModal.vue
+++ b/packages/interloper-app/app/app/components/organization/InviteModal.vue
@@ -61,9 +61,8 @@ async function submit() {
             })
             successCount++
         }
-        catch (err: any) {
-            const detail = err?.data?.detail || 'Failed to send invitation'
-            errors.push(`${invite.email}: ${detail}`)
+        catch (err) {
+            errors.push(`${invite.email}: ${errorDetail(err) ?? 'Failed to send invitation'}`)
         }
     }
 

--- a/packages/interloper-app/app/app/components/resources/ConnectionCheck.vue
+++ b/packages/interloper-app/app/app/components/resources/ConnectionCheck.vue
@@ -55,12 +55,12 @@ async function run() {
             body: { component_key: props.componentKey, config: props.config },
         })
     }
-    catch (e: any) {
+    catch (e) {
         result.value = {
             ok: false,
             live: false,
             category: 'error',
-            message: e?.data?.detail ?? 'The connection check could not be run.',
+            message: errorDetail(e) ?? 'The connection check could not be run.',
             errors: [],
         }
     }

--- a/packages/interloper-app/app/app/components/resources/Stepper.vue
+++ b/packages/interloper-app/app/app/components/resources/Stepper.vue
@@ -167,8 +167,8 @@ async function submit() {
             emit('created')
         }
     }
-    catch {
-        toast.add({ title: `Failed to ${isEditing.value ? 'update' : 'create'} ${props.kind}`, color: 'error' })
+    catch (e) {
+        toast.add(errorToast(e, `Failed to ${isEditing.value ? 'update' : 'create'} ${props.kind}`))
     }
     submitting.value = false
 }

--- a/packages/interloper-app/app/app/components/sources/ResourceStep.vue
+++ b/packages/interloper-app/app/app/components/sources/ResourceStep.vue
@@ -119,8 +119,8 @@ async function handleCreate() {
         emit('created', resource)
         if (!props.silent) toast.add({ title: `${props.definition.name} created`, color: 'success' })
     }
-    catch {
-        toast.add({ title: `Failed to create ${props.definition.name}`, color: 'error' })
+    catch (e) {
+        toast.add(errorToast(e, `Failed to create ${props.definition.name}`))
     }
     finally {
         creating.value = false

--- a/packages/interloper-app/app/app/components/sources/Stepper.vue
+++ b/packages/interloper-app/app/app/components/sources/Stepper.vue
@@ -326,8 +326,8 @@ async function submit() {
             emit('created')
         }
     }
-    catch {
-        toast.add({ title: `Failed to ${isEditMode.value ? 'update' : 'create'} source`, color: 'error' })
+    catch (e) {
+        toast.add(errorToast(e, `Failed to ${isEditMode.value ? 'update' : 'create'} source`))
     }
     finally {
         submitting.value = false

--- a/packages/interloper-app/app/app/components/ui/OAuthSignIn.vue
+++ b/packages/interloper-app/app/app/components/ui/OAuthSignIn.vue
@@ -44,7 +44,7 @@ async function handleSignIn() {
     catch (error) {
         // Closing the popup is a deliberate cancel, not a failure.
         if (!(error instanceof OAuthCancelledError)) {
-            toast.add({ title: 'Sign-in failed', color: 'error' })
+            toast.add(errorToast(error, 'Sign-in failed'))
         }
     }
     finally {

--- a/packages/interloper-app/app/app/components/ui/SchemaForm.vue
+++ b/packages/interloper-app/app/app/components/ui/SchemaForm.vue
@@ -271,10 +271,10 @@ async function fetchOptions(fieldKey: string, meta: FetchMeta) {
             })),
         })
     }
-    catch (e: any) {
+    catch (e) {
         updateFetchState(fieldKey, {
             loading: false,
-            error: e?.data?.detail ?? e?.message ?? 'Failed to fetch options',
+            error: errorDetail(e) ?? 'Failed to fetch options',
             options: [],
         })
     }

--- a/packages/interloper-app/app/app/pages/admin/index.vue
+++ b/packages/interloper-app/app/app/pages/admin/index.vue
@@ -67,8 +67,8 @@ async function submitForm() {
         formOpen.value = false
         await loadData()
     }
-    catch (err: any) {
-        toast.add({ title: err?.data?.detail || 'Operation failed', color: 'error' })
+    catch (err) {
+        toast.add(errorToast(err, 'Operation failed'))
     }
     finally {
         submitting.value = false

--- a/packages/interloper-app/app/app/pages/admin/organisations/[id].vue
+++ b/packages/interloper-app/app/app/pages/admin/organisations/[id].vue
@@ -72,8 +72,8 @@ async function removeMember(member: OrgMember) {
         toast.add({ title: `${member.name || member.email} removed`, color: 'success' })
         await loadData()
     }
-    catch (err: any) {
-        toast.add({ title: err?.data?.detail || 'Failed to remove member', color: 'error' })
+    catch (err) {
+        toast.add(errorToast(err, 'Failed to remove member'))
     }
 }
 
@@ -83,8 +83,8 @@ async function cancelInvite(member: OrgMember) {
         toast.add({ title: `Invitation to ${member.email} cancelled`, color: 'success' })
         await loadData()
     }
-    catch (err: any) {
-        toast.add({ title: err?.data?.detail || 'Failed to cancel invitation', color: 'error' })
+    catch (err) {
+        toast.add(errorToast(err, 'Failed to cancel invitation'))
     }
 }
 
@@ -94,8 +94,8 @@ async function joinOrganisation() {
         toast.add({ title: `Joined ${orgName.value ?? 'organisation'}`, color: 'success' })
         await loadData()
     }
-    catch (err: any) {
-        toast.add({ title: err?.data?.detail || 'Failed to join organisation', color: 'error' })
+    catch (err) {
+        toast.add(errorToast(err, 'Failed to join organisation'))
     }
 }
 
@@ -106,8 +106,8 @@ async function resendInvite(member: OrgMember) {
         toast.add({ title: `Invitation resent to ${member.email}`, color: 'success' })
         await loadData()
     }
-    catch (err: any) {
-        toast.add({ title: err?.data?.detail || 'Failed to resend invitation', color: 'error' })
+    catch (err) {
+        toast.add(errorToast(err, 'Failed to resend invitation'))
     }
 }
 

--- a/packages/interloper-app/app/app/pages/destinations.vue
+++ b/packages/interloper-app/app/app/pages/destinations.vue
@@ -87,7 +87,7 @@ async function handleDelete(ids: string[]) {
         toast.add({ title: `${ids.length} destination${ids.length > 1 ? 's' : ''} deleted`, color: 'success' })
     }
     catch (e) {
-        toast.add(inUseToast(e, 'Destination') ?? { title: 'Failed to delete destination', color: 'error' })
+        toast.add(inUseToast(e, 'Destination') ?? errorToast(e, 'Failed to delete destination'))
     }
 }
 

--- a/packages/interloper-app/app/app/pages/executions/runs/[run].vue
+++ b/packages/interloper-app/app/app/pages/executions/runs/[run].vue
@@ -84,8 +84,8 @@ async function onRetry(scope: 'all' | 'failed') {
         toast.add({ title: `Retry queued (${newRunId.slice(0, 8)})`, color: 'success' })
         await navigateTo(`/executions/runs/${newRunId}`)
     }
-    catch {
-        toast.add({ title: 'Failed to queue retry', color: 'error' })
+    catch (e) {
+        toast.add(errorToast(e, 'Failed to queue retry'))
     }
     finally {
         retrying.value = false

--- a/packages/interloper-app/app/app/pages/graph.vue
+++ b/packages/interloper-app/app/app/pages/graph.vue
@@ -87,7 +87,7 @@ async function onDeleteSource(sourceId: string) {
         toast.add({ title: `Source "${source?.name ?? 'Source'}" deleted`, color: 'success' })
     }
     catch (e) {
-        toast.add(inUseToast(e, 'Source') ?? { title: 'Failed to delete source', color: 'error' })
+        toast.add(inUseToast(e, 'Source') ?? errorToast(e, 'Failed to delete source'))
     }
 }
 
@@ -99,8 +99,8 @@ async function onCreateDependencies(pairs: Array<{ upstreamAssetId: string; down
             ),
         )
     }
-    catch {
-        toast.add({ title: 'Failed to create dependency', color: 'error' })
+    catch (e) {
+        toast.add(errorToast(e, 'Failed to create dependency'))
     }
 }
 
@@ -108,8 +108,8 @@ async function onDeleteDependency(payload: { upstreamAssetId: string; downstream
     try {
         await componentsStore.removeRelation(payload.downstreamAssetId, 'dependency', payload.upstreamAssetId)
     }
-    catch {
-        toast.add({ title: 'Failed to delete dependency', color: 'error' })
+    catch (e) {
+        toast.add(errorToast(e, 'Failed to delete dependency'))
     }
 }
 </script>

--- a/packages/interloper-app/app/app/pages/hooks.vue
+++ b/packages/interloper-app/app/app/pages/hooks.vue
@@ -98,7 +98,7 @@ async function handleDelete(ids: string[]) {
         toast.add({ title: `${ids.length} hook${ids.length > 1 ? 's' : ''} deleted`, color: 'success' })
     }
     catch (e) {
-        toast.add(inUseToast(e, 'Hook') ?? { title: 'Failed to delete hook', color: 'error' })
+        toast.add(inUseToast(e, 'Hook') ?? errorToast(e, 'Failed to delete hook'))
     }
 }
 </script>

--- a/packages/interloper-app/app/app/pages/invite/[token].vue
+++ b/packages/interloper-app/app/app/pages/invite/[token].vue
@@ -33,9 +33,9 @@ onMounted(async () => {
         status.value = 'success'
         await navigateTo('/')
     }
-    catch (err: any) {
+    catch (err) {
         status.value = 'error'
-        errorMessage.value = err?.data?.detail || 'Failed to accept invitation'
+        errorMessage.value = errorDetail(err) ?? 'Failed to accept invitation'
     }
 })
 </script>

--- a/packages/interloper-app/app/app/pages/jobs.vue
+++ b/packages/interloper-app/app/app/pages/jobs.vue
@@ -118,7 +118,7 @@ async function handleDelete(ids: string[]) {
         toast.add({ title: `${ids.length} job${ids.length > 1 ? 's' : ''} deleted`, color: 'success' })
     }
     catch (e) {
-        toast.add(inUseToast(e, 'Job') ?? { title: 'Failed to delete job', color: 'error' })
+        toast.add(inUseToast(e, 'Job') ?? errorToast(e, 'Failed to delete job'))
     }
 }
 </script>

--- a/packages/interloper-app/app/app/pages/organization.vue
+++ b/packages/interloper-app/app/app/pages/organization.vue
@@ -79,8 +79,8 @@ async function removeMember(member: OrgMember) {
         toast.add({ title: `${member.name || member.email} removed`, color: 'success' })
         await loadData()
     }
-    catch (err: any) {
-        toast.add({ title: err?.data?.detail || 'Failed to remove member', color: 'error' })
+    catch (err) {
+        toast.add(errorToast(err, 'Failed to remove member'))
     }
 }
 
@@ -90,8 +90,8 @@ async function cancelInvite(member: OrgMember) {
         toast.add({ title: `Invitation to ${member.email} cancelled`, color: 'success' })
         await loadData()
     }
-    catch (err: any) {
-        toast.add({ title: err?.data?.detail || 'Failed to cancel invitation', color: 'error' })
+    catch (err) {
+        toast.add(errorToast(err, 'Failed to cancel invitation'))
     }
 }
 
@@ -100,8 +100,8 @@ async function resendInvite(member: OrgMember) {
         await apiFetch(`/organisations/invitations/${member.id}/resend`, { method: 'POST' })
         toast.add({ title: `Invitation resent to ${member.email}`, color: 'success' })
     }
-    catch (err: any) {
-        toast.add({ title: err?.data?.detail || 'Failed to resend invitation', color: 'error' })
+    catch (err) {
+        toast.add(errorToast(err, 'Failed to resend invitation'))
     }
 }
 

--- a/packages/interloper-app/app/app/pages/resources/[kind].vue
+++ b/packages/interloper-app/app/app/pages/resources/[kind].vue
@@ -70,7 +70,7 @@ async function handleDelete(ids: string[]) {
         toast.add({ title: `${ids.length} resource(s) deleted`, color: 'success' })
     }
     catch (e) {
-        toast.add(inUseToast(e, pageTitle.value.slice(0, -1)) ?? { title: 'Failed to delete resource', color: 'error' })
+        toast.add(inUseToast(e, pageTitle.value.slice(0, -1)) ?? errorToast(e, 'Failed to delete resource'))
     }
 }
 

--- a/packages/interloper-app/app/app/pages/sources.vue
+++ b/packages/interloper-app/app/app/pages/sources.vue
@@ -57,8 +57,8 @@ async function runNow(source: ComponentRecord) {
         const runId = await runsStore.createRun(source.id)
         toast.add({ title: `Run queued (${runId.slice(0, 8)})`, color: 'success' })
     }
-    catch {
-        toast.add({ title: 'Failed to queue run', color: 'error' })
+    catch (e) {
+        toast.add(errorToast(e, 'Failed to queue run'))
     }
 }
 
@@ -145,7 +145,7 @@ async function handleDelete(ids: string[]) {
         toast.add({ title: `${ids.length} source${ids.length > 1 ? 's' : ''} deleted`, color: 'success' })
     }
     catch (e) {
-        toast.add(inUseToast(e, 'Source') ?? { title: 'Failed to delete source', color: 'error' })
+        toast.add(inUseToast(e, 'Source') ?? errorToast(e, 'Failed to delete source'))
     }
 }
 </script>

--- a/packages/interloper-app/app/app/pages/welcome.vue
+++ b/packages/interloper-app/app/app/pages/welcome.vue
@@ -22,8 +22,8 @@ async function create() {
         toast.add({ title: 'Organisation created', color: 'success' })
         await navigateTo('/')
     }
-    catch {
-        toast.add({ title: 'Failed to create organisation', color: 'error' })
+    catch (e) {
+        toast.add(errorToast(e, 'Failed to create organisation'))
     }
     finally {
         loading.value = false

--- a/packages/interloper-app/app/app/utils/apiErrors.ts
+++ b/packages/interloper-app/app/app/utils/apiErrors.ts
@@ -38,3 +38,32 @@ export function inUseToast(e: unknown, entity: string): { title: string, descrip
     const usedBy = usedByFromError(e)
     return usedBy ? inUseToastPayload(entity, usedBy) : null
 }
+
+/**
+ * Human-readable message carried by an API error, or `null` when it has none.
+ *
+ * Handles the three FastAPI `detail` shapes — a plain string, a `{message, …}`
+ * object (409 in-use), and a 422 validation list — plus plain `Error`s from
+ * non-HTTP flows (e.g. the OAuth popup) whose `message` is already
+ * user-facing. HTTP errors without a usable `detail` yield `null` rather than
+ * ofetch's unhelpful `[POST] "/api/…": 400` message.
+ */
+export function errorDetail(e: unknown): string | null {
+    const detail = (e as { data?: { detail?: unknown } })?.data?.detail
+    if (typeof detail === 'string' && detail) return detail
+    if (Array.isArray(detail)) {
+        const msgs = detail
+            .map(item => (item as { msg?: unknown })?.msg)
+            .filter((msg): msg is string => typeof msg === 'string')
+        if (msgs.length) return msgs.join('\n')
+    }
+    const message = (detail as { message?: unknown } | null)?.message
+    if (typeof message === 'string' && message) return message
+    if (e instanceof Error && e.message && !('response' in e)) return e.message
+    return null
+}
+
+/** Failure toast payload: `title` as the headline, the error's detail (when any) as the description. */
+export function errorToast(e: unknown, title: string): { title: string, description?: string, color: 'error' } {
+    return { title, description: errorDetail(e) ?? undefined, color: 'error' }
+}


### PR DESCRIPTION
## What

Failure notifications across the app dropped the backend's error message: creating a duplicate source showed only **"Failed to create source"** while the API returned a precise 400 detail ("Source 'demo_source' already has an instance materializing to 'demo_source.a'. Configure a distinct discriminator…").

This adds two helpers to `app/utils/apiErrors.ts` and sweeps every failure surface to use them:

- **`errorDetail(e)`** — extracts a human-readable message from any API error: plain-string `detail`, the 409 in-use `{message, used_by}` object, 422 validation lists (joined `msg`s), and plain `Error`s from non-HTTP flows (OAuth popup). Returns `null` when there's nothing useful, so callers keep their generic fallback instead of showing ofetch's `[POST] "/api/…": 400` noise.
- **`errorToast(e, title)`** — failure-toast payload: action-level title as the headline, the detail (when any) as the description.

## Where

- **Create/update steppers** (source, destination, resource, hook, job), ResourceStep, agent ConnectCard, welcome page — previously `catch { generic toast }`.
- **Delete handlers** — the `inUseToast(e, …) ?? {generic}` fallbacks (sources, destinations, hooks, jobs, resources, graph, collection table, drift banner) now carry the detail too.
- **Run/retry/dependency actions** (RunModal, AssetPanel, graph page, run detail page).
- **Org/admin pages, InviteModal, invite page** — already showed the detail but used it as the toast *title* and would break on non-string details; normalized to title + description.
- **Inline error states** (SchemaForm option fetch, ConnectionCheck, ConnectCard check, AssetPanel partition data) — raw `e?.data?.detail` reads replaced, fixing `[object Object]` rendering on 422 lists.

## Verification

- `pnpm run lint` and `pnpm exec nuxt typecheck` pass.
- Verified live on a seeded dev instance: drove the New Source wizard to a duplicate `demo_source` create — the toast now shows the full backend message under the "Failed to create source" headline.

By Digitl