### PR TITLE
feat!: reconcile schema-declared assets by default

### DIFF
--- a/docs/features/data-validation.md
+++ b/docs/features/data-validation.md
@@ -29,7 +29,7 @@ The `MaterializationStrategy` controls **how strictly** schemas are enforced. Se
 
 | Strategy | Schema required | Behavior |
 |----------|-----------------|----------|
-| `AUTO` | No | Infers a schema if missing; validates if present (no coercion) |
+| `AUTO` | No | Infers a schema if missing; reconciles if present |
 | `STRICT` | Yes | Fails on any mismatch (extras, missing, wrong types) |
 | `RECONCILE` | Yes | Aligns columns and coerces values to the schema's types |
 

--- a/docs/features/schema.md
+++ b/docs/features/schema.md
@@ -112,7 +112,7 @@ The `MaterializationStrategy` controls how schemas are enforced. Set it via the
 
 ### AUTO (default)
 
-If a schema is provided, validates data against it without coercion. If none is provided, a
+If a schema is provided, reconciles data against it (like `RECONCILE`). If none is provided, a
 schema is inferred from the data (best-effort).
 
 ```py
@@ -137,8 +137,9 @@ def my_asset():
 
 ### RECONCILE
 
-Requires a schema. Aligns columns to the schema (drops extras, adds missing as `None`) and
-coerces values to the schema's types.
+Requires a schema. Aligns columns to the schema (drops extras with a logged warning, adds
+missing nullable fields as `None`) and coerces values to the schema's types. Non-nullable
+fields must be present and free of nulls.
 
 ```py
 @il.asset(

--- a/packages/interloper-core/src/interloper/asset/base.py
+++ b/packages/interloper-core/src/interloper/asset/base.py
@@ -124,9 +124,9 @@ class Asset(Component):
         label="Materialization Strategy",
         description="How this asset's data is checked against its schema.",
         info=(
-            "'Auto' validates data against the schema (or infers a schema "
-            "when none is declared), 'Strict' fails on any mismatch, "
-            "'Reconcile' coerces values to the schema."
+            "'Auto' coerces data to the schema (or infers a schema when "
+            "none is declared), 'Strict' fails on any mismatch, "
+            "'Reconcile' requires a schema and coerces values to it."
         ),
     )
     normalizer: Normalizer | None = Field(default=None)
@@ -702,7 +702,7 @@ class Asset(Component):
     def _conform(self, result: Any) -> Any:
         """Enforce the asset's schema according to the materialization strategy.
 
-        AUTO: validate when a schema is declared, infer one otherwise.
+        AUTO: reconcile when a schema is declared, infer one otherwise.
         STRICT: schema required; reject extra, missing, or mistyped fields.
         RECONCILE: schema required; align columns and coerce values.
 
@@ -744,10 +744,10 @@ class Asset(Component):
             return result
 
         self._effective_schema = schema
-        if strategy == MaterializationStrategy.RECONCILE:
-            return conformer.reconcile(result, schema)
-        conformer.validate(result, schema, strict=strategy == MaterializationStrategy.STRICT)
-        return result
+        if strategy == MaterializationStrategy.STRICT:
+            conformer.validate(result, schema, strict=True)
+            return result
+        return conformer.reconcile(result, schema)
 
     def _infer_schema(self, conformer: Conformer, result: Any) -> type[Schema] | None:
         """Best-effort schema inference for the IO boundary (AUTO, no declared schema).

--- a/packages/interloper-core/src/interloper/normalizer/strategy.py
+++ b/packages/interloper-core/src/interloper/normalizer/strategy.py
@@ -7,8 +7,8 @@ class MaterializationStrategy(str, Enum):
     """Controls how data is validated and reconciled during materialization.
 
     Attributes:
-        AUTO: Infer schema if none provided, validate if schema is set.
-            No type coercion or column alignment.
+        AUTO: Infer a schema if none is provided; reconcile against the
+            schema when one is declared.
         STRICT: Schema is required.  Data is validated against the schema
             and materialization fails on any mismatch.
         RECONCILE: Schema is required.  Columns are aligned to match the

--- a/packages/interloper-core/src/interloper/schema/base.py
+++ b/packages/interloper-core/src/interloper/schema/base.py
@@ -6,6 +6,7 @@ import json
 import logging
 import types
 import warnings
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Union, get_args, get_origin
 
@@ -264,9 +265,14 @@ class Schema(Serializable):
         if not rows:
             return []
 
-        fields = {spec.name: cls.model_fields[spec.name] for spec in cls.field_specs()}
+        specs = cls.field_specs()
+        fields = {spec.name: cls.model_fields[spec.name] for spec in specs}
         adapters = {name: TypeAdapter(field.annotation) for name, field in fields.items()}
-        str_fields = {s.name for s in cls.field_specs() if s.type is str and not s.repeated and s.fields is None}
+        coercers = {
+            spec.name: RECONCILERS[spec.type]
+            for spec in specs
+            if spec.type in RECONCILERS and not spec.repeated and spec.fields is None
+        }
 
         dropped: set[str] = set()
         result: list[dict[str, Any]] = []
@@ -278,8 +284,8 @@ class Schema(Serializable):
                     out[name] = fields[name].get_default(call_default_factory=True)
                     continue
                 value = row.get(name)
-                if name in str_fields:
-                    value = _coerce_str_value(value)
+                if name in coercers:
+                    value = coercers[name](value)
                 try:
                     # dump_python round-trips nested models back to plain dicts.
                     out[name] = adapter.dump_python(adapter.validate_python(value))
@@ -319,6 +325,14 @@ def _coerce_str_value(value: Any) -> Any:
     if isinstance(value, (list, dict)):
         return json.dumps(value)
     return str(value)
+
+
+#: Pre-coercions applied before pydantic validation, keyed by the scalar
+#: spec type. Fills the gaps in pydantic's lax conversion table — which
+#: coerces between scalars in every direction except *to* ``str``.
+RECONCILERS: dict[type, Callable[[Any], Any]] = {
+    str: _coerce_str_value,
+}
 
 
 def _resolve_field_type(types_seen: set[type]) -> type:

--- a/packages/interloper-core/src/interloper/schema/base.py
+++ b/packages/interloper-core/src/interloper/schema/base.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+import logging
 import types
 import warnings
 from dataclasses import dataclass
@@ -14,6 +16,8 @@ from interloper.errors import SchemaError
 from interloper.serializable import Serializable
 
 warnings.filterwarnings("ignore", message=r'Field name ".*" in ".*" shadows an attribute in parent "Schema"')
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -238,12 +242,15 @@ class Schema(Serializable):
         """Reconcile rows against this schema.
 
         For each row:
-        1. Filter to only the keys defined in the schema (drop extras).
+        1. Filter to only the keys defined in the schema (drop extras — the
+           union of dropped keys is logged as a warning).
         2. For missing keys that have a default, omit them so Pydantic applies
            the default.  For missing *required* keys, supply ``None`` — Pydantic
            will accept it when the field is nullable (e.g. ``str | None``) and
            reject it otherwise, which is the desired behaviour.
-        3. Coerce values to the schema's types using ``model_validate()``.
+        3. Coerce values to the schema's types: scalar ``str`` fields are
+           stringified explicitly (pydantic's lax mode never coerces to
+           ``str``), everything else via ``model_validate()``.
 
         This is more permissive than :meth:`validate` — it actively
         transforms data to match the schema rather than rejecting mismatches.
@@ -262,10 +269,17 @@ class Schema(Serializable):
             return []
 
         schema_fields = cls._data_fields()
+        # Pydantic's lax mode never coerces to ``str`` (an int id stays an
+        # int and fails validation), so scalar ``str`` fields are stringified
+        # up front — mirroring the DataFrame conformer's ``astype("string")``
+        # and its JSON encoding of nested values.
+        str_fields = {s.name for s in cls.field_specs() if s.type is str and not s.repeated and s.fields is None}
 
+        dropped: set[str] = set()
         result: list[dict[str, Any]] = []
         for i, row in enumerate(rows):
-            filtered = {k: row[k] for k in schema_fields if k in row}
+            dropped.update(row.keys() - schema_fields)
+            filtered = {k: _coerce_str_value(row[k]) if k in str_fields else row[k] for k in schema_fields if k in row}
             for k in schema_fields - filtered.keys():
                 if cls.model_fields[k].is_required():
                     filtered[k] = None
@@ -274,6 +288,10 @@ class Schema(Serializable):
             except ValidationError as e:
                 raise SchemaError(f"Reconciliation failed on row {i}: {e}") from e
             result.append(instance.model_dump(include=schema_fields))
+        if dropped:
+            logger.warning(
+                "Reconciliation to schema '%s' dropped fields not in the schema: %s", cls.__name__, sorted(dropped)
+            )
         return result
 
     # -- Internals -------------------------------------------------------------
@@ -287,6 +305,22 @@ class Schema(Serializable):
         columns.
         """
         return {name for name in cls.model_fields if name not in Schema.model_fields}
+
+
+def _coerce_str_value(value: Any) -> Any:
+    """Coerce a value bound for a scalar ``str`` field to a string.
+
+    ``None`` passes through (nullability is pydantic's call), nested
+    ``list``/``dict`` values are JSON-encoded, anything else is stringified.
+
+    Returns:
+        The coerced value.
+    """
+    if value is None or isinstance(value, str):
+        return value
+    if isinstance(value, (list, dict)):
+        return json.dumps(value)
+    return str(value)
 
 
 def _resolve_field_type(types_seen: set[type]) -> type:

--- a/packages/interloper-core/src/interloper/schema/base.py
+++ b/packages/interloper-core/src/interloper/schema/base.py
@@ -9,7 +9,7 @@ import warnings
 from dataclasses import dataclass
 from typing import Any, Union, get_args, get_origin
 
-from pydantic import BaseModel, ConfigDict, ValidationError, create_model
+from pydantic import BaseModel, ConfigDict, TypeAdapter, ValidationError, create_model
 from typing_extensions import Self
 
 from interloper.errors import SchemaError
@@ -241,16 +241,12 @@ class Schema(Serializable):
     ) -> list[dict[str, Any]]:
         """Reconcile rows against this schema.
 
-        For each row:
-        1. Filter to only the keys defined in the schema (drop extras — the
-           union of dropped keys is logged as a warning).
-        2. For missing keys that have a default, omit them so Pydantic applies
-           the default.  For missing *required* keys, supply ``None`` — Pydantic
-           will accept it when the field is nullable (e.g. ``str | None``) and
-           reject it otherwise, which is the desired behaviour.
-        3. Coerce values to the schema's types: scalar ``str`` fields are
-           stringified explicitly (pydantic's lax mode never coerces to
-           ``str``), everything else via ``model_validate()``.
+        Fields are coerced one by one through per-field ``TypeAdapter``s —
+        the row-wise mirror of the DataFrame conformer's column-wise casts.
+        Extra keys are dropped (their union logged as a warning), missing
+        fields get their default (or ``None``, which pydantic accepts only
+        for nullable fields), and scalar ``str`` fields are stringified
+        up front since pydantic's lax mode never coerces *to* ``str``.
 
         This is more permissive than :meth:`validate` — it actively
         transforms data to match the schema rather than rejecting mismatches.
@@ -262,32 +258,34 @@ class Schema(Serializable):
             A new list of row dicts with columns aligned and types coerced.
 
         Raises:
-            SchemaError: If any row cannot be coerced (e.g. ``"abc"`` → ``int``)
+            SchemaError: If a value cannot be coerced (e.g. ``"abc"`` → ``int``)
                 or a required non-nullable field is missing.
         """
         if not rows:
             return []
 
-        schema_fields = cls._data_fields()
-        # Pydantic's lax mode never coerces to ``str`` (an int id stays an
-        # int and fails validation), so scalar ``str`` fields are stringified
-        # up front — mirroring the DataFrame conformer's ``astype("string")``
-        # and its JSON encoding of nested values.
+        fields = {spec.name: cls.model_fields[spec.name] for spec in cls.field_specs()}
+        adapters = {name: TypeAdapter(field.annotation) for name, field in fields.items()}
         str_fields = {s.name for s in cls.field_specs() if s.type is str and not s.repeated and s.fields is None}
 
         dropped: set[str] = set()
         result: list[dict[str, Any]] = []
         for i, row in enumerate(rows):
-            dropped.update(row.keys() - schema_fields)
-            filtered = {k: _coerce_str_value(row[k]) if k in str_fields else row[k] for k in schema_fields if k in row}
-            for k in schema_fields - filtered.keys():
-                if cls.model_fields[k].is_required():
-                    filtered[k] = None
-            try:
-                instance = cls.model_validate(filtered)
-            except ValidationError as e:
-                raise SchemaError(f"Reconciliation failed on row {i}: {e}") from e
-            result.append(instance.model_dump(include=schema_fields))
+            dropped.update(row.keys() - fields.keys())
+            out: dict[str, Any] = {}
+            for name, adapter in adapters.items():
+                if name not in row and not fields[name].is_required():
+                    out[name] = fields[name].get_default(call_default_factory=True)
+                    continue
+                value = row.get(name)
+                if name in str_fields:
+                    value = _coerce_str_value(value)
+                try:
+                    # dump_python round-trips nested models back to plain dicts.
+                    out[name] = adapter.dump_python(adapter.validate_python(value))
+                except ValidationError as e:
+                    raise SchemaError(f"Reconciliation failed on row {i}: {e}") from e
+            result.append(out)
         if dropped:
             logger.warning(
                 "Reconciliation to schema '%s' dropped fields not in the schema: %s", cls.__name__, sorted(dropped)

--- a/packages/interloper-core/src/interloper/source/base.py
+++ b/packages/interloper-core/src/interloper/source/base.py
@@ -112,9 +112,10 @@ class Source(Component):
         label="Materialization Strategy",
         description="Default strategy for this source's assets.",
         info=(
-            "'Auto' validates data against the schema, 'Strict' fails on any "
-            "mismatch, 'Reconcile' coerces values to the schema. Assets "
-            "declaring their own strategy keep it."
+            "'Auto' coerces data to the schema (or infers a schema when "
+            "none is declared), 'Strict' fails on any mismatch, 'Reconcile' "
+            "requires a schema and coerces values to it. Assets declaring "
+            "their own strategy keep it."
         ),
     )
     assets: list[Asset] = Field(default_factory=list)

--- a/packages/interloper-core/tests/asset/test_base.py
+++ b/packages/interloper-core/tests/asset/test_base.py
@@ -633,14 +633,23 @@ class TestAsyncAndSyncData:
 class TestConform:
     """Schema enforcement runs whether or not a normalizer is configured."""
 
-    async def test_schema_validates_without_normalizer(self):
+    async def test_schema_conforms_without_normalizer(self):
         @il.asset(schema=ConformSchema)
         def users() -> list[dict[str, Any]]:
             return [{"user_id": 1, "name": "a"}]
 
         assert await users().run_async() == [{"user_id": 1, "name": "a"}]
 
-    async def test_mismatched_data_fails_fast(self):
+    async def test_auto_with_schema_coerces_types(self):
+        # AUTO reconciles by default: an int id against a str field is cast,
+        # not rejected.
+        @il.asset(schema=ConformSchema)
+        def users() -> list[dict[str, Any]]:
+            return [{"user_id": "1", "name": 42}]
+
+        assert await users().run_async() == [{"user_id": 1, "name": "42"}]
+
+    async def test_uncoercible_data_fails_fast(self):
         from interloper.errors import SchemaError
 
         @il.asset(schema=ConformSchema)
@@ -650,11 +659,23 @@ class TestConform:
         with pytest.raises(SchemaError):
             await users().run_async()
 
-    async def test_dataframe_validated_without_normalizer(self):
+    async def test_dataframe_reconciled_without_normalizer(self):
         pd = pytest.importorskip("pandas")
-        from interloper.errors import SchemaError
 
         @il.asset(schema=StrictConformSchema)
+        def users() -> Any:
+            return pd.DataFrame([{"userId": 1, "Name": "a"}])  # wrong casing -> extras dropped, nullables filled
+
+        result = await users().run_async()
+        assert list(result.columns) == ["user_id", "name"]
+        assert result["user_id"].isna().all()
+
+    async def test_strict_rejects_mismatched_dataframe(self):
+        pd = pytest.importorskip("pandas")
+        from interloper.errors import SchemaError
+        from interloper.normalizer import MaterializationStrategy
+
+        @il.asset(schema=StrictConformSchema, materialization_strategy=MaterializationStrategy.STRICT)
         def users() -> Any:
             return pd.DataFrame([{"userId": 1, "Name": "a"}])  # wrong casing -> required fields missing
 

--- a/packages/interloper-core/tests/schema/test_base.py
+++ b/packages/interloper-core/tests/schema/test_base.py
@@ -125,6 +125,30 @@ class TestFieldSpecs:
         assert specs["b"].type is str
 
 
+class TestReconcile:
+    """Row-wise reconciliation coerces values and aligns fields."""
+
+    def test_int_values_coerced_to_str_fields(self):
+        # Pydantic's lax mode never coerces int -> str; reconcile must, to
+        # match the DataFrame conformer's astype("string").
+        rows = ShadowingSchema.reconcile([{"id": 1, "cost": 2.0, "name": 42, "day": "mon"}])
+        assert rows[0]["name"] == "42"
+
+    def test_nested_values_json_encoded_for_str_fields(self):
+        rows = ShadowingSchema.reconcile([{"id": 1, "cost": 2.0, "name": [{"a": 1}], "day": "mon"}])
+        assert rows[0]["name"] == '[{"a": 1}]'
+
+    def test_none_passes_through_str_coercion(self):
+        rows = ShadowingSchema.reconcile([{"id": 1, "cost": 2.0, "name": None, "day": "mon"}])
+        assert rows[0]["name"] is None
+
+    def test_dropped_fields_logged(self, caplog):
+        with caplog.at_level("WARNING", logger="interloper.schema.base"):
+            ShadowingSchema.reconcile([{"id": 1, "cost": 2.0, "name": "x", "day": "mon", "extra": True}])
+        assert "dropped fields" in caplog.text
+        assert "extra" in caplog.text
+
+
 class TestJsonSchema:
     """JSON Schema generation restricted to data fields."""
 

--- a/packages/interloper-pandas/src/interloper_pandas/conformer.py
+++ b/packages/interloper-pandas/src/interloper_pandas/conformer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime
 import json
+import logging
 from decimal import Decimal
 from typing import Any
 
@@ -12,6 +13,8 @@ from interloper.conformer import Conformer
 from interloper.errors import SchemaError
 from interloper.schema import FieldSpec, Schema
 from pydantic import create_model
+
+logger = logging.getLogger(__name__)
 
 
 class DataFrameConformer(Conformer):
@@ -49,19 +52,29 @@ class DataFrameConformer(Conformer):
             Reconciled DataFrame.
 
         Raises:
-            SchemaError: If a column cannot be cast to its declared type, or
-                a required non-nullable column is missing.
+            SchemaError: If a column cannot be cast to its declared type, a
+                required non-nullable column is missing, or a non-nullable
+                column contains nulls.
         """
         data = _encode_json_str_columns(data, schema)
+        specs = schema.field_specs()
+        dropped = set(data.columns) - {spec.name for spec in specs}
+        if dropped:
+            logger.warning(
+                "Reconciliation to schema '%s' dropped columns not in the schema: %s", schema.__name__, sorted(dropped)
+            )
         columns: dict[str, pd.Series] = {}
-        for spec in schema.field_specs():
+        for spec in specs:
             if spec.name in data.columns:
                 series = data[spec.name]
             elif spec.nullable:
                 series = pd.Series([None] * len(data), index=data.index, dtype=object)
             else:
                 raise SchemaError(f"Reconciliation failed: required column '{spec.name}' is missing.")
-            columns[spec.name] = _cast_series(series, spec)
+            cast = _cast_series(series, spec)
+            if not spec.nullable and cast.isna().any():
+                raise SchemaError(f"Reconciliation failed: non-nullable column '{spec.name}' contains null values.")
+            columns[spec.name] = cast
         return pd.DataFrame(columns, index=data.index)
 
     def infer(self, data: pd.DataFrame) -> type[Schema]:

--- a/packages/interloper-pandas/tests/test_conformer.py
+++ b/packages/interloper-pandas/tests/test_conformer.py
@@ -86,6 +86,26 @@ class TestDataFrameConformerReconcile:
         with pytest.raises(SchemaError, match="cannot cast"):
             DataFrameConformer().reconcile(df, TypedSchema)
 
+    def test_int_values_cast_to_string_field(self):
+        # Vendor APIs and pd.read_csv routinely yield numeric ids for str-typed
+        # fields; reconcile must cast them rather than reject the rows.
+        out = DataFrameConformer().reconcile(pd.DataFrame({"name": [143007073]}), TypedSchema)
+        assert out["name"].tolist() == ["143007073"]
+
+    def test_non_nullable_column_with_nulls_raises(self):
+
+        class Req(Schema):
+            must: int
+
+        with pytest.raises(SchemaError, match="non-nullable column 'must' contains null"):
+            DataFrameConformer().reconcile(pd.DataFrame({"must": [1, None]}), Req)
+
+    def test_dropped_columns_logged(self, caplog):
+        with caplog.at_level("WARNING", logger="interloper_pandas.conformer"):
+            DataFrameConformer().reconcile(pd.DataFrame({"id": [1], "extra": ["drop"]}), TypedSchema)
+        assert "dropped columns" in caplog.text
+        assert "extra" in caplog.text
+
 
 class JsonSchema(Schema):
     """A scalar ``str`` field that receives nested API values."""


### PR DESCRIPTION
## Context

Prod run `86820d15` (bing_ads `ads_stats`) failed conform because the report CSV's ID columns were int-inferred while the schema declares `str` — and the default `AUTO` strategy validates without coercion, so a destination-level `reconcile` never got the chance to cast. Rather than fixing this per-source, this changes the default: **an asset with a declared schema now reconciles by default**.

## Changes

- `Asset._conform`: `AUTO` with a schema takes the reconcile branch (was validate). Schema-less `AUTO` (infer + pass through), `STRICT`, and `RECONCILE` are unchanged.
- **Rows/DataFrame coercion parity**: `Schema.reconcile` now stringifies scalar `str` fields explicitly and JSON-encodes nested values — pydantic lax mode never coerces `int → str`, so the rows path previously rejected exactly the data the pandas path casts.
- **Contract teeth kept**: the DataFrame conformer now rejects nulls in non-nullable columns (parity with the rows path), and both conformers log a warning listing dropped extra columns so upstream schema drift stays visible instead of becoming silent data loss.
- Docs and field help texts updated.

## Breaking change

Assets with a declared schema on the default strategy now coerce instead of validate: extra columns are dropped (previously passed through untouched) and coercible mismatches no longer raise `SchemaError`. `STRICT` keeps the old rejecting behavior.

## Verification

- Full pre-commit suite (ruff, ty, pytest — 1110 tests) green.
- New tests: AUTO-with-schema coercion (rows + DataFrame), int→str cast on both conformers, non-nullable null rejection, dropped-column warnings, STRICT still rejecting.

By Digitl