### PR TITLE
feat(telemetry): emit stable HTTP semantic conventions

### DIFF
--- a/docs/features/telemetry.md
+++ b/docs/features/telemetry.md
@@ -207,6 +207,12 @@ When the API is served (`interloper app`), FastAPI request spans plus SQLAlchemy
 httpx client spans are enabled through the standard contrib instrumentors — REST-based
 sources get egress spans for free.
 
+HTTP spans follow the *stable* HTTP semantic conventions (`server.address`,
+`url.full`, `http.request.method`, `http.response.status_code`), not the deprecated
+ones the contrib instrumentors still default to: `init_telemetry` sets
+`OTEL_SEMCONV_STABILITY_OPT_IN=http` unless the environment already provides a
+value (e.g. `http/dup` to emit both during a migration).
+
 ## Metrics
 
 | Instrument | Type | Attributes |

--- a/packages/interloper-core/src/interloper/telemetry/setup.py
+++ b/packages/interloper-core/src/interloper/telemetry/setup.py
@@ -89,6 +89,16 @@ def init_telemetry(settings: TelemetrySettings) -> bool:
 
     from interloper.telemetry.tracer import _version
 
+    # Emit the stable HTTP semantic conventions (server.address, url.full,
+    # http.request.method, …) instead of the deprecated ones the contrib
+    # instrumentations still default to. Client spans then carry the target
+    # host natively — no downstream URL parsing to name vendor peers — and
+    # the eventual upstream default flip becomes a no-op instead of a
+    # surprise rename. Must be set before the first instrumentor
+    # initializes (they read it once per process); setdefault keeps the
+    # operator override available.
+    os.environ.setdefault("OTEL_SEMCONV_STABILITY_OPT_IN", "http")
+
     grpc = settings.protocol == "grpc"
     exporter_kwargs = _exporter_kwargs(settings)
     resource = Resource.create(

--- a/packages/interloper-core/tests/telemetry/test_setup.py
+++ b/packages/interloper-core/tests/telemetry/test_setup.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import sys
 
 import pytest
@@ -42,6 +43,16 @@ class TestInitTelemetry:
     def test_shutdown_without_init_is_safe(self):
         shutdown_telemetry()
         assert setup._initialized is False
+
+    def test_opts_into_stable_http_semconv(self, monkeypatch):
+        monkeypatch.delenv("OTEL_SEMCONV_STABILITY_OPT_IN", raising=False)
+        init_telemetry(TelemetrySettings(enabled=True, traces=False, metrics=False))
+        assert os.environ["OTEL_SEMCONV_STABILITY_OPT_IN"] == "http"
+
+    def test_operator_semconv_override_wins(self, monkeypatch):
+        monkeypatch.setenv("OTEL_SEMCONV_STABILITY_OPT_IN", "http/dup")
+        init_telemetry(TelemetrySettings(enabled=True, traces=False, metrics=False))
+        assert os.environ["OTEL_SEMCONV_STABILITY_OPT_IN"] == "http/dup"
 
     def test_instrument_fastapi_is_a_noop_when_uninitialized(self):
         setup.instrument_fastapi(object())  # must not raise or touch the app


### PR DESCRIPTION
## What

`init_telemetry` now sets `OTEL_SEMCONV_STABILITY_OPT_IN=http` (via `setdefault`, so an operator-provided value — e.g. `http/dup` — wins) before the contrib instrumentors initialize. HTTP spans switch from the deprecated conventions to the stable ones.

## Why

- **httpx client spans carry `server.address` natively.** Today the otel-collector extracts the host from `http.url` with a regex so the service graph can name vendor peers — that transform gets deleted once this rolls out (it is `nil`-guarded, so mixed fleets during rollout are fine).
- **The upstream default flip becomes a no-op.** The old conventions are deprecated; a future instrumentation bump will flip the default and rename attributes/metrics as a side effect. Opting in now, while nothing consumes the old names (dashboards run on spanmetrics, no alerts reference SDK HTTP metrics), chooses the timing.
- **Framework, not deployment env**: `child_process_env()` only forwards `INTERLOPER_OTEL_*`, so a chart-level env would silently miss run pods — where nearly all httpx traffic lives.

## Verified (fresh process, exact locked versions)

- httpx client span: `server.address=api.thetradedesk.com`, `url.full`, `http.request.method`, `http.response.status_code` ✅
- FastAPI server span: route-template name intact, gains `http.route` ✅
- SQLAlchemy span: `db.system`/`db.name` untouched (db semconv is a separate opt-in key — collector db filter and service-graph db path unaffected) ✅
- Full suite: ruff, ty, 1270 tests ✅

## Follow-up (interloper-kubernetes, after rollout)

Delete the `transform/client-peer` host-extraction block from the collector config once prod spans carry `server.address`.

By Digitl