### PR TITLE
feat(app): collapse type groups by default and drop collection pagination

### DIFF
--- a/packages/interloper-app/app/app/components/collection/Table.vue
+++ b/packages/interloper-app/app/app/components/collection/Table.vue
@@ -155,9 +155,6 @@ function onRowContextMenu(e: Event, row: any) {
     ctxMenuOpen.value = true
 }
 
-const SOURCE_PAGE_SIZE = 20
-const sourcePageIndex = ref(0)
-
 const globalFilter = ref('')
 
 const filteredData = computed(() => {
@@ -180,48 +177,10 @@ const filteredData = computed(() => {
     return data.value.filter(d => matchingAssetIds.has(d.assetId))
 })
 
-// Reset to first page when search filter changes
-watch(globalFilter, () => {
-    sourcePageIndex.value = 0
-})
-
-// Source ids ordered type-contiguously, so a source type's sources only ever
-// split across a page boundary rather than interleaving with other types.
-const uniqueSourceIds = computed(() => {
-    const byType = new Map<string, string[]>()
-    const seen = new Set<string>()
-    for (const d of filteredData.value) {
-        if (seen.has(d.sourceId)) continue
-        seen.add(d.sourceId)
-        const list = byType.get(d.sourceKey)
-        if (list) list.push(d.sourceId)
-        else byType.set(d.sourceKey, [d.sourceId])
-    }
-    return [...byType.values()].flat()
-})
-
-
-const paginatedData = computed(() => {
-    const start = sourcePageIndex.value * SOURCE_PAGE_SIZE
-    const pageSourceIds = new Set(uniqueSourceIds.value.slice(start, start + SOURCE_PAGE_SIZE))
-    return filteredData.value.filter(d => pageSourceIds.has(d.sourceId))
-})
-
 // Expanded state keyed by TanStack grouped-row id (`source_type:<key>` /
-// `source_type:<key>>source_id:<id>`). Type rows act as section headers and
-// default to expanded, so sources stay visible; user collapses are respected.
+// `source_type:<key>>source_id:<id>`). Always replace the object — TanStack
+// memoizes the row model on its identity, so in-place mutation goes stale.
 const expanded = ref<Record<string, boolean>>({})
-
-watch(paginatedData, (rows) => {
-    const additions: Record<string, boolean> = {}
-    for (const d of rows) {
-        const id = `source_type:${d.sourceKey}`
-        if (!(id in expanded.value)) additions[id] = true
-    }
-    // New object on purpose: TanStack memoizes the row model on the state
-    // object's identity, so in-place mutation would leave it stale.
-    if (Object.keys(additions).length > 0) expanded.value = { ...expanded.value, ...additions }
-}, { immediate: true })
 
 const allExpanded = ref(false)
 
@@ -230,7 +189,7 @@ function toggleAllExpanded() {
 
     if (allExpanded.value) {
         const next: Record<string, boolean> = {}
-        for (const d of paginatedData.value) {
+        for (const d of filteredData.value) {
             next[`source_type:${d.sourceKey}`] = true
             next[`source_type:${d.sourceKey}>source_id:${d.sourceId}`] = true
         }
@@ -269,7 +228,7 @@ function onRowClick(row: any) {
         </div>
 
         <UTable v-model:expanded="expanded"
-                :data="paginatedData"
+                :data="filteredData"
                 :columns="columns"
                 :loading="loading"
                 :grouping="grouping"
@@ -592,10 +551,7 @@ function onRowClick(row: any) {
             <div class="hidden" />
         </UDropdownMenu>
 
-        <TableFooter :page="sourcePageIndex + 1"
-                     :total="uniqueSourceIds.length"
-                     :page-size="SOURCE_PAGE_SIZE"
-                     @update:page="(p: number) => sourcePageIndex = p - 1">
+        <TableFooter>
             {{ sources.length }} {{ sources.length === 1 ? 'source' : 'sources' }},
             {{ assetCount }} {{ assetCount === 1 ? 'asset' : 'assets' }}
         </TableFooter>


### PR DESCRIPTION
Follow-up to #216:

- **Type groups start collapsed** — the default-expand watch is gone; type rows behave like every other tier and the page opens with just the type headers.
- **No more pagination on the collection table** — everything renders on one page. The per-source pager, page-index state, and the type-contiguous source ordering (which existed only to keep a type from splitting across pages) are removed; the footer keeps its "N sources, N assets" caption.

Verified live on a seeded dev instance: collapsed default, no pager, Expand/Collapse all working over the full (unpaginated) data. Lint and typecheck pass.

By Digitl