### PR TITLE
feat(app): recent runs, keyword aliases, and org switching in the command palette

### DIFF
--- a/packages/interloper-app/app/app/components/nav/Organisation.vue
+++ b/packages/interloper-app/app/app/components/nav/Organisation.vue
@@ -18,12 +18,10 @@ async function loadUserOrgs() {
     orgsLoaded.value = true
 }
 
+const { switchToOrg } = useOrgSwitch()
+
 async function selectOrg(org: Organisation) {
-    // Pages bespoke to one org's resource (run/backfill details) are
-    // meaningless in the new org — leave for their list page first.
-    const target = route.meta.orgSwitchTarget
-    if (typeof target === 'string') await navigateTo(target)
-    await orgStore.switchOrg(org.id)
+    await switchToOrg(org)
     orgsLoaded.value = false
 }
 

--- a/packages/interloper-app/app/app/composables/commandPalette.ts
+++ b/packages/interloper-app/app/app/composables/commandPalette.ts
@@ -1,11 +1,26 @@
 import type { CommandPaletteGroup, CommandPaletteItem } from '@nuxt/ui'
+import type { Run } from '~/types/run'
+import type { Organisation } from '~/types/organisation'
+import type { AdminOrganisation } from '~/types/admin'
+
+const RUN_STATUS_ICONS: Record<string, string> = {
+    success: 'i-lucide-circle-check',
+    failed: 'i-lucide-circle-x',
+    running: 'i-lucide-loader-circle',
+    dispatched: 'i-lucide-loader-circle',
+    canceled: 'i-lucide-circle-slash',
+}
 
 export function useCommandPalette() {
+    const { apiFetch } = useApi()
     const userStore = useUserStore()
     const componentsStore = useComponentsStore()
     const catalogStore = useCatalogStore()
+    const orgStore = useOrganisationStore()
+    const adminStore = useAdminStore()
     const colorMode = useColorMode()
     const { open: agentOpen } = useAgentPanel()
+    const { switchToOrg } = useOrgSwitch()
     const sections = useNavSections()
     const assetNames = useAssetDisplayName()
     const assetIcons = useAssetIcon()
@@ -14,11 +29,36 @@ export function useCommandPalette() {
     const searchTerm = ref('')
     const loading = computed(() => componentsStore.loading)
 
-    // Refresh entity data on open so search results are current, not a stale snapshot.
+    const recentRuns = ref<Run[]>([])
+    const userOrgs = ref<Organisation[]>([])
+    const adminOrgs = ref<AdminOrganisation[]>([])
+
+    /** component_id → display name, covering source-owned children too (targets can be assets). */
+    const runTargetNames = computed(() => {
+        const map = new Map<string, string>()
+        for (const component of componentsStore.components) {
+            map.set(component.id, component.name ?? component.key)
+            for (const child of component.children) map.set(child.id, child.name ?? child.key)
+        }
+        return map
+    })
+
+    // Refresh data on open so search results are current, not a stale snapshot.
     watch(open, (isOpen) => {
         if (!isOpen) return
         searchTerm.value = ''
         if (!componentsStore.loading) componentsStore.fetchAll()
+        apiFetch<Run[]>('/runs?limit=5').then((runs) => {
+            recentRuns.value = runs
+        }).catch(() => {})
+        orgStore.fetchOrganisations().then((orgs) => {
+            userOrgs.value = orgs
+        }).catch(() => {})
+        if (userStore.isSuperAdmin) {
+            adminStore.listOrganisations().then((orgs) => {
+                adminOrgs.value = orgs
+            }).catch(() => {})
+        }
     })
 
     defineShortcuts({
@@ -65,13 +105,49 @@ export function useCommandPalette() {
         ]
         if (userStore.isSuperAdmin)
             settingsItems.push(toItem({ label: 'Platform admin', icon: 'i-lucide-shield', to: '/admin' }))
+        for (const org of userOrgs.value) {
+            if (org.id === orgStore.organisation?.id) continue
+            settingsItems.push({
+                label: `Switch to ${org.name}`,
+                icon: 'i-lucide-building-2',
+                onSelect: () => {
+                    close()
+                    switchToOrg(org)
+                },
+            })
+        }
+
+        const runItems: CommandPaletteItem[] = recentRuns.value.map(run => ({
+            label: runTargetNames.value.get(run.component_id ?? '') ?? 'Deleted target',
+            suffix: `${statusLabel(run.status)} · ${formatDate(run.created_at)}`,
+            icon: RUN_STATUS_ICONS[run.status] ?? 'i-lucide-circle-dashed',
+            to: `/executions/runs/${run.id}`,
+            onSelect: close,
+        }))
+
+        const searching = Boolean(searchTerm.value.trim())
 
         return [
             { id: 'pages', label: 'Pages', items: sections.value.flatMap(section => section.pages.map(toItem)) },
             // Entity groups only join in once the user types — the empty palette
             // stays a compact quick-nav instead of a dump of the whole collection.
-            ...(searchTerm.value.trim() ? entityGroups(close) : []),
+            ...(searching ? entityGroups(close) : []),
+            ...(runItems.length ? [{ id: 'recent-runs', label: 'Recent runs', items: runItems }] : []),
             { id: 'actions', label: 'Actions', items: actionItems },
+            // Cross-org admin jumps are search-only: super admins may oversee many
+            // orgs, and browsing them belongs on /admin.
+            ...(searching && adminOrgs.value.length
+                ? [{
+                    id: 'admin-organisations',
+                    label: 'Administration',
+                    items: adminOrgs.value.map(org => ({
+                        label: `Admin: ${org.name}`,
+                        icon: 'i-lucide-shield',
+                        to: `/admin/organisations/${org.id}`,
+                        onSelect: close,
+                    })),
+                }]
+                : []),
             { id: 'settings', label: 'Settings', items: settingsItems },
         ]
     })

--- a/packages/interloper-app/app/app/composables/navigation.ts
+++ b/packages/interloper-app/app/app/composables/navigation.ts
@@ -2,6 +2,8 @@ export interface NavPage {
     label: string
     icon: string
     to: string
+    /** Aliases the command palette also matches on (e.g. "DAG" → Graph). Not rendered. */
+    keywords?: string[]
 }
 
 export interface NavSection {
@@ -31,15 +33,15 @@ export function useNavSections() {
         {
             label: 'Overview',
             pages: [
-                { label: 'Graph', icon: 'i-lucide-workflow', to: '/graph' },
-                { label: 'Collection', icon: 'i-lucide-library', to: '/collection' },
+                { label: 'Graph', icon: 'i-lucide-workflow', to: '/graph', keywords: ['dag', 'pipeline', 'lineage'] },
+                { label: 'Collection', icon: 'i-lucide-library', to: '/collection', keywords: ['catalog', 'library'] },
             ],
         },
         {
             label: 'Entities',
             pages: [
-                { label: 'Sources', icon: 'i-lucide-plug', to: '/sources' },
-                { label: 'Destinations', icon: 'i-lucide-database', to: '/destinations' },
+                { label: 'Sources', icon: 'i-lucide-plug', to: '/sources', keywords: ['connectors', 'integrations'] },
+                { label: 'Destinations', icon: 'i-lucide-database', to: '/destinations', keywords: ['warehouse', 'export'] },
                 ...catalogStore.resourceKinds.map(kind => ({
                     label: kindLabel(kind),
                     icon: RESOURCE_KIND_ICONS[kind] ?? 'i-lucide-box',
@@ -50,9 +52,9 @@ export function useNavSections() {
         {
             label: 'Scheduling',
             pages: [
-                { label: 'Jobs', icon: 'i-lucide-calendar-clock', to: '/jobs' },
-                { label: 'Hooks', icon: 'i-carbon-lightning', to: '/hooks' },
-                { label: 'Executions', icon: 'i-lucide-activity', to: '/executions' },
+                { label: 'Jobs', icon: 'i-lucide-calendar-clock', to: '/jobs', keywords: ['cron', 'schedule'] },
+                { label: 'Hooks', icon: 'i-carbon-lightning', to: '/hooks', keywords: ['triggers', 'automation'] },
+                { label: 'Executions', icon: 'i-lucide-activity', to: '/executions', keywords: ['runs', 'backfills', 'history'] },
             ],
         },
     ])

--- a/packages/interloper-app/app/app/composables/orgScope.ts
+++ b/packages/interloper-app/app/app/composables/orgScope.ts
@@ -1,3 +1,21 @@
+import type { Organisation } from '~/types/organisation'
+
+/** Switch the active organisation, shared by the nav switcher and the command palette. */
+export function useOrgSwitch() {
+    const route = useRoute()
+    const orgStore = useOrganisationStore()
+
+    async function switchToOrg(org: Organisation) {
+        // Pages bespoke to one org's resource (run/backfill details) are
+        // meaningless in the new org — leave for their list page first.
+        const target = route.meta.orgSwitchTarget
+        if (typeof target === 'string') await navigateTo(target)
+        await orgStore.switchOrg(org.id)
+    }
+
+    return { switchToOrg }
+}
+
 /**
  * Refetch an org-scoped store whenever the active organisation changes.
  *

--- a/packages/interloper-app/app/app/layouts/default.vue
+++ b/packages/interloper-app/app/app/layouts/default.vue
@@ -135,6 +135,7 @@ const items = computed<NavigationMenuItem[]>(() => navSections.value.flatMap((se
                         <UCommandPalette v-model:search-term="commandPaletteSearchTerm"
                                          :groups="commandPaletteGroups"
                                          :loading="commandPaletteLoading"
+                                         :fuse="{ fuseOptions: { keys: ['label', 'suffix', 'keywords'] } }"
                                          placeholder="Search..."
                                          close
                                          @update:open="commandPaletteOpen = $event" />


### PR DESCRIPTION
Replaces #207 (same single commit, rebased onto main after #206's rebase-merge — the original branch couldn't be force-pushed from this session).

## Recent runs

A "Recent runs" group shows the last 5 runs — status icon, target name, and a fuse-searchable `Status · date` suffix (typing "failed" surfaces failed runs) — deep-linking to `/executions/runs/<id>`. Fetched fresh on every palette open; target names resolve through the components store including source-owned assets, mirroring RunsTable.

## Keyword aliases

`NavPage` gains an optional `keywords` list wired into the palette's fuse keys: "dag"/"pipeline"/"lineage" → Graph, "cron"/"schedule" → Jobs, "runs"/"backfills"/"history" → Executions, "catalog" → Collection, "connectors" → Sources, "warehouse" → Destinations, "triggers" → Hooks.

## Org switching

- "Switch to \<org\>" items in the Settings group for every org the user belongs to besides the current one. The switch logic (including the leave-bespoke-page-first redirect) moved from `NavOrganisation` into a shared `useOrgSwitch()` composable, so the nav switcher and the palette can't drift.
- Super admins get search-only "Admin: \<org\>" jumps to `/admin/organisations/<id>` — search-only because admins may oversee many orgs and browsing belongs on `/admin`.

## Verified

Headless against the seeded dev instance: empty palette shows the Recent runs group ("Demo Daily — Failed · 14 Jul"); "dag"/"cron"/"runs" each resolve to exactly the right page; "admin" surfaces "Admin: Dev Org"; selecting the run lands on its detail page with the palette closed; zero console errors. Lint + `nuxt typecheck` pass. The actual org *switch* couldn't be exercised live (the dev profile belongs to a single org, and creating a throwaway org isn't cleanly deletable), but it goes through the exact code path `NavOrganisation` already uses.

By Digitl