### PR TITLE
feat(app): user deletion from the admin users table

### DIFF
--- a/packages/interloper-api/src/interloper_api/routes/admin.py
+++ b/packages/interloper-api/src/interloper_api/routes/admin.py
@@ -463,6 +463,19 @@ def list_all_users(
     ]
 
 
+@router.delete("/users/{user_id}")
+def delete_user(
+    user_id: UUID,
+    user: Profile = Depends(require_super_admin),
+    store: Store = Depends(get_store),
+) -> dict[str, str]:
+    """Delete a user entirely: profile, sessions, tokens, memberships, sent invitations."""
+    if user_id == user.id:
+        raise HTTPException(status_code=400, detail="You cannot delete your own account")
+    store.delete_profile(user_id)
+    return {"status": "ok"}
+
+
 # -- Organisations ------------------------------------------------------------
 
 

--- a/packages/interloper-api/tests/test_admin.py
+++ b/packages/interloper-api/tests/test_admin.py
@@ -33,6 +33,10 @@ class FakeStore:
         self.created_invites: list[dict] = []
         self.added_members: list[tuple[UUID, UUID, str]] = []
         self.already_member = False
+        self.deleted_profiles: list[UUID] = []
+
+    def delete_profile(self, user_id: UUID) -> None:
+        self.deleted_profiles.append(user_id)
 
     # -- users --
     def list_all_profiles(self):
@@ -222,6 +226,28 @@ def test_super_admin_lists_all_users(store: FakeStore) -> None:
     assert body[0]["email"] == "member@acme.test"
     assert [org["name"] for org in body[0]["organisations"]] == ["Acme"]
     assert body[0]["is_super_admin"] is False
+
+
+def test_non_super_admin_cannot_delete_user(store: FakeStore) -> None:
+    resp = _client(store, is_super_admin=False).delete(f"/admin/users/{uuid4()}")
+    assert resp.status_code == 403
+    assert store.deleted_profiles == []
+
+
+def test_delete_user(store: FakeStore) -> None:
+    target = uuid4()
+    resp = _client(store, is_super_admin=True).delete(f"/admin/users/{target}")
+    assert resp.status_code == 200
+    assert store.deleted_profiles == [target]
+
+
+def test_cannot_delete_own_account(store: FakeStore) -> None:
+    client = _client(store, is_super_admin=True)
+    me = _profile(is_super_admin=True)
+    client.app.dependency_overrides[get_current_user] = lambda: me
+    resp = client.delete(f"/admin/users/{me.id}")
+    assert resp.status_code == 400
+    assert store.deleted_profiles == []
 
 
 def test_super_admin_lists_all_organisations(store: FakeStore) -> None:

--- a/packages/interloper-app/app/app/layouts/admin.vue
+++ b/packages/interloper-app/app/app/layouts/admin.vue
@@ -55,10 +55,12 @@ const items = computed<NavigationMenuItem[]>(() => [
             </template>
 
             <template #default="{ collapsed }">
-                <div v-if="!collapsed"
-                     class="eyebrow text-primary px-2.5 pt-1">
-                    Admin portal
-                </div>
+                <UBadge v-if="!collapsed"
+                        color="primary"
+                        variant="subtle"
+                        size="lg"
+                        class="eyebrow w-full justify-center py-2"
+                        label="Admin portal" />
                 <UNavigationMenu :collapsed="collapsed"
                                  :items="items"
                                  orientation="vertical" />
@@ -74,6 +76,7 @@ const items = computed<NavigationMenuItem[]>(() => [
                              class="justify-start"
                              :square="collapsed"
                              @click="navigateTo('/')" />
+                    <NavUser :collapsed="collapsed" />
                     <span v-if="!collapsed && appVersion"
                           class="px-2.5 text-[10px] text-dimmed">
                         v{{ appVersion }}

--- a/packages/interloper-app/app/app/pages/admin/users/index.vue
+++ b/packages/interloper-app/app/app/pages/admin/users/index.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { h, resolveComponent } from 'vue'
-import type { TableColumn } from '@nuxt/ui'
+import type { TableColumn, DropdownMenuItem } from '@nuxt/ui'
 import type { AdminUser } from '~/types/admin'
 
 definePageMeta({
@@ -14,6 +14,9 @@ const UBadge = resolveComponent('UBadge')
 const EntityBadge = resolveComponent('EntityBadge')
 
 const adminStore = useAdminStore()
+const userStore = useUserStore()
+const toast = useToast()
+const { confirm } = useConfirm()
 
 const rows = ref<AdminUser[]>([])
 const loading = ref(false)
@@ -48,6 +51,41 @@ async function loadData() {
     finally {
         loading.value = false
     }
+}
+
+async function deleteUser(user: AdminUser) {
+    const confirmed = await confirm({
+        title: 'Delete user',
+        description: 'This permanently deletes {subject}, along with their sessions, tokens, '
+            + 'organisation memberships, and the invitations they sent. This action cannot be undone.',
+        subject: { name: user.name || user.email, icon: 'i-lucide-user' },
+        confirmColor: 'error',
+    })
+    if (!confirmed) return
+
+    try {
+        await adminStore.deleteUser(user.id)
+        toast.add({ title: `${user.name || user.email} deleted`, color: 'success' })
+        await loadData()
+    }
+    catch (err) {
+        toast.add(errorToast(err, 'Failed to delete user'))
+    }
+}
+
+function rowActions(user: AdminUser): DropdownMenuItem[][] {
+    // No self-service deletion — the backend rejects it too.
+    if (user.id === userStore.user?.id) return []
+    return [
+        [
+            {
+                label: 'Delete user',
+                icon: 'i-lucide-trash-2',
+                color: 'error' as const,
+                onSelect: () => deleteUser(user),
+            },
+        ],
+    ]
 }
 
 function initials(user: AdminUser): string {
@@ -119,6 +157,7 @@ onMounted(loadData)
         <DataTable :columns="columns"
                    :data="filteredRows"
                    :loading="loading"
+                   :row-actions="rowActions"
                    no-actions
                    search-placeholder="Search users...">
             <template #toolbar>

--- a/packages/interloper-app/app/app/stores/admin.ts
+++ b/packages/interloper-app/app/app/stores/admin.ts
@@ -28,6 +28,10 @@ export const useAdminStore = defineStore('admin', () => {
         return apiFetch<AdminUser[]>('/admin/users')
     }
 
+    function deleteUser(userId: string) {
+        return apiFetch(`/admin/users/${userId}`, { method: 'DELETE' })
+    }
+
     function listOrganisations() {
         return apiFetch<AdminOrganisation[]>('/admin/organisations')
     }
@@ -90,6 +94,7 @@ export const useAdminStore = defineStore('admin', () => {
     return {
         getConfig,
         listUsers,
+        deleteUser,
         listOrganisations,
         createOrganisation,
         renameOrganisation,

--- a/packages/interloper-db/src/interloper_db/store/auth.py
+++ b/packages/interloper-db/src/interloper_db/store/auth.py
@@ -11,7 +11,14 @@ from interloper.errors import NotFoundError
 from sqlalchemy import func
 from sqlmodel import Session, select
 
-from interloper_db.models import AuthSession, Invitation, Organisation, Profile, UserOrganisation
+from interloper_db.models import (
+    AuthSession,
+    Invitation,
+    Organisation,
+    PersonalAccessToken,
+    Profile,
+    UserOrganisation,
+)
 from interloper_db.store.base import StoreBase
 
 INVITATION_EXPIRY_DAYS = 7
@@ -152,6 +159,39 @@ class AuthMixin(StoreBase):
             for user_id, org in memberships:
                 orgs_by_user.setdefault(user_id, []).append(org)
             return [(profile, orgs_by_user.get(profile.id, [])) for profile in profiles]
+
+    def delete_profile(self, user_id: UUID) -> None:
+        """Delete a profile and everything anchored to it.
+
+        Removes the user's sessions, personal access tokens, organisation
+        memberships, and the invitations they sent, then the profile row.
+
+        Args:
+            user_id: Profile UUID.
+
+        Raises:
+            NotFoundError: If the profile is not found.
+        """
+        with self._session() as session:
+            db_profile = session.get(Profile, user_id)
+            if not db_profile:
+                raise NotFoundError(f"Profile {user_id} not found")
+
+            for db_session in session.exec(select(AuthSession).where(AuthSession.user_id == user_id)).all():
+                session.delete(db_session)
+            for token in session.exec(
+                select(PersonalAccessToken).where(PersonalAccessToken.user_id == user_id)
+            ).all():
+                session.delete(token)
+            for membership in session.exec(
+                select(UserOrganisation).where(UserOrganisation.user_id == user_id)
+            ).all():
+                session.delete(membership)
+            for invitation in session.exec(select(Invitation).where(Invitation.invited_by == user_id)).all():
+                session.delete(invitation)
+
+            session.delete(db_profile)
+            session.commit()
 
     def get_profile_by_google_id(self, google_id: str) -> Profile | None:
         """Get a profile by Google OAuth subject identifier.

--- a/packages/interloper-db/tests/store/test_auth.py
+++ b/packages/interloper-db/tests/store/test_auth.py
@@ -9,12 +9,13 @@ from uuid import uuid4
 
 import interloper as il
 import pytest
+from interloper.errors import NotFoundError
 from sqlalchemy import Engine, event
 from sqlalchemy.pool import StaticPool
 from sqlmodel import Session as SQLSession
 
 from interloper_db import engine as engine_module
-from interloper_db.models import Invitation, Organisation, Profile, UserOrganisation
+from interloper_db.models import AuthSession, Invitation, Organisation, PersonalAccessToken, Profile, UserOrganisation
 from interloper_db.store import Store
 
 
@@ -34,7 +35,7 @@ def auth_db() -> Iterator[Engine]:
         # Dashless hex to match how SQLAlchemy's Uuid type binds values on SQLite.
         dbapi_connection.create_function("gen_random_uuid", 0, lambda: uuid4().hex)
 
-    for model in (Profile, Organisation, UserOrganisation, Invitation):
+    for model in (Profile, Organisation, UserOrganisation, Invitation, AuthSession, PersonalAccessToken):
         model.__table__.create(eng)  # ty: ignore[unresolved-attribute]
     try:
         yield eng
@@ -86,6 +87,34 @@ class TestListAllProfiles:
 
         assert sorted(org.name for org in orgs[admin.id]) == ["Acme", "Beta"]
         assert orgs[loner.id] == []
+
+
+class TestDeleteProfile:
+    def test_deletes_profile_and_everything_anchored_to_it(self, store: Store):
+        admin = store.upsert_profile(google_id="g-admin", email="admin@example.com", name="Admin")
+        keeper = store.upsert_profile(google_id="g-keeper", email="keeper@example.com", name="Keeper")
+        org = store.create_organisation(name="Acme", creator_id=admin.id)
+        store.add_org_member(org.id, admin.id, "admin")
+        store.add_org_member(org.id, keeper.id, "viewer")
+        session_token = store.create_session(user_id=admin.id)
+        keeper_token = store.create_session(user_id=keeper.id)
+        store.create_token(user_id=admin.id, organisation_id=org.id, name="laptop")
+        store.create_invitation(org_id=org.id, email="new@example.com", role="viewer", invited_by=admin.id)
+
+        store.delete_profile(admin.id)
+
+        assert store.get_profile(admin.id) is None
+        assert store.resolve_session(session_token) is None
+        assert not store.has_pending_invitation("new@example.com")
+        assert store.get_user_role(admin.id, org.id) is None
+        # Other users' data is untouched.
+        assert store.get_profile(keeper.id) is not None
+        assert store.resolve_session(keeper_token) is not None
+        assert store.get_user_role(keeper.id, org.id) == "viewer"
+
+    def test_missing_profile_raises(self, store: Store):
+        with pytest.raises(NotFoundError):
+            store.delete_profile(uuid4())
 
 
 class TestGetProfileByGoogleId:


### PR DESCRIPTION
## What

- **Right-click context menu on `/admin/users`**: the shared `DataTable` already had context-menu plumbing; the users page now feeds it row actions.
- **Delete user completely**: the menu's "Delete user" action opens the standard confirm modal (user as subject badge, explicit list of what goes), then calls a new super-admin-gated `DELETE /admin/users/{id}`. `Store.delete_profile` removes everything anchored to the profile — **sessions, personal access tokens, organisation memberships, and the invitations they sent** (all four FK references to `profiles`) — then the profile row itself.
- **Admin sidebar**: the current-user menu (`NavUser`) joins the footer under Exit Admin (dark-mode toggle / logout available inside the portal), and the "Admin portal" label is now a full-width badge.

## Guards

- Deleting your own account is rejected server-side (400) and the UI doesn't offer the action on your own row.
- Org-scoped *data* the user created (sources, runs, …) is not profile-anchored in the schema, so nothing dangles — the user simply ceases to exist as an identity. Logging in again with the same Google account starts a fresh signup, subject to the domain allowlist.

## Tests / verification

- Store test builds a user with a session, token, membership, and a sent invitation, deletes them, and asserts everything is gone while another user's data is untouched (the test DB fixture now creates the sessions/tokens tables).
- API tests: 403 for non-super-admins, 400 on self-delete, delete recorded on the happy path.
- Verified live end-to-end: seeded a throwaway user in the dev instance, right-clicked (own row shows no menu), deleted through the confirm modal, and confirmed via SQL that no profile or orphaned membership rows remained.

By Digitl