### PR TITLE
feat(docker): ship the otel extras in published images

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -137,6 +137,7 @@ jobs:
           build-args: |
             CORE_EXTRAS=google-cloud
             ASSETS_EXTRAS=bing,facebook,google
+            COMMON_EXTRAS=otel
             API_EXTRAS=${{ matrix.api_extras }}
             SCHEDULER_EXTRAS=${{ matrix.scheduler_extras }}
           cache-from: type=gha,scope=docker-${{ matrix.role }}-${{ matrix.flavor }}

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ REGISTRY      := europe-docker.pkg.dev/dc-int-connectors-prd/docker
 VERSION       := $(shell python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
 CORE_EXTRAS   ?= google-cloud
 ASSETS_EXTRAS ?= bing,facebook,google
+COMMON_EXTRAS ?= otel
 
 # Image catalog. Each role is its own repository "interloper-<role>"; flavors
 # (extra-bearing variants) ride the TAG, not the image name:
@@ -100,6 +101,7 @@ docker-build-linux-%:
 	docker build --target $(call role_of,$*) -f $(call dockerfile_of,$*) --platform linux/amd64 \
 		--build-arg CORE_EXTRAS=$(CORE_EXTRAS) \
 		--build-arg ASSETS_EXTRAS=$(ASSETS_EXTRAS) \
+		--build-arg COMMON_EXTRAS=$(COMMON_EXTRAS) \
 		$(call extras_arg,$*) \
 		-t $(call image_of,$*):$(call tag_of,$*) \
 		-t $(call image_of,$*):$(call latest_of,$*) \
@@ -110,6 +112,7 @@ docker-build-%:
 	docker build --target $(call role_of,$*) -f $(call dockerfile_of,$*) \
 		--build-arg CORE_EXTRAS=$(CORE_EXTRAS) \
 		--build-arg ASSETS_EXTRAS=$(ASSETS_EXTRAS) \
+		--build-arg COMMON_EXTRAS=$(COMMON_EXTRAS) \
 		$(call extras_arg,$*) \
 		-t $(call image_of,$*):$(call tag_of,$*) \
 		-t $(call image_of,$*):$(call latest_of,$*) \

--- a/chart/interloper/values.yaml
+++ b/chart/interloper/values.yaml
@@ -196,9 +196,8 @@ auth: {}
 #   allowed_domains:
 #     - example.com
 
-# OpenTelemetry export (traces + metrics over OTLP). Requires images built
-# with the "otel" extras (interloper-core[otel]; add interloper-db[otel] /
-# interloper-api[otel] for SQLAlchemy and request spans); the scheduler
+# OpenTelemetry export (traces + metrics over OTLP). The published images
+# ship with the otel extras (COMMON_EXTRAS=otel at build time); the scheduler
 # forwards these settings (and the trace context) into the run pods it
 # launches. Exporter auth headers
 # ("key=value,key2=value2") are read from the INTERLOPER_OTEL_HEADERS key of

--- a/docker/uv-sync.sh
+++ b/docker/uv-sync.sh
@@ -7,6 +7,10 @@
 #   ASSETS_EXTRAS     → --extra {name} flags (scoped to interloper-assets)
 #   SCHEDULER_EXTRAS  → --extra {name} flags (scoped to interloper-scheduler)
 #   API_EXTRAS        → --extra {name} flags (scoped to interloper-api)
+#   COMMON_EXTRAS     → --extra {name} flags, unscoped — for extras that
+#                       several workspace packages define (e.g. otel on
+#                       core, api, and db); uv applies each to whichever
+#                       selected packages carry it
 set -e
 
 # NOTE: the install pass intentionally omits --locked. semantic-release bumps
@@ -72,6 +76,13 @@ if $INSTALL; then
     done
     if $HAS_API && [ -n "${API_EXTRAS:-}" ]; then
         for e in $(echo "$API_EXTRAS" | tr ',' ' '); do
+            EXTRA_FLAGS="$EXTRA_FLAGS --extra $e"
+        done
+    fi
+
+    # COMMON_EXTRAS → --extra flags, regardless of which packages are selected
+    if [ -n "${COMMON_EXTRAS:-}" ]; then
+        for e in $(echo "$COMMON_EXTRAS" | tr ',' ' '); do
             EXTRA_FLAGS="$EXTRA_FLAGS --extra $e"
         done
     fi

--- a/dockerfile
+++ b/dockerfile
@@ -32,12 +32,19 @@
 #   API_EXTRAS        comma-separated interloper-api extras (default: none).
 #                     Supported: agent (bundles interloper-agent so the
 #                     /agent routes mount). Each maps to --extra {name}.
+#   COMMON_EXTRAS     comma-separated extras defined by several workspace
+#                     packages (default: otel). Each maps to --extra {name},
+#                     applied to whichever selected packages carry it —
+#                     otel lands the SDK/exporters via core plus the
+#                     FastAPI/SQLAlchemy instrumentors via api/db where
+#                     those packages are in the image. Pass "" to disable.
 #
 # ================================================================
 
 ARG CORE_EXTRAS=google-cloud
 ARG ASSETS_EXTRAS=bing,facebook,google
 ARG SCHEDULER_EXTRAS=docker
+ARG COMMON_EXTRAS=otel
 
 
 # ── Python base: workspace manifests for dependency caching ────
@@ -77,6 +84,7 @@ ENV PATH="/interloper/.venv/bin:$PATH"
 
 # ── core ──────────────────────────────────────────────────────
 FROM base AS build-core
+ARG COMMON_EXTRAS
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     docker/uv-sync.sh --frozen interloper-core
@@ -92,6 +100,7 @@ FROM base AS build-scheduler
 ARG CORE_EXTRAS
 ARG ASSETS_EXTRAS
 ARG SCHEDULER_EXTRAS
+ARG COMMON_EXTRAS
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     docker/uv-sync.sh --frozen interloper-core interloper-assets interloper-db interloper-scheduler
@@ -107,6 +116,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 FROM base AS build-worker
 ARG CORE_EXTRAS
 ARG ASSETS_EXTRAS
+ARG COMMON_EXTRAS
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     docker/uv-sync.sh --frozen interloper-core interloper-assets
@@ -124,6 +134,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 FROM base AS build-api
 ARG CORE_EXTRAS
 ARG API_EXTRAS
+ARG COMMON_EXTRAS
 ENV ASSETS_EXTRAS=""
 
 RUN --mount=type=cache,target=/root/.cache/uv \

--- a/docs/features/telemetry.md
+++ b/docs/features/telemetry.md
@@ -258,10 +258,11 @@ shutdown_telemetry()  # flush before the process exits
 
 ## Kubernetes deployment
 
-The Helm chart wires everything from one block (build the images with the
-`otel` extras of the packages they carry — `interloper-db[otel]` for
-SQLAlchemy spans in the api and scheduler images, plus
-`interloper-api[otel]` for request spans in the api image):
+The Helm chart wires everything from one block. The published images ship
+with the `otel` extras of the packages they carry (`COMMON_EXTRAS=otel` at
+build time — SDK and exporters everywhere, SQLAlchemy spans where
+`interloper-db` is present, request spans in the api image); pass
+`COMMON_EXTRAS=""` when building images to leave them out.
 
 ```yaml
 otel:

--- a/interloper.yaml
+++ b/interloper.yaml
@@ -47,3 +47,13 @@ smtp:
   host: smtp.gmail.com
   port: 465
   user: "no-reply@digitlcloud.com"
+
+otel:
+  enabled: true
+  endpoint: http://localhost:4317
+  protocol: grpc
+
+  # protocol: http/protobuf   # endpoint: http://localhost:4318
+  # sample_ratio: 0.1
+  # traces: false
+  # metrics: false


### PR DESCRIPTION
## Why

#229 shipped OpenTelemetry support, but the published images bake `CORE_EXTRAS=google-cloud` only — so setting `INTERLOPER_OTEL_ENABLED=true` in a deployment logs the "install `interloper[otel]`" warning and no-ops. The SDK was never in the image. This is the gate for enabling telemetry in prod.

## What

`CORE_EXTRAS` can't carry `otel`: despite the name it maps to workspace *packages* (`google-cloud` → `--package interloper-google-cloud`), while `otel` is a pip extra defined by three packages (core, api, db — split in #229 so each package instruments only what it depends on).

- **`docker/uv-sync.sh`** gains `COMMON_EXTRAS`: unscoped `--extra` flags that uv attaches to whichever selected packages define them (same mechanism the scheduler build already relies on with `--extra k8s` across four packages).
- **`COMMON_EXTRAS=otel` becomes the default** in the dockerfile, the Makefile (local builds match prod), and the publish workflow (explicit for visibility). Each image picks up exactly the instrumentation matching its contents: SDK + exporters + httpx spans everywhere via core; SQLAlchemy spans where `interloper-db` is present (api, scheduler); FastAPI request spans in the api image; the worker image gets none of the satellite instrumentors. `COMMON_EXTRAS=""` builds without.
- Chart values comment and telemetry docs updated: images ship telemetry-capable by default; runtime remains opt-in via `INTERLOPER_OTEL_ENABLED`.

Shipping the wheels unconditionally is deliberate: activation is runtime-gated, the size cost is a few small wheels, and a "telemetry flavor" tag would double the image matrix for no behavioral difference when disabled.

## Verification

- The api and worker dependency profiles were resolved with the exact flag shapes the script produces: api gets `fastapi`/`sqlalchemy`/`httpx` instrumentors + SDK + both OTLP exporters; worker (no db/api) gets only `httpx`.
- Built the `core` image target with the new default and ran it: all otel modules import and `init_telemetry(enabled=True)` returns True instead of warning.
- `helm lint` clean; no Python changes.

By Digitl