### PR TITLE
fix: surface error details for message-less exceptions

### DIFF
--- a/packages/interloper-app/app/app/components/executions/ErrorDetailModal.vue
+++ b/packages/interloper-app/app/app/components/executions/ErrorDetailModal.vue
@@ -27,7 +27,7 @@ watch(() => props.event.traceback, (tb) => {
             :ui="{ content: 'sm:max-w-4xl' }">
         <template #body>
             <div class="space-y-4">
-                <div>
+                <div v-if="event.error">
                     <h4 class="text-xs font-medium text-muted uppercase mb-1">
                         Error
                     </h4>

--- a/packages/interloper-app/app/app/components/executions/EventsTable.vue
+++ b/packages/interloper-app/app/app/components/executions/EventsTable.vue
@@ -112,9 +112,11 @@ const columns: TableColumn<RunEvent>[] = [
         header: 'Details',
         cell: ({ row }) => {
             const event = row.original as RunEvent
-            if (event.error) {
+            // Older events may carry a traceback with an empty error string
+            // (message-less exceptions) — the detail modal must stay reachable.
+            if (event.error || event.traceback) {
                 return h('div', { class: 'flex items-center gap-2 max-w-[400px]' }, [
-                    h('span', { class: 'truncate text-sm text-error' }, event.error),
+                    h('span', { class: 'truncate text-sm text-error' }, event.error || event.message || 'Error'),
                     h(UButton, {
                         icon: 'i-lucide-expand',
                         label: 'view',

--- a/packages/interloper-core/src/interloper/asset/base.py
+++ b/packages/interloper-core/src/interloper/asset/base.py
@@ -15,7 +15,7 @@ from interloper.asset.context import ExecutionContext
 from interloper.component import Component, ComponentDefinition, RelationDefinition, RelationSlot
 from interloper.conformer import Conformer
 from interloper.destination import Destination, IOContext
-from interloper.errors import AssetError, NormalizerError, PartitionError
+from interloper.errors import AssetError, NormalizerError, PartitionError, format_exception
 from interloper.events import EventBus, EventType
 from interloper.normalizer import MaterializationStrategy, Normalizer
 from interloper.partitioning import Partition, PartitionConfig, PartitionWindow
@@ -414,9 +414,9 @@ class Asset(Component):
                 EventType.ASSET_EXEC_FAILED,
                 metadata={
                     **exec_meta,
-                    "error": str(e),
+                    "error": format_exception(e),
                     "traceback": traceback.format_exc(),
-                    "message": f"Execution of '{type(self).key}' failed: {e}",
+                    "message": f"Execution of '{type(self).key}' failed: {format_exception(e)}",
                 },
             )
             raise
@@ -622,9 +622,9 @@ class Asset(Component):
                     EventType.DEST_WRITE_FAILED,
                     metadata={
                         **dest_meta,
-                        "error": str(e),
+                        "error": format_exception(e),
                         "traceback": traceback.format_exc(),
-                        "message": f"Failed to write '{type(self).key}': {e}",
+                        "message": f"Failed to write '{type(self).key}': {format_exception(e)}",
                     },
                 )
                 raise
@@ -672,12 +672,14 @@ class Asset(Component):
                 EventType.DEST_READ_FAILED,
                 metadata={
                     **dest_meta,
-                    "error": str(e),
+                    "error": format_exception(e),
                     "traceback": traceback.format_exc(),
-                    "message": f"Failed to read '{type(upstream_asset).key}': {e}",
+                    "message": f"Failed to read '{type(upstream_asset).key}': {format_exception(e)}",
                 },
             )
-            raise AssetError(f"Failed to load data from upstream asset '{upstream_asset.key}': {e}") from e
+            raise AssetError(
+                f"Failed to load data from upstream asset '{upstream_asset.key}': {format_exception(e)}"
+            ) from e
 
         return result
 

--- a/packages/interloper-core/src/interloper/errors.py
+++ b/packages/interloper-core/src/interloper/errors.py
@@ -181,3 +181,22 @@ class ComponentDriftError(InterloperError):
     the API layer can treat drift as a recoverable, user-resolvable state
     rather than a hard failure.
     """
+
+
+# -- Formatting ----------------------------------------------------------------
+
+
+def format_exception(exc: BaseException) -> str:
+    """Format an exception as a non-empty, single-line error string.
+
+    ``str(exc)`` alone is empty for message-less exceptions (e.g.
+    ``httpx.ReadTimeout``), which downstream consumers — event rows, run
+    results, the UI — treat as "no error". Always lead with the type name so
+    the error stays identifiable either way.
+
+    Returns:
+        ``"TypeName: message"``, or just ``"TypeName"`` when the message is empty.
+    """
+    message = str(exc)
+    name = type(exc).__name__
+    return f"{name}: {message}" if message else name

--- a/packages/interloper-core/src/interloper/runner/async_runner.py
+++ b/packages/interloper-core/src/interloper/runner/async_runner.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any
 from pydantic import PrivateAttr
 
 from interloper.asset.base import Asset
-from interloper.errors import RunnerError
+from interloper.errors import RunnerError, format_exception
 from interloper.partitioning.base import Partition, PartitionWindow
 from interloper.runner.base import Runner
 from interloper.runner.results import RunResult
@@ -100,7 +100,7 @@ class AsyncRunner(Runner):
 
         except Exception as e:
             await self._flush(inflight)
-            result = self._finalize_run(error=str(e))
+            result = self._finalize_run(error=format_exception(e))
             if self.reraise:
                 raise
             return result
@@ -155,7 +155,7 @@ class AsyncRunner(Runner):
             )
             self.state.mark_asset_completed(asset)
         except Exception as e:
-            self.state.mark_asset_failed(asset, str(e), tb=traceback.format_exc())
+            self.state.mark_asset_failed(asset, format_exception(e), tb=traceback.format_exc())
             if self.reraise or self.fail_fast:
                 raise
             return None

--- a/packages/interloper-core/src/interloper/runner/multi_process.py
+++ b/packages/interloper-core/src/interloper/runner/multi_process.py
@@ -10,7 +10,7 @@ from typing import Any
 from pydantic import PrivateAttr
 
 from interloper.asset.base import Asset
-from interloper.errors import RunnerError
+from interloper.errors import RunnerError, format_exception
 from interloper.partitioning.base import Partition, PartitionWindow
 from interloper.runner.sync_runner import SyncRunner
 
@@ -46,7 +46,7 @@ def _worker(
             )
         )
     except Exception as e:  # noqa: BLE001
-        return (asset_id, False, str(e), traceback.format_exc())
+        return (asset_id, False, format_exception(e), traceback.format_exc())
     return (asset_id, True, None, None)
 
 
@@ -130,7 +130,7 @@ class MultiProcessRunner(SyncRunner):
         try:
             _key, success, error_msg, tb = future.result()
         except Exception as e:
-            self.state.mark_asset_failed(asset, str(e), tb=traceback.format_exc())
+            self.state.mark_asset_failed(asset, format_exception(e), tb=traceback.format_exc())
             if self.fail_fast or self.reraise:
                 raise
             return
@@ -147,7 +147,7 @@ class MultiProcessRunner(SyncRunner):
         try:
             _key, success, error_msg, tb = future.result()
         except Exception as e:  # noqa: BLE001
-            self.state.mark_asset_failed(asset, str(e), tb=traceback.format_exc())
+            self.state.mark_asset_failed(asset, format_exception(e), tb=traceback.format_exc())
             return
 
         if success:

--- a/packages/interloper-core/src/interloper/runner/sync_runner.py
+++ b/packages/interloper-core/src/interloper/runner/sync_runner.py
@@ -9,7 +9,7 @@ from concurrent.futures import FIRST_COMPLETED, Future, wait
 from typing import TYPE_CHECKING, Any
 
 from interloper.asset.base import Asset
-from interloper.errors import RunnerError
+from interloper.errors import RunnerError, format_exception
 from interloper.partitioning.base import Partition, PartitionWindow
 from interloper.runner.base import Runner
 from interloper.runner.results import RunResult
@@ -99,7 +99,7 @@ class SyncRunner(Runner):
 
         except Exception as e:
             self._flush(inflight)
-            result = self._finalize_run(error=str(e))
+            result = self._finalize_run(error=format_exception(e))
             if self.reraise:
                 raise
             return result
@@ -131,7 +131,7 @@ class SyncRunner(Runner):
         try:
             future.result()
         except Exception as e:
-            self.state.mark_asset_failed(asset, str(e), tb=traceback.format_exc())
+            self.state.mark_asset_failed(asset, format_exception(e), tb=traceback.format_exc())
             if self.fail_fast or self.reraise:
                 raise
             return
@@ -181,4 +181,4 @@ class SyncRunner(Runner):
             future.result()
             self.state.mark_asset_completed(asset)
         except Exception as e:  # noqa: BLE001
-            self.state.mark_asset_failed(asset, str(e), tb=traceback.format_exc())
+            self.state.mark_asset_failed(asset, format_exception(e), tb=traceback.format_exc())

--- a/packages/interloper-core/tests/test_errors.py
+++ b/packages/interloper-core/tests/test_errors.py
@@ -1,0 +1,18 @@
+"""Tests for the error formatting helpers."""
+
+from interloper.errors import format_exception
+
+
+def test_format_exception_prefixes_type_name():
+    """The type name leads so errors stay identifiable in event rows."""
+    assert format_exception(ValueError("boom")) == "ValueError: boom"
+
+
+def test_format_exception_message_less_exception():
+    """A message-less exception still yields a non-empty string."""
+    assert format_exception(TimeoutError()) == "TimeoutError"
+
+
+def test_format_exception_quoted_message():
+    """The message is rendered via str(), quirks included (KeyError quotes)."""
+    assert format_exception(KeyError("missing")) == "KeyError: 'missing'"

--- a/packages/interloper-docker/src/interloper_docker/runner.py
+++ b/packages/interloper-docker/src/interloper_docker/runner.py
@@ -25,7 +25,7 @@ import docker
 from docker.client import DockerClient
 from docker.models.containers import Container
 from interloper.asset.base import Asset
-from interloper.errors import RunnerError
+from interloper.errors import RunnerError, format_exception
 from interloper.events import EventBus, EventType
 from interloper.events.event import parse_event_from_log_line
 from interloper.partitioning.base import Partition, PartitionWindow
@@ -148,7 +148,7 @@ class DockerRunner(SyncRunner):
             )
         except Exception as e:
             # Container never started — emit from the host
-            self.state.mark_asset_failed(asset, str(e))
+            self.state.mark_asset_failed(asset, format_exception(e))
             done: Future[None] = Future()
             done.set_result(None)
             return done
@@ -180,7 +180,7 @@ class DockerRunner(SyncRunner):
             try:
                 future.result()
             except Exception as e:
-                self.state.mark_asset_failed(asset, str(e), emit=True)
+                self.state.mark_asset_failed(asset, format_exception(e), emit=True)
                 if self.fail_fast or self.reraise:
                     raise
             else:
@@ -208,7 +208,7 @@ class DockerRunner(SyncRunner):
             try:
                 future.result()
             except Exception as e:  # noqa: BLE001
-                self.state.mark_asset_failed(asset, str(e), emit=True)
+                self.state.mark_asset_failed(asset, format_exception(e), emit=True)
             else:
                 self.state.mark_asset_completed(asset, emit=True)
 

--- a/packages/interloper-k8s/src/interloper_k8s/runner.py
+++ b/packages/interloper-k8s/src/interloper_k8s/runner.py
@@ -15,7 +15,7 @@ from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Any, cast
 
 from interloper.asset.base import Asset
-from interloper.errors import RunnerError
+from interloper.errors import RunnerError, format_exception
 from interloper.events import EventBus, EventType
 from interloper.events.event import parse_event_from_log_line
 from interloper.partitioning.base import Partition, PartitionWindow
@@ -176,7 +176,7 @@ class KubernetesRunner(SyncRunner):
         try:
             self._batch_v1.create_namespaced_job(namespace=self.namespace, body=job)
         except Exception as e:
-            self.state.mark_asset_failed(asset, str(e))
+            self.state.mark_asset_failed(asset, format_exception(e))
             done: Future[None] = Future()
             done.set_result(None)
             return done
@@ -242,7 +242,7 @@ class KubernetesRunner(SyncRunner):
         try:
             future.result()
         except Exception as e:
-            self.state.mark_asset_failed(asset, str(e), emit=True)
+            self.state.mark_asset_failed(asset, format_exception(e), emit=True)
             if self.fail_fast or self.reraise:
                 raise RunnerError(f"Asset '{type(asset).key}' failed: {e}") from e
         else:
@@ -264,7 +264,7 @@ class KubernetesRunner(SyncRunner):
             try:
                 future.result()
             except Exception as e:  # noqa: BLE001
-                self.state.mark_asset_failed(asset, str(e), emit=True)
+                self.state.mark_asset_failed(asset, format_exception(e), emit=True)
             else:
                 self.state.mark_asset_completed(asset, emit=True)
 


### PR DESCRIPTION
## Context

Prod run `07160e77-cdc2-472f-b4e5-2ab0559a5d5a` (TheTradeDesk `ad_groups_stats`) failed with an `httpx.ReadTimeout`, but the failed step showed no error details in the app. The traceback **was** persisted — the problem is that `str(httpx.ReadTimeout)` is an empty string, so the event landed with `error=""` and the app gates the entire details affordance (red text + view button + traceback modal) on `event.error` being truthy.

## Changes

**Backend** — new `format_exception()` in `interloper.errors`, used everywhere an exception is stringified into an event/result error:
- runners: async, sync base, multi-process, k8s, docker (`mark_asset_failed` / `_finalize_run` / worker result tuples)
- asset hooks: `ASSET_EXEC_FAILED`, `DEST_WRITE_FAILED`, `DEST_READ_FAILED` (error field and message interpolation)

Errors now always lead with the exception type name (`ReadTimeout` / `ValueError: boom`), so they are never empty and are more identifiable in event rows.

**Frontend** — `EventsTable.vue` shows the details cell when the event has `error` **or** `traceback`, so existing events with an empty error string keep a reachable traceback modal; `ErrorDetailModal.vue` hides the empty Error block in that case.

## Verification

- `uv run ruff check`, `uv run ty check`, full pytest via pre-commit — green
- `pnpm run lint`, `pnpm exec nuxt typecheck` — green
- New unit tests for `format_exception` in `tests/test_errors.py`

By Digitl