### PR TITLE
feat(app): admin config page, unified breadcrumbs, and table polish

### DIFF
--- a/packages/interloper-api/src/interloper_api/app.py
+++ b/packages/interloper-api/src/interloper_api/app.py
@@ -39,10 +39,7 @@ logger = logging.getLogger(__name__)
 def create_app(
     store: Store | None = None,
     catalog: Catalog | None = None,
-    auth_config: Any | None = None,
-    smtp_config: Any | None = None,
-    agent_config: Any | None = None,
-    app_settings: Any | None = None,
+    settings: Any | None = None,
     cors_origins: list[str] | None = None,
     **kwargs: Any,
 ) -> FastAPI:
@@ -51,12 +48,11 @@ def create_app(
     Args:
         store: The ``Store`` instance for persistence.
         catalog: Catalog instance.
-        auth_config: ``AuthConfig`` instance for authentication settings.
-        smtp_config: ``SmtpConfig`` instance for sending invitation emails.
-        agent_config: ``AgentSettings`` instance; the agent routes mount only
-            when it's enabled (or None) and the ``agent`` extra is installed.
-        app_settings: Full ``AppSettings``; when given, a secrets-redacted
-            snapshot is built once for the super-admin ``/admin/config`` view.
+        settings: Full ``AppSettings``; the factory slices what it needs
+            (auth, smtp, agent) and builds the secrets-redacted snapshot for
+            the super-admin ``/admin/config`` view. The agent routes mount
+            only when enabled (or with no settings) and the ``agent`` extra
+            is installed.
         cors_origins: Allowed CORS origins. Only needed in dev mode for direct
             WebSocket connections that bypass the Vite proxy.
         **kwargs: Additional kwargs forwarded to ``FastAPI()``.
@@ -93,10 +89,9 @@ def create_app(
         set_store(store)
     if catalog:
         set_catalog(catalog)
-    if auth_config:
-        set_auth_config(auth_config)
-    if smtp_config:
-        set_smtp_config(smtp_config)
+    if settings:
+        set_auth_config(settings.auth)
+        set_smtp_config(settings.smtp)
 
     api = APIRouter(prefix="/api")
     api.include_router(auth.router)
@@ -111,7 +106,7 @@ def create_app(
     api.include_router(ws.router)
 
     agent_available = False
-    if agent_config is None or agent_config.enabled:
+    if settings is None or settings.agent.enabled:
         try:
             from interloper_api.routes import agent as agent_routes
 
@@ -126,10 +121,8 @@ def create_app(
         logger.info("Agent routes not mounted: disabled via settings.")
     set_features({"agent": agent_available})
 
-    if app_settings:
-        set_admin_config(
-            admin.build_config_snapshot(app_settings, features={"agent": agent_available}, catalog=catalog)
-        )
+    if settings:
+        set_admin_config(admin.build_config_snapshot(settings, features={"agent": agent_available}, catalog=catalog))
 
     @api.get("/health")
     def health() -> dict[str, str]:

--- a/packages/interloper-api/src/interloper_api/app.py
+++ b/packages/interloper-api/src/interloper_api/app.py
@@ -12,7 +12,14 @@ from interloper.catalog.base import Catalog
 from interloper.errors import ComponentDriftError, NotFoundError
 from interloper_db import Store
 
-from interloper_api.dependencies import set_auth_config, set_catalog, set_features, set_smtp_config, set_store
+from interloper_api.dependencies import (
+    set_admin_config,
+    set_auth_config,
+    set_catalog,
+    set_features,
+    set_smtp_config,
+    set_store,
+)
 from interloper_api.routes import (
     admin,
     auth,
@@ -35,6 +42,7 @@ def create_app(
     auth_config: Any | None = None,
     smtp_config: Any | None = None,
     agent_config: Any | None = None,
+    app_settings: Any | None = None,
     cors_origins: list[str] | None = None,
     **kwargs: Any,
 ) -> FastAPI:
@@ -47,6 +55,8 @@ def create_app(
         smtp_config: ``SmtpConfig`` instance for sending invitation emails.
         agent_config: ``AgentSettings`` instance; the agent routes mount only
             when it's enabled (or None) and the ``agent`` extra is installed.
+        app_settings: Full ``AppSettings``; when given, a secrets-redacted
+            snapshot is built once for the super-admin ``/admin/config`` view.
         cors_origins: Allowed CORS origins. Only needed in dev mode for direct
             WebSocket connections that bypass the Vite proxy.
         **kwargs: Additional kwargs forwarded to ``FastAPI()``.
@@ -115,6 +125,11 @@ def create_app(
     else:
         logger.info("Agent routes not mounted: disabled via settings.")
     set_features({"agent": agent_available})
+
+    if app_settings:
+        set_admin_config(
+            admin.build_config_snapshot(app_settings, features={"agent": agent_available}, catalog=catalog)
+        )
 
     @api.get("/health")
     def health() -> dict[str, str]:

--- a/packages/interloper-api/src/interloper_api/dependencies.py
+++ b/packages/interloper-api/src/interloper_api/dependencies.py
@@ -17,6 +17,7 @@ _catalog: Catalog | None = None
 _auth_config: Any | None = None
 _smtp_config: Any | None = None
 _features: dict[str, bool] = {}
+_admin_config: Any | None = None
 
 # Role hierarchy: admin > editor > viewer
 _ROLE_RANK = {"viewer": 0, "editor": 1, "admin": 2}
@@ -132,6 +133,25 @@ def get_features() -> dict[str, bool]:
         Feature name → availability; empty if never set.
     """
     return _features
+
+
+def set_admin_config(config: Any) -> None:
+    """Set the redacted instance-config snapshot (built at app creation).
+
+    Args:
+        config: The AdminConfigResponse snapshot.
+    """
+    global _admin_config  # noqa: PLW0603
+    _admin_config = config
+
+
+def get_admin_config() -> Any:
+    """Return the redacted instance-config snapshot.
+
+    Returns:
+        The AdminConfigResponse snapshot, or None if not configured.
+    """
+    return _admin_config
 
 
 # -- Auth dependencies -------------------------------------------------------

--- a/packages/interloper-api/src/interloper_api/routes/admin.py
+++ b/packages/interloper-api/src/interloper_api/routes/admin.py
@@ -8,8 +8,10 @@ no access to org-scoped *data* (sources, jobs, runs, …).
 
 from __future__ import annotations
 
+import inspect
 import logging
 from datetime import datetime
+from importlib import metadata
 from typing import Any
 from uuid import UUID
 
@@ -17,7 +19,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from interloper_db import Organisation, Profile, Store
 from pydantic import BaseModel
 
-from interloper_api.dependencies import get_store, require_super_admin
+from interloper_api.dependencies import get_admin_config, get_store, require_super_admin
 from interloper_api.email import send_invite_email
 
 logger = logging.getLogger(__name__)
@@ -39,15 +41,22 @@ class AdminOrganisationResponse(BaseModel):
     created_at: datetime | None = None
 
 
+class AdminUserOrganisation(BaseModel):
+    """Organisation reference on a user row."""
+
+    id: UUID
+    name: str
+
+
 class AdminUserResponse(BaseModel):
-    """Platform user with organisation membership count for the admin surface."""
+    """Platform user with its organisation memberships for the admin surface."""
 
     id: UUID
     email: str
     name: str | None = None
     avatar_url: str | None = None
     is_super_admin: bool = False
-    organisation_count: int
+    organisations: list[AdminUserOrganisation]
     created_at: datetime | None = None
 
 
@@ -102,6 +111,272 @@ class InvitationResponse(BaseModel):
     expires_at: datetime
 
 
+class AdminLauncherConfig(BaseModel):
+    """Launcher type plus the key-allowlisted, non-secret part of its config.
+
+    ``defaults`` carries the launcher class's own constructor defaults for
+    allowlisted keys the config doesn't set — the effective values.
+    """
+
+    type: str
+    config: dict[str, Any]
+    defaults: dict[str, Any]
+
+
+class AdminRunnerConfig(BaseModel):
+    """Runner type plus the key-allowlisted, non-secret part of its config.
+
+    ``defaults`` carries the runner class's own field defaults for
+    allowlisted keys the config doesn't set — the effective values.
+    """
+
+    type: str
+    config: dict[str, Any]
+    defaults: dict[str, Any]
+
+
+class AdminDeploymentConfig(BaseModel):
+    """What this instance is: version, execution stack, optional features."""
+
+    version: str | None = None
+    launcher: AdminLauncherConfig
+    runner: AdminRunnerConfig
+    features: dict[str, bool]
+    agent_model: str | None = None
+
+
+class AdminAuthConfig(BaseModel):
+    """Authentication and signup policy."""
+
+    signup_allowed_domains: list[str]
+    super_admin_emails: list[str]
+    google_oauth_configured: bool
+    google_redirect_uri: str
+    session_expiry_days: int
+    cookie_secure: bool
+
+
+class AdminCronConfig(BaseModel):
+    """Cron controller tuning."""
+
+    enabled: bool
+    reconcile_interval: int
+    batch_size: int
+    max_execution_delay: int | None = None
+
+
+class AdminWorkerConfig(BaseModel):
+    """Queue worker tuning."""
+
+    enabled: bool
+    poll_interval: int
+
+
+class AdminReaperConfig(BaseModel):
+    """Reaper tuning."""
+
+    enabled: bool
+    timeout: int
+    poll_interval: int
+
+
+class AdminSmtpConfig(BaseModel):
+    """SMTP status (credentials reduced to the enabled flag)."""
+
+    enabled: bool
+    host: str
+    from_addr: str
+
+
+class AdminServicesConfig(BaseModel):
+    """Background service roles and their tuning."""
+
+    cron: AdminCronConfig
+    worker: AdminWorkerConfig
+    reaper: AdminReaperConfig
+    smtp: AdminSmtpConfig
+    mcp_external_url: str
+
+
+class AdminDataConfig(BaseModel):
+    """Data-layer status and the computed catalog (kind → component keys)."""
+
+    encryption_configured: bool
+    catalog: dict[str, list[str]]
+
+
+class AdminConfigResponse(BaseModel):
+    """Read-only, secrets-redacted snapshot of the instance configuration."""
+
+    deployment: AdminDeploymentConfig
+    auth: AdminAuthConfig
+    services: AdminServicesConfig
+    data: AdminDataConfig
+
+
+# Non-secret launcher/runner config keys exposed on /admin/config. Anything not
+# listed (env injections, image_pull_secrets, credentials, …) stays server-side.
+_LAUNCHER_CONFIG_KEYS = frozenset(
+    {
+        "image",
+        "namespace",
+        "service_account_name",
+        "image_pull_policy",
+        "ttl_seconds_after_finished",
+        "node_selector",
+        "resources",
+        "volumes",
+        "runner_type",
+    }
+)
+_RUNNER_CONFIG_KEYS = frozenset(
+    {
+        "max_workers",
+        "image",
+        "namespace",
+        "service_account_name",
+        "image_pull_policy",
+        "ttl_seconds_after_finished",
+        "node_selector",
+        "resources",
+    }
+)
+
+
+def _filter_config(config: dict[str, Any] | None, allowed: frozenset[str]) -> dict[str, Any]:
+    """Keep only allowlisted keys of a launcher/runner config dict."""
+    return {key: value for key, value in (config or {}).items() if key in allowed}
+
+
+def _launcher_defaults(launcher_type: str) -> dict[str, Any]:
+    """Allowlisted constructor defaults of the registered launcher class.
+
+    Launcher defaults live in ``__init__`` signatures, invisible to settings —
+    without this, an unset value reads as "missing" when a class default
+    applies. Returns ``{}`` when the launcher package isn't installed here
+    (e.g. an API-only image) — the view then simply shows no defaults.
+    """
+    try:
+        from interloper_scheduler.launcher import LAUNCHERS
+    except ImportError:
+        return {}
+    launcher_cls = LAUNCHERS.get(launcher_type)
+    if launcher_cls is None:
+        return {}
+    return {
+        name: param.default
+        for name, param in inspect.signature(launcher_cls.__init__).parameters.items()
+        if name in _LAUNCHER_CONFIG_KEYS and param.default is not inspect.Parameter.empty and param.default is not None
+    }
+
+
+def _runner_defaults(runner_type: str) -> dict[str, Any]:
+    """Allowlisted field defaults of the registered runner class (pydantic model)."""
+    from interloper.runner.base import RUNNERS
+
+    runner_cls = RUNNERS.get(runner_type)
+    if runner_cls is None:
+        return {}
+    return {
+        name: field.default
+        for name, field in runner_cls.model_fields.items()
+        if name in _RUNNER_CONFIG_KEYS and not field.is_required() and field.default is not None
+    }
+
+
+def _catalog_by_kind(catalog: Any) -> dict[str, list[str]]:
+    """Group the hydrated catalog's component keys by kind, both sorted."""
+    by_kind: dict[str, list[str]] = {}
+    for key, definition in catalog.components.items():
+        by_kind.setdefault(definition.kind, []).append(key)
+    return {kind: sorted(keys) for kind, keys in sorted(by_kind.items())}
+
+
+def build_config_snapshot(settings: Any, features: dict[str, bool], catalog: Any = None) -> AdminConfigResponse:
+    """Build the redacted instance-config snapshot served by ``GET /admin/config``.
+
+    Every exposed field is hand-picked here (allowlist, not blocklist), so new
+    settings fields default to *not exposed* and secrets only ever surface as
+    "configured" booleans. The catalog is reported from the hydrated ``Catalog``
+    (auto-discovered universe + configured extras), not ``settings.catalog``,
+    which only holds the explicitly configured import paths.
+    """
+    try:
+        version: str | None = metadata.version("interloper-api")
+    except metadata.PackageNotFoundError:
+        version = None
+
+    launcher_config = _filter_config(settings.launcher.config, _LAUNCHER_CONFIG_KEYS)
+    # The launcher forwards a nested runner config into the containers it
+    # launches — that's where the effective run concurrency lives on k8s/docker.
+    nested_runner_config = (settings.launcher.config or {}).get("runner_config")
+    if isinstance(nested_runner_config, dict):
+        launcher_config["runner_config"] = _filter_config(nested_runner_config, _RUNNER_CONFIG_KEYS)
+
+    runner_config = _filter_config(settings.runner.config, _RUNNER_CONFIG_KEYS)
+
+    return AdminConfigResponse(
+        deployment=AdminDeploymentConfig(
+            version=version,
+            launcher=AdminLauncherConfig(
+                type=settings.launcher.type,
+                config=launcher_config,
+                defaults={
+                    key: value
+                    for key, value in _launcher_defaults(settings.launcher.type).items()
+                    if key not in launcher_config
+                },
+            ),
+            runner=AdminRunnerConfig(
+                type=settings.runner.type,
+                config=runner_config,
+                defaults={
+                    key: value
+                    for key, value in _runner_defaults(settings.runner.type).items()
+                    if key not in runner_config
+                },
+            ),
+            features=features,
+            agent_model=settings.agent.model if settings.agent.enabled else None,
+        ),
+        auth=AdminAuthConfig(
+            signup_allowed_domains=settings.auth.signup_allowed_domains,
+            super_admin_emails=settings.auth.super_admin_emails,
+            google_oauth_configured=bool(settings.auth.google_client_id and settings.auth.google_client_secret),
+            google_redirect_uri=settings.auth.google_redirect_uri,
+            session_expiry_days=settings.auth.session_expiry_days,
+            cookie_secure=settings.auth.cookie_secure,
+        ),
+        services=AdminServicesConfig(
+            cron=AdminCronConfig(
+                enabled=settings.cron.enabled,
+                reconcile_interval=settings.cron.reconcile_interval,
+                batch_size=settings.cron.batch_size,
+                max_execution_delay=settings.cron.max_execution_delay,
+            ),
+            worker=AdminWorkerConfig(
+                enabled=settings.worker.enabled,
+                poll_interval=settings.worker.poll_interval,
+            ),
+            reaper=AdminReaperConfig(
+                enabled=settings.reaper.enabled,
+                timeout=settings.reaper.timeout,
+                poll_interval=settings.reaper.poll_interval,
+            ),
+            smtp=AdminSmtpConfig(
+                enabled=settings.smtp.enabled,
+                host=settings.smtp.host,
+                from_addr=settings.smtp.from_addr,
+            ),
+            mcp_external_url=settings.mcp.external_url,
+        ),
+        data=AdminDataConfig(
+            encryption_configured=bool(settings.secrets.encryption_key),
+            catalog=_catalog_by_kind(catalog) if catalog is not None else {},
+        ),
+    )
+
+
 # -- Helpers ------------------------------------------------------------------
 
 
@@ -151,6 +426,20 @@ def _send_invitation_email(
         logger.exception("Failed to send invitation email to %s", email)
 
 
+# -- Instance config -----------------------------------------------------------
+
+
+@router.get("/config")
+def get_instance_config(
+    user: Profile = Depends(require_super_admin),
+    config: Any = Depends(get_admin_config),
+) -> AdminConfigResponse:
+    """Read-only snapshot of the instance configuration (secrets redacted)."""
+    if config is None:
+        raise HTTPException(status_code=503, detail="Instance configuration not available")
+    return config
+
+
 # -- Users --------------------------------------------------------------------
 
 
@@ -159,7 +448,7 @@ def list_all_users(
     user: Profile = Depends(require_super_admin),
     store: Store = Depends(get_store),
 ) -> list[AdminUserResponse]:
-    """List every user profile with its organisation membership count."""
+    """List every user profile with the organisations it belongs to."""
     return [
         AdminUserResponse(
             id=profile.id,
@@ -167,10 +456,10 @@ def list_all_users(
             name=profile.name,
             avatar_url=profile.avatar_url,
             is_super_admin=profile.is_super_admin,
-            organisation_count=count,
+            organisations=[AdminUserOrganisation(id=org.id, name=org.name) for org in orgs],
             created_at=profile.created_at,
         )
-        for profile, count in store.list_all_profiles()
+        for profile, orgs in store.list_all_profiles()
     ]
 
 

--- a/packages/interloper-api/tests/conftest.py
+++ b/packages/interloper-api/tests/conftest.py
@@ -1,0 +1,46 @@
+"""Shared fixtures for the API tests."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture
+def fake_settings() -> SimpleNamespace:
+    """AppSettings-shaped namespace covering every field ``create_app`` and the
+    config-snapshot builder read, with secrets planted to prove redaction."""
+    return SimpleNamespace(
+        launcher=SimpleNamespace(
+            type="kubernetes",
+            config={
+                "image": "ghcr.io/x:1",
+                "namespace": "prod",
+                "service_account_name": "sa",
+                "ttl_seconds_after_finished": 300,
+                "env": "l-secret",
+                "image_pull_secrets": ["pull-secret"],
+                "runner_config": {"max_workers": 4, "env": "nested-secret"},
+            },
+        ),
+        runner=SimpleNamespace(type="async", config={"max_workers": 8, "env": "r-secret"}),
+        agent=SimpleNamespace(enabled=True, model="gemini-2.5-flash"),
+        auth=SimpleNamespace(
+            signup_allowed_domains=["digitlcloud.com"],
+            super_admin_emails=["boss@example.com"],
+            google_client_id="cid",
+            google_client_secret="oauth-secret",
+            google_redirect_uri="https://app/api/auth/google/callback",
+            session_expiry_days=30,
+            cookie_secure=True,
+        ),
+        cron=SimpleNamespace(enabled=True, reconcile_interval=10, batch_size=50, max_execution_delay=None),
+        worker=SimpleNamespace(enabled=True, poll_interval=5),
+        reaper=SimpleNamespace(enabled=True, timeout=3600, poll_interval=60),
+        smtp=SimpleNamespace(enabled=True, host="smtp.example.com", from_addr="noreply@x", password="smtp-secret"),
+        mcp=SimpleNamespace(external_url="", token="mcp-secret"),
+        secrets=SimpleNamespace(encryption_key="key-material"),
+        postgres=SimpleNamespace(password="pg-secret"),
+        catalog=["interloper_assets.demo.source.DemoSource"],
+    )

--- a/packages/interloper-api/tests/test_admin.py
+++ b/packages/interloper-api/tests/test_admin.py
@@ -143,45 +143,8 @@ def test_non_super_admin_is_forbidden(store: FakeStore) -> None:
     assert resp.status_code == 403
 
 
-def _settings() -> SimpleNamespace:
-    """Fake AppSettings covering every field the snapshot builder reads, secrets included."""
-    return SimpleNamespace(
-        launcher=SimpleNamespace(
-            type="kubernetes",
-            config={
-                "image": "ghcr.io/x:1",
-                "namespace": "prod",
-                "service_account_name": "sa",
-                "ttl_seconds_after_finished": 300,
-                "env": "l-secret",
-                "image_pull_secrets": ["pull-secret"],
-                "runner_config": {"max_workers": 4, "env": "nested-secret"},
-            },
-        ),
-        runner=SimpleNamespace(type="async", config={"max_workers": 8, "env": "r-secret"}),
-        agent=SimpleNamespace(enabled=True, model="gemini-2.5-flash"),
-        auth=SimpleNamespace(
-            signup_allowed_domains=["digitlcloud.com"],
-            super_admin_emails=["boss@example.com"],
-            google_client_id="cid",
-            google_client_secret="oauth-secret",
-            google_redirect_uri="https://app/api/auth/google/callback",
-            session_expiry_days=30,
-            cookie_secure=True,
-        ),
-        cron=SimpleNamespace(enabled=True, reconcile_interval=10, batch_size=50, max_execution_delay=None),
-        worker=SimpleNamespace(enabled=True, poll_interval=5),
-        reaper=SimpleNamespace(enabled=True, timeout=3600, poll_interval=60),
-        smtp=SimpleNamespace(enabled=True, host="smtp.example.com", from_addr="noreply@x", password="smtp-secret"),
-        mcp=SimpleNamespace(external_url="", token="mcp-secret"),
-        secrets=SimpleNamespace(encryption_key="key-material"),
-        postgres=SimpleNamespace(password="pg-secret"),
-        catalog=["interloper_assets.demo.source.DemoSource"],
-    )
-
-
-def test_config_snapshot_redacts_secrets() -> None:
-    snapshot = admin_module.build_config_snapshot(_settings(), features={"agent": True})
+def test_config_snapshot_redacts_secrets(fake_settings: SimpleNamespace) -> None:
+    snapshot = admin_module.build_config_snapshot(fake_settings, features={"agent": True})
     payload = snapshot.model_dump_json()
     secrets = (
         "oauth-secret", "smtp-secret", "pg-secret", "key-material",
@@ -194,8 +157,8 @@ def test_config_snapshot_redacts_secrets() -> None:
     assert snapshot.services.reaper.timeout == 3600
 
 
-def test_config_snapshot_allowlists_launcher_and_runner_config() -> None:
-    snapshot = admin_module.build_config_snapshot(_settings(), features={"agent": True})
+def test_config_snapshot_allowlists_launcher_and_runner_config(fake_settings: SimpleNamespace) -> None:
+    snapshot = admin_module.build_config_snapshot(fake_settings, features={"agent": True})
     assert snapshot.deployment.launcher.config == {
         "image": "ghcr.io/x:1",
         "namespace": "prod",
@@ -209,14 +172,13 @@ def test_config_snapshot_allowlists_launcher_and_runner_config() -> None:
     assert snapshot.deployment.runner.defaults == {}
 
 
-def test_config_snapshot_surfaces_class_defaults_for_unset_config() -> None:
-    settings = _settings()
-    settings.runner = SimpleNamespace(type="async", config={})
-    snapshot = admin_module.build_config_snapshot(settings, features={"agent": True})
+def test_config_snapshot_surfaces_class_defaults_for_unset_config(fake_settings: SimpleNamespace) -> None:
+    fake_settings.runner = SimpleNamespace(type="async", config={})
+    snapshot = admin_module.build_config_snapshot(fake_settings, features={"agent": True})
     assert snapshot.deployment.runner.defaults == {"max_workers": 4}
 
 
-def test_config_snapshot_reports_hydrated_catalog_by_kind() -> None:
+def test_config_snapshot_reports_hydrated_catalog_by_kind(fake_settings: SimpleNamespace) -> None:
     catalog = SimpleNamespace(
         components={
             "demo": SimpleNamespace(kind="source"),
@@ -224,7 +186,7 @@ def test_config_snapshot_reports_hydrated_catalog_by_kind() -> None:
             "bigquery": SimpleNamespace(kind="destination"),
         }
     )
-    snapshot = admin_module.build_config_snapshot(_settings(), features={"agent": True}, catalog=catalog)
+    snapshot = admin_module.build_config_snapshot(fake_settings, features={"agent": True}, catalog=catalog)
     assert snapshot.data.catalog == {"destination": ["bigquery", "csv"], "source": ["demo"]}
 
 
@@ -233,9 +195,9 @@ def test_non_super_admin_cannot_read_config(store: FakeStore) -> None:
     assert resp.status_code == 403
 
 
-def test_super_admin_reads_config(store: FakeStore) -> None:
+def test_super_admin_reads_config(store: FakeStore, fake_settings: SimpleNamespace) -> None:
     client = _client(store, is_super_admin=True)
-    snapshot = admin_module.build_config_snapshot(_settings(), features={"agent": True})
+    snapshot = admin_module.build_config_snapshot(fake_settings, features={"agent": True})
     client.app.dependency_overrides[get_admin_config] = lambda: snapshot
     resp = client.get("/admin/config")
     assert resp.status_code == 200

--- a/packages/interloper-api/tests/test_admin.py
+++ b/packages/interloper-api/tests/test_admin.py
@@ -16,7 +16,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from interloper.errors import NotFoundError
 
-from interloper_api.dependencies import get_current_user, get_store
+from interloper_api.dependencies import get_admin_config, get_current_user, get_store
 from interloper_api.routes import admin as admin_module
 
 
@@ -46,7 +46,7 @@ class FakeStore:
                     is_super_admin=False,
                     created_at=datetime.now(timezone.utc),
                 ),
-                2,
+                [self.org],
             )
         ]
 
@@ -143,6 +143,111 @@ def test_non_super_admin_is_forbidden(store: FakeStore) -> None:
     assert resp.status_code == 403
 
 
+def _settings() -> SimpleNamespace:
+    """Fake AppSettings covering every field the snapshot builder reads, secrets included."""
+    return SimpleNamespace(
+        launcher=SimpleNamespace(
+            type="kubernetes",
+            config={
+                "image": "ghcr.io/x:1",
+                "namespace": "prod",
+                "service_account_name": "sa",
+                "ttl_seconds_after_finished": 300,
+                "env": "l-secret",
+                "image_pull_secrets": ["pull-secret"],
+                "runner_config": {"max_workers": 4, "env": "nested-secret"},
+            },
+        ),
+        runner=SimpleNamespace(type="async", config={"max_workers": 8, "env": "r-secret"}),
+        agent=SimpleNamespace(enabled=True, model="gemini-2.5-flash"),
+        auth=SimpleNamespace(
+            signup_allowed_domains=["digitlcloud.com"],
+            super_admin_emails=["boss@example.com"],
+            google_client_id="cid",
+            google_client_secret="oauth-secret",
+            google_redirect_uri="https://app/api/auth/google/callback",
+            session_expiry_days=30,
+            cookie_secure=True,
+        ),
+        cron=SimpleNamespace(enabled=True, reconcile_interval=10, batch_size=50, max_execution_delay=None),
+        worker=SimpleNamespace(enabled=True, poll_interval=5),
+        reaper=SimpleNamespace(enabled=True, timeout=3600, poll_interval=60),
+        smtp=SimpleNamespace(enabled=True, host="smtp.example.com", from_addr="noreply@x", password="smtp-secret"),
+        mcp=SimpleNamespace(external_url="", token="mcp-secret"),
+        secrets=SimpleNamespace(encryption_key="key-material"),
+        postgres=SimpleNamespace(password="pg-secret"),
+        catalog=["interloper_assets.demo.source.DemoSource"],
+    )
+
+
+def test_config_snapshot_redacts_secrets() -> None:
+    snapshot = admin_module.build_config_snapshot(_settings(), features={"agent": True})
+    payload = snapshot.model_dump_json()
+    secrets = (
+        "oauth-secret", "smtp-secret", "pg-secret", "key-material",
+        "l-secret", "nested-secret", "r-secret", "pull-secret",
+    )
+    for secret in secrets:
+        assert secret not in payload
+    assert snapshot.auth.google_oauth_configured is True
+    assert snapshot.data.encryption_configured is True
+    assert snapshot.services.reaper.timeout == 3600
+
+
+def test_config_snapshot_allowlists_launcher_and_runner_config() -> None:
+    snapshot = admin_module.build_config_snapshot(_settings(), features={"agent": True})
+    assert snapshot.deployment.launcher.config == {
+        "image": "ghcr.io/x:1",
+        "namespace": "prod",
+        "service_account_name": "sa",
+        "ttl_seconds_after_finished": 300,
+        "runner_config": {"max_workers": 4},
+    }
+    assert snapshot.deployment.runner.config == {"max_workers": 8}
+    # Explicitly configured keys are excluded from the class defaults.
+    assert snapshot.deployment.launcher.defaults == {"runner_type": "async"}
+    assert snapshot.deployment.runner.defaults == {}
+
+
+def test_config_snapshot_surfaces_class_defaults_for_unset_config() -> None:
+    settings = _settings()
+    settings.runner = SimpleNamespace(type="async", config={})
+    snapshot = admin_module.build_config_snapshot(settings, features={"agent": True})
+    assert snapshot.deployment.runner.defaults == {"max_workers": 4}
+
+
+def test_config_snapshot_reports_hydrated_catalog_by_kind() -> None:
+    catalog = SimpleNamespace(
+        components={
+            "demo": SimpleNamespace(kind="source"),
+            "csv": SimpleNamespace(kind="destination"),
+            "bigquery": SimpleNamespace(kind="destination"),
+        }
+    )
+    snapshot = admin_module.build_config_snapshot(_settings(), features={"agent": True}, catalog=catalog)
+    assert snapshot.data.catalog == {"destination": ["bigquery", "csv"], "source": ["demo"]}
+
+
+def test_non_super_admin_cannot_read_config(store: FakeStore) -> None:
+    resp = _client(store, is_super_admin=False).get("/admin/config")
+    assert resp.status_code == 403
+
+
+def test_super_admin_reads_config(store: FakeStore) -> None:
+    client = _client(store, is_super_admin=True)
+    snapshot = admin_module.build_config_snapshot(_settings(), features={"agent": True})
+    client.app.dependency_overrides[get_admin_config] = lambda: snapshot
+    resp = client.get("/admin/config")
+    assert resp.status_code == 200
+    assert resp.json()["deployment"]["launcher"]["type"] == "kubernetes"
+    assert resp.json()["auth"]["signup_allowed_domains"] == ["digitlcloud.com"]
+
+
+def test_config_unavailable_returns_503(store: FakeStore) -> None:
+    resp = _client(store, is_super_admin=True).get("/admin/config")
+    assert resp.status_code == 503
+
+
 def test_non_super_admin_cannot_list_users(store: FakeStore) -> None:
     resp = _client(store, is_super_admin=False).get("/admin/users")
     assert resp.status_code == 403
@@ -153,7 +258,7 @@ def test_super_admin_lists_all_users(store: FakeStore) -> None:
     assert resp.status_code == 200
     body = resp.json()
     assert body[0]["email"] == "member@acme.test"
-    assert body[0]["organisation_count"] == 2
+    assert [org["name"] for org in body[0]["organisations"]] == ["Acme"]
     assert body[0]["is_super_admin"] is False
 
 

--- a/packages/interloper-api/tests/test_app.py
+++ b/packages/interloper-api/tests/test_app.py
@@ -8,16 +8,17 @@ from interloper_api.app import create_app
 from interloper_api.dependencies import get_features, get_store
 
 
-def test_agent_routes_absent_when_disabled():
-    app = create_app(agent_config=SimpleNamespace(enabled=False))
+def test_agent_routes_absent_when_disabled(fake_settings: SimpleNamespace):
+    fake_settings.agent.enabled = False
+    app = create_app(settings=fake_settings)
     client = TestClient(app)
 
     assert client.post("/api/agent/sessions").status_code == 404
     assert get_features() == {"agent": False}
 
 
-def test_agent_routes_mounted_when_enabled():
-    app = create_app(agent_config=SimpleNamespace(enabled=True))
+def test_agent_routes_mounted_when_enabled(fake_settings: SimpleNamespace):
+    app = create_app(settings=fake_settings)
     app.dependency_overrides[get_store] = lambda: None
     client = TestClient(app)
 

--- a/packages/interloper-app/app/app/components/ui/PageBreadcrumb.vue
+++ b/packages/interloper-app/app/app/components/ui/PageBreadcrumb.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+/**
+ * UBreadcrumb with the app's crumb conventions wired in: build items with
+ * titleCrumb (eyebrow-styled page title) and entityCrumb (rendered as an
+ * EntityBadge) from utils/breadcrumb.
+ */
+import type { BreadcrumbItem } from '@nuxt/ui'
+
+defineProps<{
+    items: BreadcrumbItem[]
+}>()
+</script>
+
+<template>
+    <!-- min-height matches the EntityBadge rows so title-only breadcrumbs sit at the same Y on every page. -->
+    <UBreadcrumb :items="items"
+                 :ui="{ list: 'min-h-6' }">
+        <!-- Custom item slots aren't in UBreadcrumb's slot types, so the scope needs a cast. -->
+        <template #entity="scope">
+            <EntityBadge :icon="(scope as { item: BreadcrumbItem }).item.icon"
+                         :label="(scope as { item: BreadcrumbItem }).item.label ?? ''" />
+        </template>
+    </UBreadcrumb>
+</template>

--- a/packages/interloper-app/app/app/layouts/admin.vue
+++ b/packages/interloper-app/app/app/layouts/admin.vue
@@ -6,11 +6,15 @@ const appVersion = useRuntimeConfig().public.version
 
 /** Design page header rendered by the layout, declared via definePageMeta({ pageHeader }). */
 interface PageHeaderMeta {
-    eyebrow?: string
     title: string
     description?: string
 }
 const pageHeader = computed(() => route.meta.pageHeader as PageHeaderMeta | undefined)
+
+/** Eyebrow-styled page title; breadcrumb pages set titleInBreadcrumb and render it as their first crumb. */
+const pageTitle = computed(() => route.meta.titleInBreadcrumb
+    ? undefined
+    : pageHeader.value?.title ?? (route.meta.title as string | undefined))
 
 const items = computed<NavigationMenuItem[]>(() => [
     {
@@ -30,6 +34,12 @@ const items = computed<NavigationMenuItem[]>(() => [
         icon: 'i-lucide-users',
         to: '/admin/users',
         active: route.path.startsWith('/admin/users'),
+    },
+    {
+        label: 'Config',
+        icon: 'i-lucide-settings-2',
+        to: '/admin/config',
+        active: route.path.startsWith('/admin/config'),
     },
 ])
 </script>
@@ -78,17 +88,10 @@ const items = computed<NavigationMenuItem[]>(() => [
                 <div class="flex-1 min-h-0 w-full overflow-y-auto">
                     <div class="p-4 w-full"
                          :class="pageHeader && 'max-w-[1040px] mx-auto'">
-                        <div v-if="pageHeader"
-                             class="mb-6">
-                            <div v-if="pageHeader.eyebrow"
-                                 class="eyebrow text-primary">
-                                {{ pageHeader.eyebrow }}
-                            </div>
-                            <h1 class="text-[28px] font-bold tracking-[-0.022em] leading-tight text-highlighted"
-                                :class="pageHeader.eyebrow ? 'mt-2.5' : ''">
-                                {{ pageHeader.title }}
-                            </h1>
-                            <p v-if="pageHeader.description"
+                        <div v-if="pageTitle"
+                             class="mb-4">
+                            <PageBreadcrumb :items="[titleCrumb(pageTitle)]" />
+                            <p v-if="pageHeader?.description"
                                class="text-[15px] text-muted leading-relaxed max-w-[660px] mt-2.5">
                                 {{ pageHeader.description }}
                             </p>

--- a/packages/interloper-app/app/app/layouts/default.vue
+++ b/packages/interloper-app/app/app/layouts/default.vue
@@ -15,11 +15,15 @@ const appVersion = useRuntimeConfig().public.version
 
 /** Design page header rendered by the layout, declared via definePageMeta({ pageHeader }). */
 interface PageHeaderMeta {
-    eyebrow?: string
     title: string
     description?: string
 }
 const pageHeader = computed(() => route.meta.pageHeader as PageHeaderMeta | undefined)
+
+/** Eyebrow-styled page title; breadcrumb pages set titleInBreadcrumb and render it as their first crumb. */
+const pageTitle = computed(() => route.meta.titleInBreadcrumb
+    ? undefined
+    : pageHeader.value?.title ?? (route.meta.title as string | undefined))
 
 const navSections = useNavSections()
 
@@ -95,17 +99,10 @@ const items = computed<NavigationMenuItem[]>(() => navSections.value.flatMap((se
                          class="flex-1 min-h-0 w-full overflow-y-auto">
                         <div class="p-4 w-full"
                              :class="pageHeader && 'max-w-[1040px] mx-auto'">
-                            <div v-if="pageHeader"
-                                 class="mb-6">
-                                <div v-if="pageHeader.eyebrow"
-                                     class="eyebrow text-primary">
-                                    {{ pageHeader.eyebrow }}
-                                </div>
-                                <h1 class="text-[28px] font-bold tracking-[-0.022em] leading-tight text-highlighted"
-                                    :class="pageHeader.eyebrow ? 'mt-2.5' : ''">
-                                    {{ pageHeader.title }}
-                                </h1>
-                                <p v-if="pageHeader.description"
+                            <div v-if="pageTitle"
+                                 class="mb-4">
+                                <PageBreadcrumb :items="[titleCrumb(pageTitle)]" />
+                                <p v-if="pageHeader?.description"
                                    class="text-[15px] text-muted leading-relaxed max-w-[660px] mt-2.5">
                                     {{ pageHeader.description }}
                                 </p>

--- a/packages/interloper-app/app/app/pages/admin/config.vue
+++ b/packages/interloper-app/app/app/pages/admin/config.vue
@@ -1,0 +1,256 @@
+<script setup lang="ts">
+import type { AdminConfig } from '~/types/admin'
+
+definePageMeta({
+    title: 'Config',
+    layout: 'admin',
+    middleware: 'super-admin',
+    pageHeader: {
+        title: 'Config',
+        description: 'Read-only snapshot of this instance\'s runtime configuration. Secrets are redacted; dimmed values are class defaults.',
+    },
+})
+
+const adminStore = useAdminStore()
+
+const config = ref<AdminConfig | null>(null)
+const loading = ref(true)
+
+onMounted(async () => {
+    try {
+        config.value = await adminStore.getConfig()
+    }
+    catch (err) {
+        console.error('[Admin] Failed to load instance config', err)
+    }
+    finally {
+        loading.value = false
+    }
+})
+
+type Pill = { label: string, color: 'success' | 'warning' | 'error' | 'neutral' }
+
+interface ConfigRow {
+    label: string
+    value?: string
+    mono?: boolean
+    pill?: Pill
+    badges?: string[]
+    /** Sub-attributes rendered as key=value chips (tuning, hosts, URIs). Dim = class default, not configured. */
+    attrs?: { key: string, value: string, dim?: boolean }[]
+    /** Mono list under the value (catalog import paths). */
+    lines?: string[]
+}
+
+interface ConfigSection {
+    title: string
+    icon: string
+    rows: ConfigRow[]
+}
+
+function enabledPill(enabled: boolean): Pill {
+    return enabled
+        ? { label: 'Enabled', color: 'success' }
+        : { label: 'Disabled', color: 'neutral' }
+}
+
+/** Flatten a (possibly nested) config dict into dotted key=value attribute pairs. */
+function configAttrs(config: Record<string, unknown>, prefix = ''): { key: string, value: string }[] {
+    return Object.entries(config).flatMap(([key, value]) => {
+        const path = prefix ? `${prefix}.${key}` : key
+        if (value && typeof value === 'object' && !Array.isArray(value))
+            return configAttrs(value as Record<string, unknown>, path)
+        return [{ key: path, value: Array.isArray(value) ? value.join(',') : String(value) }]
+    })
+}
+
+const sections = computed<ConfigSection[]>(() => {
+    if (!config.value) return []
+    const { deployment, auth, services, data } = config.value
+    const launcher = deployment.launcher
+
+    const deploymentRows: ConfigRow[] = [
+        { label: 'Version', value: deployment.version ?? '—', mono: true },
+        {
+            label: 'Launcher',
+            value: launcher.type,
+            mono: true,
+            attrs: [
+                ...configAttrs(launcher.config),
+                ...configAttrs(launcher.defaults).map(attr => ({ ...attr, dim: true })),
+            ],
+        },
+        {
+            label: 'Runner',
+            value: deployment.runner.type,
+            mono: true,
+            attrs: [
+                ...configAttrs(deployment.runner.config),
+                ...configAttrs(deployment.runner.defaults).map(attr => ({ ...attr, dim: true })),
+            ],
+        },
+        {
+            label: 'Agent',
+            pill: enabledPill(deployment.features.agent ?? false),
+            ...(deployment.features.agent && deployment.agent_model
+                ? { attrs: [{ key: 'model', value: deployment.agent_model }] }
+                : {}),
+        },
+    ]
+
+    const authRows: ConfigRow[] = [
+        {
+            label: 'Allowed domains',
+            ...(auth.signup_allowed_domains.length
+                ? { badges: auth.signup_allowed_domains }
+                : { pill: { label: '*', color: 'warning' } }),
+        },
+        auth.super_admin_emails.length
+            ? { label: 'Super admins', badges: auth.super_admin_emails }
+            : { label: 'Super admins', value: '—' },
+        {
+            label: 'Google OAuth',
+            pill: auth.google_oauth_configured
+                ? { label: 'Configured', color: 'success' }
+                : { label: 'Not configured', color: 'error' },
+            ...(auth.google_redirect_uri
+                ? { attrs: [{ key: 'redirect_uri', value: auth.google_redirect_uri }] }
+                : {}),
+        },
+        { label: 'Session expiry', value: `${auth.session_expiry_days} days` },
+        { label: 'Secure cookies', pill: enabledPill(auth.cookie_secure) },
+    ]
+
+    const serviceRows: ConfigRow[] = [
+        {
+            label: 'Cron',
+            pill: enabledPill(services.cron.enabled),
+            attrs: [
+                { key: 'reconcile', value: `${services.cron.reconcile_interval}s` },
+                { key: 'batch', value: String(services.cron.batch_size) },
+                ...(services.cron.max_execution_delay != null
+                    ? [{ key: 'max_delay', value: `${services.cron.max_execution_delay}s` }]
+                    : []),
+            ],
+        },
+        {
+            label: 'Worker',
+            pill: enabledPill(services.worker.enabled),
+            attrs: [{ key: 'poll', value: `${services.worker.poll_interval}s` }],
+        },
+        {
+            label: 'Reaper',
+            pill: enabledPill(services.reaper.enabled),
+            attrs: [
+                { key: 'timeout', value: `${services.reaper.timeout}s` },
+                { key: 'poll', value: `${services.reaper.poll_interval}s` },
+            ],
+        },
+        {
+            label: 'SMTP',
+            pill: services.smtp.enabled
+                ? { label: 'Configured', color: 'success' }
+                : { label: 'Not configured', color: 'neutral' },
+            ...(services.smtp.enabled
+                ? {
+                        attrs: [
+                            { key: 'host', value: services.smtp.host },
+                            { key: 'from', value: services.smtp.from_addr },
+                        ],
+                    }
+                : {}),
+        },
+        ...(services.mcp_external_url ? [{ label: 'MCP URL', value: services.mcp_external_url, mono: true }] : []),
+    ]
+
+    const catalogRows: ConfigRow[] = Object.entries(data.catalog).map(([kind, keys]) => ({
+        label: `${kindLabel(kind)} (${keys.length})`,
+        lines: keys,
+    }))
+
+    const dataRows: ConfigRow[] = [
+        {
+            label: 'Encryption at rest',
+            pill: data.encryption_configured
+                ? { label: 'Configured', color: 'success' }
+                : { label: 'Missing', color: 'error' },
+        },
+        ...(catalogRows.length ? catalogRows : [{ label: 'Catalog', value: 'empty' }]),
+    ]
+
+    return [
+        { title: 'Deployment', icon: 'i-lucide-server', rows: deploymentRows },
+        { title: 'Authentication', icon: 'i-lucide-key-round', rows: authRows },
+        { title: 'Services', icon: 'i-lucide-cog', rows: serviceRows },
+        { title: 'Data', icon: 'i-lucide-database', rows: dataRows },
+    ]
+})
+</script>
+
+<template>
+    <div class="flex flex-col gap-3">
+        <div v-if="loading"
+             class="flex items-center justify-center py-16">
+            <UIcon name="i-lucide-loader-circle"
+                   class="size-5 animate-spin text-dimmed" />
+        </div>
+
+        <UAlert v-else-if="!config"
+                color="error"
+                icon="i-lucide-alert-circle"
+                title="Instance configuration unavailable" />
+
+        <div v-else
+             class="flex flex-col gap-4">
+            <section v-for="section in sections"
+                     :key="section.title"
+                     class="overflow-hidden rounded-lg border border-default bg-default">
+                <div class="flex items-center gap-2 border-b border-default bg-muted px-4 py-2.5">
+                    <UIcon :name="section.icon"
+                           class="size-4 text-muted" />
+                    <span class="text-sm font-semibold text-highlighted">{{ section.title }}</span>
+                </div>
+
+                <div class="divide-y divide-default">
+                    <div v-for="row in section.rows"
+                         :key="row.label"
+                         class="flex items-start gap-4 px-4 py-2.5 text-sm">
+                        <span class="w-56 shrink-0 pt-px text-muted">{{ row.label }}</span>
+                        <div class="min-w-0 flex-1">
+                            <div v-if="row.pill || row.badges || row.value || row.attrs"
+                                 class="flex flex-wrap items-center gap-1.5">
+                                <UBadge v-if="row.pill"
+                                        :color="row.pill.color"
+                                        variant="subtle">
+                                    {{ row.pill.label }}
+                                </UBadge>
+                                <UBadge v-for="badge in row.badges"
+                                        :key="badge"
+                                        color="neutral"
+                                        variant="outline">
+                                    {{ badge }}
+                                </UBadge>
+                                <span v-if="row.value"
+                                      class="min-w-0 break-all font-medium"
+                                      :class="row.mono && 'font-mono text-[13px]'">{{ row.value }}</span>
+                                <span v-for="attr in row.attrs"
+                                      :key="attr.key"
+                                      class="min-w-0 break-all rounded-[5px] px-1.5 py-0.5 font-mono text-xs"
+                                      :class="attr.dim ? 'bg-elevated/50 text-dimmed' : 'bg-elevated'"
+                                      :title="attr.dim ? 'Class default (not configured)' : undefined">
+                                    <span class="text-muted">{{ attr.key }}=</span>{{ attr.value }}
+                                </span>
+                            </div>
+                            <div v-if="row.lines"
+                                 class="grid grid-cols-1 gap-x-6 gap-y-0.5 lg:grid-cols-2">
+                                <span v-for="line in row.lines"
+                                      :key="line"
+                                      class="break-all font-mono text-xs">{{ line }}</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+        </div>
+    </div>
+</template>

--- a/packages/interloper-app/app/app/pages/admin/index.vue
+++ b/packages/interloper-app/app/app/pages/admin/index.vue
@@ -4,7 +4,6 @@ definePageMeta({
     layout: 'admin',
     middleware: 'super-admin',
     pageHeader: {
-        eyebrow: 'Admin portal',
         title: 'Overview',
         description: 'Platform-wide health and activity at a glance.',
     },

--- a/packages/interloper-app/app/app/pages/admin/organisations/[id].vue
+++ b/packages/interloper-app/app/app/pages/admin/organisations/[id].vue
@@ -2,7 +2,7 @@
 import type { BreadcrumbItem } from '@nuxt/ui'
 import type { OrgMember } from '~/types/organisation'
 
-definePageMeta({ title: 'Manage organisation', layout: 'admin', middleware: 'super-admin' })
+definePageMeta({ title: 'Manage organisation', layout: 'admin', middleware: 'super-admin', titleInBreadcrumb: true })
 
 const route = useRoute()
 const orgId = computed(() => route.params.id as string)
@@ -22,8 +22,8 @@ const isMember = computed(() =>
 const inviteEndpoint = computed(() => `/admin/organisations/${orgId.value}/invitations`)
 
 const breadcrumbs = computed<BreadcrumbItem[]>(() => [
-    { label: 'Organisations', icon: 'i-lucide-building-2', to: '/admin/organisations' },
-    { label: orgName.value ?? '…' },
+    titleCrumb('Organisations', '/admin/organisations'),
+    entityCrumb(orgName.value ?? '…', 'i-lucide-building-2'),
 ])
 
 async function loadData() {
@@ -116,8 +116,8 @@ watch(orgId, loadData)
 
 <template>
     <div class="flex flex-col flex-1 min-h-0">
-        <div class="px-4 pt-4 pb-2 shrink-0">
-            <UBreadcrumb :items="breadcrumbs" />
+        <div class="pb-4 shrink-0">
+            <PageBreadcrumb :items="breadcrumbs" />
         </div>
         <OrganizationMembersTable :members="rows"
                                   :loading="loading"

--- a/packages/interloper-app/app/app/pages/admin/organisations/index.vue
+++ b/packages/interloper-app/app/app/pages/admin/organisations/index.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { h } from 'vue'
 import type { TableColumn, DropdownMenuItem } from '@nuxt/ui'
 import type { AdminOrganisation } from '~/types/admin'
 
@@ -7,10 +6,6 @@ definePageMeta({
     title: 'Organisations',
     layout: 'admin',
     middleware: 'super-admin',
-    pageHeader: {
-        title: 'Organisations',
-        description: 'Every organisation on the platform, with its membership.',
-    },
 })
 
 const adminStore = useAdminStore()
@@ -78,6 +73,10 @@ async function submitForm() {
     }
 }
 
+function openOrg(org: AdminOrganisation) {
+    navigateTo(`/admin/organisations/${org.id}`)
+}
+
 function rowActions(org: AdminOrganisation): DropdownMenuItem[][] {
     return [
         [
@@ -112,20 +111,6 @@ const columns: TableColumn<AdminOrganisation>[] = [
             ? new Date(row.original.created_at).toLocaleDateString()
             : '—',
     },
-    {
-        id: 'open',
-        header: '',
-        cell: ({ row }) => h(resolveComponent('UButton'), {
-            icon: 'i-lucide-arrow-right',
-            color: 'neutral',
-            variant: 'ghost',
-            size: 'xs',
-            onClick: () => navigateTo(`/admin/organisations/${row.original.id}`),
-        }),
-        size: 50,
-        enableSorting: false,
-        enableGlobalFilter: false,
-    },
 ]
 
 onMounted(loadData)
@@ -138,7 +123,8 @@ onMounted(loadData)
                    :loading="loading"
                    :row-actions="rowActions"
                    no-actions
-                   search-placeholder="Search organisations...">
+                   search-placeholder="Search organisations..."
+                   @edit="openOrg">
             <template #toolbar>
                 <UButton icon="i-lucide-plus"
                          label="New organisation"

--- a/packages/interloper-app/app/app/pages/admin/users/index.vue
+++ b/packages/interloper-app/app/app/pages/admin/users/index.vue
@@ -7,19 +7,35 @@ definePageMeta({
     title: 'Users',
     layout: 'admin',
     middleware: 'super-admin',
-    pageHeader: {
-        title: 'Users',
-        description: 'Everyone with a profile on the platform, across all organisations.',
-    },
 })
 
 const UAvatar = resolveComponent('UAvatar')
 const UBadge = resolveComponent('UBadge')
+const EntityBadge = resolveComponent('EntityBadge')
 
 const adminStore = useAdminStore()
 
 const rows = ref<AdminUser[]>([])
 const loading = ref(false)
+
+const ALL_ORGS = 'all'
+const orgFilter = ref(ALL_ORGS)
+
+const orgOptions = computed(() => {
+    const seen = new Map<string, string>()
+    for (const user of rows.value)
+        for (const org of user.organisations) seen.set(org.id, org.name)
+    return [
+        { label: 'All organisations', value: ALL_ORGS },
+        ...[...seen]
+            .map(([id, name]) => ({ label: name, value: id }))
+            .sort((a, b) => a.label.localeCompare(b.label)),
+    ]
+})
+
+const filteredRows = computed(() => orgFilter.value === ALL_ORGS
+    ? rows.value
+    : rows.value.filter(user => user.organisations.some(org => org.id === orgFilter.value)))
 
 async function loadData() {
     loading.value = true
@@ -68,9 +84,16 @@ const columns: TableColumn<AdminUser>[] = [
         header: 'Email',
     },
     {
-        accessorKey: 'organisation_count',
+        id: 'organisations',
         header: 'Organisations',
-        cell: ({ row }) => row.original.organisation_count,
+        accessorFn: row => row.organisations.map(org => org.name).join(', '),
+        cell: ({ row }) => {
+            const orgs = row.original.organisations
+            const first = orgs[0]
+            return first
+                ? h(EntityBadge, { icon: 'i-lucide-building-2', label: first.name, extra: orgs.length - 1 })
+                : h('span', { class: 'text-dimmed' }, '—')
+        },
     },
     {
         accessorKey: 'is_super_admin',
@@ -94,9 +117,17 @@ onMounted(loadData)
 <template>
     <div class="flex flex-col flex-1 min-h-0">
         <DataTable :columns="columns"
-                   :data="rows"
+                   :data="filteredRows"
                    :loading="loading"
                    no-actions
-                   search-placeholder="Search users..." />
+                   search-placeholder="Search users...">
+            <template #toolbar>
+                <USelect v-model="orgFilter"
+                         :items="orgOptions"
+                         value-key="value"
+                         icon="i-lucide-building-2"
+                         class="w-52" />
+            </template>
+        </DataTable>
     </div>
 </template>

--- a/packages/interloper-app/app/app/pages/executions/backfills/[backfill].vue
+++ b/packages/interloper-app/app/app/pages/executions/backfills/[backfill].vue
@@ -1,17 +1,22 @@
 <script setup lang="ts">
 import { h, resolveComponent } from 'vue'
-import type { TableColumn } from '@nuxt/ui'
+import type { TableColumn, BreadcrumbItem } from '@nuxt/ui'
 import type { Run } from '~/types/run'
 import type { Backfill } from '~/types/backfill'
 
 // orgSwitchTarget: this page is bespoke to one org's backfill — switching org
 // from the nav lands on the backfills list instead.
-definePageMeta({ title: 'Backfill', orgSwitchTarget: '/executions?tab=backfills' })
+definePageMeta({ title: 'Backfill', orgSwitchTarget: '/executions?tab=backfills', titleInBreadcrumb: true })
 
 const UBadge = resolveComponent('UBadge')
 
 const route = useRoute()
 const backfillId = route.params.backfill!.toString()
+
+const breadcrumbs: BreadcrumbItem[] = [
+    titleCrumb('Backfills', '/executions?tab=backfills'),
+    { ...entityCrumb(backfillId.substring(0, 8), 'i-lucide-calendar-range'), class: 'font-mono' },
+]
 
 const { apiFetch } = useApi()
 const backfillsStore = useBackfillsStore()
@@ -95,12 +100,7 @@ const columns: TableColumn<Run>[] = withSortableHeaders([
              resource-label="backfill">
         <div>
             <div class="flex items-center gap-3 mb-4 shrink-0">
-            <NuxtLink to="/executions?tab=backfills"
-                      class="text-sm text-muted hover:text-default">
-                Backfills
-            </NuxtLink>
-            <span class="text-sm text-muted">/</span>
-            <span class="text-sm font-medium font-mono">{{ backfillId.substring(0, 8) }}</span>
+            <PageBreadcrumb :items="breadcrumbs" />
             <UBadge v-if="backfill"
                     :color="statusColor(backfill.status)"
                     variant="subtle">

--- a/packages/interloper-app/app/app/pages/executions/runs/[run].vue
+++ b/packages/interloper-app/app/app/pages/executions/runs/[run].vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { BreadcrumbItem } from '@nuxt/ui'
 import type { RunEvent } from '~/stores/events'
 import type { Run } from '~/types/run'
 import type { ExecutionStatus } from '~/types/asset_execution'
@@ -11,6 +12,11 @@ definePageMeta({ title: 'Run', orgSwitchTarget: '/executions?tab=runs', fullBlee
 
 const route = useRoute()
 const runId = route.params.run!.toString()
+
+const breadcrumbs: BreadcrumbItem[] = [
+    titleCrumb('Runs', '/executions?tab=runs'),
+    { ...entityCrumb(runId, 'i-lucide-activity'), class: 'font-mono' },
+]
 
 const runsStore = useRunsStore()
 const eventsStore = useEventsStore()
@@ -131,12 +137,7 @@ onUnmounted(() => {
         <div class="flex flex-col h-full min-h-0">
             <div class="flex flex-col gap-4 mb-4 shrink-0 px-4 pt-4">
                 <div class="flex items-center gap-3">
-                    <NuxtLink to="/executions?tab=runs"
-                              class="text-sm text-muted hover:text-default">
-                        Runs
-                    </NuxtLink>
-                    <span class="text-sm text-muted">/</span>
-                    <span class="text-sm font-medium font-mono">{{ runId }}</span>
+                    <PageBreadcrumb :items="breadcrumbs" />
                     <UBadge v-if="run"
                             :color="statusColor(run.status)">
                         {{ statusLabel(run.status) }}

--- a/packages/interloper-app/app/app/pages/organization.vue
+++ b/packages/interloper-app/app/app/pages/organization.vue
@@ -4,7 +4,6 @@ import type { OrgMember } from '~/types/organisation'
 definePageMeta({
     title: 'Organization',
     pageHeader: {
-        eyebrow: 'Workspace',
         title: 'Members',
         description: 'Invite your team to your workspace and give everyone the right level of access. '
             + 'Roles control who can build pipelines, who can only read data, and who can manage the workspace.',

--- a/packages/interloper-app/app/app/stores/admin.ts
+++ b/packages/interloper-app/app/app/stores/admin.ts
@@ -1,4 +1,4 @@
-import type { AdminOrganisation, AdminUser } from '~/types/admin'
+import type { AdminConfig, AdminOrganisation, AdminUser } from '~/types/admin'
 
 interface MemberResponse {
     id: string
@@ -19,6 +19,10 @@ interface InvitationResponse {
 /** Cross-organisation management API, restricted to super-admins server-side. */
 export const useAdminStore = defineStore('admin', () => {
     const { apiFetch } = useApi()
+
+    function getConfig() {
+        return apiFetch<AdminConfig>('/admin/config')
+    }
 
     function listUsers() {
         return apiFetch<AdminUser[]>('/admin/users')
@@ -84,6 +88,7 @@ export const useAdminStore = defineStore('admin', () => {
     }
 
     return {
+        getConfig,
         listUsers,
         listOrganisations,
         createOrganisation,

--- a/packages/interloper-app/app/app/types/admin.ts
+++ b/packages/interloper-app/app/app/types/admin.ts
@@ -5,12 +5,54 @@ export interface AdminOrganisation {
     created_at: string | null
 }
 
+export interface AdminUserOrganisation {
+    id: string
+    name: string
+}
+
+export interface AdminConfig {
+    deployment: {
+        version: string | null
+        launcher: {
+            type: string
+            config: Record<string, unknown>
+            defaults: Record<string, unknown>
+        }
+        runner: {
+            type: string
+            config: Record<string, unknown>
+            defaults: Record<string, unknown>
+        }
+        features: Record<string, boolean>
+        agent_model: string | null
+    }
+    auth: {
+        signup_allowed_domains: string[]
+        super_admin_emails: string[]
+        google_oauth_configured: boolean
+        google_redirect_uri: string
+        session_expiry_days: number
+        cookie_secure: boolean
+    }
+    services: {
+        cron: { enabled: boolean, reconcile_interval: number, batch_size: number, max_execution_delay: number | null }
+        worker: { enabled: boolean, poll_interval: number }
+        reaper: { enabled: boolean, timeout: number, poll_interval: number }
+        smtp: { enabled: boolean, host: string, from_addr: string }
+        mcp_external_url: string
+    }
+    data: {
+        encryption_configured: boolean
+        catalog: Record<string, string[]>
+    }
+}
+
 export interface AdminUser {
     id: string
     email: string
     name: string | null
     avatar_url: string | null
     is_super_admin: boolean
-    organisation_count: number
+    organisations: AdminUserOrganisation[]
     created_at: string | null
 }

--- a/packages/interloper-app/app/app/utils/breadcrumb.ts
+++ b/packages/interloper-app/app/app/utils/breadcrumb.ts
@@ -1,0 +1,16 @@
+import type { BreadcrumbItem } from '@nuxt/ui'
+
+/**
+ * First breadcrumb item styled as the page title (eyebrow design).
+ * translate-y-px drops the 11px uppercase label onto the baseline of the
+ * adjacent 14px crumbs; the negative margin swallows the letter-spacing's
+ * trailing space so the gap around the separator stays symmetric.
+ */
+export function titleCrumb(label: string, to?: string): BreadcrumbItem {
+    return { label, to, class: 'eyebrow text-primary translate-y-px -mr-[0.14em]' }
+}
+
+/** Breadcrumb item for an entity, rendered as an EntityBadge by PageBreadcrumb. */
+export function entityCrumb(label: string, icon: string): BreadcrumbItem {
+    return { label, icon, slot: 'entity' }
+}

--- a/packages/interloper-core/src/interloper/cli/services.py
+++ b/packages/interloper-core/src/interloper/cli/services.py
@@ -70,10 +70,7 @@ def run_services(
         app = create_app(
             store=store,
             catalog=catalog,
-            auth_config=settings.auth,
-            smtp_config=settings.smtp,
-            agent_config=settings.agent,
-            app_settings=settings,
+            settings=settings,
             cors_origins=cors_origins,
         )
 

--- a/packages/interloper-core/src/interloper/cli/services.py
+++ b/packages/interloper-core/src/interloper/cli/services.py
@@ -73,6 +73,7 @@ def run_services(
             auth_config=settings.auth,
             smtp_config=settings.smtp,
             agent_config=settings.agent,
+            app_settings=settings,
             cors_origins=cors_origins,
         )
 

--- a/packages/interloper-db/src/interloper_db/store/auth.py
+++ b/packages/interloper-db/src/interloper_db/store/auth.py
@@ -134,23 +134,24 @@ class AuthMixin(StoreBase):
         with self._session() as session:
             return session.get(Profile, user_id)
 
-    def list_all_profiles(self) -> list[tuple[Profile, int]]:
-        """List every profile with its organisation membership count (super-admin only).
+    def list_all_profiles(self) -> list[tuple[Profile, list[Organisation]]]:
+        """List every profile with the organisations it belongs to (super-admin only).
 
         Returns:
-            List of ``(Profile, organisation_count)`` tuples.
+            List of ``(Profile, organisations)`` tuples.
         """
         with self._session() as session:
             profiles = session.exec(select(Profile)).all()
-            counts = dict(
-                session.exec(
-                    select(
-                        UserOrganisation.user_id,
-                        func.count(UserOrganisation.organisation_id),  # ty: ignore[invalid-argument-type]
-                    ).group_by(UserOrganisation.user_id)  # ty: ignore[invalid-argument-type]
-                ).all()
-            )
-            return [(profile, counts.get(profile.id, 0)) for profile in profiles]
+            memberships = session.exec(
+                select(UserOrganisation.user_id, Organisation).join(
+                    Organisation,
+                    UserOrganisation.organisation_id == Organisation.id,  # ty: ignore[invalid-argument-type]
+                )
+            ).all()
+            orgs_by_user: dict[UUID, list[Organisation]] = {}
+            for user_id, org in memberships:
+                orgs_by_user.setdefault(user_id, []).append(org)
+            return [(profile, orgs_by_user.get(profile.id, [])) for profile in profiles]
 
     def get_profile_by_google_id(self, google_id: str) -> Profile | None:
         """Get a profile by Google OAuth subject identifier.

--- a/packages/interloper-db/tests/store/test_auth.py
+++ b/packages/interloper-db/tests/store/test_auth.py
@@ -74,7 +74,7 @@ class TestAcceptInvitation:
 
 
 class TestListAllProfiles:
-    def test_lists_profiles_with_membership_counts(self, store: Store):
+    def test_lists_profiles_with_their_organisations(self, store: Store):
         admin = store.upsert_profile(google_id="g-admin", email="admin@example.com", name="Admin")
         loner = store.upsert_profile(google_id="g-loner", email="loner@example.com", name="Loner")
         org_a = store.create_organisation(name="Acme", creator_id=admin.id)
@@ -82,10 +82,10 @@ class TestListAllProfiles:
         store.add_org_member(org_a.id, admin.id, "admin")
         store.add_org_member(org_b.id, admin.id, "admin")
 
-        counts = {profile.id: count for profile, count in store.list_all_profiles()}
+        orgs = {profile.id: organisations for profile, organisations in store.list_all_profiles()}
 
-        assert counts[admin.id] == 2
-        assert counts[loner.id] == 0
+        assert sorted(org.name for org in orgs[admin.id]) == ["Acme", "Beta"]
+        assert orgs[loner.id] == []
 
 
 class TestGetProfileByGoogleId:


### PR DESCRIPTION
Follow-ups on the admin portal dashboard shipped in #221.

## Admin config page

New **Config** sidebar entry → `/admin/config`: a read-only, secrets-redacted snapshot of the instance configuration, rendered as key/value tables per section (Deployment / Authentication / Services / Data) with `key=value` chips for sub-attributes.

- `GET /admin/config` is gated by `require_super_admin` and serves a snapshot built **once at startup**: `create_app` receives the full `AppSettings` + hydrated `Catalog` and reduces them through `build_config_snapshot`. Routes never see live settings.
- **Allowlist, not blocklist**: every exposed field is hand-picked into explicit response models, so new settings default to *not exposed*. Secrets only surface as booleans (`google_oauth_configured`, `encryption_configured`, SMTP `enabled`); launcher/runner configs pass through a key allowlist (`env`, `image_pull_secrets`, credentials are dropped) — a test stuffs secrets into every corner and asserts none survive serialization.
- **Effective values**: launcher/runner class defaults are introspected from the `LAUNCHERS`/`RUNNERS` registries (constructor signature / pydantic fields) and shown as dimmed chips when not explicitly configured — e.g. an unconfigured async runner honestly reads `max_workers=4`. Degrades to no defaults on API-only images without the scheduler package.
- **Computed catalog**: reports the hydrated catalog grouped by kind (sources, connections, destinations, hooks, jobs…) instead of `settings.catalog` — which misses everything auto-discovered via entry points.
- The signup allowlist state reads `Allowed domains: *` (warning) when open, or the domain badges when configured.
- Overview stays an empty placeholder for the future stats / requires-attention sections.

## UBreadcrumb everywhere + eyebrow titles

- The run/backfill detail pages drop their hand-rolled `NuxtLink + "/" + span` trails for real `UBreadcrumb`s; a new `PageBreadcrumb` wrapper renders entity crumbs (org name, run/backfill ids) as `EntityBadge` chips.
- Every page in both portals now shows its title in the design's mono-uppercase eyebrow style, rendered by the layouts as a single-crumb breadcrumb so the title sits at the **identical pixel position on every page**; breadcrumb pages integrate it as their first crumb (`titleInBreadcrumb` meta). `titleCrumb`/`entityCrumb` builders in `utils/breadcrumb.ts` own the optical alignment corrections (baseline nudge + tracking trailing-space compensation).

## Table polish

- Organisations: trailing arrow column removed, whole row navigates to the org.
- Users: organisation column shows `EntityBadge` (+N) instead of a count, with a toolbar org filter — backed by `/admin/users` returning the actual memberships (`Store.list_all_profiles` now joins organisations).
- Admin table pages go full width, consistent with the base portal.

## Verification

Every step was verified live against a seeded dev instance via headless Chrome (row navigation, filters, breadcrumb rendering and pixel alignment, config snapshot content incl. redaction and dimmed defaults). Full suite green: 1160+ Python tests, ruff, ty, ESLint, nuxt typecheck.

By Digitl