### PR TITLE
feat(app): entity search and actions in the command palette

### DIFF
--- a/packages/interloper-app/app/app/composables/commandPalette.ts
+++ b/packages/interloper-app/app/app/composables/commandPalette.ts
@@ -2,8 +2,24 @@ import type { CommandPaletteGroup, CommandPaletteItem } from '@nuxt/ui'
 
 export function useCommandPalette() {
     const userStore = useUserStore()
+    const componentsStore = useComponentsStore()
+    const catalogStore = useCatalogStore()
+    const colorMode = useColorMode()
+    const { open: agentOpen } = useAgentPanel()
     const sections = useNavSections()
+    const assetNames = useAssetDisplayName()
+    const assetIcons = useAssetIcon()
+
     const open = ref(false)
+    const searchTerm = ref('')
+    const loading = computed(() => componentsStore.loading)
+
+    // Refresh entity data on open so search results are current, not a stale snapshot.
+    watch(open, (isOpen) => {
+        if (!isOpen) return
+        searchTerm.value = ''
+        if (!componentsStore.loading) componentsStore.fetchAll()
+    })
 
     defineShortcuts({
         meta_k: {
@@ -20,6 +36,30 @@ export function useCommandPalette() {
         }
         const toItem = (page: NavPage): CommandPaletteItem => ({ ...page, onSelect: close })
 
+        const actionItems: CommandPaletteItem[] = [
+            toItem({ label: 'New source…', icon: 'i-lucide-plus', to: '/sources?new=1' }),
+            ...componentsStore.byKind('job').map(job =>
+                toItem({ label: `Run job: ${job.name ?? job.key}`, icon: 'i-lucide-play', to: `/jobs?run=${job.id}` })),
+            {
+                label: colorMode.value === 'dark' ? 'Switch to light mode' : 'Switch to dark mode',
+                icon: colorMode.value === 'dark' ? 'i-lucide-sun' : 'i-lucide-moon',
+                onSelect: () => {
+                    colorMode.preference = colorMode.value === 'dark' ? 'light' : 'dark'
+                    close()
+                },
+            },
+        ]
+        if (userStore.agentAvailable) {
+            actionItems.push({
+                label: agentOpen.value ? 'Close agent panel' : 'Open agent panel',
+                icon: 'i-lucide-sparkles',
+                onSelect: () => {
+                    agentOpen.value = !agentOpen.value
+                    close()
+                },
+            })
+        }
+
         const settingsItems: CommandPaletteItem[] = [
             toItem({ label: 'Organization', icon: 'i-lucide-building-2', to: '/organization' }),
         ]
@@ -27,18 +67,79 @@ export function useCommandPalette() {
             settingsItems.push(toItem({ label: 'Platform admin', icon: 'i-lucide-shield', to: '/admin' }))
 
         return [
-            {
-                id: 'pages',
-                label: 'Pages',
-                items: sections.value.flatMap(section => section.pages.map(toItem)),
-            },
-            {
-                id: 'settings',
-                label: 'Settings',
-                items: settingsItems,
-            },
+            { id: 'pages', label: 'Pages', items: sections.value.flatMap(section => section.pages.map(toItem)) },
+            // Entity groups only join in once the user types — the empty palette
+            // stays a compact quick-nav instead of a dump of the whole collection.
+            ...(searchTerm.value.trim() ? entityGroups(close) : []),
+            { id: 'actions', label: 'Actions', items: actionItems },
+            { id: 'settings', label: 'Settings', items: settingsItems },
         ]
     })
 
-    return { open, groups }
+    /** One group per component kind, built from the org's collection. Empty groups are dropped. */
+    function entityGroups(close: () => void): CommandPaletteGroup[] {
+        const sources = componentsStore.byKind('source')
+
+        const groups: CommandPaletteGroup[] = [
+            {
+                id: 'entity-sources',
+                label: 'Sources',
+                items: sources.map(source => ({
+                    label: source.name ?? source.key,
+                    suffix: catalogStore.getSourceDefinition(source.key)?.name,
+                    icon: componentIcon(source.key),
+                    to: '/sources',
+                    onSelect: close,
+                })),
+            },
+            {
+                id: 'entity-assets',
+                label: 'Assets',
+                items: sources.flatMap(source => source.children.map((asset) => {
+                    const names = assetNames.value.get(asset.id)
+                    return {
+                        label: names?.assetName ?? asset.name ?? asset.key,
+                        suffix: names?.sourceName,
+                        icon: assetIcons.value.get(asset.id) ?? 'i-lucide-box',
+                        to: `/graph?select=${asset.id}`,
+                        onSelect: close,
+                    }
+                })),
+            },
+            {
+                id: 'entity-destinations',
+                label: 'Destinations',
+                items: componentsStore.byKind('destination').map(destination => ({
+                    label: destination.name ?? destination.key,
+                    icon: componentIcon(destination.key),
+                    to: '/destinations',
+                    onSelect: close,
+                })),
+            },
+            ...catalogStore.resourceKinds.map(kind => ({
+                id: `entity-${kind}`,
+                label: kindLabel(kind),
+                items: componentsStore.byKind(kind).map(resource => ({
+                    label: resource.name ?? resource.key,
+                    icon: RESOURCE_KIND_ICONS[kind] ?? 'i-lucide-box',
+                    to: `/resources/${kind}`,
+                    onSelect: close,
+                })),
+            })),
+            {
+                id: 'entity-jobs',
+                label: 'Jobs',
+                items: componentsStore.byKind('job').map(job => ({
+                    label: job.name ?? job.key,
+                    icon: 'i-lucide-calendar-clock',
+                    to: '/jobs',
+                    onSelect: close,
+                })),
+            },
+        ]
+
+        return groups.filter(group => group.items && group.items.length > 0)
+    }
+
+    return { open, searchTerm, loading, groups }
 }

--- a/packages/interloper-app/app/app/layouts/default.vue
+++ b/packages/interloper-app/app/app/layouts/default.vue
@@ -4,7 +4,12 @@ import type { NavigationMenuItem } from '@nuxt/ui'
 const route = useRoute()
 
 const userStore = useUserStore()
-const { open: commandPaletteOpen, groups: commandPaletteGroups } = useCommandPalette()
+const {
+    open: commandPaletteOpen,
+    searchTerm: commandPaletteSearchTerm,
+    loading: commandPaletteLoading,
+    groups: commandPaletteGroups,
+} = useCommandPalette()
 const { open: agentOpen, width: agentWidth, dragging: agentDragging } = useAgentPanel()
 const appVersion = useRuntimeConfig().public.version
 
@@ -127,7 +132,9 @@ const items = computed<NavigationMenuItem[]>(() => navSections.value.flatMap((se
                 </UDashboardPanel>
                 <UModal v-model:open="commandPaletteOpen">
                     <template #content>
-                        <UCommandPalette :groups="commandPaletteGroups"
+                        <UCommandPalette v-model:search-term="commandPaletteSearchTerm"
+                                         :groups="commandPaletteGroups"
+                                         :loading="commandPaletteLoading"
                                          placeholder="Search..."
                                          close
                                          @update:open="commandPaletteOpen = $event" />

--- a/packages/interloper-app/app/app/pages/graph.vue
+++ b/packages/interloper-app/app/app/pages/graph.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { SplitterGroup, SplitterPanel, SplitterResizeHandle } from 'reka-ui'
 import type { ComponentRecord } from '~/types/component'
+import { qualifiedKey } from '~/types/catalog'
 
 definePageMeta({ title: 'Graph', fullBleed: true })
 
@@ -67,6 +68,21 @@ function onAssetClick(asset: ComponentRecord, assetDefn: AssetDefinition | undef
     panelOpen.value = true
     closing.value = false
 }
+
+// Deep link (command palette): /graph?select=<assetId> opens the asset panel
+// once the asset and its source land in the store.
+const route = useRoute()
+const router = useRouter()
+watchEffect(() => {
+    const id = route.query.select
+    if (typeof id !== 'string') return
+    const asset = componentsStore.byId(id)
+    if (!asset?.parent_id) return
+    const source = componentsStore.byId(asset.parent_id)
+    if (!source) return
+    onAssetClick(asset, catalogStore.getAssetDefinition(qualifiedKey(source.key, asset.key)), source)
+    router.replace({ query: { ...route.query, select: undefined } })
+})
 
 function onPanelClose() {
     closing.value = true

--- a/packages/interloper-app/app/app/pages/jobs.vue
+++ b/packages/interloper-app/app/app/pages/jobs.vue
@@ -44,6 +44,19 @@ function openRun(job: ComponentRecord) {
     runModalOpen.value = true
 }
 
+// Deep link (command palette): /jobs?run=<id> opens the run modal for that
+// job as soon as it lands in the store.
+const route = useRoute()
+const router = useRouter()
+watchEffect(() => {
+    const id = route.query.run
+    if (typeof id !== 'string') return
+    const job = componentsStore.byId(id)
+    if (!job || job.kind !== 'job') return
+    openRun(job)
+    router.replace({ query: { ...route.query, run: undefined } })
+})
+
 /** Onboarding cards shown in the empty state. */
 const SETUP_STEPS = [
     { to: '/sources', icon: 'i-lucide-plug', title: 'Step 1 · Connect a source', sub: 'Pull from Google Ads, Meta, Bing & more', link: 'Go to Sources' },

--- a/packages/interloper-app/app/app/pages/sources.vue
+++ b/packages/interloper-app/app/app/pages/sources.vue
@@ -35,6 +35,15 @@ const {
 componentsStore.fetchAll()
 componentsStore.fetchRelations()
 
+// Deep link (command palette): /sources?new=1 opens the create wizard.
+const route = useRoute()
+const router = useRouter()
+watchEffect(() => {
+    if (route.query.new === undefined) return
+    handleCreate()
+    router.replace({ query: { ...route.query, new: undefined } })
+})
+
 // ── Run now ─────────────────────────────────────────────────────
 
 const runsStore = useRunsStore()


### PR DESCRIPTION
Follow-up to #204: the palette becomes a real search bar and a command surface, not just a page-jumper.

## Entity search

Typing searches the org's collection, grouped by kind (fuzzy-matched on label + suffix):

- **Sources** (suffix: catalog type name) → `/sources`
- **Assets** (suffix: owning source) → `/graph?select=<id>` — the graph opens with that asset's panel
- **Destinations** → `/destinations`
- **Resource kinds** (connections, configs, …) → `/resources/<kind>`
- **Jobs** → `/jobs`

Entity groups only join once a search term is typed — the empty palette stays the compact quick-nav (Pages / Actions / Settings) instead of dumping the whole collection. Component data refetches on every open so results are never a stale snapshot, with the palette's loading state bound while it resolves.

## Actions

- **New source…** → `/sources?new=1` opens the create wizard
- **Run job: \<name\>** (one per job) → `/jobs?run=<id>` opens the regular run modal — partition date + explicit confirm, so nothing runs by accident
- **Switch to light/dark mode**
- **Open/close agent panel** (when the agent is available)

## Deep links

Each target page owns its query param via a `watchEffect` that waits for the target to land in the components store, acts, and strips the param (`/sources?new=1`, `/jobs?run=<id>`, `/graph?select=<id>`). They work from anywhere, not just the palette.

## Verified

Driven headlessly against a seeded dev instance: empty palette shows no entity dump; "demo" surfaces both sources, all assets (with source suffixes), and the job; selecting asset **B** lands on the graph with its panel open (schema, dependencies, destinations); "New source…" opens the wizard on the catalog picker; "Run job: Demo Daily" opens the run modal; the theme action flips `html.dark`. Palette closes on every selection. Lint + `nuxt typecheck` pass. (Two 500s observed on `partition-row-counts` are a pre-existing shared-dev-DB decryption issue, unrelated.)

By Digitl