### PR TITLE
feat(api): gate signup behind an email-domain allowlist

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,9 @@ INTERLOPER_AUTH_GOOGLE_CLIENT_SECRET=
 # Comma-separated emails promoted to super-admin on login (promote-only).
 # The seed above already covers dev; this is the production bootstrap path.
 # INTERLOPER_AUTH_SUPER_ADMIN_EMAILS=
+# Comma-separated email domains allowed to sign up (first login). Empty keeps
+# signup open. Existing profiles, super-admins and invited emails always pass.
+# INTERLOPER_AUTH_SIGNUP_ALLOWED_DOMAINS=
 
 
 # ── Connector OAuth (connecting data sources from the UI) ────────────────────

--- a/chart/interloper/values.yaml
+++ b/chart/interloper/values.yaml
@@ -184,12 +184,17 @@ smtp: {}
 # Auth config (OAuth client ID; the client secret goes in
 # secrets.googleClientSecret). super_admin_emails bootstraps the first
 # platform super-admin(s): listed users are promoted when they log in
-# (promote-only — removing an email never demotes).
+# (promote-only — removing an email never demotes). signup_allowed_domains
+# restricts signup to the listed email domains (plus super-admins and
+# invited emails); empty keeps signup open. Existing profiles always
+# keep signing in.
 auth: {}
 # auth:
 #   google_client_id: "..."
 #   super_admin_emails:
 #     - you@example.com
+#   signup_allowed_domains:
+#     - example.com
 
 # Extra interloper.yaml sections rendered verbatim into the generated
 # ConfigMap — tuning the chart has no opinion on (server, cron, worker,

--- a/packages/interloper-api/src/interloper_api/routes/auth.py
+++ b/packages/interloper-api/src/interloper_api/routes/auth.py
@@ -22,6 +22,25 @@ GOOGLE_USERINFO_URL = "https://www.googleapis.com/oauth2/v2/userinfo"
 router = APIRouter(prefix="/auth", tags=["auth"])
 
 
+def _signup_allowed(email: str, auth_config: Any, store: Store) -> bool:
+    """Decide whether a first-time login may create a profile.
+
+    An empty ``signup_allowed_domains`` keeps signup open (the default).
+    Otherwise the email must be on an allowed domain, be a configured
+    super-admin, or hold a pending invitation.
+    """
+    allowed_domains = auth_config.signup_allowed_domains
+    if not allowed_domains:
+        return True
+
+    email = email.lower()
+    if email in auth_config.super_admin_emails:
+        return True
+    if email.rsplit("@", 1)[-1] in allowed_domains:
+        return True
+    return store.has_pending_invitation(email)
+
+
 class OrganisationResponse(BaseModel):
     """Organisation summary for auth responses."""
 
@@ -122,6 +141,11 @@ def google_callback(
 
     if not google_id or not email:
         raise HTTPException(status_code=401, detail="Incomplete user info from Google")
+
+    # Gate signup only: existing profiles always sign in, a first login must
+    # pass the allowlist before a profile is created.
+    if not store.get_profile_by_google_id(google_id) and not _signup_allowed(email, auth_config, store):
+        return RedirectResponse(url="/login?error=signup_not_allowed", status_code=302)
 
     # Upsert profile
     profile = store.upsert_profile(

--- a/packages/interloper-api/tests/test_auth.py
+++ b/packages/interloper-api/tests/test_auth.py
@@ -1,9 +1,10 @@
-"""Tests for ``interloper_api.routes.auth`` — super-admin bootstrap on login.
+"""Tests for ``interloper_api.routes.auth`` — login callback policies.
 
 The Google OAuth exchange is faked at the httpx layer; a lightweight fake store
-records the promotion calls. The property under test: a user whose email is in
-``auth_config.super_admin_emails`` is promoted on login, everyone else is not,
-and the promotion is promote-only (an existing super-admin is left alone).
+records the calls. Two properties under test: a user whose email is in
+``auth_config.super_admin_emails`` is promoted on login (promote-only — an
+existing super-admin is left alone), and ``signup_allowed_domains`` gates
+profile creation for first-time logins without touching existing profiles.
 """
 
 from __future__ import annotations
@@ -22,11 +23,21 @@ from interloper_api.routes import auth as auth_module
 class FakeStore:
     """In-memory stand-in implementing only the methods the callback calls."""
 
-    def __init__(self, *, is_super_admin: bool = False) -> None:
+    def __init__(self, *, is_super_admin: bool = False, exists: bool = False, invited: bool = False) -> None:
         self.profile = SimpleNamespace(id=uuid4(), is_super_admin=is_super_admin)
+        self.exists = exists
+        self.invited = invited
         self.promoted: list[UUID] = []
+        self.upserted = False
+
+    def get_profile_by_google_id(self, google_id: str) -> SimpleNamespace | None:
+        return self.profile if self.exists else None
+
+    def has_pending_invitation(self, email: str) -> bool:
+        return self.invited
 
     def upsert_profile(self, **kwargs) -> SimpleNamespace:
+        self.upserted = True
         return self.profile
 
     def set_super_admin(self, user_id: UUID) -> SimpleNamespace:
@@ -38,7 +49,7 @@ class FakeStore:
         return "token"
 
 
-def _auth_config(super_admin_emails: list[str]) -> SimpleNamespace:
+def _auth_config(super_admin_emails: list[str], signup_allowed_domains: list[str]) -> SimpleNamespace:
     return SimpleNamespace(
         google_client_id="client-id",
         google_client_secret="client-secret",
@@ -46,14 +57,21 @@ def _auth_config(super_admin_emails: list[str]) -> SimpleNamespace:
         cookie_secure=False,
         session_expiry_days=1,
         super_admin_emails=super_admin_emails,
+        signup_allowed_domains=signup_allowed_domains,
     )
 
 
-def _client(store: FakeStore, super_admin_emails: list[str]) -> TestClient:
+def _client(
+    store: FakeStore,
+    super_admin_emails: list[str] | None = None,
+    signup_allowed_domains: list[str] | None = None,
+) -> TestClient:
     app = FastAPI()
     app.include_router(auth_module.router)
     app.dependency_overrides[get_store] = lambda: store
-    app.dependency_overrides[get_auth_config] = lambda: _auth_config(super_admin_emails)
+    app.dependency_overrides[get_auth_config] = lambda: _auth_config(
+        super_admin_emails or [], signup_allowed_domains or []
+    )
     return TestClient(app, follow_redirects=False)
 
 
@@ -94,3 +112,50 @@ def test_existing_super_admin_is_not_touched() -> None:
     resp = _client(store, ["boss@example.com"]).get("/auth/google/callback", params={"code": "c"})
     assert resp.status_code == 302
     assert store.promoted == []
+
+
+def test_signup_blocked_when_domain_not_allowed() -> None:
+    store = FakeStore()
+    client = _client(store, signup_allowed_domains=["digitlcloud.com"])
+    resp = client.get("/auth/google/callback", params={"code": "c"})
+    assert resp.status_code == 302
+    assert resp.headers["location"] == "/login?error=signup_not_allowed"
+    assert not store.upserted
+    assert "session_token" not in resp.cookies
+
+
+def test_signup_allowed_for_listed_domain() -> None:
+    store = FakeStore()
+    resp = _client(store, signup_allowed_domains=["example.com"]).get("/auth/google/callback", params={"code": "c"})
+    assert resp.status_code == 302
+    assert resp.headers["location"] == "/"
+    assert store.upserted
+
+
+def test_existing_profile_bypasses_allowlist() -> None:
+    store = FakeStore(exists=True)
+    resp = _client(store, signup_allowed_domains=["digitlcloud.com"]).get(
+        "/auth/google/callback", params={"code": "c"}
+    )
+    assert resp.status_code == 302
+    assert resp.headers["location"] == "/"
+    assert store.upserted
+
+
+def test_invited_email_can_sign_up() -> None:
+    store = FakeStore(invited=True)
+    resp = _client(store, signup_allowed_domains=["digitlcloud.com"]).get(
+        "/auth/google/callback", params={"code": "c"}
+    )
+    assert resp.status_code == 302
+    assert resp.headers["location"] == "/"
+    assert store.upserted
+
+
+def test_super_admin_email_can_sign_up() -> None:
+    store = FakeStore()
+    client = _client(store, super_admin_emails=["boss@example.com"], signup_allowed_domains=["digitlcloud.com"])
+    resp = client.get("/auth/google/callback", params={"code": "c"})
+    assert resp.status_code == 302
+    assert resp.headers["location"] == "/"
+    assert store.promoted == [store.profile.id]

--- a/packages/interloper-app/app/app/pages/login.vue
+++ b/packages/interloper-app/app/app/pages/login.vue
@@ -7,7 +7,11 @@ definePageMeta({
 const route = useRoute()
 const userStore = useUserStore()
 const loading = ref(false)
-const error = ref('')
+
+const errorMessages: Record<string, string> = {
+    signup_not_allowed: 'This Google account is not allowed to sign up. Ask an administrator for an invitation.',
+}
+const error = ref(errorMessages[route.query.error as string] ?? '')
 
 function signInWithGoogle() {
     loading.value = true

--- a/packages/interloper-core/src/interloper/settings.py
+++ b/packages/interloper-core/src/interloper/settings.py
@@ -50,6 +50,12 @@ class AuthSettings(BaseSettings):
     Google email is listed gets ``is_super_admin`` set on login. Promotion only —
     removing an email never demotes an existing super-admin. The env var takes a
     comma-separated list (``INTERLOPER_AUTH_SUPER_ADMIN_EMAILS=a@x.com,b@x.com``).
+
+    ``signup_allowed_domains`` restricts who can sign up (first login creates a
+    profile). Empty (the default) keeps signup open to any Google account. When
+    set, a new profile is only created for emails on a listed domain, configured
+    super-admins, or emails holding a pending invitation; existing profiles
+    always keep signing in. Comma-separated env var, like the emails list.
     """
 
     model_config = SettingsConfigDict(env_prefix=f"{PREFIX}AUTH_")
@@ -60,18 +66,20 @@ class AuthSettings(BaseSettings):
     cookie_secure: bool = True
     session_expiry_days: int = 30
     super_admin_emails: Annotated[list[str], NoDecode] = Field(default_factory=list)
+    signup_allowed_domains: Annotated[list[str], NoDecode] = Field(default_factory=list)
 
-    @field_validator("super_admin_emails", mode="before")
+    @field_validator("super_admin_emails", "signup_allowed_domains", mode="before")
     @classmethod
-    def _parse_super_admin_emails(cls, value: Any) -> list[str]:
+    def _parse_comma_list(cls, value: Any) -> list[str]:
         """Accept a comma-separated string (env) or a list (YAML).
 
         Returns:
-            Trimmed, lowercased email list with empty entries dropped.
+            Trimmed, lowercased entries with empties dropped and any leading
+            ``@`` stripped (so ``@example.com`` and ``example.com`` both work).
         """
         if isinstance(value, str):
             value = value.split(",")
-        return [email.strip().lower() for email in value if email and email.strip()]
+        return [entry.strip().lower().lstrip("@") for entry in value if entry and entry.strip()]
 
 
 class SecretsSettings(BaseSettings):

--- a/packages/interloper-core/tests/test_settings.py
+++ b/packages/interloper-core/tests/test_settings.py
@@ -45,3 +45,19 @@ def test_auth_settings_super_admin_emails_list():
     settings = AuthSettings(super_admin_emails=["Admin@Example.com"])
 
     assert settings.super_admin_emails == ["admin@example.com"]
+
+
+def test_auth_settings_signup_allowed_domains_default():
+    """Signup stays open (empty allowlist) unless configured."""
+    settings = AuthSettings()
+
+    assert settings.signup_allowed_domains == []
+
+
+def test_auth_settings_signup_allowed_domains_env(monkeypatch: pytest.MonkeyPatch):
+    """Comma-separated env list; entries trimmed, lowercased, leading @ stripped."""
+    monkeypatch.setenv("INTERLOPER_AUTH_SIGNUP_ALLOWED_DOMAINS", " Digitlcloud.com ,@example.com,")
+
+    settings = AppSettings()
+
+    assert settings.auth.signup_allowed_domains == ["digitlcloud.com", "example.com"]

--- a/packages/interloper-db/src/interloper_db/store/auth.py
+++ b/packages/interloper-db/src/interloper_db/store/auth.py
@@ -134,6 +134,18 @@ class AuthMixin(StoreBase):
         with self._session() as session:
             return session.get(Profile, user_id)
 
+    def get_profile_by_google_id(self, google_id: str) -> Profile | None:
+        """Get a profile by Google OAuth subject identifier.
+
+        Args:
+            google_id: Google OAuth subject identifier.
+
+        Returns:
+            The Profile or None.
+        """
+        with self._session() as session:
+            return session.exec(select(Profile).where(Profile.google_id == google_id)).first()
+
     # -- Sessions -------------------------------------------------------------
 
     def create_session(self, user_id: UUID, organisation_id: UUID | None = None) -> str:
@@ -500,6 +512,22 @@ class AuthMixin(StoreBase):
                 raise NotFoundError(f"Invitation {invitation_id} not found")
             session.delete(db_invitation)
             session.commit()
+
+    def has_pending_invitation(self, email: str) -> bool:
+        """Check whether a non-expired invitation exists for an email.
+
+        Args:
+            email: Email address, matched case-insensitively.
+
+        Returns:
+            True when at least one pending invitation has not expired.
+        """
+        now = datetime.now(timezone.utc)
+        with self._session() as session:
+            db_invitations = session.exec(
+                select(Invitation).where(func.lower(Invitation.email) == email.lower())
+            ).all()
+            return any(_as_utc(invitation.expires_at) > now for invitation in db_invitations)
 
     def accept_invitation(self, token: str, user_id: UUID) -> Organisation | None:
         """Accept an invitation: add user to org and delete the invitation.

--- a/packages/interloper-db/tests/store/test_auth.py
+++ b/packages/interloper-db/tests/store/test_auth.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from datetime import datetime, timedelta, timezone
 from typing import Any
 from uuid import uuid4
 
@@ -10,6 +11,7 @@ import interloper as il
 import pytest
 from sqlalchemy import Engine, event
 from sqlalchemy.pool import StaticPool
+from sqlmodel import Session as SQLSession
 
 from interloper_db import engine as engine_module
 from interloper_db.models import Invitation, Organisation, Profile, UserOrganisation
@@ -69,3 +71,43 @@ class TestAcceptInvitation:
         invitee = store.upsert_profile(google_id="g-invitee", email="new@example.com", name="New")
 
         assert store.accept_invitation("no-such-token", invitee.id) is None
+
+
+class TestGetProfileByGoogleId:
+    def test_returns_matching_profile(self, store: Store):
+        profile = store.upsert_profile(google_id="g-1", email="user@example.com", name="User")
+
+        found = store.get_profile_by_google_id("g-1")
+
+        assert found is not None
+        assert found.id == profile.id
+
+    def test_returns_none_when_absent(self, store: Store):
+        assert store.get_profile_by_google_id("g-missing") is None
+
+
+class TestHasPendingInvitation:
+    def _invite(self, store: Store, email: str) -> Invitation:
+        admin = store.upsert_profile(google_id="g-admin", email="admin@example.com", name="Admin")
+        org = store.create_organisation(name="Acme", creator_id=admin.id)
+        return store.create_invitation(org_id=org.id, email=email, role="member", invited_by=admin.id)
+
+    def test_pending_invitation_matches_case_insensitively(self, store: Store):
+        self._invite(store, "New@Example.com")
+
+        assert store.has_pending_invitation("new@example.com")
+
+    def test_no_invitation_returns_false(self, store: Store):
+        assert not store.has_pending_invitation("nobody@example.com")
+
+    def test_expired_invitation_returns_false(self, store: Store, auth_db: Engine):
+        invitation = self._invite(store, "new@example.com")
+
+        with SQLSession(auth_db) as session:
+            db_invitation = session.get(Invitation, invitation.id)
+            assert db_invitation is not None
+            db_invitation.expires_at = datetime.now(timezone.utc) - timedelta(days=1)
+            session.add(db_invitation)
+            session.commit()
+
+        assert not store.has_pending_invitation("new@example.com")


### PR DESCRIPTION
## What

Adds `INTERLOPER_AUTH_SIGNUP_ALLOWED_DOMAINS` (`auth.signup_allowed_domains` in `interloper.yaml` / chart values): an opt-in allowlist that gates **signup** — first-login profile creation — in the Google OAuth callback.

- **Empty (default): no behavior change** — signup stays open, so deploying this is a no-op until the value is set.
- When set, a first-time login (no existing profile for the `google_id`) only gets a profile if the email is on a listed domain, is a configured super-admin, or holds a pending (non-expired) invitation — so the invite-an-external flow keeps working with no extra steps.
- Existing profiles always sign in; enabling the setting can never lock out current users.
- Rejected signups are redirected to `/login?error=signup_not_allowed`; the login page shows an explanatory alert. No profile row, no session cookie.

## Why

The prod OAuth client requests only `openid email profile`, and Google's test-user restriction for consent screens in *Testing* status explicitly [does not apply to that scope subset](https://support.google.com/cloud/answer/15549945) — any Google account can complete the flow, and the callback upserts a profile for whoever comes back. Effectively open signup. Google-side options don't fit: *Internal* hard-blocks all non-Workspace accounts (no exceptions), and adding a decoy scope to trigger test-user enforcement abuses an unverified-app mechanism. Hence an app-level gate.

## Changes

- `interloper-core`: `AuthSettings.signup_allowed_domains` — comma-separated env / YAML list, shared validator with `super_admin_emails` (trim, lowercase, tolerate leading `@`).
- `interloper-db`: `get_profile_by_google_id` + `has_pending_invitation` (case-insensitive, expiry-aware) store methods.
- `interloper-api`: `_signup_allowed` gate in the Google callback, before `upsert_profile`.
- `interloper-app`: login page maps the `error` query param onto the existing alert.
- chart: documented `auth.signup_allowed_domains` in `values.yaml` — the `auth:` block already passes through to the generated `interloper.yaml` verbatim, verified with `helm template`.
- `.env.example`: documented next to `SUPER_ADMIN_EMAILS`.

## Notes for review

- The gate deliberately targets profile *creation*, not login — blocking login for existing out-of-policy profiles is a separate (destructive) decision; those can be deleted manually once the gate is live.
- Tests cover all three layers: settings parsing, store methods (including expired invitations), and six callback cases. Full suite: 1151 passed; ruff/ty/ESLint/nuxt typecheck clean.

By Digitl