### PR TITLE
feat(app): recent runs, keyword aliases, and org switching in the command palette

### DIFF
--- a/packages/interloper-app/app/app/components/nav/Organisation.vue
+++ b/packages/interloper-app/app/app/components/nav/Organisation.vue
@@ -18,12 +18,10 @@ async function loadUserOrgs() {
     orgsLoaded.value = true
 }
 
+const { switchToOrg } = useOrgSwitch()
+
 async function selectOrg(org: Organisation) {
-    // Pages bespoke to one org's resource (run/backfill details) are
-    // meaningless in the new org — leave for their list page first.
-    const target = route.meta.orgSwitchTarget
-    if (typeof target === 'string') await navigateTo(target)
-    await orgStore.switchOrg(org.id)
+    await switchToOrg(org)
     orgsLoaded.value = false
 }
 

--- a/packages/interloper-app/app/app/composables/commandPalette.ts
+++ b/packages/interloper-app/app/app/composables/commandPalette.ts
@@ -2,8 +2,24 @@ import type { CommandPaletteGroup, CommandPaletteItem } from '@nuxt/ui'
 
 export function useCommandPalette() {
     const userStore = useUserStore()
+    const componentsStore = useComponentsStore()
+    const catalogStore = useCatalogStore()
+    const colorMode = useColorMode()
+    const { open: agentOpen } = useAgentPanel()
     const sections = useNavSections()
+    const assetNames = useAssetDisplayName()
+    const assetIcons = useAssetIcon()
+
     const open = ref(false)
+    const searchTerm = ref('')
+    const loading = computed(() => componentsStore.loading)
+
+    // Refresh entity data on open so search results are current, not a stale snapshot.
+    watch(open, (isOpen) => {
+        if (!isOpen) return
+        searchTerm.value = ''
+        if (!componentsStore.loading) componentsStore.fetchAll()
+    })
 
     defineShortcuts({
         meta_k: {
@@ -20,6 +36,30 @@ export function useCommandPalette() {
         }
         const toItem = (page: NavPage): CommandPaletteItem => ({ ...page, onSelect: close })
 
+        const actionItems: CommandPaletteItem[] = [
+            toItem({ label: 'New source…', icon: 'i-lucide-plus', to: '/sources?new=1' }),
+            ...componentsStore.byKind('job').map(job =>
+                toItem({ label: `Run job: ${job.name ?? job.key}`, icon: 'i-lucide-play', to: `/jobs?run=${job.id}` })),
+            {
+                label: colorMode.value === 'dark' ? 'Switch to light mode' : 'Switch to dark mode',
+                icon: colorMode.value === 'dark' ? 'i-lucide-sun' : 'i-lucide-moon',
+                onSelect: () => {
+                    colorMode.preference = colorMode.value === 'dark' ? 'light' : 'dark'
+                    close()
+                },
+            },
+        ]
+        if (userStore.agentAvailable) {
+            actionItems.push({
+                label: agentOpen.value ? 'Close agent panel' : 'Open agent panel',
+                icon: 'i-lucide-sparkles',
+                onSelect: () => {
+                    agentOpen.value = !agentOpen.value
+                    close()
+                },
+            })
+        }
+
         const settingsItems: CommandPaletteItem[] = [
             toItem({ label: 'Organization', icon: 'i-lucide-building-2', to: '/organization' }),
         ]
@@ -27,18 +67,79 @@ export function useCommandPalette() {
             settingsItems.push(toItem({ label: 'Platform admin', icon: 'i-lucide-shield', to: '/admin' }))
 
         return [
-            {
-                id: 'pages',
-                label: 'Pages',
-                items: sections.value.flatMap(section => section.pages.map(toItem)),
-            },
-            {
-                id: 'settings',
-                label: 'Settings',
-                items: settingsItems,
-            },
+            { id: 'pages', label: 'Pages', items: sections.value.flatMap(section => section.pages.map(toItem)) },
+            // Entity groups only join in once the user types — the empty palette
+            // stays a compact quick-nav instead of a dump of the whole collection.
+            ...(searchTerm.value.trim() ? entityGroups(close) : []),
+            { id: 'actions', label: 'Actions', items: actionItems },
+            { id: 'settings', label: 'Settings', items: settingsItems },
         ]
     })
 
-    return { open, groups }
+    /** One group per component kind, built from the org's collection. Empty groups are dropped. */
+    function entityGroups(close: () => void): CommandPaletteGroup[] {
+        const sources = componentsStore.byKind('source')
+
+        const groups: CommandPaletteGroup[] = [
+            {
+                id: 'entity-sources',
+                label: 'Sources',
+                items: sources.map(source => ({
+                    label: source.name ?? source.key,
+                    suffix: catalogStore.getSourceDefinition(source.key)?.name,
+                    icon: componentIcon(source.key),
+                    to: '/sources',
+                    onSelect: close,
+                })),
+            },
+            {
+                id: 'entity-assets',
+                label: 'Assets',
+                items: sources.flatMap(source => source.children.map((asset) => {
+                    const names = assetNames.value.get(asset.id)
+                    return {
+                        label: names?.assetName ?? asset.name ?? asset.key,
+                        suffix: names?.sourceName,
+                        icon: assetIcons.value.get(asset.id) ?? 'i-lucide-box',
+                        to: `/graph?select=${asset.id}`,
+                        onSelect: close,
+                    }
+                })),
+            },
+            {
+                id: 'entity-destinations',
+                label: 'Destinations',
+                items: componentsStore.byKind('destination').map(destination => ({
+                    label: destination.name ?? destination.key,
+                    icon: componentIcon(destination.key),
+                    to: '/destinations',
+                    onSelect: close,
+                })),
+            },
+            ...catalogStore.resourceKinds.map(kind => ({
+                id: `entity-${kind}`,
+                label: kindLabel(kind),
+                items: componentsStore.byKind(kind).map(resource => ({
+                    label: resource.name ?? resource.key,
+                    icon: RESOURCE_KIND_ICONS[kind] ?? 'i-lucide-box',
+                    to: `/resources/${kind}`,
+                    onSelect: close,
+                })),
+            })),
+            {
+                id: 'entity-jobs',
+                label: 'Jobs',
+                items: componentsStore.byKind('job').map(job => ({
+                    label: job.name ?? job.key,
+                    icon: 'i-lucide-calendar-clock',
+                    to: '/jobs',
+                    onSelect: close,
+                })),
+            },
+        ]
+
+        return groups.filter(group => group.items && group.items.length > 0)
+    }
+
+    return { open, searchTerm, loading, groups }
 }

--- a/packages/interloper-app/app/app/composables/commandPalette.ts
+++ b/packages/interloper-app/app/app/composables/commandPalette.ts
@@ -1,11 +1,26 @@
 import type { CommandPaletteGroup, CommandPaletteItem } from '@nuxt/ui'
+import type { Run } from '~/types/run'
+import type { Organisation } from '~/types/organisation'
+import type { AdminOrganisation } from '~/types/admin'
+
+const RUN_STATUS_ICONS: Record<string, string> = {
+    success: 'i-lucide-circle-check',
+    failed: 'i-lucide-circle-x',
+    running: 'i-lucide-loader-circle',
+    dispatched: 'i-lucide-loader-circle',
+    canceled: 'i-lucide-circle-slash',
+}
 
 export function useCommandPalette() {
+    const { apiFetch } = useApi()
     const userStore = useUserStore()
     const componentsStore = useComponentsStore()
     const catalogStore = useCatalogStore()
+    const orgStore = useOrganisationStore()
+    const adminStore = useAdminStore()
     const colorMode = useColorMode()
     const { open: agentOpen } = useAgentPanel()
+    const { switchToOrg } = useOrgSwitch()
     const sections = useNavSections()
     const assetNames = useAssetDisplayName()
     const assetIcons = useAssetIcon()
@@ -14,11 +29,36 @@ export function useCommandPalette() {
     const searchTerm = ref('')
     const loading = computed(() => componentsStore.loading)
 
-    // Refresh entity data on open so search results are current, not a stale snapshot.
+    const recentRuns = ref<Run[]>([])
+    const userOrgs = ref<Organisation[]>([])
+    const adminOrgs = ref<AdminOrganisation[]>([])
+
+    /** component_id → display name, covering source-owned children too (targets can be assets). */
+    const runTargetNames = computed(() => {
+        const map = new Map<string, string>()
+        for (const component of componentsStore.components) {
+            map.set(component.id, component.name ?? component.key)
+            for (const child of component.children) map.set(child.id, child.name ?? child.key)
+        }
+        return map
+    })
+
+    // Refresh data on open so search results are current, not a stale snapshot.
     watch(open, (isOpen) => {
         if (!isOpen) return
         searchTerm.value = ''
         if (!componentsStore.loading) componentsStore.fetchAll()
+        apiFetch<Run[]>('/runs?limit=5').then((runs) => {
+            recentRuns.value = runs
+        }).catch(() => {})
+        orgStore.fetchOrganisations().then((orgs) => {
+            userOrgs.value = orgs
+        }).catch(() => {})
+        if (userStore.isSuperAdmin) {
+            adminStore.listOrganisations().then((orgs) => {
+                adminOrgs.value = orgs
+            }).catch(() => {})
+        }
     })
 
     defineShortcuts({
@@ -65,13 +105,49 @@ export function useCommandPalette() {
         ]
         if (userStore.isSuperAdmin)
             settingsItems.push(toItem({ label: 'Platform admin', icon: 'i-lucide-shield', to: '/admin' }))
+        for (const org of userOrgs.value) {
+            if (org.id === orgStore.organisation?.id) continue
+            settingsItems.push({
+                label: `Switch to ${org.name}`,
+                icon: 'i-lucide-building-2',
+                onSelect: () => {
+                    close()
+                    switchToOrg(org)
+                },
+            })
+        }
+
+        const runItems: CommandPaletteItem[] = recentRuns.value.map(run => ({
+            label: runTargetNames.value.get(run.component_id ?? '') ?? 'Deleted target',
+            suffix: `${statusLabel(run.status)} · ${formatDate(run.created_at)}`,
+            icon: RUN_STATUS_ICONS[run.status] ?? 'i-lucide-circle-dashed',
+            to: `/executions/runs/${run.id}`,
+            onSelect: close,
+        }))
+
+        const searching = Boolean(searchTerm.value.trim())
 
         return [
             { id: 'pages', label: 'Pages', items: sections.value.flatMap(section => section.pages.map(toItem)) },
             // Entity groups only join in once the user types — the empty palette
             // stays a compact quick-nav instead of a dump of the whole collection.
-            ...(searchTerm.value.trim() ? entityGroups(close) : []),
+            ...(searching ? entityGroups(close) : []),
+            ...(runItems.length ? [{ id: 'recent-runs', label: 'Recent runs', items: runItems }] : []),
             { id: 'actions', label: 'Actions', items: actionItems },
+            // Cross-org admin jumps are search-only: super admins may oversee many
+            // orgs, and browsing them belongs on /admin.
+            ...(searching && adminOrgs.value.length
+                ? [{
+                    id: 'admin-organisations',
+                    label: 'Administration',
+                    items: adminOrgs.value.map(org => ({
+                        label: `Admin: ${org.name}`,
+                        icon: 'i-lucide-shield',
+                        to: `/admin/organisations/${org.id}`,
+                        onSelect: close,
+                    })),
+                }]
+                : []),
             { id: 'settings', label: 'Settings', items: settingsItems },
         ]
     })

--- a/packages/interloper-app/app/app/composables/navigation.ts
+++ b/packages/interloper-app/app/app/composables/navigation.ts
@@ -2,6 +2,8 @@ export interface NavPage {
     label: string
     icon: string
     to: string
+    /** Aliases the command palette also matches on (e.g. "DAG" → Graph). Not rendered. */
+    keywords?: string[]
 }
 
 export interface NavSection {
@@ -31,15 +33,15 @@ export function useNavSections() {
         {
             label: 'Overview',
             pages: [
-                { label: 'Graph', icon: 'i-lucide-workflow', to: '/graph' },
-                { label: 'Collection', icon: 'i-lucide-library', to: '/collection' },
+                { label: 'Graph', icon: 'i-lucide-workflow', to: '/graph', keywords: ['dag', 'pipeline', 'lineage'] },
+                { label: 'Collection', icon: 'i-lucide-library', to: '/collection', keywords: ['catalog', 'library'] },
             ],
         },
         {
             label: 'Entities',
             pages: [
-                { label: 'Sources', icon: 'i-lucide-plug', to: '/sources' },
-                { label: 'Destinations', icon: 'i-lucide-database', to: '/destinations' },
+                { label: 'Sources', icon: 'i-lucide-plug', to: '/sources', keywords: ['connectors', 'integrations'] },
+                { label: 'Destinations', icon: 'i-lucide-database', to: '/destinations', keywords: ['warehouse', 'export'] },
                 ...catalogStore.resourceKinds.map(kind => ({
                     label: kindLabel(kind),
                     icon: RESOURCE_KIND_ICONS[kind] ?? 'i-lucide-box',
@@ -50,9 +52,9 @@ export function useNavSections() {
         {
             label: 'Scheduling',
             pages: [
-                { label: 'Jobs', icon: 'i-lucide-calendar-clock', to: '/jobs' },
-                { label: 'Hooks', icon: 'i-carbon-lightning', to: '/hooks' },
-                { label: 'Executions', icon: 'i-lucide-activity', to: '/executions' },
+                { label: 'Jobs', icon: 'i-lucide-calendar-clock', to: '/jobs', keywords: ['cron', 'schedule'] },
+                { label: 'Hooks', icon: 'i-carbon-lightning', to: '/hooks', keywords: ['triggers', 'automation'] },
+                { label: 'Executions', icon: 'i-lucide-activity', to: '/executions', keywords: ['runs', 'backfills', 'history'] },
             ],
         },
     ])

--- a/packages/interloper-app/app/app/composables/orgScope.ts
+++ b/packages/interloper-app/app/app/composables/orgScope.ts
@@ -1,3 +1,21 @@
+import type { Organisation } from '~/types/organisation'
+
+/** Switch the active organisation, shared by the nav switcher and the command palette. */
+export function useOrgSwitch() {
+    const route = useRoute()
+    const orgStore = useOrganisationStore()
+
+    async function switchToOrg(org: Organisation) {
+        // Pages bespoke to one org's resource (run/backfill details) are
+        // meaningless in the new org — leave for their list page first.
+        const target = route.meta.orgSwitchTarget
+        if (typeof target === 'string') await navigateTo(target)
+        await orgStore.switchOrg(org.id)
+    }
+
+    return { switchToOrg }
+}
+
 /**
  * Refetch an org-scoped store whenever the active organisation changes.
  *

--- a/packages/interloper-app/app/app/layouts/default.vue
+++ b/packages/interloper-app/app/app/layouts/default.vue
@@ -4,7 +4,12 @@ import type { NavigationMenuItem } from '@nuxt/ui'
 const route = useRoute()
 
 const userStore = useUserStore()
-const { open: commandPaletteOpen, groups: commandPaletteGroups } = useCommandPalette()
+const {
+    open: commandPaletteOpen,
+    searchTerm: commandPaletteSearchTerm,
+    loading: commandPaletteLoading,
+    groups: commandPaletteGroups,
+} = useCommandPalette()
 const { open: agentOpen, width: agentWidth, dragging: agentDragging } = useAgentPanel()
 const appVersion = useRuntimeConfig().public.version
 
@@ -127,7 +132,9 @@ const items = computed<NavigationMenuItem[]>(() => navSections.value.flatMap((se
                 </UDashboardPanel>
                 <UModal v-model:open="commandPaletteOpen">
                     <template #content>
-                        <UCommandPalette :groups="commandPaletteGroups"
+                        <UCommandPalette v-model:search-term="commandPaletteSearchTerm"
+                                         :groups="commandPaletteGroups"
+                                         :loading="commandPaletteLoading"
                                          placeholder="Search..."
                                          close
                                          @update:open="commandPaletteOpen = $event" />

--- a/packages/interloper-app/app/app/layouts/default.vue
+++ b/packages/interloper-app/app/app/layouts/default.vue
@@ -135,6 +135,7 @@ const items = computed<NavigationMenuItem[]>(() => navSections.value.flatMap((se
                         <UCommandPalette v-model:search-term="commandPaletteSearchTerm"
                                          :groups="commandPaletteGroups"
                                          :loading="commandPaletteLoading"
+                                         :fuse="{ fuseOptions: { keys: ['label', 'suffix', 'keywords'] } }"
                                          placeholder="Search..."
                                          close
                                          @update:open="commandPaletteOpen = $event" />

--- a/packages/interloper-app/app/app/pages/graph.vue
+++ b/packages/interloper-app/app/app/pages/graph.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { SplitterGroup, SplitterPanel, SplitterResizeHandle } from 'reka-ui'
 import type { ComponentRecord } from '~/types/component'
+import { qualifiedKey } from '~/types/catalog'
 
 definePageMeta({ title: 'Graph', fullBleed: true })
 
@@ -67,6 +68,21 @@ function onAssetClick(asset: ComponentRecord, assetDefn: AssetDefinition | undef
     panelOpen.value = true
     closing.value = false
 }
+
+// Deep link (command palette): /graph?select=<assetId> opens the asset panel
+// once the asset and its source land in the store.
+const route = useRoute()
+const router = useRouter()
+watchEffect(() => {
+    const id = route.query.select
+    if (typeof id !== 'string') return
+    const asset = componentsStore.byId(id)
+    if (!asset?.parent_id) return
+    const source = componentsStore.byId(asset.parent_id)
+    if (!source) return
+    onAssetClick(asset, catalogStore.getAssetDefinition(qualifiedKey(source.key, asset.key)), source)
+    router.replace({ query: { ...route.query, select: undefined } })
+})
 
 function onPanelClose() {
     closing.value = true

--- a/packages/interloper-app/app/app/pages/jobs.vue
+++ b/packages/interloper-app/app/app/pages/jobs.vue
@@ -44,6 +44,19 @@ function openRun(job: ComponentRecord) {
     runModalOpen.value = true
 }
 
+// Deep link (command palette): /jobs?run=<id> opens the run modal for that
+// job as soon as it lands in the store.
+const route = useRoute()
+const router = useRouter()
+watchEffect(() => {
+    const id = route.query.run
+    if (typeof id !== 'string') return
+    const job = componentsStore.byId(id)
+    if (!job || job.kind !== 'job') return
+    openRun(job)
+    router.replace({ query: { ...route.query, run: undefined } })
+})
+
 /** Onboarding cards shown in the empty state. */
 const SETUP_STEPS = [
     { to: '/sources', icon: 'i-lucide-plug', title: 'Step 1 · Connect a source', sub: 'Pull from Google Ads, Meta, Bing & more', link: 'Go to Sources' },

--- a/packages/interloper-app/app/app/pages/sources.vue
+++ b/packages/interloper-app/app/app/pages/sources.vue
@@ -35,6 +35,15 @@ const {
 componentsStore.fetchAll()
 componentsStore.fetchRelations()
 
+// Deep link (command palette): /sources?new=1 opens the create wizard.
+const route = useRoute()
+const router = useRouter()
+watchEffect(() => {
+    if (route.query.new === undefined) return
+    handleCreate()
+    router.replace({ query: { ...route.query, new: undefined } })
+})
+
 // ── Run now ─────────────────────────────────────────────────────
 
 const runsStore = useRunsStore()


### PR DESCRIPTION
Stacked on #206 (base branch: `feat/command-palette-search` — merge that first; this auto-retargets to `main` when its branch is deleted).

## Recent runs

A "Recent runs" group shows the last 5 runs — status icon, target name, and a fuse-searchable `Status · date` suffix (typing "failed" surfaces failed runs) — deep-linking to `/executions/runs/<id>`. Fetched fresh on every palette open; target names resolve through the components store including source-owned assets, mirroring RunsTable.

## Keyword aliases

`NavPage` gains an optional `keywords` list wired into the palette's fuse keys: "dag"/"pipeline"/"lineage" → Graph, "cron"/"schedule" → Jobs, "runs"/"backfills"/"history" → Executions, "catalog" → Collection, "connectors" → Sources, "warehouse" → Destinations, "triggers" → Hooks.

## Org switching

- "Switch to \<org\>" items in the Settings group for every org the user belongs to besides the current one. The switch logic (including the leave-bespoke-page-first redirect) moved from `NavOrganisation` into a shared `useOrgSwitch()` composable, so the nav switcher and the palette can't drift.
- Super admins get search-only "Admin: \<org\>" jumps to `/admin/organisations/<id>` — search-only because admins may oversee many orgs and browsing belongs on `/admin`.

## Verified

Headless against the seeded dev instance: empty palette shows the Recent runs group ("Demo Daily — Failed · 14 Jul"); "dag"/"cron"/"runs" each resolve to exactly the right page; "admin" surfaces "Admin: Dev Org"; selecting the run lands on its detail page with the palette closed; zero console errors. Lint + `nuxt typecheck` pass. The actual org *switch* couldn't be exercised live (the dev profile belongs to a single org, and creating a throwaway org isn't cleanly deletable), but it goes through the exact code path `NavOrganisation` already uses.

By Digitl