### PR TITLE
refactor(db)!: demote backfill_id and partition_or_window on events to data

### DIFF
--- a/packages/interloper-api/src/interloper_api/routes/runs.py
+++ b/packages/interloper-api/src/interloper_api/routes/runs.py
@@ -83,7 +83,6 @@ class EventResponse(BaseModel):
     component_id: UUID | None = None
     component_kind: str | None
     component_key: str | None
-    partition_or_window: str | None
     error: str | None
     traceback: str | None
     message: str | None
@@ -158,7 +157,6 @@ def _event_to_response(event: Event) -> EventResponse:
         component_id=event.component_id,
         component_kind=event.component_kind,
         component_key=event.component_key,
-        partition_or_window=event.partition_or_window,
         error=event.error,
         traceback=event.traceback,
         message=event.message,

--- a/packages/interloper-app/app/app/stores/events.ts
+++ b/packages/interloper-app/app/app/stores/events.ts
@@ -8,7 +8,6 @@ export interface RunEvent {
     component_id: string | null
     component_kind: string | null
     component_key: string | null
-    partition_or_window: string | null
     error: string | null
     traceback: string | null
     message: string | null

--- a/packages/interloper-db/src/interloper_db/migrations/versions/006_demote_event_scope_columns.py
+++ b/packages/interloper-db/src/interloper_db/migrations/versions/006_demote_event_scope_columns.py
@@ -1,0 +1,65 @@
+"""Demote backfill_id and partition_or_window on events to ``data``.
+
+Neither column earned its place: nothing anywhere read ``backfill_id``
+(backfill scoping goes through ``runs``), and ``partition_or_window`` was
+never filtered or rendered and always equals the run's ``partition_date``
+for persisted events. Both match the profile of the ``data`` JSONB column,
+where the metadata spill now carries them; existing values are folded into
+``data`` before the columns drop so history is preserved.
+
+Idempotent: fresh databases get the columnless shape from ``create_all()``,
+so every step no-ops when the columns are already gone.
+
+Revision ID: 006
+Revises: 005
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "006"
+down_revision: str | None = "005"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    columns = {column["name"] for column in sa.inspect(bind).get_columns("events")}
+
+    if "backfill_id" in columns:
+        op.execute(
+            """
+            UPDATE events
+            SET data = coalesce(data, '{}'::jsonb) || jsonb_build_object('backfill_id', backfill_id::text)
+            WHERE backfill_id IS NOT NULL
+            """
+        )
+        op.drop_column("events", "backfill_id")
+
+    if "partition_or_window" in columns:
+        op.execute(
+            """
+            UPDATE events
+            SET data = coalesce(data, '{}'::jsonb) || jsonb_build_object('partition_or_window', partition_or_window)
+            WHERE partition_or_window IS NOT NULL
+            """
+        )
+        op.drop_column("events", "partition_or_window")
+
+
+def downgrade() -> None:
+    op.add_column("events", sa.Column("partition_or_window", sa.String(), nullable=True))
+    op.add_column("events", sa.Column("backfill_id", sa.Uuid(), sa.ForeignKey("backfills.id"), nullable=True))
+    op.execute(
+        """
+        UPDATE events
+        SET backfill_id = (data ->> 'backfill_id')::uuid,
+            partition_or_window = data ->> 'partition_or_window',
+            data = nullif(data - 'backfill_id' - 'partition_or_window', '{}'::jsonb)
+        WHERE data ?| array['backfill_id', 'partition_or_window']
+        """
+    )

--- a/packages/interloper-db/src/interloper_db/models.py
+++ b/packages/interloper-db/src/interloper_db/models.py
@@ -383,9 +383,7 @@ class Event(SQLModel, table=True):
     )
     org_id: UUID
     run_id: UUID | None = SQLField(default=None, foreign_key="runs.id")
-    backfill_id: UUID | None = SQLField(default=None, foreign_key="backfills.id")
     event_type: str
-    partition_or_window: str | None = None
     error: str | None = None
     traceback: str | None = None
     component_id: UUID | None = SQLField(default=None)

--- a/packages/interloper-db/src/interloper_db/store/runs.py
+++ b/packages/interloper-db/src/interloper_db/store/runs.py
@@ -71,12 +71,14 @@ def _sanitize_data(meta: dict[str, Any]) -> dict[str, Any] | None:
     return json.loads(encoded) or None
 
 
-#: Metadata keys persisted as structured ``events`` columns — everything
-#: else spills into the ``data`` JSONB column.
+#: Metadata keys whose content is already represented by a structured
+#: ``events`` column — everything else spills into the ``data`` JSONB
+#: column. ``asset_id``/``asset_key`` are the compat aliases core emitters
+#: use for the component columns; ``run_id`` is redundant with the
+#: ``save_event`` argument that fills the column.
 _PROMOTED_METADATA_KEYS = frozenset(
     {
         "run_id",
-        "backfill_id",
         # Also arrives via run metadata; the column is authoritative.
         "org_id",
         "asset_id",
@@ -84,7 +86,6 @@ _PROMOTED_METADATA_KEYS = frozenset(
         "component_id",
         "component_kind",
         "component_key",
-        "partition_or_window",
         "error",
         "traceback",
         "message",
@@ -119,17 +120,17 @@ def _event_values(event: il.Event, org_id: UUID, run_id: UUID | None) -> dict[st
         "id": event_id,
         "org_id": org_id,
         "run_id": run_id,
-        "backfill_id": UUID(meta["backfill_id"]) if meta.get("backfill_id") else None,
         "event_type": event.type.value,
         "component_id": UUID(str(component_id)) if component_id else None,
         "component_kind": _sanitize_text(component_kind),
         "component_key": _sanitize_text(component_key),
-        "partition_or_window": _sanitize_text(meta.get("partition_or_window")),
         "error": _sanitize_text(meta.get("error")),
         "traceback": _sanitize_text(meta.get("traceback")),
         "message": _sanitize_text(meta.get("message")),
         "level": _sanitize_text(meta.get("level")),
-        "data": _sanitize_data({k: v for k, v in meta.items() if k not in _PROMOTED_METADATA_KEYS}),
+        # None values are the absence of a key, not payload — producers emit
+        # them unconditionally (backfill_id on non-backfill runs, …).
+        "data": _sanitize_data({k: v for k, v in meta.items() if k not in _PROMOTED_METADATA_KEYS and v is not None}),
         "timestamp": event.timestamp,
     }
 

--- a/packages/interloper-db/tests/test_events.py
+++ b/packages/interloper-db/tests/test_events.py
@@ -121,6 +121,27 @@ def test_event_values_spills_unpromoted_metadata_into_data() -> None:
     assert values["error"] == "boom"
 
 
+def test_event_values_spills_demoted_scope_keys_into_data() -> None:
+    """backfill_id / partition_or_window have no column since 006 — they ride
+    in ``data``, and the None values producers emit unconditionally don't."""
+    values = _event_values(
+        _framework_event(
+            {
+                "backfill_id": "b0e0a72f-7e2f-49a8-bb3e-9adfa22a1eb3",
+                "partition_or_window": "2026-08-04",
+                "target_kind": None,
+            }
+        ),
+        org_id=uuid4(),
+        run_id=None,
+    )
+    assert values["data"] == {
+        "backfill_id": "b0e0a72f-7e2f-49a8-bb3e-9adfa22a1eb3",
+        "partition_or_window": "2026-08-04",
+    }
+    assert "backfill_id" not in values and "partition_or_window" not in values
+
+
 def test_event_values_without_component_or_extras() -> None:
     run_id = uuid4()
     values = _event_values(_framework_event({"message": "run done"}), org_id=uuid4(), run_id=run_id)


### PR DESCRIPTION
Follow-up to #230, applying its own promote-when-hot policy to two columns that predate it.

## Why

Neither column earns a structured slot:

- **`backfill_id`** — zero readers anywhere in the codebase. It was written on every save and never filtered, joined, rendered, or exported. Backfill scoping goes through `runs` (`Run.backfill_id`, indexed via `ix_runs_backfill_id_status`), so "events of a backfill" is one indexed hop even if that feature ever ships. Its bare FK (no `ondelete`) also silently blocked `backfills` deletion for no benefit.
- **`partition_or_window`** — exposed in the API/frontend types but rendered nowhere, never filtered, unindexed, and redundant for every persisted event: it always equals the run's `partition_date` (window materializations only happen through manual entrypoints that create no run and persist no events). It's also kind-specific (asset events only) — exactly the profile `data` was made for.

## What

- Both keys now ride in **`data`** via the metadata spill — producers are untouched; removing the keys from `_PROMOTED_METADATA_KEYS` is all it took.
- The spill now also **drops `None` values**: producers emit `backfill_id: None` / `partition_or_window: None` unconditionally, and as columns those were invisible NULLs — as JSON they'd be noise on every row.
- `EventResponse` and the frontend `RunEvent` drop `partition_or_window` (`backfill_id` was never exposed).
- **Migration 006** folds existing column values into `data` before dropping (merging with pre-existing payloads), so history is preserved; idempotent on fresh databases, and the downgrade restores the columns from `data` and strips the spill keys.

## Verification

- Full suite green: ruff, ty, 1214 pytest tests, frontend lint + `nuxt typecheck`.
- Live against Postgres: fresh provision no-ops (columnless shape from `create_all`); a simulated 0.54.0 database (rev 005 with populated columns, with and without pre-existing `data` payloads) upgrades with values folded correctly; downgrade round-trips.

**BREAKING CHANGE**: the `events` table drops the `backfill_id` and `partition_or_window` columns (values move into `data`), and `EventResponse` no longer carries `partition_or_window`.

By Digitl