### PR TITLE
fix(app): command palette shortcut, close-on-select, and full page coverage

### DIFF
--- a/packages/interloper-app/app/app/composables/commandPalette.ts
+++ b/packages/interloper-app/app/app/composables/commandPalette.ts
@@ -1,36 +1,41 @@
-import type { CommandPaletteGroup } from '@nuxt/ui'
-
-/** Capitalize and pluralize a kind string: "connection" → "Connections". */
-function kindLabel(kind: string): string {
-    return kind.charAt(0).toUpperCase() + kind.slice(1) + 's'
-}
-
-const RESOURCE_KIND_ICONS: Record<string, string> = {
-    connection: 'i-lucide-key-round',
-    config: 'i-lucide-settings',
-}
+import type { CommandPaletteGroup, CommandPaletteItem } from '@nuxt/ui'
 
 export function useCommandPalette() {
-    const catalogStore = useCatalogStore()
+    const userStore = useUserStore()
+    const sections = useNavSections()
     const open = ref(false)
 
+    defineShortcuts({
+        meta_k: {
+            usingInput: true,
+            handler: () => {
+                open.value = !open.value
+            },
+        },
+    })
+
     const groups = computed<CommandPaletteGroup[]>(() => {
-        const resourceItems = catalogStore.resourceKinds.map(kind => ({
-            label: kindLabel(kind),
-            icon: RESOURCE_KIND_ICONS[kind] ?? 'i-lucide-box',
-            to: `/resources/${kind}`,
-        }))
+        const close = () => {
+            open.value = false
+        }
+        const toItem = (page: NavPage): CommandPaletteItem => ({ ...page, onSelect: close })
+
+        const settingsItems: CommandPaletteItem[] = [
+            toItem({ label: 'Organization', icon: 'i-lucide-building-2', to: '/organization' }),
+        ]
+        if (userStore.isSuperAdmin)
+            settingsItems.push(toItem({ label: 'Platform admin', icon: 'i-lucide-shield', to: '/admin' }))
 
         return [
             {
                 id: 'pages',
                 label: 'Pages',
-                items: [
-                    { label: 'Sources', icon: 'i-lucide-plug', to: '/sources' },
-                    { label: 'Destinations', icon: 'i-lucide-database', to: '/destinations' },
-                    ...resourceItems,
-                    { label: 'Jobs', icon: 'i-lucide-calendar-clock', to: '/jobs' },
-                ],
+                items: sections.value.flatMap(section => section.pages.map(toItem)),
+            },
+            {
+                id: 'settings',
+                label: 'Settings',
+                items: settingsItems,
             },
         ]
     })

--- a/packages/interloper-app/app/app/composables/navigation.ts
+++ b/packages/interloper-app/app/app/composables/navigation.ts
@@ -1,0 +1,59 @@
+export interface NavPage {
+    label: string
+    icon: string
+    to: string
+}
+
+export interface NavSection {
+    label: string
+    pages: NavPage[]
+}
+
+/** Icons for resource kinds — fallback to generic box. */
+export const RESOURCE_KIND_ICONS: Record<string, string> = {
+    connection: 'i-lucide-key-round',
+    config: 'i-lucide-settings',
+}
+
+/** Capitalize and pluralize a kind string: "connection" → "Connections". */
+export function kindLabel(kind: string): string {
+    return kind.charAt(0).toUpperCase() + kind.slice(1) + 's'
+}
+
+/**
+ * Single source of truth for the app's main pages: both the sidebar nav and
+ * the command palette derive from it, so they can't drift apart.
+ */
+export function useNavSections() {
+    const catalogStore = useCatalogStore()
+
+    return computed<NavSection[]>(() => [
+        {
+            label: 'Overview',
+            pages: [
+                { label: 'Graph', icon: 'i-lucide-workflow', to: '/graph' },
+                { label: 'Collection', icon: 'i-lucide-library', to: '/collection' },
+            ],
+        },
+        {
+            label: 'Entities',
+            pages: [
+                { label: 'Sources', icon: 'i-lucide-plug', to: '/sources' },
+                { label: 'Destinations', icon: 'i-lucide-database', to: '/destinations' },
+                ...catalogStore.resourceKinds.map(kind => ({
+                    label: kindLabel(kind),
+                    icon: RESOURCE_KIND_ICONS[kind] ?? 'i-lucide-box',
+                    to: `/resources/${kind}`,
+                })),
+            ],
+        },
+        {
+            label: 'Scheduling',
+            pages: [
+                { label: 'Jobs', icon: 'i-lucide-calendar-clock', to: '/jobs' },
+                { label: 'Hooks', icon: 'i-carbon-lightning', to: '/hooks' },
+                { label: 'Executions', icon: 'i-lucide-activity', to: '/executions' },
+            ],
+        },
+    ])
+}

--- a/packages/interloper-app/app/app/layouts/default.vue
+++ b/packages/interloper-app/app/app/layouts/default.vue
@@ -3,7 +3,6 @@ import type { NavigationMenuItem } from '@nuxt/ui'
 
 const route = useRoute()
 
-const catalogStore = useCatalogStore()
 const userStore = useUserStore()
 const { open: commandPaletteOpen, groups: commandPaletteGroups } = useCommandPalette()
 const { open: agentOpen, width: agentWidth, dragging: agentDragging } = useAgentPanel()
@@ -17,95 +16,21 @@ interface PageHeaderMeta {
 }
 const pageHeader = computed(() => route.meta.pageHeader as PageHeaderMeta | undefined)
 
-/** Icons for resource kinds — fallback to generic box. */
-const RESOURCE_KIND_ICONS: Record<string, string> = {
-    connection: 'i-lucide-key-round',
-    config: 'i-lucide-settings',
-}
+const navSections = useNavSections()
 
-/** Capitalize and pluralize a kind string: "connection" → "Connections". */
-function kindLabel(kind: string): string {
-    return kind.charAt(0).toUpperCase() + kind.slice(1) + 's'
-}
-
-const items = computed<NavigationMenuItem[]>(() => {
-    const nav: NavigationMenuItem[] = [
-        {
-            label: 'Overview',
-            type: 'label',
-        },
-        {
-            label: 'Graph',
-            icon: 'i-lucide-workflow',
-            to: '/graph',
-            active: route.path === '/graph',
-        },
-        {
-            label: 'Collection',
-            icon: 'i-lucide-library',
-            to: '/collection',
-            active: route.path === '/collection',
-        },
-        {
-            label: 'Entities',
-            type: 'label',
-            class: 'mt-2',
-        },
-        {
-            label: 'Sources',
-            icon: 'i-lucide-plug',
-            to: '/sources',
-            active: route.path === '/sources',
-        },
-        {
-            label: 'Destinations',
-            icon: 'i-lucide-database',
-            to: '/destinations',
-            active: route.path === '/destinations',
-        },
-    ]
-
-    // Dynamic resource kinds from catalog
-    if (catalogStore.resourceKinds.length > 0) {
-        for (const kind of catalogStore.resourceKinds) {
-            nav.push({
-                label: kindLabel(kind),
-                icon: RESOURCE_KIND_ICONS[kind] ?? 'i-lucide-box',
-                to: `/resources/${kind}`,
-                active: route.path === `/resources/${kind}`,
-            })
-        }
-    }
-
-    // Scheduling — always visible
-    nav.push(
-        {
-            label: 'Scheduling',
-            type: 'label',
-            class: 'mt-2',
-        },
-        {
-            label: 'Jobs',
-            icon: 'i-lucide-calendar-clock',
-            to: '/jobs',
-            active: route.path === '/jobs',
-        },
-        {
-            label: 'Hooks',
-            icon: 'i-carbon-lightning',
-            to: '/hooks',
-            active: route.path === '/hooks',
-        },
-        {
-            label: 'Executions',
-            icon: 'i-lucide-activity',
-            to: '/executions',
-            active: route.path.startsWith('/executions'),
-        },
-    )
-
-    return nav
-})
+const items = computed<NavigationMenuItem[]>(() => navSections.value.flatMap((section, index) => [
+    {
+        label: section.label,
+        type: 'label' as const,
+        class: index > 0 ? 'mt-2' : undefined,
+    },
+    ...section.pages.map(page => ({
+        label: page.label,
+        icon: page.icon,
+        to: page.to,
+        active: route.path === page.to || route.path.startsWith(`${page.to}/`),
+    })),
+]))
 </script>
 
 <template>


### PR DESCRIPTION
## Problem

The sidebar search bar was half-wired:

- The button advertised **⌘K**, but no shortcut was registered anywhere — the hint was decorative.
- Selecting an item **navigated but never closed the modal**, leaving the palette stuck open over the new page.
- It only listed 4 pages (Sources, Destinations, Connections, Jobs) — Graph, Collection, Hooks, Executions, Organization, and Admin were unreachable from search.

## Fix

- Nav sections now live in a single `useNavSections()` composable; the sidebar menu and the command palette both derive from it, so the palette can never drift out of sync with the nav again.
- `defineShortcuts` registers `meta_k` (with `usingInput: true`, so it also fires from inside page search inputs) to toggle the palette.
- Every palette item closes the modal on select.
- Added a Settings group: Organization always, Platform admin when the user is a super-admin.

## Verified

Driven headlessly against a seeded dev instance: ⌘K opens and toggles the palette (including while an input is focused), all 10 pages are listed, selecting an item navigates **and** dismisses the modal, sidebar nav renders identically to before, no console errors. Lint + `nuxt typecheck` pass.

By Digitl