### PR TITLE
refactor(db)!: generalize the events table to components

### DIFF
--- a/packages/interloper-api/src/interloper_api/routes/runs.py
+++ b/packages/interloper-api/src/interloper_api/routes/runs.py
@@ -80,13 +80,15 @@ class EventResponse(BaseModel):
     org_id: UUID
     run_id: UUID | None
     event_type: str
-    asset_id: UUID | None = None
-    asset_key: str | None
+    component_id: UUID | None = None
+    component_kind: str | None
+    component_key: str | None
     partition_or_window: str | None
     error: str | None
     traceback: str | None
     message: str | None
     level: str | None
+    data: dict[str, object] | None
     timestamp: str
 
 
@@ -153,13 +155,15 @@ def _event_to_response(event: Event) -> EventResponse:
         org_id=event.org_id,
         run_id=event.run_id,
         event_type=event.event_type,
-        asset_id=event.asset_id,
-        asset_key=event.asset_key,
+        component_id=event.component_id,
+        component_kind=event.component_kind,
+        component_key=event.component_key,
         partition_or_window=event.partition_or_window,
         error=event.error,
         traceback=event.traceback,
         message=event.message,
         level=event.level,
+        data=event.data,
         timestamp=str(event.timestamp),
     )
 
@@ -273,7 +277,7 @@ def list_run_events(
     response: Response,
     limit: int = 100,
     offset: int = 0,
-    asset_id: Annotated[list[UUID] | None, Query()] = None,
+    component_id: Annotated[list[UUID] | None, Query()] = None,
     event_type: Annotated[list[str] | None, Query()] = None,
     user: Profile = Depends(get_current_user),
     store: Store = Depends(get_store),
@@ -281,20 +285,21 @@ def list_run_events(
     """List events for a run, oldest first.
 
     Events are ordered ``timestamp ASC`` and paged with ``limit``/``offset``.
-    ``asset_id`` and ``event_type`` may each be repeated to narrow the listing
-    to one or more assets (e.g. every asset sharing a status) and/or event
-    types (e.g. a "Lifecycle"/"Errors"/"Logs" tab); the two compose. The total
-    number of matching events (ignoring ``limit``/``offset``, honouring the
-    filters) is returned in the ``X-Total-Count`` response header so clients can
-    page through every event — including the terminal/outcome events
-    (``asset_completed``, ``asset_failed``, ``run_failed``, …) that sort last.
+    ``component_id`` and ``event_type`` may each be repeated to narrow the
+    listing to one or more components (e.g. every asset sharing a status)
+    and/or event types (e.g. a "Lifecycle"/"Errors"/"Logs" tab); the two
+    compose. The total number of matching events (ignoring
+    ``limit``/``offset``, honouring the filters) is returned in the
+    ``X-Total-Count`` response header so clients can page through every event
+    — including the terminal/outcome events (``asset_completed``,
+    ``asset_failed``, ``run_failed``, …) that sort last.
     """
     _load_authorized_run(run_id, user, store)
     limit = max(1, min(limit, MAX_EVENTS_PAGE_SIZE))
     offset = max(0, offset)
-    total = store.count_events(run_id=run_id, asset_ids=asset_id, event_types=event_type)
+    total = store.count_events(run_id=run_id, component_ids=component_id, event_types=event_type)
     response.headers["X-Total-Count"] = str(total)
     events = store.list_events(
-        run_id=run_id, asset_ids=asset_id, event_types=event_type, limit=limit, offset=offset
+        run_id=run_id, component_ids=component_id, event_types=event_type, limit=limit, offset=offset
     )
     return [_event_to_response(e) for e in events]

--- a/packages/interloper-api/tests/test_run_events.py
+++ b/packages/interloper-api/tests/test_run_events.py
@@ -46,10 +46,10 @@ class FakeStore:
         *,
         run_id: UUID | None = None,
         org_id: UUID | None = None,
-        asset_ids: list[UUID] | None = None,
+        component_ids: list[UUID] | None = None,
         event_types: list[str] | None = None,
     ) -> int:
-        self.count_calls.append((asset_ids, event_types))
+        self.count_calls.append((component_ids, event_types))
         return self.total
 
     def list_events(
@@ -57,12 +57,12 @@ class FakeStore:
         *,
         run_id: UUID | None = None,
         org_id: UUID | None = None,
-        asset_ids: list[UUID] | None = None,
+        component_ids: list[UUID] | None = None,
         event_types: list[str] | None = None,
         limit: int = 100,
         offset: int = 0,
     ) -> list:
-        self.list_calls.append((run_id, limit, offset, asset_ids, event_types))
+        self.list_calls.append((run_id, limit, offset, component_ids, event_types))
         # Return as many fake events as the page would hold, capped at the total.
         n = max(0, min(limit, self.total - offset))
         return [
@@ -107,21 +107,21 @@ def test_limit_is_clamped_to_max_page_size(store: FakeStore) -> None:
     assert store.list_calls[-1][1] == MAX_EVENTS_PAGE_SIZE
 
 
-def test_forwards_asset_filter_to_list_and_count(store: FakeStore) -> None:
-    asset_id = uuid4()
-    resp = _client(store).get(f"/runs/{_RUN_ID}/events?asset_id={asset_id}")
+def test_forwards_component_filter_to_list_and_count(store: FakeStore) -> None:
+    component_id = uuid4()
+    resp = _client(store).get(f"/runs/{_RUN_ID}/events?component_id={component_id}")
     assert resp.status_code == 200
-    # A single asset_id arrives as a one-element list.
-    assert store.list_calls[-1] == (_RUN_ID, 100, 0, [asset_id], None)
+    # A single component_id arrives as a one-element list.
+    assert store.list_calls[-1] == (_RUN_ID, 100, 0, [component_id], None)
     # X-Total-Count must reflect the same filter the listing used.
-    assert store.count_calls[-1] == ([asset_id], None)
+    assert store.count_calls[-1] == ([component_id], None)
 
 
-def test_forwards_multiple_asset_filters(store: FakeStore) -> None:
+def test_forwards_multiple_component_filters(store: FakeStore) -> None:
     a, b = uuid4(), uuid4()
-    resp = _client(store).get(f"/runs/{_RUN_ID}/events?asset_id={a}&asset_id={b}")
+    resp = _client(store).get(f"/runs/{_RUN_ID}/events?component_id={a}&component_id={b}")
     assert resp.status_code == 200
-    # Repeated asset_id params filter the listing to the whole set (e.g. one status).
+    # Repeated component_id params filter the listing to the whole set (e.g. one status).
     assert store.list_calls[-1] == (_RUN_ID, 100, 0, [a, b], None)
     assert store.count_calls[-1] == ([a, b], None)
 
@@ -134,8 +134,8 @@ def test_forwards_event_type_filter_to_list_and_count(store: FakeStore) -> None:
     assert store.count_calls[-1] == (None, ["log", "asset_failed"])
 
 
-def test_invalid_asset_filter_is_rejected(store: FakeStore) -> None:
-    resp = _client(store).get(f"/runs/{_RUN_ID}/events?asset_id=not-a-uuid")
+def test_invalid_component_filter_is_rejected(store: FakeStore) -> None:
+    resp = _client(store).get(f"/runs/{_RUN_ID}/events?component_id=not-a-uuid")
     assert resp.status_code == 422
 
 

--- a/packages/interloper-app/app/app/components/executions/ErrorDetailModal.vue
+++ b/packages/interloper-app/app/app/components/executions/ErrorDetailModal.vue
@@ -10,7 +10,7 @@ const emit = defineEmits<{
 }>()
 
 const title = computed(() => {
-    const key = props.event.asset_key ?? 'Unknown'
+    const key = props.event.component_key ?? 'Unknown'
     return `Error: ${key}`
 })
 

--- a/packages/interloper-app/app/app/components/executions/EventsTable.vue
+++ b/packages/interloper-app/app/app/components/executions/EventsTable.vue
@@ -73,18 +73,18 @@ const columns: TableColumn<RunEvent>[] = [
         header: 'Source',
         cell: ({ row }) => {
             const event = row.original as RunEvent
-            const names = event.asset_id ? assetDisplayName.value.get(event.asset_id) : null
+            const names = event.component_id ? assetDisplayName.value.get(event.component_id) : null
             if (!names) return h('span', { class: 'text-muted' }, '—')
             return h(EntityBadge, { icon: names.sourceIcon, label: names.sourceName })
         },
     },
     {
-        accessorKey: 'asset_key',
+        accessorKey: 'component_key',
         header: 'Asset',
         cell: ({ row }) => {
             const event = row.original as RunEvent
-            const names = event.asset_id ? assetDisplayName.value.get(event.asset_id) : null
-            const label = names?.assetName ?? event.asset_key
+            const names = event.component_id ? assetDisplayName.value.get(event.component_id) : null
+            const label = names?.assetName ?? event.component_key
             if (!label) return h('span', { class: 'text-muted' }, '—')
             return h(EntityBadge, { label })
         },

--- a/packages/interloper-app/app/app/pages/executions/runs/[run].vue
+++ b/packages/interloper-app/app/app/pages/executions/runs/[run].vue
@@ -56,7 +56,7 @@ const eventAssetIds = computed<string[] | null>(() => {
         .filter(e => statuses.includes(e.status) && e.asset_id)
         .map(e => e.asset_id!)
 })
-watch(eventAssetIds, ids => eventsStore.filterByAssets(ids))
+watch(eventAssetIds, ids => eventsStore.filterByComponents(ids))
 
 // Switching the status pill clears any single-asset drill-down.
 watch(statusFilter, () => { selectedAsset.value = null })
@@ -79,7 +79,7 @@ const viewTabs = [
 ]
 
 const markerTime = computed(() => eventInFocus.value?.timestamp ? new Date(eventInFocus.value.timestamp) : null)
-const highlightedAsset = computed(() => eventInFocus.value?.asset_id ?? null)
+const highlightedAsset = computed(() => eventInFocus.value?.component_id ?? null)
 
 const retrying = ref(false)
 

--- a/packages/interloper-app/app/app/stores/events.ts
+++ b/packages/interloper-app/app/app/stores/events.ts
@@ -5,13 +5,15 @@ export interface RunEvent {
     org_id: string
     run_id: string | null
     event_type: EventType
-    asset_id: string | null
-    asset_key: string | null
+    component_id: string | null
+    component_kind: string | null
+    component_key: string | null
     partition_or_window: string | null
     error: string | null
     traceback: string | null
     message: string | null
     level: string | null
+    data: Record<string, unknown> | null
     timestamp: string
 }
 
@@ -26,11 +28,11 @@ export const useEventsStore = defineStore('events', () => {
      * State
      **********************/
     const runId = ref<string | null>(null)
-    // Server-side asset filter — one or more assets (e.g. every asset sharing a
-    // status). Events are paged from the server, so filtering must happen there
-    // too — filtering only the loaded pages client-side would hide every
-    // matching event that hasn't been scrolled into view yet.
-    const assetIds = ref<string[] | null>(null)
+    // Server-side component filter — one or more components (e.g. every asset
+    // sharing a status). Events are paged from the server, so filtering must
+    // happen there too — filtering only the loaded pages client-side would hide
+    // every matching event that hasn't been scrolled into view yet.
+    const componentIds = ref<string[] | null>(null)
     // Server-side event-type filter — the category tab (Lifecycle / Errors /
     // Logs). Composes with the asset filter; same server-paging rationale.
     const eventTypes = ref<string[] | null>(null)
@@ -105,7 +107,7 @@ export const useEventsStore = defineStore('events', () => {
             limit: String(EVENTS_PAGE_SIZE),
             offset: String(nextOffset.value),
         })
-        for (const aid of assetIds.value ?? []) params.append('asset_id', aid)
+        for (const cid of componentIds.value ?? []) params.append('component_id', cid)
         for (const et of eventTypes.value ?? []) params.append('event_type', et)
         const res = await apiFetchRaw<RunEvent[]>(`/runs/${id}/events?${params}`)
         if (epoch !== fetchEpoch) return // state was reset while in flight
@@ -125,7 +127,7 @@ export const useEventsStore = defineStore('events', () => {
         scope: () => runId.value ? orgStore.organisation?.id : null,
         shouldHandle: (record: Record<string, any>) =>
             record.run_id === runId.value
-            && (!assetIds.value || assetIds.value.includes(record.asset_id))
+            && (!componentIds.value || componentIds.value.includes(record.component_id))
             && (!eventTypes.value || eventTypes.value.includes(record.event_type)),
         onInsert: (record: Record<string, any>) => _upsert(record as RunEvent),
     })
@@ -162,15 +164,15 @@ export const useEventsStore = defineStore('events', () => {
      */
     async function fetchForRun(id: string) {
         runId.value = id
-        assetIds.value = null
+        componentIds.value = null
         eventTypes.value = null
         await _reload()
     }
 
-    /** Re-page from the start filtered to a set of assets (`null` clears it). */
-    async function filterByAssets(assets: string[] | null) {
-        if (!runId.value || _sameFilter(assets, assetIds.value)) return
-        assetIds.value = assets
+    /** Re-page from the start filtered to a set of components (`null` clears it). */
+    async function filterByComponents(components: string[] | null) {
+        if (!runId.value || _sameFilter(components, componentIds.value)) return
+        componentIds.value = components
         await _reload()
     }
 
@@ -203,13 +205,9 @@ export const useEventsStore = defineStore('events', () => {
         return events.value.find(e => e.id === id)
     }
 
-    function byAssetKey(key: string): RunEvent[] {
-        return events.value.filter(e => e.asset_key === key)
-    }
-
     function $reset() {
         runId.value = null
-        assetIds.value = null
+        componentIds.value = null
         eventTypes.value = null
         fetchEpoch++
         events.value = []
@@ -222,7 +220,7 @@ export const useEventsStore = defineStore('events', () => {
 
     return {
         runId,
-        assetIds,
+        componentIds,
         eventTypes,
         events,
         total,
@@ -231,11 +229,10 @@ export const useEventsStore = defineStore('events', () => {
         hasMore,
         error,
         fetchForRun,
-        filterByAssets,
+        filterByComponents,
         filterByEventTypes,
         loadMore,
         findById,
-        byAssetKey,
         _upsert,
         $reset,
     }

--- a/packages/interloper-app/app/app/types/event.ts
+++ b/packages/interloper-app/app/app/types/event.ts
@@ -21,4 +21,6 @@ export type EventType =
     | 'backfill_started'
     | 'backfill_completed'
     | 'backfill_failed'
+    | 'hook_fired'
+    | 'hook_failed'
     | 'log'

--- a/packages/interloper-app/app/app/utils/events.ts
+++ b/packages/interloper-app/app/app/utils/events.ts
@@ -25,6 +25,8 @@ const iconMap: Record<EventType, string> = {
     backfill_started: 'i-lucide-rewind',
     backfill_completed: 'i-lucide-flag',
     backfill_failed: 'i-lucide-alert-circle',
+    hook_fired: 'i-lucide-webhook',
+    hook_failed: 'i-lucide-alert-circle',
     log: 'i-lucide-align-left',
 }
 
@@ -51,6 +53,8 @@ const labelMap: Record<EventType, string> = {
     backfill_started: 'Backfill Started',
     backfill_completed: 'Backfill Completed',
     backfill_failed: 'Backfill Failed',
+    hook_fired: 'Hook Fired',
+    hook_failed: 'Hook Failed',
     log: 'Log',
 }
 
@@ -77,6 +81,8 @@ const LIFECYCLE_TYPES: EventType[] = [
     'backfill_started',
     'backfill_completed',
     'backfill_failed',
+    'hook_fired',
+    'hook_failed',
 ]
 
 /** Every failure event, derived so new `*_failed` types are picked up automatically. */

--- a/packages/interloper-db/src/interloper_db/migrations/versions/002_asset_executions.py
+++ b/packages/interloper-db/src/interloper_db/migrations/versions/002_asset_executions.py
@@ -1,5 +1,11 @@
 """Create asset_executions view.
 
+Edited in place when the ``events`` table was generalized to components
+(migration 005): tables come from ``create_all()`` against the current
+models, so this view must reference the current column names to apply on a
+fresh database. Databases that ran the original version get the same
+definition re-applied by 005.
+
 Revision ID: 002
 Revises: 001
 """
@@ -23,12 +29,12 @@ WITH ranked AS (
     SELECT
         e.run_id,
         e.org_id,
-        e.asset_id,
-        e.asset_key,
+        e.component_id AS asset_id,
+        e.component_key AS asset_key,
         e.event_type,
         e.timestamp,
         row_number() OVER (
-            PARTITION BY e.run_id, e.asset_id
+            PARTITION BY e.run_id, e.component_id
             ORDER BY
                 CASE e.event_type
                     WHEN 'asset_failed' THEN 1
@@ -41,17 +47,17 @@ WITH ranked AS (
                 e.timestamp DESC
         ) AS rn,
         min(CASE WHEN e.event_type = 'asset_queued' THEN e.timestamp END) OVER (
-            PARTITION BY e.run_id, e.asset_id
+            PARTITION BY e.run_id, e.component_id
         ) AS queued_at,
         min(CASE WHEN e.event_type = 'asset_started' THEN e.timestamp END) OVER (
-            PARTITION BY e.run_id, e.asset_id
+            PARTITION BY e.run_id, e.component_id
         ) AS started_at,
         max(CASE WHEN e.event_type IN ('asset_completed', 'asset_failed', 'asset_canceled')
             THEN e.timestamp END) OVER (
-            PARTITION BY e.run_id, e.asset_id
+            PARTITION BY e.run_id, e.component_id
         ) AS completed_at
     FROM events e
-    WHERE e.asset_id IS NOT NULL
+    WHERE e.component_id IS NOT NULL AND e.component_kind = 'asset'
 )
 SELECT
     r.run_id,

--- a/packages/interloper-db/src/interloper_db/migrations/versions/005_component_events.py
+++ b/packages/interloper-db/src/interloper_db/migrations/versions/005_component_events.py
@@ -1,0 +1,179 @@
+"""Generalize the events table to components.
+
+``asset_id``/``asset_key`` become ``component_id``/``component_key``, joined
+by ``component_kind`` — an event can now reference a component of any kind
+(hooks, jobs, …), mirroring the single ``components`` table. A ``data``
+JSONB column keeps whatever producer metadata the structured columns don't
+carry, so new event shapes need no further schema changes.
+
+Also swaps the events realtime trigger onto a size-guarded notify function:
+``pg_notify`` caps payloads at ~8KB while event text fields may hold 60KB,
+so an oversized record previously made the trigger raise and abort the
+INSERT, silently dropping the event.
+
+Idempotent: fresh databases get the new shape from ``create_all()`` (and the
+new view from the edited migration 002), so every step no-ops when its work
+is already done.
+
+Revision ID: 005
+Revises: 004
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "005"
+down_revision: str | None = "004"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+# Same definition as (the edited) migration 002 — re-applied here so
+# databases that ran the original asset_id-based version pick up the renamed
+# base columns and the kind guard.
+_VIEW_SQL = """
+CREATE OR REPLACE VIEW asset_executions AS
+WITH ranked AS (
+    SELECT
+        e.run_id,
+        e.org_id,
+        e.component_id AS asset_id,
+        e.component_key AS asset_key,
+        e.event_type,
+        e.timestamp,
+        row_number() OVER (
+            PARTITION BY e.run_id, e.component_id
+            ORDER BY
+                CASE e.event_type
+                    WHEN 'asset_failed' THEN 1
+                    WHEN 'asset_canceled' THEN 2
+                    WHEN 'asset_completed' THEN 3
+                    WHEN 'asset_started' THEN 4
+                    WHEN 'asset_skipped' THEN 5
+                    WHEN 'asset_queued' THEN 6
+                END,
+                e.timestamp DESC
+        ) AS rn,
+        min(CASE WHEN e.event_type = 'asset_queued' THEN e.timestamp END) OVER (
+            PARTITION BY e.run_id, e.component_id
+        ) AS queued_at,
+        min(CASE WHEN e.event_type = 'asset_started' THEN e.timestamp END) OVER (
+            PARTITION BY e.run_id, e.component_id
+        ) AS started_at,
+        max(CASE WHEN e.event_type IN ('asset_completed', 'asset_failed', 'asset_canceled')
+            THEN e.timestamp END) OVER (
+            PARTITION BY e.run_id, e.component_id
+        ) AS completed_at
+    FROM events e
+    WHERE e.component_id IS NOT NULL AND e.component_kind = 'asset'
+)
+SELECT
+    r.run_id,
+    r.org_id,
+    r.asset_id,
+    r.asset_key,
+    CASE r.event_type
+        WHEN 'asset_failed' THEN 'failed'
+        WHEN 'asset_canceled' THEN 'canceled'
+        WHEN 'asset_completed' THEN 'success'
+        WHEN 'asset_started' THEN 'running'
+        WHEN 'asset_skipped' THEN 'skipped'
+        WHEN 'asset_queued' THEN 'queued'
+    END AS status,
+    r.started_at,
+    r.completed_at,
+    r.queued_at AS created_at
+FROM ranked r
+WHERE r.rn = 1
+"""
+
+_NOTIFY_EVENT_FN = """
+CREATE OR REPLACE FUNCTION notify_event_change()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    rec jsonb;
+BEGIN
+    rec := to_jsonb(NEW);
+    -- pg_notify rejects payloads over ~8KB, and raising here aborts the
+    -- INSERT itself. Cap the unbounded fields instead of losing the event;
+    -- subscribers get the full row when they refetch through the API.
+    IF octet_length(rec::text) > 7000 THEN
+        rec := (rec - 'data') || jsonb_build_object(
+            'error', left(NEW.error, 1000),
+            'traceback', left(NEW.traceback, 1000),
+            'message', left(NEW.message, 1000)
+        );
+    END IF;
+    PERFORM pg_notify('table_changes', jsonb_build_object(
+        'table', TG_TABLE_NAME,
+        'op', TG_OP,
+        'org_id', NEW.org_id,
+        'record', rec
+    )::text);
+    RETURN NEW;
+END;
+$$
+"""
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    columns = {column["name"] for column in sa.inspect(bind).get_columns("events")}
+
+    if "asset_id" in columns:
+        op.alter_column("events", "asset_id", new_column_name="component_id")
+    if "asset_key" in columns:
+        op.alter_column("events", "asset_key", new_column_name="component_key")
+    if "component_kind" not in columns:
+        op.add_column("events", sa.Column("component_kind", sa.String(), nullable=True))
+        # Every pre-existing component-linked event row was an asset event.
+        op.execute("UPDATE events SET component_kind = 'asset' WHERE component_id IS NOT NULL")
+    if "data" not in columns:
+        op.add_column("events", sa.Column("data", postgresql.JSONB(), nullable=True))
+
+    op.execute("DROP INDEX IF EXISTS ix_events_asset_lookup")
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_events_component_lookup "
+        "ON events (run_id, component_id, event_type, timestamp)"
+    )
+
+    op.execute(_VIEW_SQL)
+
+    op.execute(_NOTIFY_EVENT_FN)
+    op.execute(
+        "CREATE OR REPLACE TRIGGER trg_events_notify "
+        "AFTER INSERT ON events "
+        "FOR EACH ROW EXECUTE FUNCTION notify_event_change()"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "CREATE OR REPLACE TRIGGER trg_events_notify "
+        "AFTER INSERT ON events "
+        "FOR EACH ROW EXECUTE FUNCTION notify_table_change()"
+    )
+    op.execute("DROP FUNCTION IF EXISTS notify_event_change()")
+
+    op.execute("DROP VIEW IF EXISTS asset_executions")
+
+    op.execute("DROP INDEX IF EXISTS ix_events_component_lookup")
+    op.drop_column("events", "data")
+    op.drop_column("events", "component_kind")
+    op.alter_column("events", "component_key", new_column_name="asset_key")
+    op.alter_column("events", "component_id", new_column_name="asset_id")
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_events_asset_lookup ON events (run_id, asset_key, event_type, timestamp)"
+    )
+    # Recreate the view in its original asset-column shape.
+    op.execute(
+        _VIEW_SQL.replace("e.component_id AS asset_id", "e.asset_id")
+        .replace("e.component_key AS asset_key", "e.asset_key")
+        .replace("PARTITION BY e.run_id, e.component_id", "PARTITION BY e.run_id, e.asset_id")
+        .replace("WHERE e.component_id IS NOT NULL AND e.component_kind = 'asset'", "WHERE e.asset_id IS NOT NULL")
+    )

--- a/packages/interloper-db/src/interloper_db/models.py
+++ b/packages/interloper-db/src/interloper_db/models.py
@@ -359,12 +359,21 @@ class Run(SQLModel, table=True):
 
 
 class Event(SQLModel, table=True):
-    """An execution event persisted for observability."""
+    """An execution event persisted for observability.
+
+    Follows the same contract as ``components``: ``component_id``/
+    ``component_kind``/``component_key`` reference the component the event
+    concerns — any kind, no schema change per kind. Deliberately no foreign
+    key: events are history and outlive the component; the denormalized
+    kind/key snapshot keeps a deleted component's events readable. The
+    structured columns carry only what every consumer renders; the rest of
+    the producer's metadata lands losslessly in ``data``.
+    """
 
     __tablename__: ClassVar[str] = "events"
     __table_args__: ClassVar[tuple[Any, ...]] = (
         Index("ix_events_run_id_timestamp", "run_id", "timestamp"),
-        Index("ix_events_asset_lookup", "run_id", "asset_key", "event_type", "timestamp"),
+        Index("ix_events_component_lookup", "run_id", "component_id", "event_type", "timestamp"),
     )
 
     id: UUID = SQLField(
@@ -379,10 +388,12 @@ class Event(SQLModel, table=True):
     partition_or_window: str | None = None
     error: str | None = None
     traceback: str | None = None
-    asset_id: UUID | None = SQLField(default=None)
-    asset_key: str | None = None
+    component_id: UUID | None = SQLField(default=None)
+    component_kind: str | None = None
+    component_key: str | None = None
     message: str | None = None
     level: str | None = None
+    data: dict[str, Any] | None = SQLField(default=None, sa_column=Column(PortableJSON))
     timestamp: datetime = SQLField(sa_column=Column(TZDateTime))
 
 

--- a/packages/interloper-db/src/interloper_db/store/runs.py
+++ b/packages/interloper-db/src/interloper_db/store/runs.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import json
 import logging
 from collections.abc import Sequence
 from datetime import datetime, timedelta, timezone
@@ -44,10 +45,97 @@ def _sanitize_text(value: str | None, *, max_len: int = _MAX_EVENT_TEXT) -> str 
     return cleaned
 
 
+def _sanitize_data(meta: dict[str, Any]) -> dict[str, Any] | None:
+    """Make a metadata dict safe to persist as JSONB, best-effort.
+
+    Non-JSON values are coerced through ``str``; a dict that still can't be
+    encoded (circular refs, NaN) is dropped rather than failing the event
+    write. Postgres ``jsonb`` rejects NUL escapes the same way ``text``
+    rejects NUL bytes, so they are stripped from the encoded form; an
+    oversized payload is replaced by a marker so the write can't fail on
+    size either.
+
+    Returns:
+        The cleaned dict, or ``None`` when there is nothing worth storing.
+    """
+    if not meta:
+        return None
+    try:
+        encoded = json.dumps(meta, default=str, allow_nan=False)
+    except (TypeError, ValueError):
+        return None
+    if len(encoded) > _MAX_EVENT_TEXT:
+        return {"truncated": True}
+    if "\\u0000" in encoded:
+        encoded = encoded.replace("\\u0000", "")
+    return json.loads(encoded) or None
+
+
+#: Metadata keys persisted as structured ``events`` columns — everything
+#: else spills into the ``data`` JSONB column.
+_PROMOTED_METADATA_KEYS = frozenset(
+    {
+        "run_id",
+        "backfill_id",
+        "asset_id",
+        "asset_key",
+        "component_id",
+        "component_kind",
+        "component_key",
+        "partition_or_window",
+        "error",
+        "traceback",
+        "message",
+        "level",
+    }
+)
+
+
+def _event_values(event: il.Event, org_id: UUID, run_id: UUID | None) -> dict[str, Any]:
+    """Map a framework event onto ``events`` column values.
+
+    The component reference comes from ``component_id``/``component_kind``/
+    ``component_key`` metadata; the ``asset_id``/``asset_key`` keys the asset
+    runners emit map onto the same columns (with kind ``"asset"``), so core
+    emitters need no knowledge of the persistence schema. Metadata not
+    covered by a structured column lands losslessly in ``data``.
+
+    Returns:
+        Column values for an ``events`` insert.
+    """
+    meta = event.metadata
+    try:
+        event_id = UUID(event.id)
+    except (ValueError, TypeError):
+        event_id = uuid4()
+
+    component_id = meta.get("component_id") or meta.get("asset_id")
+    component_kind = meta.get("component_kind") or ("asset" if meta.get("asset_id") else None)
+    component_key = meta.get("component_key") or meta.get("asset_key")
+
+    return {
+        "id": event_id,
+        "org_id": org_id,
+        "run_id": run_id,
+        "backfill_id": UUID(meta["backfill_id"]) if meta.get("backfill_id") else None,
+        "event_type": event.type.value,
+        "component_id": UUID(str(component_id)) if component_id else None,
+        "component_kind": _sanitize_text(component_kind),
+        "component_key": _sanitize_text(component_key),
+        "partition_or_window": _sanitize_text(meta.get("partition_or_window")),
+        "error": _sanitize_text(meta.get("error")),
+        "traceback": _sanitize_text(meta.get("traceback")),
+        "message": _sanitize_text(meta.get("message")),
+        "level": _sanitize_text(meta.get("level")),
+        "data": _sanitize_data({k: v for k, v in meta.items() if k not in _PROMOTED_METADATA_KEYS}),
+        "timestamp": event.timestamp,
+    }
+
+
 def _event_filters(
     run_id: UUID | None,
     org_id: UUID | None,
-    asset_ids: Sequence[UUID] | None,
+    component_ids: Sequence[UUID] | None,
     event_types: Sequence[str] | None,
 ) -> list[Any]:
     """The shared where-clauses of :meth:`RunMixin.list_events` / ``count_events``.
@@ -62,8 +150,8 @@ def _event_filters(
         filters.append(Event.run_id == run_id)
     if org_id:
         filters.append(Event.org_id == org_id)
-    if asset_ids:
-        filters.append(col(Event.asset_id).in_(asset_ids))
+    if component_ids:
+        filters.append(col(Event.component_id).in_(component_ids))
     if event_types:
         filters.append(col(Event.event_type).in_(event_types))
     return filters
@@ -112,35 +200,15 @@ class RunMixin(StoreBase):
         Returns:
             The saved Event row.
         """
-        meta = event.metadata
-        try:
-            event_id = UUID(event.id)
-        except (ValueError, TypeError):
-            event_id = uuid4()
-
-        values: dict[str, object | None] = {
-            "id": event_id,
-            "org_id": org_id,
-            "run_id": run_id,
-            "backfill_id": UUID(meta["backfill_id"]) if meta.get("backfill_id") else None,
-            "event_type": event.type.value,
-            "asset_id": UUID(meta["asset_id"]) if meta.get("asset_id") else None,
-            "asset_key": _sanitize_text(meta.get("asset_key")),
-            "partition_or_window": _sanitize_text(meta.get("partition_or_window")),
-            "error": _sanitize_text(meta.get("error")),
-            "traceback": _sanitize_text(meta.get("traceback")),
-            "message": _sanitize_text(meta.get("message")),
-            "level": _sanitize_text(meta.get("level")),
-            "timestamp": event.timestamp,
-        }
+        values = _event_values(event, org_id, run_id)
 
         with self._session() as session:
             stmt = pg_insert(Event).values(**values).on_conflict_do_nothing(index_elements=["id"])
             session.execute(stmt)  # ty: ignore[deprecated]
             session.commit()
-            saved = session.get(Event, event_id)
+            saved = session.get(Event, values["id"])
             if saved is None:  # pragma: no cover - only if the row was concurrently deleted
-                raise RuntimeError(f"Event {event_id} missing immediately after upsert")
+                raise RuntimeError(f"Event {values['id']} missing immediately after upsert")
             return saved
 
     def list_events(
@@ -148,12 +216,12 @@ class RunMixin(StoreBase):
         *,
         run_id: UUID | None = None,
         org_id: UUID | None = None,
-        asset_ids: Sequence[UUID] | None = None,
+        component_ids: Sequence[UUID] | None = None,
         event_types: Sequence[str] | None = None,
         limit: int = 100,
         offset: int = 0,
     ) -> list[Event]:
-        """List events, optionally filtered by run, asset(s) and/or type(s).
+        """List events, optionally filtered by run, component(s) and/or type(s).
 
         Ordering is ``timestamp ASC, id ASC`` — stable and deterministic so
         ``offset``/``limit`` paging never skips or repeats a row when several
@@ -162,7 +230,7 @@ class RunMixin(StoreBase):
         Args:
             run_id: Optional run filter.
             org_id: Optional org filter.
-            asset_ids: Optional filter to events of any of these assets.
+            component_ids: Optional filter to events of any of these components.
             event_types: Optional filter to events of any of these types.
             limit: Max results (default 100).
             offset: Pagination offset.
@@ -173,7 +241,7 @@ class RunMixin(StoreBase):
         with self._session() as session:
             statement = (
                 select(Event)
-                .where(*_event_filters(run_id, org_id, asset_ids, event_types))
+                .where(*_event_filters(run_id, org_id, component_ids, event_types))
                 .order_by(col(Event.timestamp).asc(), col(Event.id).asc())
                 .offset(offset)
                 .limit(limit)
@@ -185,7 +253,7 @@ class RunMixin(StoreBase):
         *,
         run_id: UUID | None = None,
         org_id: UUID | None = None,
-        asset_ids: Sequence[UUID] | None = None,
+        component_ids: Sequence[UUID] | None = None,
         event_types: Sequence[str] | None = None,
     ) -> int:
         """Count events matching the same filters as :meth:`list_events`.
@@ -193,7 +261,7 @@ class RunMixin(StoreBase):
         Args:
             run_id: Optional run filter.
             org_id: Optional org filter.
-            asset_ids: Optional filter to events of any of these assets.
+            component_ids: Optional filter to events of any of these components.
             event_types: Optional filter to events of any of these types.
 
         Returns:
@@ -201,7 +269,9 @@ class RunMixin(StoreBase):
         """
         with self._session() as session:
             statement = (
-                select(func.count()).select_from(Event).where(*_event_filters(run_id, org_id, asset_ids, event_types))
+                select(func.count())
+                .select_from(Event)
+                .where(*_event_filters(run_id, org_id, component_ids, event_types))
             )
             return session.exec(statement).one()
 

--- a/packages/interloper-db/tests/test_events.py
+++ b/packages/interloper-db/tests/test_events.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
-from interloper_db.store.runs import _sanitize_text
+import datetime as dt
+from uuid import UUID, uuid4
+
+import interloper as il
+
+from interloper_db.store.runs import _event_values, _sanitize_data, _sanitize_text
 
 
 def test_sanitize_strips_nul_bytes() -> None:
@@ -27,3 +32,105 @@ def test_sanitize_truncates_oversized() -> None:
     assert out.startswith("x" * 10)
     assert out.endswith("[truncated]")
     assert len(out) < 100
+
+
+# -- _sanitize_data --------------------------------------------------------------
+
+
+def test_sanitize_data_passes_json_through() -> None:
+    assert _sanitize_data({"a": 1, "b": ["x", None]}) == {"a": 1, "b": ["x", None]}
+
+
+def test_sanitize_data_empty_becomes_none() -> None:
+    assert _sanitize_data({}) is None
+
+
+def test_sanitize_data_coerces_non_json_values() -> None:
+    """Non-JSON values go through ``str`` rather than failing the write."""
+    out = _sanitize_data({"when": dt.date(2026, 8, 5)})
+    assert out == {"when": "2026-08-05"}
+
+
+def test_sanitize_data_strips_nul_escapes() -> None:
+    """Postgres jsonb rejects NUL escapes just like text rejects NUL bytes."""
+    assert _sanitize_data({"k": "a\x00b"}) == {"k": "ab"}
+
+
+def test_sanitize_data_replaces_oversized_payloads() -> None:
+    assert _sanitize_data({"blob": "x" * 100_000}) == {"truncated": True}
+
+
+def test_sanitize_data_drops_unencodable_payloads() -> None:
+    assert _sanitize_data({"nan": float("nan")}) is None
+
+
+# -- _event_values ---------------------------------------------------------------
+
+
+def _framework_event(metadata: dict[str, object]) -> il.Event:
+    return il.Event(
+        type=il.EventType.ASSET_COMPLETED,
+        timestamp=dt.datetime(2026, 8, 5, tzinfo=dt.timezone.utc),
+        metadata=metadata,
+    )
+
+
+def test_event_values_maps_asset_metadata_onto_component_columns() -> None:
+    """The ``asset_id``/``asset_key`` keys core emitters use land on the
+    component columns with kind ``asset`` — core needs no schema knowledge."""
+    asset_id = uuid4()
+    values = _event_values(
+        _framework_event({"asset_id": str(asset_id), "asset_key": "ads", "message": "done"}),
+        org_id=uuid4(),
+        run_id=None,
+    )
+    assert values["component_id"] == asset_id
+    assert values["component_kind"] == "asset"
+    assert values["component_key"] == "ads"
+    assert values["message"] == "done"
+
+
+def test_event_values_accepts_explicit_component_metadata() -> None:
+    hook_id = uuid4()
+    values = _event_values(
+        _framework_event({"component_id": str(hook_id), "component_kind": "hook", "component_key": "slack"}),
+        org_id=uuid4(),
+        run_id=None,
+    )
+    assert values["component_id"] == hook_id
+    assert values["component_kind"] == "hook"
+    assert values["component_key"] == "slack"
+
+
+def test_event_values_spills_unpromoted_metadata_into_data() -> None:
+    """Metadata without a structured column persists losslessly in ``data``."""
+    values = _event_values(
+        _framework_event(
+            {
+                "asset_id": str(uuid4()),
+                "asset_key": "ads",
+                "asset_qualified_key": "facebook.ads",
+                "source_id": "src-1",
+                "error": "boom",
+            }
+        ),
+        org_id=uuid4(),
+        run_id=None,
+    )
+    assert values["data"] == {"asset_qualified_key": "facebook.ads", "source_id": "src-1"}
+    assert values["error"] == "boom"
+
+
+def test_event_values_without_component_or_extras() -> None:
+    run_id = uuid4()
+    values = _event_values(_framework_event({"message": "run done"}), org_id=uuid4(), run_id=run_id)
+    assert values["run_id"] == run_id
+    assert values["component_id"] is None
+    assert values["component_kind"] is None
+    assert values["data"] is None
+
+
+def test_event_values_preserves_producer_assigned_id() -> None:
+    event = _framework_event({})
+    values = _event_values(event, org_id=uuid4(), run_id=None)
+    assert values["id"] == UUID(event.id)

--- a/packages/interloper-db/tests/test_run_events.py
+++ b/packages/interloper-db/tests/test_run_events.py
@@ -50,14 +50,14 @@ def _seed(events: list[Event]) -> None:
         session.commit()
 
 
-def _make_events(n: int, *, run_id: UUID = _RUN_ID, start: int = 0, asset_id: UUID | None = None) -> list[Event]:
+def _make_events(n: int, *, run_id: UUID = _RUN_ID, start: int = 0, component_id: UUID | None = None) -> list[Event]:
     """Build ``n`` events for a run, one second apart, oldest first."""
     return [
         Event(
             id=uuid4(),
             org_id=_ORG_ID,
             run_id=run_id,
-            asset_id=asset_id,
+            component_id=component_id,
             event_type="asset_materializing" if i < n - 1 else "asset_completed",
             timestamp=_BASE_TS + timedelta(seconds=start + i),
         )
@@ -136,23 +136,23 @@ def test_filters_isolate_runs(store: RunMixin) -> None:
 
 def test_asset_filter_lists_and_counts_only_that_asset(store: RunMixin) -> None:
     asset_a, asset_b = uuid4(), uuid4()
-    _seed(_make_events(150, asset_id=asset_a))
-    _seed(_make_events(30, start=150, asset_id=asset_b))
+    _seed(_make_events(150, component_id=asset_a))
+    _seed(_make_events(30, start=150, component_id=asset_b))
 
-    assert store.count_events(run_id=_RUN_ID, asset_ids=[asset_a]) == 150
-    assert store.count_events(run_id=_RUN_ID, asset_ids=[asset_b]) == 30
+    assert store.count_events(run_id=_RUN_ID, component_ids=[asset_a]) == 150
+    assert store.count_events(run_id=_RUN_ID, component_ids=[asset_b]) == 30
 
     # Paging honours the filter: asset_a events past the first unfiltered
     # page are reachable through the filtered offsets.
-    page2 = store.list_events(run_id=_RUN_ID, asset_ids=[asset_a], limit=100, offset=100)
+    page2 = store.list_events(run_id=_RUN_ID, component_ids=[asset_a], limit=100, offset=100)
     assert len(page2) == 50
-    assert all(e.asset_id == asset_a for e in page2)
+    assert all(e.component_id == asset_a for e in page2)
 
     # asset_b's events all live beyond the first 150 rows of the run, yet its
     # filtered first page surfaces them.
-    page_b = store.list_events(run_id=_RUN_ID, asset_ids=[asset_b], limit=100, offset=0)
+    page_b = store.list_events(run_id=_RUN_ID, component_ids=[asset_b], limit=100, offset=0)
     assert len(page_b) == 30
-    assert all(e.asset_id == asset_b for e in page_b)
+    assert all(e.component_id == asset_b for e in page_b)
 
 
 def test_event_type_filter_lists_and_counts_only_those_types(store: RunMixin) -> None:
@@ -171,29 +171,29 @@ def test_event_type_filter_lists_and_counts_only_those_types(store: RunMixin) ->
 
 def test_asset_and_event_type_filters_compose(store: RunMixin) -> None:
     asset_a, asset_b = uuid4(), uuid4()
-    _seed(_make_events(5, asset_id=asset_a))
-    _seed(_make_events(5, start=5, asset_id=asset_b))
+    _seed(_make_events(5, component_id=asset_a))
+    _seed(_make_events(5, start=5, component_id=asset_b))
 
     # Each asset has exactly one "asset_completed"; narrowing to asset_a's set
     # of one type yields just that asset's completion.
-    assert store.count_events(run_id=_RUN_ID, asset_ids=[asset_a], event_types=["asset_completed"]) == 1
-    page = store.list_events(run_id=_RUN_ID, asset_ids=[asset_a], event_types=["asset_completed"])
+    assert store.count_events(run_id=_RUN_ID, component_ids=[asset_a], event_types=["asset_completed"]) == 1
+    page = store.list_events(run_id=_RUN_ID, component_ids=[asset_a], event_types=["asset_completed"])
     assert len(page) == 1
-    assert page[0].asset_id == asset_a
+    assert page[0].component_id == asset_a
     assert page[0].event_type == "asset_completed"
 
 
 def test_asset_filter_accepts_multiple_assets(store: RunMixin) -> None:
     asset_a, asset_b, asset_c = uuid4(), uuid4(), uuid4()
-    _seed(_make_events(10, asset_id=asset_a))
-    _seed(_make_events(5, start=10, asset_id=asset_b))
-    _seed(_make_events(7, start=15, asset_id=asset_c))
+    _seed(_make_events(10, component_id=asset_a))
+    _seed(_make_events(5, start=10, component_id=asset_b))
+    _seed(_make_events(7, start=15, component_id=asset_c))
 
     # A set of asset ids (e.g. every asset of one status) is the union of each.
-    assert store.count_events(run_id=_RUN_ID, asset_ids=[asset_a, asset_b]) == 15
-    page = store.list_events(run_id=_RUN_ID, asset_ids=[asset_a, asset_b], limit=100, offset=0)
+    assert store.count_events(run_id=_RUN_ID, component_ids=[asset_a, asset_b]) == 15
+    page = store.list_events(run_id=_RUN_ID, component_ids=[asset_a, asset_b], limit=100, offset=0)
     assert len(page) == 15
-    assert all(e.asset_id in {asset_a, asset_b} for e in page)
+    assert all(e.component_id in {asset_a, asset_b} for e in page)
 
 
 # -- complete_run job stamping -------------------------------------------------

--- a/packages/interloper-scheduler/src/interloper_scheduler/executor.py
+++ b/packages/interloper-scheduler/src/interloper_scheduler/executor.py
@@ -11,10 +11,36 @@ from uuid import UUID
 import interloper as il
 from interloper.runner import ExecutionStatus, Runner
 from interloper_db import Store
-from interloper_db.models import ComponentRelation, Run
+from interloper_db.models import Component, ComponentRelation, Run
 from sqlmodel import Session, col, select
 
 logger = logging.getLogger(__name__)
+
+
+def run_event_metadata(run: Run, target: Component | None) -> dict[str, Any]:
+    """Run-level event metadata: the run's ids plus its target's identity.
+
+    The runner spreads this dict into every event it emits, and the
+    ``target_*`` keys have no structured ``events`` column — they land in
+    each event's ``data``, making events self-describing for telemetry
+    (which job/source/asset the run materialized, under what name at the
+    time) without a join through ``runs``.
+
+    Returns:
+        The metadata dict.
+    """
+    metadata: dict[str, Any] = {
+        "run_id": str(run.id),
+        "backfill_id": str(run.backfill_id) if run.backfill_id else None,
+    }
+    if target is not None:
+        metadata |= {
+            "target_id": str(target.id),
+            "target_kind": target.kind,
+            "target_key": target.key,
+            "target_name": target.name,
+        }
+    return metadata
 
 
 class RunExecutor:
@@ -42,7 +68,7 @@ class RunExecutor:
             ``True`` if the run completed successfully, ``False`` otherwise.
         """
         org_id: UUID | None = None
-        backfill_id: str | None = None
+        run_metadata: dict[str, Any] = {"run_id": str(run_id), "backfill_id": None}
 
         try:
             logger.info("Starting run %s", run_id)
@@ -55,9 +81,9 @@ class RunExecutor:
 
                 component_id = db_run.component_id
                 org_id = db_run.org_id
-                backfill_id = str(db_run.backfill_id) if db_run.backfill_id else None
                 partition_date = db_run.partition_date
                 retry_of = db_run.retry_of if db_run.retry_scope == "failed" else None
+                run_metadata = run_event_metadata(db_run, session.get(Component, component_id))
 
                 self._mark_running(session, db_run)
 
@@ -76,7 +102,7 @@ class RunExecutor:
             dag = il.DAG(*assets)
             partition = il.TimePartition(partition_date) if partition_date else None
 
-            result = self._run_dag(dag, partition, org_id=org_id, run_id=run_id, backfill_id=backfill_id)
+            result = self._run_dag(dag, partition, org_id=org_id, run_id=run_id, metadata=run_metadata)
 
             success = result.status == ExecutionStatus.COMPLETED
             logger.info("Run %s completed: %s", run_id, result.status.name)
@@ -86,13 +112,8 @@ class RunExecutor:
         except Exception as e:
             logger.exception("Run %s failed: %s", run_id, e)
             try:
-                metadata: dict[str, Any] = {
-                    "run_id": str(run_id),
-                    "backfill_id": backfill_id,
-                    "error": str(e),
-                }
                 if org_id is not None:
-                    event = il.Event(type=il.EventType.RUN_FAILED, metadata=metadata)
+                    event = il.Event(type=il.EventType.RUN_FAILED, metadata={**run_metadata, "error": str(e)})
                     self._store.save_event(event, org_id=org_id, run_id=run_id)
                 self._store.complete_run(run_id, success=False)
             except Exception:
@@ -169,7 +190,7 @@ class RunExecutor:
         *,
         org_id: UUID,
         run_id: UUID,
-        backfill_id: str | None,
+        metadata: dict[str, Any],
     ) -> il.RunResult:
         def handle_event(event: il.Event) -> None:
             self._store.save_event(event, org_id=org_id, run_id=run_id)
@@ -177,16 +198,7 @@ class RunExecutor:
         # A fresh copy per execution: the runner template is shared across
         # runs, but run state and the event handler are per-run.
         runner = self._runner.model_copy(update={"on_event": handle_event})
-        return asyncio.run(
-            runner.run(
-                dag,
-                partition,
-                metadata={
-                    "run_id": str(run_id),
-                    "backfill_id": backfill_id,
-                },
-            )
-        )
+        return asyncio.run(runner.run(dag, partition, metadata=metadata))
 
 
 def _target_assets(component: il.Component) -> list[il.Asset]:

--- a/packages/interloper-scheduler/src/interloper_scheduler/hooks.py
+++ b/packages/interloper-scheduler/src/interloper_scheduler/hooks.py
@@ -209,6 +209,9 @@ class HookController(Controller):
                 id=claim,
                 type=outcome,
                 metadata={
+                    "component_id": str(hook_row.id),
+                    "component_kind": "hook",
+                    "component_key": hook_row.key,
                     "message": f"Hook '{hook_row.name}' ({hook_row.key}) reacted to {event_type}",
                     "error": error,
                 },

--- a/packages/interloper-scheduler/src/interloper_scheduler/reaper.py
+++ b/packages/interloper-scheduler/src/interloper_scheduler/reaper.py
@@ -29,10 +29,11 @@ from typing import TYPE_CHECKING
 
 import interloper as il
 from interloper_db import Store
-from interloper_db.models import Run
+from interloper_db.models import Component, Run
 from sqlmodel import Session, select
 
 from interloper_scheduler.controller import Controller
+from interloper_scheduler.executor import run_event_metadata
 from interloper_scheduler.launcher import RunStatus
 
 if TYPE_CHECKING:
@@ -151,13 +152,13 @@ class Reaper(Controller):
         logger.warning("Reaping run %s: %s", run.id, error)
 
         try:
+            target = None
+            if run.component_id:
+                with Session(self._store.engine) as session:
+                    target = session.get(Component, run.component_id)
             event = il.Event(
                 type=il.EventType.RUN_FAILED,
-                metadata={
-                    "run_id": str(run.id),
-                    "backfill_id": str(run.backfill_id) if run.backfill_id else None,
-                    "error": error,
-                },
+                metadata={**run_event_metadata(run, target), "error": error},
             )
             self._store.save_event(event, org_id=run.org_id, run_id=run.id)
         except Exception:

--- a/packages/interloper-scheduler/tests/test_executor_retry.py
+++ b/packages/interloper-scheduler/tests/test_executor_retry.py
@@ -11,9 +11,10 @@ from typing import Any
 from uuid import UUID, uuid4
 
 import pytest
+from interloper_db.models import Component, Run
 
 from interloper_scheduler import executor as executor_module
-from interloper_scheduler.executor import RunExecutor
+from interloper_scheduler.executor import RunExecutor, run_event_metadata
 
 
 class _FakeStore:
@@ -146,3 +147,31 @@ def test_closest_ancestor_status_wins(monkeypatch: pytest.MonkeyPatch) -> None:
     executor._skip_succeeded_assets(mid_id, [asset])  # ty: ignore[invalid-argument-type]
 
     assert asset.materializable is False
+
+
+# -- run_event_metadata ----------------------------------------------------------
+
+
+def test_run_event_metadata_carries_target_context() -> None:
+    org = uuid4()
+    target = Component(org_id=org, kind="job", key="nightly", name="Nightly sync")
+    run = Run(id=uuid4(), org_id=org, component_id=target.id, backfill_id=uuid4())
+
+    metadata = run_event_metadata(run, target)
+
+    assert metadata == {
+        "run_id": str(run.id),
+        "backfill_id": str(run.backfill_id),
+        "target_id": str(target.id),
+        "target_kind": "job",
+        "target_key": "nightly",
+        "target_name": "Nightly sync",
+    }
+
+
+def test_run_event_metadata_without_target() -> None:
+    run = Run(id=uuid4(), org_id=uuid4())
+
+    metadata = run_event_metadata(run, None)
+
+    assert metadata == {"run_id": str(run.id), "backfill_id": None}

--- a/packages/interloper-scheduler/tests/test_hooks.py
+++ b/packages/interloper-scheduler/tests/test_hooks.py
@@ -18,6 +18,7 @@ from interloper_db import Store
 from interloper_db import engine as engine_module
 from interloper_db.models import Component, ComponentRelation, Run
 from interloper_db.models import Event as EventRow
+from interloper_db.store.runs import _event_values
 from sqlalchemy import event
 from sqlalchemy.pool import StaticPool
 from sqlmodel import Session, select
@@ -47,15 +48,7 @@ def store(monkeypatch: pytest.MonkeyPatch) -> Iterator[Store]:
     store = Store(catalog=il.Catalog.from_assets([DemoSource, demo_asset]))
 
     def sqlite_save_event(event: il.Event, org_id: UUID, run_id: UUID | None = None) -> EventRow:
-        row = EventRow(
-            id=UUID(event.id),
-            org_id=org_id,
-            run_id=run_id,
-            event_type=event.type.value,
-            message=event.metadata.get("message"),
-            error=event.metadata.get("error"),
-            timestamp=event.timestamp,
-        )
+        row = EventRow(**_event_values(event, org_id, run_id))
         with Session(eng) as session:
             if session.get(EventRow, row.id) is None:
                 session.add(row)
@@ -125,7 +118,7 @@ class TestHookEvaluation:
         source = store.create_component(_ORG, kind="source", key="demo_source", name="Demo")
         leaf = next(c for c in source.children if c.key == "e")
         root = next(c for c in source.children if c.key == "a")
-        store.create_component(
+        hook = store.create_component(
             _ORG, kind="hook", key="trigger_hook", name="Cascade",
             config={"events": ["run_completed"]},
             relations={"watch": [(leaf.id, "")], "target": [(root.id, "")]},
@@ -142,6 +135,10 @@ class TestHookEvaluation:
             events = session.exec(select(EventRow)).all()
             assert [e.event_type for e in events] == ["hook_fired"]
             assert events[0].run_id == run.id
+            # The claim carries the firing hook's identity, queryable per hook.
+            assert events[0].component_id == hook.id
+            assert events[0].component_kind == "hook"
+            assert events[0].component_key == "trigger_hook"
 
     def test_claim_prevents_refiring(self, store: Store):
         source = store.create_component(_ORG, kind="source", key="demo_source", name="Demo")

--- a/packages/interloper-scheduler/tests/test_reaper.py
+++ b/packages/interloper-scheduler/tests/test_reaper.py
@@ -16,7 +16,7 @@ from interloper_db.models import Event as EventRow
 from interloper_db.store.runs import _event_values
 from sqlalchemy import event
 from sqlalchemy.pool import StaticPool
-from sqlmodel import Session
+from sqlmodel import Session, select
 
 from interloper_scheduler.launcher import Launcher, RunState, RunStatus
 from interloper_scheduler.reaper import Reaper
@@ -123,3 +123,33 @@ class TestTimeoutFallback:
         assert reaper._reap() == 1
         assert _status(store, fresh) == "dispatched"
         assert _status(store, stale) == "failed"
+
+
+class TestTargetContext:
+    def test_reaped_run_event_carries_target_context_in_data(self, store: Store) -> None:
+        with Session(store.engine) as session:
+            target = Component(org_id=_ORG, kind="job", key="nightly", name="Nightly sync")
+            session.add(target)
+            session.commit()
+            target_id = target.id
+        run = store.create_run(_ORG, component_id=target_id)
+        assert run.id is not None
+        with Session(store.engine) as session:
+            db_run = session.get(Run, run.id)
+            assert db_run is not None
+            db_run.status = "dispatched"
+            db_run.created_at = dt.datetime.now(dt.timezone.utc) - dt.timedelta(seconds=1200)
+            session.add(db_run)
+            session.commit()
+
+        assert Reaper(store=store, launcher=None, timeout=600)._reap() == 1
+
+        with Session(store.engine) as session:
+            reaped_event = session.exec(select(EventRow).where(EventRow.run_id == run.id)).one()
+            assert reaped_event.event_type == "run_failed"
+            assert reaped_event.data == {
+                "target_id": str(target_id),
+                "target_kind": "job",
+                "target_key": "nightly",
+                "target_name": "Nightly sync",
+            }

--- a/packages/interloper-scheduler/tests/test_reaper.py
+++ b/packages/interloper-scheduler/tests/test_reaper.py
@@ -13,6 +13,7 @@ from interloper_db import Store
 from interloper_db import engine as engine_module
 from interloper_db.models import Backfill, Component, ComponentRelation, Run
 from interloper_db.models import Event as EventRow
+from interloper_db.store.runs import _event_values
 from sqlalchemy import event
 from sqlalchemy.pool import StaticPool
 from sqlmodel import Session
@@ -55,14 +56,7 @@ def store(monkeypatch: pytest.MonkeyPatch) -> Iterator[Store]:
     store = Store(catalog=il.Catalog(components={}))
 
     def sqlite_save_event(event: il.Event, org_id: UUID, run_id: UUID | None = None) -> EventRow:
-        row = EventRow(
-            id=UUID(event.id),
-            org_id=org_id,
-            run_id=run_id,
-            event_type=event.type.value,
-            error=event.metadata.get("error"),
-            timestamp=event.timestamp,
-        )
+        row = EventRow(**_event_values(event, org_id, run_id))
         with Session(eng) as session:
             session.add(row)
             session.commit()

--- a/packages/interloper-toolkit/src/interloper_toolkit/models.py
+++ b/packages/interloper-toolkit/src/interloper_toolkit/models.py
@@ -311,7 +311,7 @@ class RunDetail(BaseModel):
 class RunErrorEvent(BaseModel):
     """One error event of a failed run."""
 
-    asset_key: str | None = None
+    component_key: str | None = None
     error: str
     timestamp: datetime
 

--- a/packages/interloper-toolkit/src/interloper_toolkit/scheduling.py
+++ b/packages/interloper-toolkit/src/interloper_toolkit/scheduling.py
@@ -140,7 +140,7 @@ def list_failures(ctx: ToolkitContext, limit: int = 20) -> FailureList | ToolErr
             run_id = run.id
             events = ctx.store.list_events(run_id=run_id)
             errors = [
-                RunErrorEvent(asset_key=e.asset_key, error=e.error, timestamp=e.timestamp)
+                RunErrorEvent(component_key=e.component_key, error=e.error, timestamp=e.timestamp)
                 for e in events
                 if e.error
             ]


### PR DESCRIPTION
## Why

The unified-components consolidation stopped one table short. `events` could only reference assets (`asset_id`/`asset_key` columns), and persistence flattened the open `Event.metadata` dict into a fixed, lossy set of columns:

- Hook firing claims squashed the hook's identity into free text (`"Hook 'X' (key) reacted to run_completed"`) — unqueryable; any future kind's events (jobs, connection checks, drift) had nowhere to point.
- `save_event` cherry-picked seven metadata keys and silently dropped the rest (`asset_qualified_key`, `source_id`, …), contradicting the components-table principle that new kinds need no schema changes.
- Two adjacent defects: the lookup index covered `asset_key` while the filter queried `asset_id`, and the realtime trigger's full-record `pg_notify` (~8KB cap) made any event with an oversized traceback abort its own INSERT — the event was silently dropped.

## What

`events` now follows the same contract as `components`:

- **`component_id` / `component_kind` / `component_key`** replace `asset_id`/`asset_key` — an event references a component of any kind, no schema change per kind. Deliberately no FK: events are history and outlive the component; the denormalized kind/key snapshot keeps a deleted component's events readable.
- **`data` JSONB** captures whatever producer metadata the structured columns don't, losslessly (NUL-stripped, size-capped, best-effort).
- **`save_event`** maps the `asset_id`/`asset_key` keys core emitters use onto the component columns with kind `"asset"` — core needs no knowledge of the persistence schema. Hook claims now carry the hook's id/kind/key and are queryable per hook.
- **Lookup index** now covers `component_id`, the column the filter actually uses.
- **Realtime trigger** moves to a size-guarded `notify_event_change()`: oversized records get their unbounded fields truncated in the notification instead of aborting the INSERT. Small events notify exactly as before.
- **API/frontend** renamed end-to-end (`EventResponse` fields, `?component_id=` filter, events store/table/modal); `hook_fired`/`hook_failed` get proper icons/labels on the run page.

## Run target context in `data` (telemetry)

First consumer of the open `data` column: the executor threads the run's target identity into the run-level metadata (`run_event_metadata()` in the scheduler, also used by the reaper and the executor's failure path). The runner spreads run metadata into every event it emits, so **every event of a run now carries `target_id` / `target_kind` / `target_key` / `target_name` in `data`** — self-describing events for telemetry (which job/source/asset the run materialized, under its name at the time) with zero schema change. `target_kind` disambiguates: scheduled runs target jobs; manual runs may target a source or a single asset. The `runs` join remains the authoritative attribution path; the embedded context is the denormalized export-friendly convenience.

Deliberately `target_*`, not `component_*`, keys: run metadata merges underneath each asset event's own identity, and `save_event` prefers explicit `component_*` — reusing those keys would overwrite every asset event's component columns with the target's identity.

## Migration

- **005** is fully idempotent: renames + `component_kind='asset'` backfill on upgrading DBs; a near-no-op on fresh ones (where `create_all` already builds the new shape). Recreates `asset_executions` over the new columns with a `component_kind = 'asset'` guard (view *output* columns keep their `asset_*` names, so the read model, executor, and timeline UI are untouched) and swaps the events trigger.
- **002 is edited in place**: `create_all` builds tables from current models *before* running migrations, so on a fresh database the old view SQL referencing `e.asset_id` would fail. Deployed DBs already past 002 get the same definition re-applied by 005.

## Verification

- Full suite green: ruff, ty, 1213 pytest tests, frontend lint + `nuxt typecheck`.
- Live-verified against Postgres in both directions: fresh provision (columns/index/trigger/view), a 70KB-traceback event persisting through the size-guarded trigger (previously aborted), hook-event identity + `data` spill round-trip, kind-guarded view excluding hook rows, downgrade to 004, re-upgrade with correct rename + backfill of a legacy row, and `create_all` idempotence on the migrated DB.
- Target context live-verified end-to-end: a real demo-source run through `RunExecutor` + `AsyncRunner` persisted 19 events across 10 types (lifecycle, exec, log, `run_failed`), every one carrying `target_*` in `data`.

**BREAKING CHANGE**: events API/store surface renames — `EventResponse` `asset_id`/`asset_key` → `component_id`/`component_kind`/`component_key` (+ `data`), the `?asset_id=` filter on `/runs/{id}/events` → `?component_id=`, and `list_events`/`count_events` `asset_ids` → `component_ids`.

By Digitl