### PR TITLE
fix(app): scope asset dependency warnings to the owning source instance

### DIFF
--- a/packages/interloper-app/app/app/composables/warnings.ts
+++ b/packages/interloper-app/app/app/composables/warnings.ts
@@ -36,15 +36,12 @@ export function useAssetWarnings() {
         return map
     })
 
-    /**
-     * Qualified key → asset id.
-     * Built from all sources so cross-source lookups work.
-     */
-    const assetIdByQualifiedKey = computed(() => {
-        const map = new Map<string, string>()
+    /** asset id → asset record, across all sources. */
+    const assetById = computed(() => {
+        const map = new Map<string, ComponentRecord>()
         for (const source of sources.value) {
             for (const asset of source.children) {
-                map.set(qualifiedKey(source.key, asset.key), asset.id)
+                map.set(asset.id, asset)
             }
         }
         return map
@@ -103,8 +100,18 @@ export function useAssetWarnings() {
         if (defn) {
             const recorded = upstreamsByAssetId.value.get(assetId) ?? new Set()
             for (const [_param, depQk] of Object.entries(requiredDependencies(defn))) {
-                const upstreamId = assetIdByQualifiedKey.value.get(depQk)
-                if (!upstreamId || !recorded.has(upstreamId)) {
+                // A dep is satisfied by a recorded upstream matching the declared
+                // identity — a sibling of this source instance for intra-source
+                // deps, any instance of the named source for cross-source ones.
+                const { sourceKey: depSourceKey, assetKey: depAssetKey } = parseQualifiedKey(depQk)
+                const intraSource = !depSourceKey || depSourceKey === source?.key
+                const satisfied = [...recorded].some((upstreamId) => {
+                    const upstream = assetById.value.get(upstreamId)
+                    if (!upstream || upstream.key !== depAssetKey) return false
+                    const upstreamSource = sourceByAssetId.value.get(upstreamId)
+                    return intraSource ? upstreamSource?.id === source?.id : upstreamSource?.key === depSourceKey
+                })
+                if (!satisfied) {
                     const depDefn = getAssetDefinition(depQk)
                     const depName = depDefn?.name ?? depQk
                     warnings.push({ category: 'dependency', message: `Missing dependency: ${depName}` })


### PR DESCRIPTION
## What

Fixes false `Missing dependency` warnings on a source's downstream assets whenever a second instance of the same source definition exists (repro: add two `demo_source` sources via the UI — the first one's assets `b`–`e` all start warning).

## Why

`useAssetWarnings` resolved each declared upstream through a global qualified-key → asset-id map. Two instances of the same source share the catalog key, so the later instance's assets overwrote the earlier one's in the map: the first source's `b` resolved its `a` dep to the *second* source's `a`, which is never among its recorded dependency edges → spurious warning. The backend wiring is per-instance and was never at fault.

## How

Inverted the check in `warnings.ts`: instead of resolving the declared dep to one global id, each *recorded* upstream edge is matched against the declared dependency's identity — intra-source deps (bare key, or qualified with the asset's own source key) must be satisfied by a sibling of the same source instance; cross-source deps by any instance of the named source.

## Reviewer notes

- Verified live on a seeded dev instance: four coexisting `demo_source` instances show no dependency warnings, while a control source enabled with only asset `b` (upstream `a` genuinely absent) still shows the warning — no false negatives introduced.
- `pnpm run lint` and `nuxt typecheck` pass; the only lint warning is the pre-existing `v-html` one.

By Digitl