### PR TITLE
fix(assets): give each Bing Ads reporting manager its own working directory

### DIFF
--- a/packages/interloper-assets/src/interloper_assets/bing_ads/connection.py
+++ b/packages/interloper-assets/src/interloper_assets/bing_ads/connection.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 from functools import cached_property
 from typing import Any
 from xml.etree import ElementTree as ET
@@ -132,10 +133,18 @@ class BingAdsConnection(il.RefreshTokenOAuthConnection):
         return ServiceClient("ReportingService", 13, self.authorization_data(account_id))
 
     def reporting_service_manager(self, account_id: str) -> Any:
-        """Return a ReportingServiceManager for downloading reports."""
+        """Return a ReportingServiceManager for downloading reports.
+
+        A fresh ``working_directory`` per manager: the SDK defaults to a
+        shared ``/tmp`` path it creates with a racy exists-then-makedirs,
+        so concurrent report assets in one pod crash with ``FileExistsError``.
+        """
         from bingads.v13.reporting.reporting_service_manager import ReportingServiceManager
 
-        return ReportingServiceManager(self.authorization_data(account_id))
+        return ReportingServiceManager(
+            self.authorization_data(account_id),
+            working_directory=tempfile.mkdtemp(prefix="bingads-"),
+        )
 
     @il.fetch_field_provider
     async def accounts(self) -> list[dict[str, str]]:

--- a/packages/interloper-assets/tests/test_bing_ads.py
+++ b/packages/interloper-assets/tests/test_bing_ads.py
@@ -11,6 +11,7 @@ in prod for AmazonAds; see ``test_amazon_ads.py``).
 
 from __future__ import annotations
 
+import os
 from types import SimpleNamespace
 from typing import Any
 
@@ -23,6 +24,7 @@ from interloper_pandas import DataFrameNormalizer
 from suds import WebFault
 
 from interloper_assets.bing_ads import constants
+from interloper_assets.bing_ads.connection import BingAdsConnection
 from interloper_assets.bing_ads.schemas import AdsStats
 from interloper_assets.bing_ads.source import BingAds, _translate_soap_fault
 
@@ -123,3 +125,39 @@ class TestTranslateSoapFault:
     def test_non_webfault_is_left_untouched(self):
         # Returns None (does not raise) so the caller re-raises the original.
         assert _translate_soap_fault(ValueError("boom")) is None
+
+
+class TestReportingServiceManagerWorkingDirectory:
+    """Each manager must get its own working directory.
+
+    The SDK defaults to a shared ``/tmp/BingAdsSDKPython`` created with a racy
+    exists-then-makedirs, so concurrent report assets in one pod crash with
+    ``FileExistsError`` (prod runs 7c88e1be / 1205e329).
+    """
+
+    def test_each_manager_gets_a_fresh_working_directory(self, monkeypatch):
+        import bingads.v13.reporting.reporting_service_manager as rsm_module
+
+        captured: list[dict[str, Any]] = []
+
+        class FakeManager:
+            def __init__(self, authorization_data: Any, **kwargs: Any):
+                captured.append(kwargs)
+
+        monkeypatch.setattr(rsm_module, "ReportingServiceManager", FakeManager)
+        monkeypatch.setattr(BingAdsConnection, "authorization_data", lambda self, account_id: SimpleNamespace())
+
+        connection = BingAdsConnection(
+            client_id="cid",
+            client_secret="secret",
+            refresh_token="token",
+            developer_token="dev",
+        )
+        connection.reporting_service_manager("123")
+        connection.reporting_service_manager("456")
+
+        dirs = [kwargs["working_directory"] for kwargs in captured]
+        assert len(dirs) == 2
+        assert dirs[0] != dirs[1]
+        for path in dirs:
+            assert os.path.isdir(path)


### PR DESCRIPTION
## Problem

Prod runs of the **Bing Ads** source fail with:

```
FileExistsError: [Errno 17] File exists: '/tmp/BingAdsSDKPython'
```

(runs `7c88e1be-394d-40e0-beca-77c45b5c4e96` and its retry `1205e329-e8af-4a80-be69-e72ec79e8987`, both attempts failing identically within ~8s).

## Root cause

`BingAdsConnection.reporting_service_manager` constructed `ReportingServiceManager` without a `working_directory`, so the SDK falls back to the shared `/tmp/BingAdsSDKPython` and creates it with a racy exists-then-makedirs:

```python
if not os.path.exists(self._working_directory):
    os.makedirs(self._working_directory)
```

The runner starts the 13 per-account `ads_stats` assets concurrently (`asyncio.to_thread`) in one fresh pod. Several threads pass the exists check simultaneously on the empty `/tmp`; the loser of the `makedirs` race crashes, failing its asset, cancelling the in-flight siblings, and failing the run. Retrying re-launches the failed assets concurrently into another fresh pod and hits the same race.

## Fix

Pass a unique `working_directory=tempfile.mkdtemp(prefix="bingads-")` per manager. This removes the makedirs race entirely and additionally keeps concurrent downloads' SDK temp files apart.

Regression test pins that each manager receives a fresh, existing, distinct working directory.

By Digitl