### PR TITLE
fix(app): remove dead Settings link from the user menu

### DIFF
--- a/packages/interloper-app/app/app/components/nav/User.vue
+++ b/packages/interloper-app/app/app/components/nav/User.vue
@@ -42,18 +42,11 @@ const items = computed<DropdownMenuItem[][]>(() => {
     }
 
     groups.push(
-        [
-            {
-                label: 'Settings',
-                icon: 'i-lucide-sliders-horizontal',
-                onSelect: () => navigateTo('/settings'),
-            },
-            {
-                label: colorMode.value === 'dark' ? 'Light Mode' : 'Dark Mode',
-                icon: colorMode.value === 'dark' ? 'i-lucide-sun' : 'i-lucide-moon',
-                onSelect: toggleColorMode,
-            },
-        ],
+        [{
+            label: colorMode.value === 'dark' ? 'Light Mode' : 'Dark Mode',
+            icon: colorMode.value === 'dark' ? 'i-lucide-sun' : 'i-lucide-moon',
+            onSelect: toggleColorMode,
+        }],
         [{
             label: 'Log out',
             icon: 'i-lucide-log-out',


### PR DESCRIPTION
## Problem

The user dropdown (NavUser) had a "Settings" item pointing at `/settings` — a page that has **never existed** in the repo's history (the link shipped in the initial scaffold commit `fa2a02a` and no `pages/settings.vue` was ever added, on any branch). Clicking it landed on a 404.

## Fix

Remove the item rather than build an empty page: the only user-level preference today (color mode) is already a toggle in the same menu, and org management has its own `/organization` page reachable from the org switcher (and the command palette as of #204). One-line revert if a real settings page ever materializes.

Lint + `nuxt typecheck` pass.

By Digitl