### PR TITLE
feat(app): organisation deletion with name confirmation

### DIFF
--- a/packages/interloper-api/src/interloper_api/routes/admin.py
+++ b/packages/interloper-api/src/interloper_api/routes/admin.py
@@ -72,6 +72,12 @@ class UpdateOrganisationRequest(BaseModel):
     name: str
 
 
+class DeleteOrganisationRequest(BaseModel):
+    """Confirmation body for deleting an organisation — must repeat its exact name."""
+
+    name: str
+
+
 class MemberResponse(BaseModel):
     """Organisation member."""
 
@@ -528,6 +534,21 @@ def update_organisation(
         member_count=len(members),
         created_at=org.created_at,
     )
+
+
+@router.delete("/organisations/{org_id}")
+def delete_organisation(
+    org_id: UUID,
+    body: DeleteOrganisationRequest,
+    user: Profile = Depends(require_super_admin),
+    store: Store = Depends(get_store),
+) -> dict[str, str]:
+    """Delete an organisation and all its data. The body must repeat the exact name."""
+    org = _require_org(store, org_id)
+    if body.name != org.name:
+        raise HTTPException(status_code=400, detail="Organisation name does not match")
+    store.delete_organisation(org_id)
+    return {"status": "ok"}
 
 
 # -- Members ------------------------------------------------------------------

--- a/packages/interloper-api/tests/test_admin.py
+++ b/packages/interloper-api/tests/test_admin.py
@@ -34,9 +34,13 @@ class FakeStore:
         self.added_members: list[tuple[UUID, UUID, str]] = []
         self.already_member = False
         self.deleted_profiles: list[UUID] = []
+        self.deleted_organisations: list[UUID] = []
 
     def delete_profile(self, user_id: UUID) -> None:
         self.deleted_profiles.append(user_id)
+
+    def delete_organisation(self, org_id: UUID) -> None:
+        self.deleted_organisations.append(org_id)
 
     # -- users --
     def list_all_profiles(self):
@@ -266,6 +270,28 @@ def test_create_organisation_does_not_add_creator(store: FakeStore) -> None:
     assert resp.status_code == 201
     assert resp.json()["name"] == "New"
     assert resp.json()["member_count"] == 0
+
+
+def test_delete_organisation_requires_matching_name(store: FakeStore) -> None:
+    client = _client(store, is_super_admin=True)
+    resp = client.request("DELETE", f"/admin/organisations/{store.org.id}", json={"name": "Wrong"})
+    assert resp.status_code == 400
+    assert store.deleted_organisations == []
+
+
+def test_delete_organisation(store: FakeStore) -> None:
+    client = _client(store, is_super_admin=True)
+    resp = client.request("DELETE", f"/admin/organisations/{store.org.id}", json={"name": "Acme"})
+    assert resp.status_code == 200
+    assert store.deleted_organisations == [store.org.id]
+
+
+def test_non_super_admin_cannot_delete_organisation(store: FakeStore) -> None:
+    resp = _client(store, is_super_admin=False).request(
+        "DELETE", f"/admin/organisations/{store.org.id}", json={"name": "Acme"}
+    )
+    assert resp.status_code == 403
+    assert store.deleted_organisations == []
 
 
 def test_rename_organisation(store: FakeStore) -> None:

--- a/packages/interloper-app/app/app/pages/admin/organisations/index.vue
+++ b/packages/interloper-app/app/app/pages/admin/organisations/index.vue
@@ -34,11 +34,42 @@ async function loadData() {
     }
 }
 
+// Delete modal state — confirmed by typing the organisation's exact name.
+const deleteOpen = ref(false)
+const deleteTarget = ref<AdminOrganisation | null>(null)
+const deleteConfirmName = ref('')
+const deleting = ref(false)
+
 function openCreate() {
     formMode.value = 'create'
     formName.value = ''
     formTarget.value = null
     formOpen.value = true
+}
+
+function openDelete(org: AdminOrganisation) {
+    deleteTarget.value = org
+    deleteConfirmName.value = ''
+    deleteOpen.value = true
+}
+
+async function submitDelete() {
+    const target = deleteTarget.value
+    if (!target || deleteConfirmName.value !== target.name) return
+
+    deleting.value = true
+    try {
+        await adminStore.deleteOrganisation(target.id, deleteConfirmName.value)
+        toast.add({ title: `Organisation "${target.name}" deleted`, color: 'success' })
+        deleteOpen.value = false
+        await loadData()
+    }
+    catch (err) {
+        toast.add(errorToast(err, 'Failed to delete organisation'))
+    }
+    finally {
+        deleting.value = false
+    }
 }
 
 function openRename(org: AdminOrganisation) {
@@ -91,6 +122,14 @@ function rowActions(org: AdminOrganisation): DropdownMenuItem[][] {
                 onSelect: () => openRename(org),
             },
         ],
+        [
+            {
+                label: 'Delete organisation',
+                icon: 'i-lucide-trash-2',
+                color: 'error' as const,
+                onSelect: () => openDelete(org),
+            },
+        ],
     ]
 }
 
@@ -131,6 +170,38 @@ onMounted(loadData)
                          @click="openCreate" />
             </template>
         </DataTable>
+
+        <UModal v-model:open="deleteOpen"
+                title="Delete organisation"
+                :ui="{ footer: 'justify-end' }">
+            <template #body>
+                <div class="flex flex-col gap-3">
+                    <p class="text-sm text-muted">
+                        This permanently deletes
+                        <EntityBadge icon="i-lucide-building-2"
+                                     :label="deleteTarget?.name ?? ''" />
+                        with all its members, invitations, components, and execution history.
+                        This action cannot be undone.
+                    </p>
+                    <UInput v-model="deleteConfirmName"
+                            :placeholder="`Type “${deleteTarget?.name}” to confirm`"
+                            autofocus
+                            class="w-full"
+                            @keydown.enter="submitDelete" />
+                </div>
+            </template>
+            <template #footer>
+                <UButton label="Cancel"
+                         color="neutral"
+                         variant="outline"
+                         @click="deleteOpen = false" />
+                <UButton label="Delete"
+                         color="error"
+                         :disabled="deleteConfirmName !== deleteTarget?.name || deleting"
+                         :loading="deleting"
+                         @click="submitDelete" />
+            </template>
+        </UModal>
 
         <UModal v-model:open="formOpen"
                 :title="formMode === 'create' ? 'New organisation' : 'Rename organisation'"

--- a/packages/interloper-app/app/app/stores/admin.ts
+++ b/packages/interloper-app/app/app/stores/admin.ts
@@ -50,6 +50,14 @@ export const useAdminStore = defineStore('admin', () => {
         })
     }
 
+    /** Deletes the organisation and all its data; `name` must repeat the exact name. */
+    function deleteOrganisation(orgId: string, name: string) {
+        return apiFetch(`/admin/organisations/${orgId}`, {
+            method: 'DELETE',
+            body: { name },
+        })
+    }
+
     function listMembers(orgId: string) {
         return apiFetch<MemberResponse[]>(`/admin/organisations/${orgId}/members`)
     }
@@ -98,6 +106,7 @@ export const useAdminStore = defineStore('admin', () => {
         listOrganisations,
         createOrganisation,
         renameOrganisation,
+        deleteOrganisation,
         listMembers,
         joinOrganisation,
         updateMemberRole,

--- a/packages/interloper-db/src/interloper_db/store/auth.py
+++ b/packages/interloper-db/src/interloper_db/store/auth.py
@@ -8,15 +8,20 @@ from datetime import datetime, timedelta, timezone
 from uuid import UUID
 
 from interloper.errors import NotFoundError
-from sqlalchemy import func
+from sqlalchemy import delete, func, update
 from sqlmodel import Session, select
 
 from interloper_db.models import (
     AuthSession,
+    Backfill,
+    Component,
+    ComponentRelation,
+    Event,
     Invitation,
     Organisation,
     PersonalAccessToken,
     Profile,
+    Run,
     UserOrganisation,
 )
 from interloper_db.store.base import StoreBase
@@ -366,6 +371,47 @@ class AuthMixin(StoreBase):
                 ).all()
             )
             return [(org, counts.get(org.id, 0)) for org in organisations]
+
+    def delete_organisation(self, org_id: UUID) -> None:
+        """Delete an organisation and everything it owns.
+
+        Removes the org's execution history (events, runs, backfills), its
+        components and their relations, and its tokens, invitations, and
+        memberships. Live sessions and profiles pointing at the org are
+        detached (org reference cleared), not deleted. Bulk statements —
+        ordered children-first — so the cascade never depends on ORM-loaded
+        state. The ``asset_executions`` view follows the events.
+
+        Args:
+            org_id: Organisation UUID.
+
+        Raises:
+            NotFoundError: If the organisation is not found.
+        """
+        with self._session() as session:
+            db_organisation = session.get(Organisation, org_id)
+            if not db_organisation:
+                raise NotFoundError(f"Organisation {org_id} not found")
+
+            # ty misreads SQLModel column comparisons in DML where() as plain bools.
+            statements = (
+                delete(Event).where(Event.org_id == org_id),  # ty: ignore[invalid-argument-type]
+                delete(Run).where(Run.org_id == org_id),  # ty: ignore[invalid-argument-type]
+                delete(Backfill).where(Backfill.org_id == org_id),  # ty: ignore[invalid-argument-type]
+                delete(ComponentRelation).where(ComponentRelation.org_id == org_id),  # ty: ignore[invalid-argument-type]
+                delete(Component).where(Component.org_id == org_id),  # ty: ignore[invalid-argument-type]
+                delete(PersonalAccessToken).where(PersonalAccessToken.organisation_id == org_id),  # ty: ignore[invalid-argument-type]
+                delete(Invitation).where(Invitation.organisation_id == org_id),  # ty: ignore[invalid-argument-type]
+                delete(UserOrganisation).where(UserOrganisation.organisation_id == org_id),  # ty: ignore[invalid-argument-type]
+                update(AuthSession).where(AuthSession.organisation_id == org_id).values(organisation_id=None),  # ty: ignore[invalid-argument-type]
+                update(Profile).where(Profile.last_organisation_id == org_id).values(last_organisation_id=None),  # ty: ignore[invalid-argument-type]
+            )
+            connection = session.connection()
+            for statement in statements:
+                connection.execute(statement)
+
+            session.delete(db_organisation)
+            session.commit()
 
     def get_organisation(self, org_id: UUID) -> Organisation | None:
         """Get an organisation by ID.

--- a/packages/interloper-db/tests/store/test_auth.py
+++ b/packages/interloper-db/tests/store/test_auth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime as dt
 from collections.abc import Iterator
 from datetime import datetime, timedelta, timezone
 from typing import Any
@@ -13,9 +14,22 @@ from interloper.errors import NotFoundError
 from sqlalchemy import Engine, event
 from sqlalchemy.pool import StaticPool
 from sqlmodel import Session as SQLSession
+from sqlmodel import select
 
 from interloper_db import engine as engine_module
-from interloper_db.models import AuthSession, Invitation, Organisation, PersonalAccessToken, Profile, UserOrganisation
+from interloper_db.models import (
+    AuthSession,
+    Backfill,
+    Component,
+    ComponentRelation,
+    Event,
+    Invitation,
+    Organisation,
+    PersonalAccessToken,
+    Profile,
+    Run,
+    UserOrganisation,
+)
 from interloper_db.store import Store
 
 
@@ -35,7 +49,9 @@ def auth_db() -> Iterator[Engine]:
         # Dashless hex to match how SQLAlchemy's Uuid type binds values on SQLite.
         dbapi_connection.create_function("gen_random_uuid", 0, lambda: uuid4().hex)
 
-    for model in (Profile, Organisation, UserOrganisation, Invitation, AuthSession, PersonalAccessToken):
+    auth_models = (Profile, Organisation, UserOrganisation, Invitation, AuthSession, PersonalAccessToken)
+    org_data_models = (Component, ComponentRelation, Backfill, Run, Event)
+    for model in auth_models + org_data_models:
         model.__table__.create(eng)  # ty: ignore[unresolved-attribute]
     try:
         yield eng
@@ -87,6 +103,73 @@ class TestListAllProfiles:
 
         assert sorted(org.name for org in orgs[admin.id]) == ["Acme", "Beta"]
         assert orgs[loner.id] == []
+
+
+class TestDeleteOrganisation:
+    def _seed_org_data(self, session: SQLSession, org_id) -> None:
+        """Plant one row of every org-owned kind directly (no catalog needed)."""
+        source = Component(org_id=org_id, kind="source", key="demo")
+        asset = Component(org_id=org_id, kind="asset", key="demo.a", parent_id=source.id)
+        session.add(source)
+        session.add(asset)
+        session.add(
+            ComponentRelation(
+                src_id=asset.id, dst_id=source.id, org_id=org_id, src_kind="asset", dst_kind="source", type="owner"
+            )
+        )
+        backfill = Backfill(org_id=org_id, start_date=dt.date(2026, 1, 1), end_date=dt.date(2026, 1, 2))
+        session.add(backfill)
+        session.commit()
+        run = Run(org_id=org_id, component_id=source.id)
+        session.add(run)
+        session.commit()
+        session.add(Event(org_id=org_id, run_id=run.id, event_type="run_started", timestamp=datetime.now(timezone.utc)))
+        session.commit()
+
+    def test_deletes_org_and_everything_it_owns(self, store: Store, auth_db: Engine):
+        admin = store.upsert_profile(google_id="g-admin", email="admin@example.com", name="Admin")
+        org = store.create_organisation(name="Doomed", creator_id=admin.id)
+        keeper = store.create_organisation(name="Keeper", creator_id=admin.id)
+        store.add_org_member(org.id, admin.id, "admin")
+        store.add_org_member(keeper.id, admin.id, "admin")
+        store.create_invitation(org_id=org.id, email="new@example.com", role="viewer", invited_by=admin.id)
+        store.create_token(user_id=admin.id, organisation_id=org.id, name="laptop")
+        session_token = store.create_session(user_id=admin.id, organisation_id=org.id)
+        with SQLSession(auth_db) as session:
+            self._seed_org_data(session, org.id)
+            db_admin = session.get(Profile, admin.id)
+            assert db_admin is not None
+            db_admin.last_organisation_id = org.id
+            session.add(db_admin)
+            session.commit()
+
+        store.delete_organisation(org.id)
+
+        assert store.get_organisation(org.id) is None
+        with SQLSession(auth_db) as session:
+            for model in (Component, ComponentRelation, Backfill, Run, Event):
+                assert session.exec(select(model).where(model.org_id == org.id)).first() is None
+            assert (
+                session.exec(select(UserOrganisation).where(UserOrganisation.organisation_id == org.id)).first()
+                is None
+            )
+            assert session.exec(select(Invitation).where(Invitation.organisation_id == org.id)).first() is None
+            assert (
+                session.exec(select(PersonalAccessToken).where(PersonalAccessToken.organisation_id == org.id)).first()
+                is None
+            )
+        # The user, their session, and the other organisation survive; org refs are cleared.
+        resolved = store.resolve_session(session_token)
+        assert resolved is not None
+        profile, auth_session = resolved
+        assert auth_session.organisation_id is None
+        assert profile.last_organisation_id is None
+        assert store.get_organisation(keeper.id) is not None
+        assert store.get_user_role(admin.id, keeper.id) == "admin"
+
+    def test_missing_organisation_raises(self, store: Store):
+        with pytest.raises(NotFoundError):
+            store.delete_organisation(uuid4())
 
 
 class TestDeleteProfile:


### PR DESCRIPTION
## What

The admin organisations table gains a destructive **"Delete organisation"** row action (context menu / row menu), guarded by a type-the-name confirmation.

- **Modal**: states exactly what will be removed (members, invitations, components, execution history) and keeps the Delete button disabled until the input matches the organisation's name exactly.
- **Server-side confirmation too**: `DELETE /admin/organisations/{id}` (super-admin gated) requires the body to repeat the exact name — a mismatch is a 400, so a stray API call can't delete anything by id alone.

## Cascade

Components, runs, events, and backfills carry `org_id` as a plain column (no FK), so the store deletes explicitly, children-first, with bulk statements (no dependence on ORM-loaded state — see the `passive_deletes` pitfall from PR #174):

events → runs → backfills → component relations → components → personal access tokens → invitations → memberships

People are **detached, not deleted**: sessions bound to the org get their org context cleared and `Profile.last_organisation_id` pointers are nulled — users keep their accounts and other memberships. The `asset_executions` view empties with the events.

## Tests / verification

- Store test seeds one row of every org-owned kind (component + child asset, relation, backfill, run, event, token, invitation, membership, org-bound session, `last_organisation_id`) plus a keeper org, deletes, and asserts total cleanup with the keeper org, the user, and their session intact.
- API tests: 403 for non-super-admins, 400 on name mismatch, delete recorded on exact match.
- Verified live end-to-end in a dev instance: created a throwaway org, wrong name kept Delete disabled, correct name deleted it (toast, gone from table and API).

By Digitl