### PR TITLE
fix(app): stop losing the login error query to trailing-slash redirects

### DIFF
--- a/docker/frontend.nginx.conf.template
+++ b/docker/frontend.nginx.conf.template
@@ -34,9 +34,13 @@ server {
     }
 
     # SPA client-side routing: any unknown path falls back to index.html
-    # so Vue Router can handle it.
+    # so Vue Router can handle it. $uri/index.html (not $uri/) serves
+    # pre-rendered route directories without nginx's trailing-slash 301 —
+    # that redirect turned /login?error=… into /login/?error=…, which the
+    # auth middleware no longer recognised as the login page, losing the
+    # query on its own redirect.
     location / {
-        try_files $uri $uri/ /index.html;
+        try_files $uri $uri/index.html /index.html;
     }
 
     # Long-cache hashed build artifacts; never cache index.html.

--- a/packages/interloper-app/app/app/middleware/auth.global.ts
+++ b/packages/interloper-app/app/app/middleware/auth.global.ts
@@ -1,5 +1,11 @@
 export default defineNuxtRouteMiddleware(async (to) => {
-    if (to.path.startsWith('/auth/'))
+    // Proxies may add a trailing slash (nginx directory redirects); canonicalize
+    // so /login/ is /login everywhere, keeping the query intact.
+    const path = to.path.length > 1 ? to.path.replace(/\/+$/, '') : to.path
+    if (path !== to.path)
+        return navigateTo({ path, query: to.query, hash: to.hash }, { replace: true })
+
+    if (path.startsWith('/auth/'))
         return
 
     const userStore = useUserStore()
@@ -11,7 +17,7 @@ export default defineNuxtRouteMiddleware(async (to) => {
     }
 
     // Redirect to home if already authenticated and visiting /login
-    if (to.path === '/login') {
+    if (path === '/login') {
         if (userStore.authenticated)
             return navigateTo('/')
         return
@@ -32,9 +38,9 @@ export default defineNuxtRouteMiddleware(async (to) => {
     // - /admin/*: allow super-admins through (they may belong to no org)
     // - All other routes: redirect to /welcome so user can create one
     if (!organisationStore.organisation) {
-        if (to.path.startsWith('/invite/') || to.path === '/welcome')
+        if (path.startsWith('/invite/') || path === '/welcome')
             return
-        if (to.path.startsWith('/admin') && userStore.isSuperAdmin)
+        if (path.startsWith('/admin') && userStore.isSuperAdmin)
             return
         return navigateTo('/welcome')
     }


### PR DESCRIPTION
## Bug

Rejected signups in prod land on a bare login page instead of seeing the "not allowed to sign up" error. Repro: `https://app.interloper.dev/login?error=signup_not_allowed` ends up at `/login?redirect=/login/?error=signup_not_allowed` with no alert.

Two compounding causes, prod-only (dev has no nginx):

1. **nginx**: `try_files $uri $uri/ /index.html` — the `$uri/` clause matches the pre-rendered route *directories* of the built SPA (`login/index.html`, …) and emits nginx's automatic trailing-slash **301**: `/login?error=…` → `/login/?error=…`.
2. **auth middleware**: `to.path === '/login'` doesn't match `/login/`, so the middleware treats the login page as a protected route and redirects to `/login?redirect=…`, dropping the error param.

## Fix

- nginx template: `try_files $uri $uri/index.html /index.html` — serves pre-rendered directories directly, no redirect (for any route, not just /login).
- auth middleware: canonicalize trailing-slash paths up front (`navigateTo({ path, query, hash }, { replace: true })`) so hand-typed `/login/?error=…` also works, and all path comparisons see the normalized form.

## Verification

Reproduced and verified against the real prod shape — `nginx:alpine` with the templated config serving the built SPA:
- before: `/login` → 301; after: 200.
- `/login?error=signup_not_allowed` → error alert shown, URL unchanged.
- `/login/?error=signup_not_allowed` → canonicalized to `/login?error=…`, error alert shown.

By Digitl