### PR TITLE
fix(app): drop gray node rings, thicken card borders, colorize tag badges

### DIFF
--- a/packages/interloper-app/app/app/components/graph/AssetNode.vue
+++ b/packages/interloper-app/app/app/components/graph/AssetNode.vue
@@ -232,7 +232,7 @@ const contextMenuItems = computed<ContextMenuItem[][]>(() => {
                 </UTooltip>
             </div>
 
-            <div class="rounded-xl border border-default bg-default px-4 py-3"
+            <div class="rounded-xl border-2 border-default bg-default px-4 py-3"
                  :class="ringClass">
                 <div class="flex items-center gap-2">
                     <UIcon name="i-lucide-box"
@@ -250,7 +250,7 @@ const contextMenuItems = computed<ContextMenuItem[][]>(() => {
                      class="mt-1.5 flex flex-wrap gap-1 pl-6">
                     <UBadge v-for="tag in tags"
                             :key="tag"
-                            color="neutral"
+                            :color="tagColor(tag)"
                             variant="subtle"
                             size="sm"
                             :label="tag" />

--- a/packages/interloper-app/app/app/components/graph/SourceNode.vue
+++ b/packages/interloper-app/app/app/components/graph/SourceNode.vue
@@ -239,7 +239,7 @@ const ringClass = computed(() => {
 
             <!-- Main card: one header row in both states; expanded grows downward
                  (assets render as nested canvas nodes). -->
-            <div class="relative flex h-full w-full flex-col overflow-hidden rounded-2xl border border-[var(--ui-border-accented)]"
+            <div class="relative flex h-full w-full flex-col overflow-hidden rounded-2xl border-2 border-[var(--ui-border-accented)]"
                  :class="[container ? 'bg-muted' : 'bg-default', ringClass]">
                 <div class="flex h-[68px] shrink-0 items-center gap-3 px-4"
                      :class="container && 'border-b border-default bg-default'">

--- a/packages/interloper-app/app/app/components/graph/SourceTypeNode.vue
+++ b/packages/interloper-app/app/app/components/graph/SourceTypeNode.vue
@@ -58,7 +58,7 @@ const ringClass = computed(() => {
              :class="[
                  open
                      ? 'border-2 border-dashed border-[var(--ui-text-dimmed)]/50 bg-transparent'
-                     : 'overflow-hidden border border-[var(--ui-border-accented)] bg-default',
+                     : 'overflow-hidden border-[1.5px] border-[var(--ui-border-accented)] bg-default',
                  ringClass,
              ]">
             <div class="flex h-[68px] shrink-0 items-center gap-3 px-4">

--- a/packages/interloper-app/app/app/composables/nodeStatus.ts
+++ b/packages/interloper-app/app/app/composables/nodeStatus.ts
@@ -19,18 +19,22 @@ export function statusDotClass(state: GraphNodeState): string {
     return STATUS_DOT[state]
 }
 
-/** Ring/border tint per node state. Healthy (idle) is the default look — no ring. */
+/**
+ * Ring/border tint per node state. Healthy (idle) and the gray states keep
+ * the default card look — their dot is enough; rings are reserved for states
+ * that demand attention or are live.
+ */
 const STATUS_RING: Record<GraphNodeState, string> = {
     idle: '',
     attention: 'ring-2 ring-[var(--ui-warning)]/70',
-    paused: 'ring-2 ring-[var(--ui-text-dimmed)]/40',
-    queued: 'ring-2 ring-[var(--ui-text-dimmed)]/40',
-    pending: 'ring-2 ring-[var(--ui-text-dimmed)]/40',
+    paused: '',
+    queued: '',
+    pending: '',
     running: 'ring-2 ring-[var(--ui-info)]/70',
     success: 'ring-2 ring-[var(--ui-success)]/60',
     failed: 'ring-2 ring-[var(--ui-error)]/70',
-    skipped: 'ring-2 ring-[var(--ui-text-dimmed)]/40',
-    canceled: 'ring-2 ring-[var(--ui-text-dimmed)]/40',
+    skipped: '',
+    canceled: '',
 }
 
 export function statusRingClass(state: GraphNodeState): string {


### PR DESCRIPTION
Third polish pass on the graph node redesign (follows #198, #199):

- **Gray states lose the status ring**: `paused`, `queued`, `pending`, `skipped`, and `canceled` now render the plain card — their gray dot carries the state, same treatment #199 gave `idle`. Rings remain for `attention`, `running`, `success`, and `failed`.
- **Thicker card borders**: source and asset cards go to 2px (collapsed group cards to 1.5px) so node edges read crisply against the canvas.
- **Colorized tag badges**: asset-card tag badges use the existing deterministic `tagColor()` utility (as in `AssetSelect`) instead of flat neutral, so Report/Entity/etc. each keep a stable color.

Net-zero experiments reverted along the way: the canvas background stays white and the expanded source body stays `bg-muted`.

By Digitl