### PR TITLE
feat(app): three-way group-by tabs and flat asset view on the graph

### DIFF
--- a/packages/interloper-app/app/app/components/graph/AssetGraph.vue
+++ b/packages/interloper-app/app/app/components/graph/AssetGraph.vue
@@ -19,7 +19,7 @@ const props = withDefaults(defineProps<{
 }>(), {
     sourceIds: undefined,
     readonly: false,
-    groupBy: 'none',
+    groupBy: 'type',
     statusFilter: 'all',
     showNewSourceButton: true,
     selectedId: null,

--- a/packages/interloper-app/app/app/components/graph/GraphCanvas.vue
+++ b/packages/interloper-app/app/app/components/graph/GraphCanvas.vue
@@ -34,7 +34,7 @@ const props = withDefaults(defineProps<{
     compact?: boolean
 }>(), {
     editable: false,
-    groupBy: 'none',
+    groupBy: 'source',
     loading: false,
     isValidConnection: undefined,
     materializingAssetIds: undefined,
@@ -270,6 +270,8 @@ function getGroupDimensions(groupId: string): { width: number; height: number } 
 function representativeOf(assetId: string): string | null {
     const sourceId = assetToSource.value.get(assetId)
     if (sourceId === undefined) return null
+    // Flat asset view: no containers, every asset speaks for itself.
+    if (props.groupBy === 'asset') return assetId
     if (sourceId === null) return assetId
     const groupId = groupOfSource.value.get(sourceId)
     if (groupId && !isGroupExpanded(groupId)) return groupId
@@ -281,6 +283,7 @@ function representativeOf(assetId: string): string | null {
 function topLevelOf(assetId: string): string | null {
     const sourceId = assetToSource.value.get(assetId)
     if (sourceId === undefined) return null
+    if (props.groupBy === 'asset') return assetId
     if (sourceId === null) return assetId
     return groupOfSource.value.get(sourceId) ?? sourceId
 }
@@ -313,23 +316,29 @@ const topLevelEdges = computed(() => {
 
 /** Layout top-level nodes (groups + ungrouped sources + standalone assets) using DAG layout. */
 const sourceLayout = computed(() => {
-    const layoutNodes = [
-        ...[...groups.value.keys()].map((groupId) => {
-            const dims = getGroupDimensions(groupId)
-            return { id: groupId, width: dims.width, height: dims.height }
-        }),
-        ...sourceEntries.value
-            .filter(entry => !groupOfSource.value.has(entry.source.id))
-            .map((entry) => {
-                const dims = getSourceDimensions(entry.source.id)
-                return { id: entry.source.id, width: dims.width, height: dims.height }
-            }),
-        ...standaloneEntries.value.map(entry => ({
+    const layoutNodes = props.groupBy === 'asset'
+        ? assetEntries.value.map(entry => ({
             id: entry.asset.id,
             width: ASSET_W,
             height: measuredHeights.value.get(entry.asset.id) ?? ASSET_H,
-        })),
-    ]
+        }))
+        : [
+            ...[...groups.value.keys()].map((groupId) => {
+                const dims = getGroupDimensions(groupId)
+                return { id: groupId, width: dims.width, height: dims.height }
+            }),
+            ...sourceEntries.value
+                .filter(entry => !groupOfSource.value.has(entry.source.id))
+                .map((entry) => {
+                    const dims = getSourceDimensions(entry.source.id)
+                    return { id: entry.source.id, width: dims.width, height: dims.height }
+                }),
+            ...standaloneEntries.value.map(entry => ({
+                id: entry.asset.id,
+                width: ASSET_W,
+                height: measuredHeights.value.get(entry.asset.id) ?? ASSET_H,
+            })),
+        ]
 
     return layoutDag(layoutNodes, topLevelEdges.value, {
         // gapX = within-layer, gapY = between-layer. In LR that means the
@@ -446,6 +455,21 @@ function pushSourceNodes(result: Node[], entry: GraphSourceEntry, pos: { x: numb
 const nodes = computed<Node[]>(() => {
     const result: Node[] = []
 
+    // Flat asset view: every asset is a top-level node, no containers.
+    if (props.groupBy === 'asset') {
+        for (const entry of assetEntries.value) {
+            const pos = sourceLayout.value.positions.get(entry.asset.id) ?? { x: 0, y: 0 }
+            result.push({
+                id: entry.asset.id,
+                type: 'asset',
+                position: { x: pos.x, y: pos.y },
+                data: { asset: entry.asset, assetDefn: entry.assetDefn, source: entry.source, status: entry.status },
+                connectable: true,
+            })
+        }
+        return applyFocus(result)
+    }
+
     // Group nodes first — VueFlow requires parents before their children.
     for (const [groupId, members] of groups.value) {
         const pos = sourceLayout.value.positions.get(groupId) ?? { x: 0, y: 0 }
@@ -497,17 +521,22 @@ const nodes = computed<Node[]>(() => {
         })
     }
 
-    // Selection focus. Set opacity explicitly on EVERY node each pass — only
-    // setting it on faded nodes leaves a stale 0.28 that VueFlow never clears,
-    // so nodes would stay dimmed after the selection moves.
+    return applyFocus(result)
+})
+
+/**
+ * Selection focus. Set opacity explicitly on EVERY node each pass — only
+ * setting it on faded nodes leaves a stale 0.28 that VueFlow never clears,
+ * so nodes would stay dimmed after the selection moves.
+ */
+function applyFocus(result: Node[]): Node[] {
     const f = focus.value
     for (const node of result) {
         const faded = f ? !f.nodeIds.has(node.id) : false
         node.style = { opacity: faded ? '0.28' : '1', transition: 'opacity 0.2s ease' }
     }
-
     return result
-})
+}
 
 /** Styled edges: faint gray by default; the selection's incident edges go blue, the rest dim. */
 const edges = computed<Edge[]>(() => {

--- a/packages/interloper-app/app/app/components/graph/Toolbar.vue
+++ b/packages/interloper-app/app/app/components/graph/Toolbar.vue
@@ -1,10 +1,16 @@
 <script setup lang="ts">
 /**
  * Graph canvas toolbar. Status filter pills on the left with the group-by
- * switch beside them; the `end` slot holds host actions (e.g. New Source),
+ * tabs beside them; the `end` slot holds host actions (e.g. New Source),
  * pushed to the right.
  */
-const groupBy = defineModel<GroupBy>('groupBy', { default: 'none' })
+const groupBy = defineModel<GroupBy>('groupBy', { default: 'type' })
+
+const GROUP_OPTIONS = [
+    { value: 'type', label: 'Type', icon: 'i-lucide-group' },
+    { value: 'source', label: 'Source', icon: 'i-lucide-plug' },
+    { value: 'asset', label: 'Asset', icon: 'i-lucide-box' },
+]
 const statusFilter = defineModel<StatusFilter>('statusFilter', { default: 'all' })
 
 const props = defineProps<{
@@ -28,6 +34,7 @@ const filterItems = computed(() => FILTERS
 <template>
     <div class="flex shrink-0 items-center gap-2 border-b border-default px-4 py-2">
         <!-- Status filter -->
+        <span class="text-xs text-muted">Status</span>
         <UTabs v-model="statusFilter"
                :items="filterItems"
                variant="pill"
@@ -40,11 +47,13 @@ const filterItems = computed(() => FILTERS
             </template>
         </UTabs>
 
-        <!-- Group by type toggle -->
-        <USwitch :model-value="groupBy === 'type'"
-                 label="Group by type"
-                 size="xs"
-                 @update:model-value="groupBy = $event ? 'type' : 'none'" />
+        <!-- Group by -->
+        <span class="text-xs text-muted">Group by</span>
+        <UTabs v-model="groupBy"
+               :items="GROUP_OPTIONS"
+               variant="pill"
+               size="xs"
+               :content="false" />
 
         <div class="ml-auto">
             <slot name="end" />

--- a/packages/interloper-app/app/app/pages/graph.vue
+++ b/packages/interloper-app/app/app/pages/graph.vue
@@ -17,7 +17,7 @@ const catalogStore = useCatalogStore()
 const toast = useToast()
 
 // Canvas view controls (toolbar-owned)
-const groupBy = ref<GroupBy>('none')
+const groupBy = ref<GroupBy>('type')
 const statusFilter = ref<StatusFilter>('all')
 
 const { sourceStatus } = useNodeStatus()
@@ -120,8 +120,7 @@ async function onDeleteDependency(payload: { upstreamAssetId: string; downstream
                       :counts="statusCounts">
             <template #end>
                 <UButton icon="i-lucide-plus"
-                         label="New Source"
-                         size="sm"
+                         label="New source"
                          @click="onCreateSource" />
             </template>
         </GraphToolbar>

--- a/packages/interloper-app/app/app/types/graph.ts
+++ b/packages/interloper-app/app/app/types/graph.ts
@@ -33,8 +33,12 @@ export function stateFromExecution(status: ExecutionStatus): GraphNodeState {
     return status
 }
 
-/** How top-level nodes are grouped on the canvas. */
-export type GroupBy = 'none' | 'type'
+/**
+ * Which hierarchy level forms the top-level nodes on the canvas:
+ * `type` nests sources under their catalog type, `source` shows sources
+ * (the pre-grouping default), `asset` flattens everything to bare assets.
+ */
+export type GroupBy = 'type' | 'source' | 'asset'
 
 /** Source health filter for the collection graph (derived states only). */
 export type StatusFilter = 'all' | 'healthy' | 'attention' | 'paused'


### PR DESCRIPTION
Builds on the graph grouping/redesign series (#198, #199, #201):

- **"Group by" tab switcher**: the toolbar switch becomes a labeled three-option pill tab group — **Type / Source / Asset** — and the status filter gets a matching "Status" label. `GroupBy` drops `'none'` in favour of `'source'` (the pre-grouping behavior; still the canvas default, so the run graph is unaffected).
- **New flat asset view**: `asset` mode renders every asset as a top-level node with no source/group containers — the complete asset-level dependency DAG with all edges visible. It reuses the ancestor-walk projection (short-circuited to the asset itself) and the shared layout, so it's a thin branch in `GraphCanvas`, not a parallel renderer. Asset clicks still resolve their owning source, so the detail panel keeps working.
- **Group by type is the collection default** — the graph opens grouped; orgs without duplicate source types see no difference (singleton types never form groups).
- **Toolbar "New source" button** now matches the /sources page (default size, same label casing).

By Digitl