### PR TITLE
feat(app): surface asset warnings in the asset panel and refresh its layout

### DIFF
--- a/packages/interloper-app/app/app/components/graph/AssetPanel.vue
+++ b/packages/interloper-app/app/app/components/graph/AssetPanel.vue
@@ -20,9 +20,15 @@ const componentsStore = useComponentsStore()
 const toast = useToast()
 const { apiFetch } = useApi()
 const { statusBadge } = useDrift()
+const { getWarnings } = useAssetWarnings()
 const sourceDefn = computed(() => catalogStore.getSourceDefinition(props.source.key))
 
 const driftBadge = computed(() => statusBadge(props.asset.status))
+
+/** Same warnings as the graph node badge; drift supersedes them for missing assets. */
+const warnings = computed(() =>
+    props.asset.status === 'missing' ? [] : getWarnings(props.asset.id, props.asset.key),
+)
 
 const icon = computed(() => props.assetDefn ? componentIcon(props.assetDefn.key) : 'i-lucide-box')
 const sourceIcon = computed(() => componentIcon(props.source.key))
@@ -83,8 +89,8 @@ const destinations = computed(() => {
             const defn = catalogStore.catalog[dest.key]
             return {
                 id: dest.id,
-                key: dest.key,
                 label: dest.name ?? defn?.name ?? dest.key,
+                typeName: defn?.name ?? dest.key,
                 icon: componentIcon(dest.key, 'i-lucide-hard-drive'),
             }
         })
@@ -230,10 +236,9 @@ const dependencyRows = computed(() => {
         const { sourceKey } = parseQualifiedKey(qk)
         return {
             param,
-            qk,
             name: catalogStore.getAssetDefinition(qk)?.name ?? qk,
+            sourceName: (sourceKey && catalogStore.getSourceDefinition(sourceKey)?.name) || sourceKey || qk,
             icon: componentIcon(sourceKey || qk),
-            sourceKey,
         }
     })
 })
@@ -258,7 +263,7 @@ const dependencyRows = computed(() => {
                 </div>
                 <UButton class="shrink-0 ml-auto"
                          icon="i-lucide-play"
-                         label="Run now"
+                         label="Materialize"
                          color="neutral"
                          variant="outline"
                          size="xs"
@@ -271,61 +276,49 @@ const dependencyRows = computed(() => {
                          size="xs"
                          @click="emit('close')" />
             </div>
+
+            <div v-if="assetDefn?.tags?.length"
+                 class="mt-3 flex flex-wrap gap-1">
+                <UBadge v-for="tag in assetDefn.tags"
+                        :key="tag"
+                        :color="tagColor(tag)"
+                        variant="subtle"
+                        size="sm"
+                        :label="tag" />
+            </div>
+
+            <!-- Warnings — same set as the graph node badge. -->
+            <UAlert v-if="warnings.length"
+                    color="warning"
+                    icon="i-lucide-triangle-alert"
+                    variant="subtle"
+                    class="mt-3"
+                    :title="warnings.length === 1 ? 'Warning' : `${warnings.length} warnings`">
+                <template #description>
+                    <ul class="flex flex-col gap-1"
+                        :class="warnings.length > 1 && 'list-disc pl-4'">
+                        <li v-for="(w, i) in warnings"
+                            :key="i">
+                            {{ w.message }}
+                        </li>
+                    </ul>
+                </template>
+            </UAlert>
         </div>
 
         <div class="flex-1 min-h-0 border-l border-t border-default overflow-auto">
-            <!-- Drift notice — this asset no longer resolves against the catalog. -->
-            <UAlert v-if="driftBadge"
-                    :color="driftBadge.color"
-                    :icon="driftBadge.icon"
-                    variant="subtle"
-                    class="m-5 mb-0"
-                    :title="driftBadge.label"
-                    :description="asset.status === 'missing'
-                        ? 'Its catalog key was renamed or removed in code. It can\'t materialize — remove the source (or edit it to drop this asset), or restore the catalog entry.'
-                        : 'This component is not enabled in the current deployment.'" />
-
-            <!-- Materialization -->
-            <UCollapsible default-open
-                          class="border-b border-default">
-                <button class="flex items-center gap-2 w-full px-5 py-4.5 group cursor-pointer">
-                    <UIcon name="i-lucide-chevron-right"
-                           class="size-3.5 shrink-0 text-dimmed group-data-[state=open]:rotate-90 transition-transform duration-200" />
-                    <span class="text-xs font-semibold text-muted uppercase tracking-wide">Materialization</span>
-                </button>
-
-                <template #content>
-                    <!-- pt-px throughout: card rings render 1px outside the box and the
-                         collapsible content is overflow-hidden, which clips them without it. -->
-                    <div class="px-5 pt-px pb-4 flex flex-col gap-2">
-                        <!-- Latest materialization -->
-                        <UCard :ui="{ body: 'flex items-center gap-4 !p-4' }">
-                            <UIcon :name="materialization.icon"
-                                   class="size-10 shrink-0"
-                                   :class="[materialization.color, materialization.spin && 'animate-spin']" />
-                            <div class="min-w-0 flex-1">
-                                <div class="text-sm font-medium text-highlighted">
-                                    Latest materialization: <span :class="materialization.color">{{ materialization.label }}</span>
-                                </div>
-                                <div class="truncate text-xs text-muted">{{ materializationMeta }}</div>
-                            </div>
-                        </UCard>
-
-                        <!-- History heatmap (max last 7 runs) -->
-                        <UCard v-if="history.length"
-                               :ui="{ body: '!p-4' }">
-                            <div class="mb-2.5 text-xs font-medium text-muted">Materialization history</div>
-                            <div class="flex gap-1.5">
-                                <div v-for="run in history"
-                                     :key="run.id"
-                                     class="size-7 rounded-md"
-                                     :style="{ backgroundColor: heatColor(run.status) }"
-                                     :title="historyTooltip(run)" />
-                            </div>
-                        </UCard>
-                    </div>
-                </template>
-            </UCollapsible>
+            <!-- Drift notice — this asset no longer resolves against the catalog.
+                 UAlert is w-full, so pad a wrapper rather than margin the alert. -->
+            <div v-if="driftBadge"
+                 class="px-5 pt-5">
+                <UAlert :color="driftBadge.color"
+                        :icon="driftBadge.icon"
+                        variant="subtle"
+                        :title="driftBadge.label"
+                        :description="asset.status === 'missing'
+                            ? 'Its catalog key was renamed or removed in code. It can\'t materialize — remove the source (or edit it to drop this asset), or restore the catalog entry.'
+                            : 'This component is not enabled in the current deployment.'" />
+            </div>
 
             <!-- Description -->
             <UCollapsible default-open
@@ -337,7 +330,7 @@ const dependencyRows = computed(() => {
                 </button>
 
                 <template #content>
-                    <div class="px-5 pt-px pb-4">
+                    <div class="px-5 pb-4">
                         <p v-if="assetDefn?.description"
                            class="text-sm">
                             {{ assetDefn.description }}
@@ -350,84 +343,41 @@ const dependencyRows = computed(() => {
                 </template>
             </UCollapsible>
 
-            <!-- Schema -->
-            <UCollapsible v-if="schemaFields.length"
-                          default-open
+            <!-- Materialization -->
+            <UCollapsible default-open
                           class="border-b border-default">
                 <button class="flex items-center gap-2 w-full px-5 py-4.5 group cursor-pointer">
                     <UIcon name="i-lucide-chevron-right"
                            class="size-3.5 shrink-0 text-dimmed group-data-[state=open]:rotate-90 transition-transform duration-200" />
-                    <span class="text-xs font-semibold text-muted uppercase tracking-wide">Schema</span>
-                    <UBadge color="neutral"
-                            variant="subtle"
-                            class="ml-auto">
-                        {{ schemaFields.length }}
-                    </UBadge>
+                    <span class="text-xs font-semibold text-muted uppercase tracking-wide">Materialization</span>
                 </button>
 
                 <template #content>
-                    <div class="px-5 pt-px pb-4">
-                        <div class="bg-muted rounded-md p-2 overflow-x-auto">
-                            <table class="w-full text-sm">
-                                <thead>
-                                    <tr class="border-b border-default text-left text-xs text-muted">
-                                        <th class="p-1.5 font-medium whitespace-nowrap">Name</th>
-                                        <th class="p-1.5 font-medium whitespace-nowrap">Type</th>
-                                        <th class="p-1.5 font-medium whitespace-nowrap">Description</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    <tr v-for="field in schemaFields"
-                                        :key="field.name"
-                                        class="border-b border-default last:border-0">
-                                        <td class="p-1.5 font-mono text-xs whitespace-nowrap">{{ field.name }}</td>
-                                        <td class="p-1.5 whitespace-nowrap">
-                                            <UBadge color="neutral"
-                                                    variant="subtle">
-                                                {{ field.type }}
-                                            </UBadge>
-                                        </td>
-                                        <td class="p-1.5 text-muted whitespace-nowrap">{{ field.description }}</td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
-                </template>
-            </UCollapsible>
-
-            <!-- Dependencies -->
-            <UCollapsible v-if="dependencyRows.length"
-                          default-open
-                          class="border-b border-default">
-                <button class="flex items-center gap-2 w-full px-5 py-4.5 group cursor-pointer">
-                    <UIcon name="i-lucide-chevron-right"
-                           class="size-3.5 shrink-0 text-dimmed group-data-[state=open]:rotate-90 transition-transform duration-200" />
-                    <span class="text-xs font-semibold text-muted uppercase tracking-wide">Upstream dependencies</span>
-                    <UBadge color="neutral"
-                            variant="subtle"
-                            class="ml-auto">
-                        {{ dependencyRows.length }}
-                    </UBadge>
-                </button>
-
-                <template #content>
-                    <div class="px-5 pt-px pb-4 flex flex-col gap-1.5">
-                        <div v-for="dep in dependencyRows"
-                             :key="dep.param"
-                             class="flex items-center gap-2.5 rounded-md bg-muted px-3 py-2">
-                            <UIcon :name="dep.icon"
-                                   class="size-4 shrink-0 text-muted" />
+                    <div class="px-5 pb-4 flex flex-col gap-2">
+                        <!-- Latest materialization -->
+                        <div class="flex items-center gap-4 rounded-md bg-muted p-4">
+                            <UIcon :name="materialization.icon"
+                                   class="size-10 shrink-0"
+                                   :class="[materialization.color, materialization.spin && 'animate-spin']" />
                             <div class="min-w-0 flex-1">
-                                <div class="truncate text-sm">{{ dep.name }}</div>
-                                <div class="truncate font-mono text-xs text-dimmed">{{ dep.qk }}</div>
+                                <div class="text-sm font-medium text-highlighted">
+                                    Latest materialization: <span :class="materialization.color">{{ materialization.label }}</span>
+                                </div>
+                                <div class="truncate text-xs text-muted">{{ materializationMeta }}</div>
                             </div>
-                            <UBadge color="neutral"
-                                    variant="subtle"
-                                    size="sm"
-                                    class="shrink-0 font-mono">
-                                {{ dep.param }}
-                            </UBadge>
+                        </div>
+
+                        <!-- History heatmap (max last 7 runs) -->
+                        <div v-if="history.length"
+                             class="rounded-md bg-muted p-4">
+                            <div class="mb-2.5 text-xs font-medium text-muted">Materialization history</div>
+                            <div class="flex gap-1.5">
+                                <div v-for="run in history"
+                                     :key="run.id"
+                                     class="size-7 rounded-md"
+                                     :style="{ backgroundColor: heatColor(run.status) }"
+                                     :title="historyTooltip(run)" />
+                            </div>
                         </div>
                     </div>
                 </template>
@@ -449,19 +399,19 @@ const dependencyRows = computed(() => {
                 </button>
 
                 <template #content>
-                    <div class="px-5 pt-px pb-4">
+                    <div class="px-5 pb-4">
                         <div v-if="destinations.length"
                              class="flex flex-col gap-2">
-                            <UCard v-for="dest in destinations"
-                                   :key="dest.id"
-                                   :ui="{ body: 'flex items-center gap-4 !p-4' }">
+                            <div v-for="dest in destinations"
+                                 :key="dest.id"
+                                 class="flex items-center gap-4 rounded-md bg-muted p-4">
                                 <UIcon :name="dest.icon"
                                        class="size-10 shrink-0" />
                                 <div class="min-w-0 flex-1">
                                     <div class="text-sm font-medium">{{ dest.label }}</div>
-                                    <div class="text-xs text-muted">{{ dest.key }}</div>
+                                    <div class="text-xs text-muted">{{ dest.typeName }}</div>
                                 </div>
-                            </UCard>
+                            </div>
                         </div>
                         <p v-else
                            class="text-sm text-dimmed italic">
@@ -488,7 +438,7 @@ const dependencyRows = computed(() => {
                 </button>
 
                 <template #content>
-                    <div class="px-5 pt-px pb-4">
+                    <div class="px-5 pb-4">
                         <!-- Loading -->
                         <div v-if="partitionLoading"
                              class="flex items-center justify-center py-6">
@@ -523,24 +473,85 @@ const dependencyRows = computed(() => {
                 </template>
             </UCollapsible>
 
-            <!-- Tags -->
-            <UCollapsible v-if="assetDefn?.tags?.length"
+            <!-- Dependencies -->
+            <UCollapsible v-if="dependencyRows.length"
                           default-open
                           class="border-b border-default">
                 <button class="flex items-center gap-2 w-full px-5 py-4.5 group cursor-pointer">
                     <UIcon name="i-lucide-chevron-right"
                            class="size-3.5 shrink-0 text-dimmed group-data-[state=open]:rotate-90 transition-transform duration-200" />
-                    <span class="text-xs font-semibold text-muted uppercase tracking-wide">Tags</span>
+                    <span class="text-xs font-semibold text-muted uppercase tracking-wide">Upstream dependencies</span>
+                    <UBadge color="neutral"
+                            variant="subtle"
+                            class="ml-auto">
+                        {{ dependencyRows.length }}
+                    </UBadge>
                 </button>
 
                 <template #content>
-                    <div class="px-5 pt-px pb-4 flex flex-wrap gap-1">
-                        <UBadge v-for="tag in assetDefn.tags"
-                                :key="tag"
-                                variant="subtle"
-                                size="sm">
-                            {{ tag }}
-                        </UBadge>
+                    <div class="px-5 pb-4 flex flex-col gap-1.5">
+                        <div v-for="dep in dependencyRows"
+                             :key="dep.param"
+                             class="flex items-center gap-2.5 rounded-md bg-muted px-3 py-2">
+                            <UIcon :name="dep.icon"
+                                   class="size-4 shrink-0 text-muted" />
+                            <div class="min-w-0 flex-1">
+                                <div class="truncate text-sm">{{ dep.name }}</div>
+                                <div class="truncate text-xs text-muted">{{ dep.sourceName }}</div>
+                            </div>
+                            <UBadge color="neutral"
+                                    variant="subtle"
+                                    size="sm"
+                                    class="shrink-0 font-mono">
+                                {{ dep.param }}
+                            </UBadge>
+                        </div>
+                    </div>
+                </template>
+            </UCollapsible>
+
+            <!-- Schema -->
+            <UCollapsible v-if="schemaFields.length"
+                          default-open
+                          class="border-b border-default">
+                <button class="flex items-center gap-2 w-full px-5 py-4.5 group cursor-pointer">
+                    <UIcon name="i-lucide-chevron-right"
+                           class="size-3.5 shrink-0 text-dimmed group-data-[state=open]:rotate-90 transition-transform duration-200" />
+                    <span class="text-xs font-semibold text-muted uppercase tracking-wide">Schema</span>
+                    <UBadge color="neutral"
+                            variant="subtle"
+                            class="ml-auto">
+                        {{ schemaFields.length }}
+                    </UBadge>
+                </button>
+
+                <template #content>
+                    <div class="px-5 pb-4">
+                        <div class="bg-muted rounded-md p-2 overflow-x-auto">
+                            <table class="w-full text-sm">
+                                <thead>
+                                    <tr class="border-b border-default text-left text-xs text-muted">
+                                        <th class="p-1.5 font-medium whitespace-nowrap">Name</th>
+                                        <th class="p-1.5 font-medium whitespace-nowrap">Type</th>
+                                        <th class="p-1.5 font-medium whitespace-nowrap">Description</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr v-for="field in schemaFields"
+                                        :key="field.name"
+                                        class="border-b border-default last:border-0">
+                                        <td class="p-1.5 font-mono text-xs whitespace-nowrap">{{ field.name }}</td>
+                                        <td class="p-1.5 whitespace-nowrap">
+                                            <UBadge color="neutral"
+                                                    variant="subtle">
+                                                {{ field.type }}
+                                            </UBadge>
+                                        </td>
+                                        <td class="p-1.5 text-muted whitespace-nowrap">{{ field.description }}</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
                     </div>
                 </template>
             </UCollapsible>


### PR DESCRIPTION
## What

- **Asset warnings in the info panel** — the warnings already shown on graph nodes as a badge + tooltip (missing dependency, no destination configured, not associated with any job) now also appear in the asset info panel. They render as a warning alert in the panel header, reusing the same `useAssetWarnings().getWarnings()` call as the node badge so the two surfaces can never disagree. Hidden for `missing` assets, where the drift alert supersedes them.
- **Tags in the header** — tag badges (colored via `tagColor`, matching the graph nodes) move under the title row; the standalone Tags section is removed.
- **Section reorder** — Description → Materialization → Destinations → Partitions → Upstream dependencies → Schema.
- **Consistent card styling** — the materialization and destination cards drop `UCard` for the same `bg-muted` rounded boxes used by the schema table and dependency rows. With no card rings left, the `pt-px` ring-clip workaround is removed from every section.
- **Names over keys** — destination and upstream-dependency card subtitles show catalog names (e.g. "BigQuery") instead of raw/qualified keys, falling back to keys when unresolvable.
- **Button label** — "Run now" → "Materialize" (behavior unchanged).

## Why

Warning information was only discoverable by hovering the node badge on the graph; the panel is where users inspect an asset, so it should carry the same signal. The rest aligns the panel's presentation with itself and with the graph.

## Notes for review

- Fixes a latent clipping bug: `UAlert`'s theme is `w-full`, so a margined alert inside the panel's overflow container extended past the right edge. Alerts (including the pre-existing drift notice) now sit in padded wrappers instead.
- `pnpm run lint` and `pnpm exec nuxt typecheck` pass (the single lint warning is the pre-existing `v-html` one in `ErrorDetailModal.vue`).

By Digitl