### PR TITLE
feat(app): give the admin portal its own dashboard and sidebar

### DIFF
--- a/packages/interloper-api/src/interloper_api/routes/admin.py
+++ b/packages/interloper-api/src/interloper_api/routes/admin.py
@@ -39,6 +39,18 @@ class AdminOrganisationResponse(BaseModel):
     created_at: datetime | None = None
 
 
+class AdminUserResponse(BaseModel):
+    """Platform user with organisation membership count for the admin surface."""
+
+    id: UUID
+    email: str
+    name: str | None = None
+    avatar_url: str | None = None
+    is_super_admin: bool = False
+    organisation_count: int
+    created_at: datetime | None = None
+
+
 class CreateOrganisationRequest(BaseModel):
     """Request body for creating an organisation."""
 
@@ -137,6 +149,29 @@ def _send_invitation_email(
         )
     except Exception:
         logger.exception("Failed to send invitation email to %s", email)
+
+
+# -- Users --------------------------------------------------------------------
+
+
+@router.get("/users")
+def list_all_users(
+    user: Profile = Depends(require_super_admin),
+    store: Store = Depends(get_store),
+) -> list[AdminUserResponse]:
+    """List every user profile with its organisation membership count."""
+    return [
+        AdminUserResponse(
+            id=profile.id,
+            email=profile.email,
+            name=profile.name,
+            avatar_url=profile.avatar_url,
+            is_super_admin=profile.is_super_admin,
+            organisation_count=count,
+            created_at=profile.created_at,
+        )
+        for profile, count in store.list_all_profiles()
+    ]
 
 
 # -- Organisations ------------------------------------------------------------

--- a/packages/interloper-api/tests/test_admin.py
+++ b/packages/interloper-api/tests/test_admin.py
@@ -34,6 +34,22 @@ class FakeStore:
         self.added_members: list[tuple[UUID, UUID, str]] = []
         self.already_member = False
 
+    # -- users --
+    def list_all_profiles(self):
+        return [
+            (
+                SimpleNamespace(
+                    id=self.member.id,
+                    email=self.member.email,
+                    name=self.member.name,
+                    avatar_url=None,
+                    is_super_admin=False,
+                    created_at=datetime.now(timezone.utc),
+                ),
+                2,
+            )
+        ]
+
     # -- organisations --
     def list_all_organisations(self):
         return [(self.org, 1)]
@@ -125,6 +141,20 @@ def store() -> FakeStore:
 def test_non_super_admin_is_forbidden(store: FakeStore) -> None:
     resp = _client(store, is_super_admin=False).get("/admin/organisations")
     assert resp.status_code == 403
+
+
+def test_non_super_admin_cannot_list_users(store: FakeStore) -> None:
+    resp = _client(store, is_super_admin=False).get("/admin/users")
+    assert resp.status_code == 403
+
+
+def test_super_admin_lists_all_users(store: FakeStore) -> None:
+    resp = _client(store, is_super_admin=True).get("/admin/users")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body[0]["email"] == "member@acme.test"
+    assert body[0]["organisation_count"] == 2
+    assert body[0]["is_super_admin"] is False
 
 
 def test_super_admin_lists_all_organisations(store: FakeStore) -> None:

--- a/packages/interloper-app/app/app/layouts/admin.vue
+++ b/packages/interloper-app/app/app/layouts/admin.vue
@@ -1,0 +1,102 @@
+<script setup lang="ts">
+import type { NavigationMenuItem } from '@nuxt/ui'
+
+const route = useRoute()
+const appVersion = useRuntimeConfig().public.version
+
+/** Design page header rendered by the layout, declared via definePageMeta({ pageHeader }). */
+interface PageHeaderMeta {
+    eyebrow?: string
+    title: string
+    description?: string
+}
+const pageHeader = computed(() => route.meta.pageHeader as PageHeaderMeta | undefined)
+
+const items = computed<NavigationMenuItem[]>(() => [
+    {
+        label: 'Overview',
+        icon: 'i-lucide-layout-dashboard',
+        to: '/admin',
+        active: route.path === '/admin',
+    },
+    {
+        label: 'Organisations',
+        icon: 'i-lucide-building-2',
+        to: '/admin/organisations',
+        active: route.path.startsWith('/admin/organisations'),
+    },
+    {
+        label: 'Users',
+        icon: 'i-lucide-users',
+        to: '/admin/users',
+        active: route.path.startsWith('/admin/users'),
+    },
+])
+</script>
+
+<template>
+    <UDashboardGroup storage-key="dashboard-admin">
+        <UDashboardSidebar collapsible
+                           resizable
+                           :ui="{ footer: 'border-t border-default' }">
+            <template #header="{ collapsed }">
+                <NavLogo v-if="!collapsed" />
+                <UDashboardSidebarCollapse :class="collapsed ? 'mx-auto' : 'ms-auto'" />
+            </template>
+
+            <template #default="{ collapsed }">
+                <div v-if="!collapsed"
+                     class="eyebrow text-primary px-2.5 pt-1">
+                    Admin portal
+                </div>
+                <UNavigationMenu :collapsed="collapsed"
+                                 :items="items"
+                                 orientation="vertical" />
+            </template>
+
+            <template #footer="{ collapsed }">
+                <div class="flex flex-col gap-1 w-full">
+                    <UButton :label="collapsed ? undefined : 'Exit Admin'"
+                             icon="i-lucide-arrow-left"
+                             color="neutral"
+                             variant="ghost"
+                             block
+                             class="justify-start"
+                             :square="collapsed"
+                             @click="navigateTo('/')" />
+                    <span v-if="!collapsed && appVersion"
+                          class="px-2.5 text-[10px] text-dimmed">
+                        v{{ appVersion }}
+                    </span>
+                </div>
+            </template>
+        </UDashboardSidebar>
+
+        <UDashboardPanel
+                         :ui="{ body: '!p-0 !gap-0 overflow-hidden [&>*]:flex-1 [&>*]:flex [&>*]:flex-col [&>*]:min-h-0' }">
+            <template #body>
+                <div class="flex-1 min-h-0 w-full overflow-y-auto">
+                    <div class="p-4 w-full"
+                         :class="pageHeader && 'max-w-[1040px] mx-auto'">
+                        <div v-if="pageHeader"
+                             class="mb-6">
+                            <div v-if="pageHeader.eyebrow"
+                                 class="eyebrow text-primary">
+                                {{ pageHeader.eyebrow }}
+                            </div>
+                            <h1 class="text-[28px] font-bold tracking-[-0.022em] leading-tight text-highlighted"
+                                :class="pageHeader.eyebrow ? 'mt-2.5' : ''">
+                                {{ pageHeader.title }}
+                            </h1>
+                            <p v-if="pageHeader.description"
+                               class="text-[15px] text-muted leading-relaxed max-w-[660px] mt-2.5">
+                                {{ pageHeader.description }}
+                            </p>
+                        </div>
+                        <slot />
+                    </div>
+                </div>
+            </template>
+        </UDashboardPanel>
+    </UDashboardGroup>
+</template>

--- a/packages/interloper-app/app/app/pages/admin/index.vue
+++ b/packages/interloper-app/app/app/pages/admin/index.vue
@@ -1,171 +1,22 @@
 <script setup lang="ts">
-import { h } from 'vue'
-import type { TableColumn, DropdownMenuItem, BreadcrumbItem } from '@nuxt/ui'
-import type { AdminOrganisation } from '~/types/admin'
-
-definePageMeta({ title: 'Organisations', middleware: 'super-admin' })
-
-const breadcrumbs: BreadcrumbItem[] = [
-    { label: 'Platform admin', icon: 'i-lucide-shield' },
-    { label: 'Organisations', icon: 'i-lucide-building-2' },
-]
-
-const adminStore = useAdminStore()
-const toast = useToast()
-
-const rows = ref<AdminOrganisation[]>([])
-const loading = ref(false)
-
-// Create / rename modal state
-const formOpen = ref(false)
-const formMode = ref<'create' | 'rename'>('create')
-const formName = ref('')
-const formTarget = ref<AdminOrganisation | null>(null)
-const submitting = ref(false)
-
-async function loadData() {
-    loading.value = true
-    try {
-        rows.value = await adminStore.listOrganisations()
-    }
-    catch (err) {
-        console.error('[Admin] Failed to load organisations', err)
-    }
-    finally {
-        loading.value = false
-    }
-}
-
-function openCreate() {
-    formMode.value = 'create'
-    formName.value = ''
-    formTarget.value = null
-    formOpen.value = true
-}
-
-function openRename(org: AdminOrganisation) {
-    formMode.value = 'rename'
-    formName.value = org.name
-    formTarget.value = org
-    formOpen.value = true
-}
-
-async function submitForm() {
-    const name = formName.value.trim()
-    if (!name) return
-
-    submitting.value = true
-    try {
-        if (formMode.value === 'create') {
-            await adminStore.createOrganisation(name)
-            toast.add({ title: `Organisation "${name}" created`, color: 'success' })
-        }
-        else if (formTarget.value) {
-            await adminStore.renameOrganisation(formTarget.value.id, name)
-            toast.add({ title: 'Organisation renamed', color: 'success' })
-        }
-        formOpen.value = false
-        await loadData()
-    }
-    catch (err) {
-        toast.add(errorToast(err, 'Operation failed'))
-    }
-    finally {
-        submitting.value = false
-    }
-}
-
-function rowActions(org: AdminOrganisation): DropdownMenuItem[][] {
-    return [
-        [
-            {
-                label: 'Manage members',
-                icon: 'i-lucide-users',
-                onSelect: () => navigateTo(`/admin/organisations/${org.id}`),
-            },
-            {
-                label: 'Rename',
-                icon: 'i-lucide-pencil',
-                onSelect: () => openRename(org),
-            },
-        ],
-    ]
-}
-
-const columns: TableColumn<AdminOrganisation>[] = [
-    {
-        accessorKey: 'name',
-        header: 'Name',
+definePageMeta({
+    title: 'Admin overview',
+    layout: 'admin',
+    middleware: 'super-admin',
+    pageHeader: {
+        eyebrow: 'Admin portal',
+        title: 'Overview',
+        description: 'Platform-wide health and activity at a glance.',
     },
-    {
-        accessorKey: 'member_count',
-        header: 'Members',
-        cell: ({ row }) => row.original.member_count,
-    },
-    {
-        accessorKey: 'created_at',
-        header: 'Created',
-        cell: ({ row }) => row.original.created_at
-            ? new Date(row.original.created_at).toLocaleDateString()
-            : '—',
-    },
-    {
-        id: 'open',
-        header: '',
-        cell: ({ row }) => h(resolveComponent('UButton'), {
-            icon: 'i-lucide-arrow-right',
-            color: 'neutral',
-            variant: 'ghost',
-            size: 'xs',
-            onClick: () => navigateTo(`/admin/organisations/${row.original.id}`),
-        }),
-        size: 50,
-        enableSorting: false,
-        enableGlobalFilter: false,
-    },
-]
-
-onMounted(loadData)
+})
 </script>
 
 <template>
-    <div class="flex flex-col flex-1 min-h-0">
-        <div class="pb-4">
-            <UBreadcrumb :items="breadcrumbs" />
-        </div>
-        <DataTable :columns="columns"
-                   :data="rows"
-                   :loading="loading"
-                   :row-actions="rowActions"
-                   no-actions
-                   search-placeholder="Search organisations...">
-            <template #toolbar>
-                <UButton icon="i-lucide-plus"
-                         label="New organisation"
-                         @click="openCreate" />
-            </template>
-        </DataTable>
-
-        <UModal v-model:open="formOpen"
-                :title="formMode === 'create' ? 'New organisation' : 'Rename organisation'"
-                :ui="{ footer: 'justify-end' }">
-            <template #body>
-                <UInput v-model="formName"
-                        placeholder="Organisation name"
-                        autofocus
-                        class="w-full"
-                        @keydown.enter="submitForm" />
-            </template>
-            <template #footer>
-                <UButton label="Cancel"
-                         color="neutral"
-                         variant="outline"
-                         @click="formOpen = false" />
-                <UButton :label="formMode === 'create' ? 'Create' : 'Save'"
-                         :disabled="!formName.trim() || submitting"
-                         :loading="submitting"
-                         @click="submitForm" />
-            </template>
-        </UModal>
+    <div class="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-default py-24 text-center">
+        <UIcon name="i-lucide-layout-dashboard"
+               class="size-8 text-dimmed" />
+        <p class="text-sm text-muted">
+            Nothing here yet — platform metrics will land on this page.
+        </p>
     </div>
 </template>

--- a/packages/interloper-app/app/app/pages/admin/organisations/[id].vue
+++ b/packages/interloper-app/app/app/pages/admin/organisations/[id].vue
@@ -2,7 +2,7 @@
 import type { BreadcrumbItem } from '@nuxt/ui'
 import type { OrgMember } from '~/types/organisation'
 
-definePageMeta({ title: 'Manage organisation', middleware: 'super-admin' })
+definePageMeta({ title: 'Manage organisation', layout: 'admin', middleware: 'super-admin' })
 
 const route = useRoute()
 const orgId = computed(() => route.params.id as string)
@@ -22,8 +22,7 @@ const isMember = computed(() =>
 const inviteEndpoint = computed(() => `/admin/organisations/${orgId.value}/invitations`)
 
 const breadcrumbs = computed<BreadcrumbItem[]>(() => [
-    { label: 'Platform admin', icon: 'i-lucide-shield' },
-    { label: 'Organisations', icon: 'i-lucide-building-2', to: '/admin' },
+    { label: 'Organisations', icon: 'i-lucide-building-2', to: '/admin/organisations' },
     { label: orgName.value ?? '…' },
 ])
 

--- a/packages/interloper-app/app/app/pages/admin/organisations/index.vue
+++ b/packages/interloper-app/app/app/pages/admin/organisations/index.vue
@@ -1,0 +1,171 @@
+<script setup lang="ts">
+import { h } from 'vue'
+import type { TableColumn, DropdownMenuItem } from '@nuxt/ui'
+import type { AdminOrganisation } from '~/types/admin'
+
+definePageMeta({
+    title: 'Organisations',
+    layout: 'admin',
+    middleware: 'super-admin',
+    pageHeader: {
+        title: 'Organisations',
+        description: 'Every organisation on the platform, with its membership.',
+    },
+})
+
+const adminStore = useAdminStore()
+const toast = useToast()
+
+const rows = ref<AdminOrganisation[]>([])
+const loading = ref(false)
+
+// Create / rename modal state
+const formOpen = ref(false)
+const formMode = ref<'create' | 'rename'>('create')
+const formName = ref('')
+const formTarget = ref<AdminOrganisation | null>(null)
+const submitting = ref(false)
+
+async function loadData() {
+    loading.value = true
+    try {
+        rows.value = await adminStore.listOrganisations()
+    }
+    catch (err) {
+        console.error('[Admin] Failed to load organisations', err)
+    }
+    finally {
+        loading.value = false
+    }
+}
+
+function openCreate() {
+    formMode.value = 'create'
+    formName.value = ''
+    formTarget.value = null
+    formOpen.value = true
+}
+
+function openRename(org: AdminOrganisation) {
+    formMode.value = 'rename'
+    formName.value = org.name
+    formTarget.value = org
+    formOpen.value = true
+}
+
+async function submitForm() {
+    const name = formName.value.trim()
+    if (!name) return
+
+    submitting.value = true
+    try {
+        if (formMode.value === 'create') {
+            await adminStore.createOrganisation(name)
+            toast.add({ title: `Organisation "${name}" created`, color: 'success' })
+        }
+        else if (formTarget.value) {
+            await adminStore.renameOrganisation(formTarget.value.id, name)
+            toast.add({ title: 'Organisation renamed', color: 'success' })
+        }
+        formOpen.value = false
+        await loadData()
+    }
+    catch (err) {
+        toast.add(errorToast(err, 'Operation failed'))
+    }
+    finally {
+        submitting.value = false
+    }
+}
+
+function rowActions(org: AdminOrganisation): DropdownMenuItem[][] {
+    return [
+        [
+            {
+                label: 'Manage members',
+                icon: 'i-lucide-users',
+                onSelect: () => navigateTo(`/admin/organisations/${org.id}`),
+            },
+            {
+                label: 'Rename',
+                icon: 'i-lucide-pencil',
+                onSelect: () => openRename(org),
+            },
+        ],
+    ]
+}
+
+const columns: TableColumn<AdminOrganisation>[] = [
+    {
+        accessorKey: 'name',
+        header: 'Name',
+    },
+    {
+        accessorKey: 'member_count',
+        header: 'Members',
+        cell: ({ row }) => row.original.member_count,
+    },
+    {
+        accessorKey: 'created_at',
+        header: 'Created',
+        cell: ({ row }) => row.original.created_at
+            ? new Date(row.original.created_at).toLocaleDateString()
+            : '—',
+    },
+    {
+        id: 'open',
+        header: '',
+        cell: ({ row }) => h(resolveComponent('UButton'), {
+            icon: 'i-lucide-arrow-right',
+            color: 'neutral',
+            variant: 'ghost',
+            size: 'xs',
+            onClick: () => navigateTo(`/admin/organisations/${row.original.id}`),
+        }),
+        size: 50,
+        enableSorting: false,
+        enableGlobalFilter: false,
+    },
+]
+
+onMounted(loadData)
+</script>
+
+<template>
+    <div class="flex flex-col flex-1 min-h-0">
+        <DataTable :columns="columns"
+                   :data="rows"
+                   :loading="loading"
+                   :row-actions="rowActions"
+                   no-actions
+                   search-placeholder="Search organisations...">
+            <template #toolbar>
+                <UButton icon="i-lucide-plus"
+                         label="New organisation"
+                         @click="openCreate" />
+            </template>
+        </DataTable>
+
+        <UModal v-model:open="formOpen"
+                :title="formMode === 'create' ? 'New organisation' : 'Rename organisation'"
+                :ui="{ footer: 'justify-end' }">
+            <template #body>
+                <UInput v-model="formName"
+                        placeholder="Organisation name"
+                        autofocus
+                        class="w-full"
+                        @keydown.enter="submitForm" />
+            </template>
+            <template #footer>
+                <UButton label="Cancel"
+                         color="neutral"
+                         variant="outline"
+                         @click="formOpen = false" />
+                <UButton :label="formMode === 'create' ? 'Create' : 'Save'"
+                         :disabled="!formName.trim() || submitting"
+                         :loading="submitting"
+                         @click="submitForm" />
+            </template>
+        </UModal>
+    </div>
+</template>

--- a/packages/interloper-app/app/app/pages/admin/users/index.vue
+++ b/packages/interloper-app/app/app/pages/admin/users/index.vue
@@ -1,0 +1,102 @@
+<script setup lang="ts">
+import { h, resolveComponent } from 'vue'
+import type { TableColumn } from '@nuxt/ui'
+import type { AdminUser } from '~/types/admin'
+
+definePageMeta({
+    title: 'Users',
+    layout: 'admin',
+    middleware: 'super-admin',
+    pageHeader: {
+        title: 'Users',
+        description: 'Everyone with a profile on the platform, across all organisations.',
+    },
+})
+
+const UAvatar = resolveComponent('UAvatar')
+const UBadge = resolveComponent('UBadge')
+
+const adminStore = useAdminStore()
+
+const rows = ref<AdminUser[]>([])
+const loading = ref(false)
+
+async function loadData() {
+    loading.value = true
+    try {
+        rows.value = await adminStore.listUsers()
+    }
+    catch (err) {
+        console.error('[Admin] Failed to load users', err)
+    }
+    finally {
+        loading.value = false
+    }
+}
+
+function initials(user: AdminUser): string {
+    const name = user.name?.trim()
+    if (name) {
+        const parts = name.split(/\s+/)
+        const first = parts[0]?.[0] ?? ''
+        const last = parts.length > 1 ? (parts[parts.length - 1]?.[0] ?? '') : ''
+        return (last ? first + last : first).toUpperCase()
+    }
+    return user.email?.charAt(0).toUpperCase() ?? '?'
+}
+
+const columns: TableColumn<AdminUser>[] = [
+    {
+        accessorKey: 'name',
+        header: 'Name',
+        cell: ({ row }) => {
+            const user = row.original
+            const avatar = h(UAvatar, {
+                src: user.avatar_url ?? undefined,
+                alt: user.name ?? user.email,
+                text: initials(user),
+                size: 'sm',
+            })
+            const name = user.name
+                ? h('span', { class: 'font-semibold text-highlighted' }, user.name)
+                : h('span', { class: 'text-dimmed' }, '—')
+            return h('div', { class: 'flex items-center gap-3' }, [avatar, name])
+        },
+    },
+    {
+        accessorKey: 'email',
+        header: 'Email',
+    },
+    {
+        accessorKey: 'organisation_count',
+        header: 'Organisations',
+        cell: ({ row }) => row.original.organisation_count,
+    },
+    {
+        accessorKey: 'is_super_admin',
+        header: 'Super admin',
+        cell: ({ row }) => row.original.is_super_admin
+            ? h(UBadge, { label: 'Super admin', icon: 'i-lucide-shield', color: 'primary', variant: 'subtle' })
+            : h('span', { class: 'text-dimmed' }, '—'),
+    },
+    {
+        accessorKey: 'created_at',
+        header: 'Joined',
+        cell: ({ row }) => row.original.created_at
+            ? new Date(row.original.created_at).toLocaleDateString()
+            : '—',
+    },
+]
+
+onMounted(loadData)
+</script>
+
+<template>
+    <div class="flex flex-col flex-1 min-h-0">
+        <DataTable :columns="columns"
+                   :data="rows"
+                   :loading="loading"
+                   no-actions
+                   search-placeholder="Search users..." />
+    </div>
+</template>

--- a/packages/interloper-app/app/app/stores/admin.ts
+++ b/packages/interloper-app/app/app/stores/admin.ts
@@ -1,4 +1,4 @@
-import type { AdminOrganisation } from '~/types/admin'
+import type { AdminOrganisation, AdminUser } from '~/types/admin'
 
 interface MemberResponse {
     id: string
@@ -19,6 +19,10 @@ interface InvitationResponse {
 /** Cross-organisation management API, restricted to super-admins server-side. */
 export const useAdminStore = defineStore('admin', () => {
     const { apiFetch } = useApi()
+
+    function listUsers() {
+        return apiFetch<AdminUser[]>('/admin/users')
+    }
 
     function listOrganisations() {
         return apiFetch<AdminOrganisation[]>('/admin/organisations')
@@ -80,6 +84,7 @@ export const useAdminStore = defineStore('admin', () => {
     }
 
     return {
+        listUsers,
         listOrganisations,
         createOrganisation,
         renameOrganisation,

--- a/packages/interloper-app/app/app/types/admin.ts
+++ b/packages/interloper-app/app/app/types/admin.ts
@@ -4,3 +4,13 @@ export interface AdminOrganisation {
     member_count: number
     created_at: string | null
 }
+
+export interface AdminUser {
+    id: string
+    email: string
+    name: string | null
+    avatar_url: string | null
+    is_super_admin: boolean
+    organisation_count: number
+    created_at: string | null
+}

--- a/packages/interloper-db/src/interloper_db/store/auth.py
+++ b/packages/interloper-db/src/interloper_db/store/auth.py
@@ -134,6 +134,24 @@ class AuthMixin(StoreBase):
         with self._session() as session:
             return session.get(Profile, user_id)
 
+    def list_all_profiles(self) -> list[tuple[Profile, int]]:
+        """List every profile with its organisation membership count (super-admin only).
+
+        Returns:
+            List of ``(Profile, organisation_count)`` tuples.
+        """
+        with self._session() as session:
+            profiles = session.exec(select(Profile)).all()
+            counts = dict(
+                session.exec(
+                    select(
+                        UserOrganisation.user_id,
+                        func.count(UserOrganisation.organisation_id),  # ty: ignore[invalid-argument-type]
+                    ).group_by(UserOrganisation.user_id)  # ty: ignore[invalid-argument-type]
+                ).all()
+            )
+            return [(profile, counts.get(profile.id, 0)) for profile in profiles]
+
     def get_profile_by_google_id(self, google_id: str) -> Profile | None:
         """Get a profile by Google OAuth subject identifier.
 

--- a/packages/interloper-db/tests/store/test_auth.py
+++ b/packages/interloper-db/tests/store/test_auth.py
@@ -73,6 +73,21 @@ class TestAcceptInvitation:
         assert store.accept_invitation("no-such-token", invitee.id) is None
 
 
+class TestListAllProfiles:
+    def test_lists_profiles_with_membership_counts(self, store: Store):
+        admin = store.upsert_profile(google_id="g-admin", email="admin@example.com", name="Admin")
+        loner = store.upsert_profile(google_id="g-loner", email="loner@example.com", name="Loner")
+        org_a = store.create_organisation(name="Acme", creator_id=admin.id)
+        org_b = store.create_organisation(name="Beta", creator_id=admin.id)
+        store.add_org_member(org_a.id, admin.id, "admin")
+        store.add_org_member(org_b.id, admin.id, "admin")
+
+        counts = {profile.id: count for profile, count in store.list_all_profiles()}
+
+        assert counts[admin.id] == 2
+        assert counts[loner.id] == 0
+
+
 class TestGetProfileByGoogleId:
     def test_returns_matching_profile(self, store: Store):
         profile = store.upsert_profile(google_id="g-1", email="user@example.com", name="User")


### PR DESCRIPTION
## What

Entering the admin portal (`/admin`) now switches to a **separate dashboard** instead of rendering admin pages inside the main app shell: same visual language (collapsible/resizable sidebar, page headers), but a dedicated sidebar with three pages and an **Exit Admin** button at the bottom that returns to the main app.

- **Overview** (`/admin`) — empty placeholder for future platform metrics.
- **Organisations** (`/admin/organisations`) — the existing cross-org table, moved from `/admin`; the org detail page's breadcrumb now points to the new path.
- **Users** (`/admin/users`) — new platform-wide user list: avatar/name, email, organisation count, super-admin badge, join date.

## Backend

The users page needed one new endpoint: `GET /admin/users`, gated by `require_super_admin` like the rest of the admin surface, backed by a new `Store.list_all_profiles()` returning `(Profile, organisation_count)` tuples (mirrors `list_all_organisations`).

## Notes for review

- The admin layout deliberately omits the command palette and agent panel, and uses its own sidebar-width storage key (`dashboard-admin`) so collapsing one sidebar doesn't affect the other.
- Admin pages now use the `pageHeader` meta pattern instead of breadcrumbs; only the org detail page keeps breadcrumbs (it's the one nested view).
- Entry point is unchanged: the "Platform admin" item in the user menu still navigates to `/admin`.

## Verification

Full checks green (ruff, ty, pytest incl. new endpoint/store tests, ESLint, nuxt typecheck). Verified live in a seeded dev instance via headless Chrome: all three pages render with the dedicated sidebar, org drill-down breadcrumb links back to `/admin/organisations`, and Exit Admin lands back on `/` with the main sidebar restored.

By Digitl