### PR TITLE
feat(chart)!: app config moves from the config block to root-level values

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ Both run against [dev/interloper.yaml](dev/interloper.yaml), which carries **onl
 Built from a single multi-target [dockerfile](dockerfile). The image catalog is defined in the [Makefile](Makefile): one image per role (`interloper-<role>`), with **flavors** (extra-bearing variants) riding the **tag** as a `-<flavor>` suffix — not a separate image name.
 
 - `ROLES` (`api`, `frontend`, `worker`, `scheduler`) → image `interloper-<role>:<version>` (base, no flavor extras).
-- `FLAVORS_<role>` defines the per-role flavors and `EXTRAS_ARG_<role>` the build arg that carries them: `scheduler` → `k8s`, `docker` (via `SCHEDULER_EXTRAS`); `api` → `agent` (via `API_EXTRAS`). These build `interloper-scheduler:<version>-k8s`, `interloper-api:<version>-agent`, etc. (plus matching `latest-<flavor>` tags). The Helm chart picks the scheduler tag suffix from `config.launcher.type` and the api `-agent` tag from `agent.enabled`.
+- `FLAVORS_<role>` defines the per-role flavors and `EXTRAS_ARG_<role>` the build arg that carries them: `scheduler` → `k8s`, `docker` (via `SCHEDULER_EXTRAS`); `api` → `agent` (via `API_EXTRAS`). These build `interloper-scheduler:<version>-k8s`, `interloper-api:<version>-agent`, etc. (plus matching `latest-<flavor>` tags). The Helm chart picks the scheduler tag suffix from `launcher.type` and the api `-agent` tag from `agent.enabled`.
 - Build one target: `make docker-build-<role>` (base) or `make docker-build-<role>-<flavor>` (e.g. `docker-build-scheduler-k8s`, `docker-build-api-agent`).
 - Build everything: `make docker-build` (host arch) or `make docker-build-linux` (linux/amd64 for the registry).
 - Push: `make docker-push`, or `make docker-build-push` to build linux + push in one step.

--- a/chart/interloper/README.md
+++ b/chart/interloper/README.md
@@ -30,7 +30,7 @@ ghcr.io/digitl-cloud/interloper-frontend:<version>
 ghcr.io/digitl-cloud/interloper-worker:<version>             # kubernetes runner per-asset Job target
 ```
 
-The chart picks the scheduler tag suffix from `config.launcher.type`
+The chart picks the scheduler tag suffix from `launcher.type`
 automatically, and the api `-agent` tag when `agent.enabled=true` — no
 manual mapping. Override `image.registry` (and `image.pullSecrets` for a
 private registry) to pull from elsewhere.
@@ -87,25 +87,39 @@ ingress:
     enabled: true
     secretName: interloper-tls
 
-config:
-  launcher:
-    type: kubernetes
-    # image + namespace + service_account_name are auto-filled from the release
-  runner:
-    type: async
-  catalog:
-    - interloper_assets.demo.source.DemoSource
-    - interloper_google_cloud.BigQueryDestination
+launcher:
+  type: kubernetes
+  # image + namespace + service_account_name are auto-filled from the release
+
+runner:
+  type: async
+
+catalog:
+  - interloper_assets.demo.source.DemoSource
+  - interloper_google_cloud.BigQueryDestination
 ```
 
 ## Configuration
 
-### `config.*` — interloper.yaml
+### App settings — interloper.yaml
 
-Everything under `config` is rendered into a ConfigMap mounted at
-`/etc/interloper/interloper.yaml`.  The chart auto-fills Kubernetes
-launcher defaults (`image`, `namespace`, `service_account_name`) from
-the release context, so you rarely need to set them manually.
+App runtime settings are root-level values, one block per feature:
+`launcher`, `runner`, `catalog`, `smtp`, `auth`, and `agent`.  The chart
+renders them into a ConfigMap mounted at
+`/etc/interloper/interloper.yaml`, auto-filling Kubernetes launcher and
+runner defaults (`image`, `namespace`, `service_account_name`) from the
+release context, so you rarely need to set them manually.
+
+Secret-bearing fields never go through the ConfigMap — they are injected
+as env vars from the chart's Secret (`secrets.*`), pairing with their
+feature block: `auth.google_client_id` + `secrets.googleClientSecret`,
+`smtp.user` + `secrets.smtpPassword`, `externalPostgres` +
+`secrets.postgresPassword`.
+
+Anything else interloper.yaml accepts (server, cron, worker, reaper, mcp
+tuning) goes under `extraConfig`, which is rendered verbatim into the
+generated file.  Chart-managed and secret-bearing sections are rejected
+there — a YAML-provided field would override the injected env vars.
 
 ### `secrets.*`
 

--- a/chart/interloper/templates/_helpers.tpl
+++ b/chart/interloper/templates/_helpers.tpl
@@ -59,7 +59,7 @@ Secret name — either user-provided existingSecret or chart-generated.
 
 {{/*
 Flavor token for the scheduler image, derived from the runtime launcher
-choice (config.launcher.type). Flavors are tag suffixes on the single
+choice (launcher.type). Flavors are tag suffixes on the single
 interloper-scheduler image, matching the build-time SCHEDULER_EXTRAS that
 produced each variant.
 
@@ -68,7 +68,7 @@ produced each variant.
   docker     → "docker"
 */}}
 {{- define "interloper.schedulerFlavor" -}}
-{{- $type := .Values.config.launcher.type | default "in_process" -}}
+{{- $type := .Values.launcher.type | default "in_process" -}}
 {{- if eq $type "kubernetes" -}}k8s
 {{- else if eq $type "docker" -}}docker
 {{- end -}}
@@ -186,5 +186,11 @@ Contains Postgres connection info + the encryption key secret.
     secretKeyRef:
       name: {{ include "interloper.secretName" . }}
       key: INTERLOPER_AUTH_GOOGLE_CLIENT_SECRET
+      optional: true
+- name: INTERLOPER_SMTP_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "interloper.secretName" . }}
+      key: INTERLOPER_SMTP_PASSWORD
       optional: true
 {{- end -}}

--- a/chart/interloper/templates/api-deployment.yaml
+++ b/chart/interloper/templates/api-deployment.yaml
@@ -43,7 +43,7 @@ spec:
           {{- end }}
           ports:
             - name: http
-              containerPort: {{ .Values.config.server.port | default 3000 }}
+              containerPort: {{ dig "server" "port" 3000 .Values.extraConfig }}
               protocol: TCP
           {{- with .Values.api.extraEnvFrom }}
           envFrom:

--- a/chart/interloper/templates/configmap.yaml
+++ b/chart/interloper/templates/configmap.yaml
@@ -1,18 +1,43 @@
 {{/*
 Generated interloper.yaml mounted into every pod at /etc/interloper/interloper.yaml.
-The launcher, runner, and agent sections get auto-filled from chart values
-(cluster-aware defaults, the root agent block) when the user hasn't set
-them explicitly.
+Assembled from the root-level feature blocks (agent, launcher, runner,
+catalog, smtp, auth) plus the extraConfig passthrough. Kubernetes launcher
+and runner defaults (image, namespace, service account) are auto-filled
+from the release context.
+
+Chart-managed sections may not appear in extraConfig (their root block is
+the single source of truth), and neither may secret-bearing ones: a field
+provided via YAML beats the env var the chart injects, so extraConfig.postgres
+or extraConfig.secrets would silently override the Secret-fed credentials.
 */}}
-{{- $cfg := deepCopy .Values.config -}}
-{{- if not (hasKey $cfg "agent") -}}
-  {{- $_ := set $cfg "agent" (dict "enabled" .Values.agent.enabled) -}}
-  {{- with .Values.agent.model -}}
-    {{- $_ := set $cfg.agent "model" . -}}
+{{- range $key := list "postgres" "secrets" -}}
+  {{- if hasKey $.Values.extraConfig $key -}}
+    {{- fail (printf "extraConfig.%s is not allowed — it would override the credentials the chart injects via env vars; use postgresql/externalPostgres and `secrets` instead" $key) -}}
   {{- end -}}
 {{- end -}}
-{{- if eq (default "" (dig "launcher" "type" "" $cfg)) "kubernetes" -}}
-  {{- if not (hasKey $cfg "launcher") -}}{{- $_ := set $cfg "launcher" dict -}}{{- end -}}
+{{- range $key := list "agent" "launcher" "runner" "catalog" "smtp" "auth" -}}
+  {{- if hasKey $.Values.extraConfig $key -}}
+    {{- fail (printf "extraConfig.%s is not allowed — this section is chart-managed; set the root-level `%s` value instead" $key $key) -}}
+  {{- end -}}
+{{- end -}}
+{{- $cfg := deepCopy .Values.extraConfig -}}
+{{- $agent := dict "enabled" .Values.agent.enabled -}}
+{{- with .Values.agent.model -}}
+  {{- $_ := set $agent "model" . -}}
+{{- end -}}
+{{- $_ := set $cfg "agent" $agent -}}
+{{- $_ := set $cfg "launcher" (deepCopy .Values.launcher) -}}
+{{- $_ := set $cfg "runner" (deepCopy .Values.runner) -}}
+{{- with .Values.catalog -}}
+  {{- $_ := set $cfg "catalog" . -}}
+{{- end -}}
+{{- with .Values.smtp -}}
+  {{- $_ := set $cfg "smtp" . -}}
+{{- end -}}
+{{- with .Values.auth -}}
+  {{- $_ := set $cfg "auth" . -}}
+{{- end -}}
+{{- if eq (default "" $cfg.launcher.type) "kubernetes" -}}
   {{- if not (hasKey $cfg.launcher "config") -}}{{- $_ := set $cfg.launcher "config" dict -}}{{- end -}}
   {{- if not $cfg.launcher.config.image -}}
     {{- $_ := set $cfg.launcher.config "image" (include "interloper.schedulerImage" .) -}}
@@ -24,8 +49,7 @@ them explicitly.
     {{- $_ := set $cfg.launcher.config "service_account_name" (include "interloper.serviceAccountName" .) -}}
   {{- end -}}
 {{- end -}}
-{{- if has (default "" (dig "runner" "type" "" $cfg)) (list "kubernetes" "k8s") -}}
-  {{- if not (hasKey $cfg "runner") -}}{{- $_ := set $cfg "runner" dict -}}{{- end -}}
+{{- if has (default "" $cfg.runner.type) (list "kubernetes" "k8s") -}}
   {{- if not (hasKey $cfg.runner "config") -}}{{- $_ := set $cfg.runner "config" dict -}}{{- end -}}
   {{- if not $cfg.runner.config.image -}}
     {{- $_ := set $cfg.runner.config "image" (include "interloper.workerImage" .) -}}

--- a/chart/interloper/values.yaml
+++ b/chart/interloper/values.yaml
@@ -127,6 +127,12 @@ dbInit:
 # =============================================================================
 # Configuration
 # =============================================================================
+#
+# App runtime settings live at the root, one block per feature. The chart
+# renders them into the generated interloper.yaml (and pairs secret-bearing
+# fields with env vars from `secrets`); blocks the chart must act on itself
+# (agent, launcher) also drive image selection. `extraConfig` passes any
+# remaining interloper.yaml sections through verbatim.
 
 # Agent (ADK chat) support. When enabled, the chart deploys the
 # `interloper-api:<tag>-agent` image, which bundles interloper-agent, and
@@ -145,61 +151,55 @@ agent:
   enabled: false
   model: ""  # defaults to gemini-2.5-flash
 
-# The chart generates an interloper.yaml ConfigMap from this block.
-# Any value set here becomes part of the config file mounted into the pods.
-config:
-  server:
-    host: "0.0.0.0"
-    port: 3000
+# How runs are launched (where they execute). The launcher type also selects
+# the scheduler image flavor (kubernetes → "-k8s", docker → "-docker").
+launcher:
+  type: kubernetes
+  config:
+    image: ""  # defaults to scheduler image (set automatically if empty)
+    namespace: ""  # defaults to release namespace
+    # service_account_name: "{{ .Release.Name }}-launcher"  # auto-filled if rbac.create
+    # image_pull_policy: IfNotPresent
+    # resources:
+    #   requests: {cpu: "100m", memory: "256Mi"}
+    #   limits: {memory: "512Mi"}
 
-  cron:
-    reconcile_interval: 10
+# How the DAG runs inside each launched container.
+runner:
+  type: async
+  config: {}
 
-  worker:
-    poll_interval: 5
+# Catalog: list of dotted import paths for sources, assets, destinations.
+catalog: []
+# - interloper_assets.demo.source.DemoSource
+# - interloper_google_cloud.BigQueryDestination
 
-  # Reaper: kills timed-out runs (singleton, paired with cron).
+# SMTP config for sending emails (password via secrets.smtpPassword)
+smtp: {}
+# smtp:
+#   host: smtp.gmail.com
+#   port: 465
+#   user: "no-reply@example.com"
+
+# Auth config (OAuth client ID; the client secret goes in
+# secrets.googleClientSecret). super_admin_emails bootstraps the first
+# platform super-admin(s): listed users are promoted when they log in
+# (promote-only — removing an email never demotes).
+auth: {}
+# auth:
+#   google_client_id: "..."
+#   super_admin_emails:
+#     - you@example.com
+
+# Extra interloper.yaml sections rendered verbatim into the generated
+# ConfigMap — tuning the chart has no opinion on (server, cron, worker,
+# reaper, mcp). Sections owned by a root-level block (agent, launcher,
+# runner, catalog, smtp, auth) are rejected here, as are secret-bearing
+# ones (postgres, secrets): a YAML-provided field beats the env var the
+# chart injects, so allowing them would silently override credentials.
+extraConfig:
   reaper:
-    timeout: 3600
-    poll_interval: 10
-
-  # How runs are launched (where they execute).
-  launcher:
-    type: kubernetes
-    config:
-      image: ""  # defaults to scheduler image (set automatically if empty)
-      namespace: ""  # defaults to release namespace
-      # service_account_name: "{{ .Release.Name }}-launcher"  # auto-filled if rbac.create
-      # image_pull_policy: IfNotPresent
-      # resources:
-      #   requests: {cpu: "100m", memory: "256Mi"}
-      #   limits: {memory: "512Mi"}
-
-  # How the DAG runs inside each launched container.
-  runner:
-    type: async
-    config: {}
-
-  # Catalog: list of dotted import paths for sources, assets, destinations.
-  catalog: []
-  # - interloper_assets.demo.source.DemoSource
-  # - interloper_google_cloud.BigQueryDestination
-
-  # SMTP config for sending emails (password via secrets.smtpPassword)
-  smtp: {}
-  # smtp:
-  #   host: smtp.gmail.com
-  #   port: 465
-  #   user: "no-reply@example.com"
-
-  # Auth config (OAuth client ID). super_admin_emails bootstraps the first
-  # platform super-admin(s): listed users are promoted when they log in
-  # (promote-only — removing an email never demotes).
-  auth: {}
-  # auth:
-  #   google_client_id: "..."
-  #   super_admin_emails:
-  #     - you@example.com
+    timeout: 3600  # generous for long data loads; the app default (600s) reaps too eagerly
 
 # =============================================================================
 # Secrets


### PR DESCRIPTION
## Why

The chart's values interface had grown inconsistent about what lives under the `config` passthrough vs at the root:

- **`agent` split-brain** — root `agent.enabled` picks the `-agent` api image flavor, but the block was only copied into the generated `interloper.yaml` when `config.agent` was unset, so `config.agent` could enable agent routes on an image that doesn't ship the agent package. `config.launcher.type` had the same hazard with the scheduler `-k8s`/`-docker` flavor.
- **Feature blocks torn in half** — `config.auth` paired with `secrets.googleClientSecret`, `config.smtp` with `secrets.smtpPassword`.
- **`secrets.smtpPassword` was dead** — the Secret carried `INTERLOPER_SMTP_PASSWORD` but `commonEnv` never injected it into any pod.
- **Restated app defaults** — the default `config` block duplicated `server`/`cron`/`worker` app defaults (drift bait) while hiding the one deliberate override (`reaper.timeout: 3600`).
- Nothing stopped a `config.postgres` block from clobbering the Secret-fed credentials (a YAML-provided field beats its env var in pydantic-settings).

## What

App settings are now root-level feature blocks — `launcher`, `runner`, `catalog`, `smtp`, `auth`, `agent` — and the chart assembles `interloper.yaml` from them, giving image-flavor-driving sections a single source. Remaining tuning (`server`, `cron`, `worker`, `reaper`, `mcp`) goes under `extraConfig`, rendered verbatim; the template rejects chart-managed keys there, and `postgres`/`secrets` with a credential-override explanation. `INTERLOPER_SMTP_PASSWORD` is now injected via `commonEnv` (optional, like the other secret keys).

Verified with `helm template`/`helm lint`: default render, feature-block render, `runner.type=kubernetes` auto-fill, `-docker`/`-agent` flavor selection, `extraConfig.server.port` → containerPort, and both guard failure messages.

## BREAKING CHANGE

The `config` values block is gone. Migration: move `config.launcher/runner/catalog/smtp/auth` to the same keys at the root, `config.agent` to the root `agent` block, and any server/cron/worker/reaper/mcp tuning under `extraConfig`.

By Digitl