### PR TITLE
fix(api): require viewer auth on catalog routes

### DIFF
--- a/packages/interloper-api/src/interloper_api/routes/catalog.py
+++ b/packages/interloper-api/src/interloper_api/routes/catalog.py
@@ -7,9 +7,9 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException
 from interloper.catalog.base import Catalog
 
-from interloper_api.dependencies import get_catalog
+from interloper_api.dependencies import get_catalog, require_viewer
 
-router = APIRouter(prefix="/catalog", tags=["catalog"])
+router = APIRouter(prefix="/catalog", tags=["catalog"], dependencies=[Depends(require_viewer)])
 
 
 @router.get("/")

--- a/packages/interloper-api/tests/test_catalog.py
+++ b/packages/interloper-api/tests/test_catalog.py
@@ -1,0 +1,37 @@
+"""Tests for ``interloper_api.routes.catalog`` — viewer auth gating."""
+
+from __future__ import annotations
+
+import interloper as il
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from interloper_api.dependencies import get_catalog, get_store, require_viewer
+from interloper_api.routes import catalog as catalog_module
+
+
+def _app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(catalog_module.router)
+    app.dependency_overrides[get_store] = lambda: None
+    app.dependency_overrides[get_catalog] = lambda: il.Catalog(components={})
+    return app
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["/catalog/", "/catalog/resource-kinds", "/catalog/some-key", "/catalog/kind/source"],
+)
+def test_unauthenticated_requests_rejected(path: str):
+    resp = TestClient(_app()).get(path)
+    assert resp.status_code == 401
+
+
+def test_viewer_can_read_catalog():
+    app = _app()
+    app.dependency_overrides[require_viewer] = lambda: None
+    client = TestClient(app)
+
+    assert client.get("/catalog/").status_code == 200
+    assert client.get("/catalog/resource-kinds").status_code == 200


### PR DESCRIPTION
## Summary
- The catalog router (`/api/catalog/*`) had no auth dependency on any route — the full component catalog (source/asset/resource/destination definitions incl. config schemas) was readable unauthenticated, unlike every other router.
- Gate the whole router with `dependencies=[Depends(require_viewer)]` so all four routes (`/`, `/{key}`, `/kind/{kind}`, `/resource-kinds`) — and any future ones — require an authenticated org member.

## Impact check
Nothing relies on unauthenticated catalog access:
- **Frontend**: `fetchCatalog()` runs in `auth.global.ts` only after auth + org are resolved; the login/welcome/invite pages never touch it.
- **Agent**: consumes the catalog in-process via `Depends(get_catalog)`, not over HTTP.
- **Docs/examples**: no references to the HTTP endpoints.

## Tests
- New `tests/test_catalog.py`: unauthenticated requests to all four routes return 401; an authorized viewer still gets 200.

By Digitl