### PR TITLE
refactor(auth)!: rename signup_allowed_domains to allowed_domains

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,7 +45,7 @@ INTERLOPER_AUTH_GOOGLE_CLIENT_SECRET=
 # INTERLOPER_AUTH_SUPER_ADMIN_EMAILS=
 # Comma-separated email domains allowed to sign up (first login). Empty keeps
 # signup open. Existing profiles, super-admins and invited emails always pass.
-# INTERLOPER_AUTH_SIGNUP_ALLOWED_DOMAINS=
+# INTERLOPER_AUTH_ALLOWED_DOMAINS=
 
 
 # ── Connector OAuth (connecting data sources from the UI) ────────────────────

--- a/chart/interloper/values.yaml
+++ b/chart/interloper/values.yaml
@@ -184,7 +184,7 @@ smtp: {}
 # Auth config (OAuth client ID; the client secret goes in
 # secrets.googleClientSecret). super_admin_emails bootstraps the first
 # platform super-admin(s): listed users are promoted when they log in
-# (promote-only — removing an email never demotes). signup_allowed_domains
+# (promote-only — removing an email never demotes). allowed_domains
 # restricts signup to the listed email domains (plus super-admins and
 # invited emails); empty keeps signup open. Existing profiles always
 # keep signing in.
@@ -193,7 +193,7 @@ auth: {}
 #   google_client_id: "..."
 #   super_admin_emails:
 #     - you@example.com
-#   signup_allowed_domains:
+#   allowed_domains:
 #     - example.com
 
 # Extra interloper.yaml sections rendered verbatim into the generated

--- a/packages/interloper-api/src/interloper_api/routes/admin.py
+++ b/packages/interloper-api/src/interloper_api/routes/admin.py
@@ -154,7 +154,7 @@ class AdminDeploymentConfig(BaseModel):
 class AdminAuthConfig(BaseModel):
     """Authentication and signup policy."""
 
-    signup_allowed_domains: list[str]
+    allowed_domains: list[str]
     super_admin_emails: list[str]
     google_oauth_configured: bool
     google_redirect_uri: str
@@ -346,7 +346,7 @@ def build_config_snapshot(settings: Any, features: dict[str, bool], catalog: Any
             agent_model=settings.agent.model if settings.agent.enabled else None,
         ),
         auth=AdminAuthConfig(
-            signup_allowed_domains=settings.auth.signup_allowed_domains,
+            allowed_domains=settings.auth.allowed_domains,
             super_admin_emails=settings.auth.super_admin_emails,
             google_oauth_configured=bool(settings.auth.google_client_id and settings.auth.google_client_secret),
             google_redirect_uri=settings.auth.google_redirect_uri,

--- a/packages/interloper-api/src/interloper_api/routes/auth.py
+++ b/packages/interloper-api/src/interloper_api/routes/auth.py
@@ -25,11 +25,11 @@ router = APIRouter(prefix="/auth", tags=["auth"])
 def _signup_allowed(email: str, auth_config: Any, store: Store) -> bool:
     """Decide whether a first-time login may create a profile.
 
-    An empty ``signup_allowed_domains`` keeps signup open (the default).
+    An empty ``allowed_domains`` keeps signup open (the default).
     Otherwise the email must be on an allowed domain, be a configured
     super-admin, or hold a pending invitation.
     """
-    allowed_domains = auth_config.signup_allowed_domains
+    allowed_domains = auth_config.allowed_domains
     if not allowed_domains:
         return True
 

--- a/packages/interloper-api/tests/conftest.py
+++ b/packages/interloper-api/tests/conftest.py
@@ -27,7 +27,7 @@ def fake_settings() -> SimpleNamespace:
         runner=SimpleNamespace(type="async", config={"max_workers": 8, "env": "r-secret"}),
         agent=SimpleNamespace(enabled=True, model="gemini-2.5-flash"),
         auth=SimpleNamespace(
-            signup_allowed_domains=["digitlcloud.com"],
+            allowed_domains=["digitlcloud.com"],
             super_admin_emails=["boss@example.com"],
             google_client_id="cid",
             google_client_secret="oauth-secret",

--- a/packages/interloper-api/tests/test_admin.py
+++ b/packages/interloper-api/tests/test_admin.py
@@ -210,7 +210,7 @@ def test_super_admin_reads_config(store: FakeStore, fake_settings: SimpleNamespa
     resp = client.get("/admin/config")
     assert resp.status_code == 200
     assert resp.json()["deployment"]["launcher"]["type"] == "kubernetes"
-    assert resp.json()["auth"]["signup_allowed_domains"] == ["digitlcloud.com"]
+    assert resp.json()["auth"]["allowed_domains"] == ["digitlcloud.com"]
 
 
 def test_config_unavailable_returns_503(store: FakeStore) -> None:

--- a/packages/interloper-api/tests/test_auth.py
+++ b/packages/interloper-api/tests/test_auth.py
@@ -3,7 +3,7 @@
 The Google OAuth exchange is faked at the httpx layer; a lightweight fake store
 records the calls. Two properties under test: a user whose email is in
 ``auth_config.super_admin_emails`` is promoted on login (promote-only — an
-existing super-admin is left alone), and ``signup_allowed_domains`` gates
+existing super-admin is left alone), and ``allowed_domains`` gates
 profile creation for first-time logins without touching existing profiles.
 """
 
@@ -49,7 +49,7 @@ class FakeStore:
         return "token"
 
 
-def _auth_config(super_admin_emails: list[str], signup_allowed_domains: list[str]) -> SimpleNamespace:
+def _auth_config(super_admin_emails: list[str], allowed_domains: list[str]) -> SimpleNamespace:
     return SimpleNamespace(
         google_client_id="client-id",
         google_client_secret="client-secret",
@@ -57,20 +57,20 @@ def _auth_config(super_admin_emails: list[str], signup_allowed_domains: list[str
         cookie_secure=False,
         session_expiry_days=1,
         super_admin_emails=super_admin_emails,
-        signup_allowed_domains=signup_allowed_domains,
+        allowed_domains=allowed_domains,
     )
 
 
 def _client(
     store: FakeStore,
     super_admin_emails: list[str] | None = None,
-    signup_allowed_domains: list[str] | None = None,
+    allowed_domains: list[str] | None = None,
 ) -> TestClient:
     app = FastAPI()
     app.include_router(auth_module.router)
     app.dependency_overrides[get_store] = lambda: store
     app.dependency_overrides[get_auth_config] = lambda: _auth_config(
-        super_admin_emails or [], signup_allowed_domains or []
+        super_admin_emails or [], allowed_domains or []
     )
     return TestClient(app, follow_redirects=False)
 
@@ -116,7 +116,7 @@ def test_existing_super_admin_is_not_touched() -> None:
 
 def test_signup_blocked_when_domain_not_allowed() -> None:
     store = FakeStore()
-    client = _client(store, signup_allowed_domains=["digitlcloud.com"])
+    client = _client(store, allowed_domains=["digitlcloud.com"])
     resp = client.get("/auth/google/callback", params={"code": "c"})
     assert resp.status_code == 302
     assert resp.headers["location"] == "/login?error=signup_not_allowed"
@@ -126,7 +126,7 @@ def test_signup_blocked_when_domain_not_allowed() -> None:
 
 def test_signup_allowed_for_listed_domain() -> None:
     store = FakeStore()
-    resp = _client(store, signup_allowed_domains=["example.com"]).get("/auth/google/callback", params={"code": "c"})
+    resp = _client(store, allowed_domains=["example.com"]).get("/auth/google/callback", params={"code": "c"})
     assert resp.status_code == 302
     assert resp.headers["location"] == "/"
     assert store.upserted
@@ -134,7 +134,7 @@ def test_signup_allowed_for_listed_domain() -> None:
 
 def test_existing_profile_bypasses_allowlist() -> None:
     store = FakeStore(exists=True)
-    resp = _client(store, signup_allowed_domains=["digitlcloud.com"]).get(
+    resp = _client(store, allowed_domains=["digitlcloud.com"]).get(
         "/auth/google/callback", params={"code": "c"}
     )
     assert resp.status_code == 302
@@ -144,7 +144,7 @@ def test_existing_profile_bypasses_allowlist() -> None:
 
 def test_invited_email_can_sign_up() -> None:
     store = FakeStore(invited=True)
-    resp = _client(store, signup_allowed_domains=["digitlcloud.com"]).get(
+    resp = _client(store, allowed_domains=["digitlcloud.com"]).get(
         "/auth/google/callback", params={"code": "c"}
     )
     assert resp.status_code == 302
@@ -154,7 +154,7 @@ def test_invited_email_can_sign_up() -> None:
 
 def test_super_admin_email_can_sign_up() -> None:
     store = FakeStore()
-    client = _client(store, super_admin_emails=["boss@example.com"], signup_allowed_domains=["digitlcloud.com"])
+    client = _client(store, super_admin_emails=["boss@example.com"], allowed_domains=["digitlcloud.com"])
     resp = client.get("/auth/google/callback", params={"code": "c"})
     assert resp.status_code == 302
     assert resp.headers["location"] == "/"

--- a/packages/interloper-app/app/app/pages/admin/config.vue
+++ b/packages/interloper-app/app/app/pages/admin/config.vue
@@ -101,8 +101,8 @@ const sections = computed<ConfigSection[]>(() => {
     const authRows: ConfigRow[] = [
         {
             label: 'Allowed domains',
-            ...(auth.signup_allowed_domains.length
-                ? { badges: auth.signup_allowed_domains }
+            ...(auth.allowed_domains.length
+                ? { badges: auth.allowed_domains }
                 : { pill: { label: '*', color: 'warning' } }),
         },
         auth.super_admin_emails.length

--- a/packages/interloper-app/app/app/types/admin.ts
+++ b/packages/interloper-app/app/app/types/admin.ts
@@ -27,7 +27,7 @@ export interface AdminConfig {
         agent_model: string | null
     }
     auth: {
-        signup_allowed_domains: string[]
+        allowed_domains: string[]
         super_admin_emails: string[]
         google_oauth_configured: boolean
         google_redirect_uri: string

--- a/packages/interloper-core/src/interloper/settings.py
+++ b/packages/interloper-core/src/interloper/settings.py
@@ -51,7 +51,7 @@ class AuthSettings(BaseSettings):
     removing an email never demotes an existing super-admin. The env var takes a
     comma-separated list (``INTERLOPER_AUTH_SUPER_ADMIN_EMAILS=a@x.com,b@x.com``).
 
-    ``signup_allowed_domains`` restricts who can sign up (first login creates a
+    ``allowed_domains`` restricts who can sign up (first login creates a
     profile). Empty (the default) keeps signup open to any Google account. When
     set, a new profile is only created for emails on a listed domain, configured
     super-admins, or emails holding a pending invitation; existing profiles
@@ -66,9 +66,9 @@ class AuthSettings(BaseSettings):
     cookie_secure: bool = True
     session_expiry_days: int = 30
     super_admin_emails: Annotated[list[str], NoDecode] = Field(default_factory=list)
-    signup_allowed_domains: Annotated[list[str], NoDecode] = Field(default_factory=list)
+    allowed_domains: Annotated[list[str], NoDecode] = Field(default_factory=list)
 
-    @field_validator("super_admin_emails", "signup_allowed_domains", mode="before")
+    @field_validator("super_admin_emails", "allowed_domains", mode="before")
     @classmethod
     def _parse_comma_list(cls, value: Any) -> list[str]:
         """Accept a comma-separated string (env) or a list (YAML).

--- a/packages/interloper-core/tests/test_settings.py
+++ b/packages/interloper-core/tests/test_settings.py
@@ -47,17 +47,17 @@ def test_auth_settings_super_admin_emails_list():
     assert settings.super_admin_emails == ["admin@example.com"]
 
 
-def test_auth_settings_signup_allowed_domains_default():
+def test_auth_settings_allowed_domains_default():
     """Signup stays open (empty allowlist) unless configured."""
     settings = AuthSettings()
 
-    assert settings.signup_allowed_domains == []
+    assert settings.allowed_domains == []
 
 
-def test_auth_settings_signup_allowed_domains_env(monkeypatch: pytest.MonkeyPatch):
+def test_auth_settings_allowed_domains_env(monkeypatch: pytest.MonkeyPatch):
     """Comma-separated env list; entries trimmed, lowercased, leading @ stripped."""
-    monkeypatch.setenv("INTERLOPER_AUTH_SIGNUP_ALLOWED_DOMAINS", " Digitlcloud.com ,@example.com,")
+    monkeypatch.setenv("INTERLOPER_AUTH_ALLOWED_DOMAINS", " Digitlcloud.com ,@example.com,")
 
     settings = AppSettings()
 
-    assert settings.auth.signup_allowed_domains == ["digitlcloud.com", "example.com"]
+    assert settings.auth.allowed_domains == ["digitlcloud.com", "example.com"]


### PR DESCRIPTION
Renames the signup allowlist setting to `auth.allowed_domains` / `INTERLOPER_AUTH_ALLOWED_DOMAINS` in all locations and forms: the `AuthSettings` field, the `/admin/config` snapshot field (+ frontend type and config page), chart values documentation, and `.env.example`. Internal helper/test names that describe the *signup gating* semantics (`_signup_allowed`, the `signup_not_allowed` login error code) intentionally keep their names.

**BREAKING CHANGE**: deployments configuring `auth.signup_allowed_domains` or `INTERLOPER_AUTH_SIGNUP_ALLOWED_DOMAINS` must rename the key. (No known deployment sets it yet — prod is being configured with the new name in the same rollout.)

Full suite green: 1171 Python tests, ruff, ty, ESLint, nuxt typecheck.

By Digitl