### PR TITLE
fix(app): polish graph node status rings and badges

### DIFF
--- a/packages/interloper-app/app/app/components/graph/AssetNode.vue
+++ b/packages/interloper-app/app/app/components/graph/AssetNode.vue
@@ -156,7 +156,7 @@ const contextMenuItems = computed<ContextMenuItem[][]>(() => {
                  class="absolute -left-2 -top-2 z-10">
                 <UTooltip :delay-duration="0"
                           :content="{ side: 'top', sideOffset: 6 }">
-                    <div class="flex size-5 items-center justify-center rounded-full border border-muted/50 bg-muted/50">
+                    <div class="flex size-5 items-center justify-center rounded-full border border-[var(--ui-border-accented)] bg-muted">
                         <UIcon name="i-lucide-loader-2"
                                class="size-3 shrink-0 animate-spin text-muted" />
                     </div>
@@ -171,7 +171,7 @@ const contextMenuItems = computed<ContextMenuItem[][]>(() => {
                       :delay-duration="0"
                       :content="{ side: 'top', sideOffset: 6 }"
                       class="absolute -right-2 -top-2 z-10">
-                <div class="flex size-5 items-center justify-center rounded-full border border-error/80 bg-error/20">
+                <div class="flex size-5 items-center justify-center rounded-full border border-[color-mix(in_srgb,var(--ui-error)_80%,var(--ui-bg))] bg-[color-mix(in_srgb,var(--ui-error)_20%,var(--ui-bg))]">
                     <UIcon :name="driftBadge?.icon ?? 'i-lucide-unplug'"
                            class="size-3 shrink-0 text-error" />
                 </div>
@@ -186,7 +186,7 @@ const contextMenuItems = computed<ContextMenuItem[][]>(() => {
                       :content="{ side: 'top', sideOffset: 6 }"
                       :ui="{ content: 'bg-transparent ring-0 shadow-none p-0 rounded-none' }"
                       class="absolute -right-2 -top-2 z-10">
-                <div class="flex size-5 items-center justify-center rounded-full border border-warning/80 bg-warning/20">
+                <div class="flex size-5 items-center justify-center rounded-full border border-[color-mix(in_srgb,var(--ui-warning)_80%,var(--ui-bg))] bg-[color-mix(in_srgb,var(--ui-warning)_20%,var(--ui-bg))]">
                     <UIcon name="i-lucide-triangle-alert"
                            class="size-3 shrink-0 text-warning" />
                 </div>
@@ -216,7 +216,7 @@ const contextMenuItems = computed<ContextMenuItem[][]>(() => {
                  class="absolute -bottom-2 -right-2 z-10">
                 <UTooltip :delay-duration="0"
                           :content="{ side: 'bottom', sideOffset: 6 }">
-                    <div class="relative flex size-6 items-center justify-center rounded-full border border-primary/25 bg-primary/10">
+                    <div class="relative flex size-6 items-center justify-center rounded-full border border-[color-mix(in_srgb,var(--ui-primary)_25%,var(--ui-bg))] bg-[color-mix(in_srgb,var(--ui-primary)_10%,var(--ui-bg))]">
                         <UIcon :name="destinationBadge.icon"
                                class="size-3.5 shrink-0 text-highlighted" />
                         <span v-if="destinationBadge.isMulti"

--- a/packages/interloper-app/app/app/components/graph/GraphCanvas.vue
+++ b/packages/interloper-app/app/app/components/graph/GraphCanvas.vue
@@ -84,13 +84,15 @@ function toggleGroup(groupId: string) {
 // Layout constants (assets render smaller in compact / run mode)
 const ASSET_W = props.compact ? 200 : 240
 const ASSET_H = props.compact ? 44 : 64
-const STACK_GAP = 14
+// Wide enough that corner badges (hanging ~12px past a card's edge) never
+// touch the neighbouring card or its badges.
+const STACK_GAP = 28
 /** Horizontal gap between dependency ranks inside an expanded container. */
 const INNER_GAP_RANK = 48
 const SRC_PADDING = 16
 const GRP_PADDING = 24
 const SRC_HEADER_H = 68
-const SRC_BODY_TOP = 12
+const SRC_BODY_TOP = 16
 /** Container width: one asset column plus side padding; collapsed cards match. */
 const SRC_W = ASSET_W + SRC_PADDING * 2
 const COLLAPSED_W = SRC_W

--- a/packages/interloper-app/app/app/components/graph/SourceNode.vue
+++ b/packages/interloper-app/app/app/components/graph/SourceNode.vue
@@ -156,7 +156,7 @@ const ringClass = computed(() => {
                  class="absolute -left-2.5 -top-2.5 z-10">
                 <UTooltip :delay-duration="0"
                           :content="{ side: 'top', sideOffset: 6 }">
-                    <div class="flex size-7 items-center justify-center rounded-full border border-muted/50 bg-muted/50">
+                    <div class="flex size-7 items-center justify-center rounded-full border border-[var(--ui-border-accented)] bg-muted">
                         <UIcon name="i-lucide-loader-2"
                                class="size-4 shrink-0 animate-spin text-muted" />
                     </div>
@@ -173,7 +173,9 @@ const ringClass = computed(() => {
                       :content="{ side: 'top', sideOffset: 6 }"
                       class="absolute -right-2.5 -top-2.5 z-10">
                 <div class="flex size-7 items-center justify-center rounded-full border"
-                     :class="driftStatus === 'missing' ? 'border-error/40 bg-error/25' : 'border-warning/40 bg-warning/25'">
+                     :class="driftStatus === 'missing'
+                         ? 'border-[color-mix(in_srgb,var(--ui-error)_40%,var(--ui-bg))] bg-[color-mix(in_srgb,var(--ui-error)_25%,var(--ui-bg))]'
+                         : 'border-[color-mix(in_srgb,var(--ui-warning)_40%,var(--ui-bg))] bg-[color-mix(in_srgb,var(--ui-warning)_25%,var(--ui-bg))]'">
                     <UIcon :name="driftBadge?.icon ?? 'i-lucide-unplug'"
                            class="size-4 shrink-0"
                            :class="driftStatus === 'missing' ? 'text-error' : 'text-warning'" />
@@ -189,7 +191,7 @@ const ringClass = computed(() => {
                       :content="{ side: 'top', sideOffset: 6 }"
                       :ui="{ content: 'bg-transparent ring-0 shadow-none p-0 rounded-none' }"
                       class="absolute -right-2.5 -top-2.5 z-10">
-                <div class="flex size-7 items-center justify-center rounded-full border border-warning/40 bg-warning/25">
+                <div class="flex size-7 items-center justify-center rounded-full border border-[color-mix(in_srgb,var(--ui-warning)_40%,var(--ui-bg))] bg-[color-mix(in_srgb,var(--ui-warning)_25%,var(--ui-bg))]">
                     <UIcon name="i-lucide-triangle-alert"
                            class="size-4 shrink-0 text-warning" />
                 </div>
@@ -219,7 +221,7 @@ const ringClass = computed(() => {
                  class="absolute -bottom-3 -right-3 z-10">
                 <UTooltip :delay-duration="0"
                           :content="{ side: 'bottom', sideOffset: 6 }">
-                    <div class="relative flex size-8 items-center justify-center rounded-full border border-primary/80 bg-primary/20">
+                    <div class="relative flex size-8 items-center justify-center rounded-full border border-[color-mix(in_srgb,var(--ui-primary)_80%,var(--ui-bg))] bg-[color-mix(in_srgb,var(--ui-primary)_20%,var(--ui-bg))]">
                         <UIcon :name="destinationBadge.icon"
                                class="size-4 shrink-0 text-primary" />
                         <span v-if="destinationBadge.isMulti"

--- a/packages/interloper-app/app/app/composables/nodeStatus.ts
+++ b/packages/interloper-app/app/app/composables/nodeStatus.ts
@@ -19,9 +19,9 @@ export function statusDotClass(state: GraphNodeState): string {
     return STATUS_DOT[state]
 }
 
-/** Ring/border tint applied to a node in the Status view mode. */
+/** Ring/border tint per node state. Healthy (idle) is the default look — no ring. */
 const STATUS_RING: Record<GraphNodeState, string> = {
-    idle: 'ring-2 ring-[var(--ui-success)]/40',
+    idle: '',
     attention: 'ring-2 ring-[var(--ui-warning)]/70',
     paused: 'ring-2 ring-[var(--ui-text-dimmed)]/40',
     queued: 'ring-2 ring-[var(--ui-text-dimmed)]/40',


### PR DESCRIPTION
Follow-up polish on the graph node redesign (#198):

- **Healthy nodes lose the ring**: `idle` no longer draws a green status ring — the plain card with its green dot is the default look, so colored borders are reserved for states that need attention (warning/paused/error, and live run states).
- **Opaque corner badges**: the warning/drift, destination, and materializing badges swap their translucent fills (`bg-warning/25`-style) for fully opaque `color-mix(…, var(--ui-bg))` equivalents — same tinted look, but nothing shows through when badges sit over edges or neighbouring cards, and it composites correctly in dark mode.
- **Wider stack gap**: vertical spacing between stacked nodes inside containers goes 14 → 28px (and the header-to-first-child inset 12 → 16px), so a card's bottom-hanging destination badge and the next card's top-hanging warning badge can never collide. Badge placement itself is unchanged from #198.

By Digitl