### PR TITLE
fix!: never top up a source's assets implicitly on update

### DIFF
--- a/packages/interloper-db/src/interloper_db/store/components.py
+++ b/packages/interloper-db/src/interloper_db/store/components.py
@@ -152,8 +152,8 @@ class ComponentMixin(RelationMixin):
     ) -> Component:
         """Update a component's spec. ``None`` leaves a facet untouched.
 
-        Source kinds always top up newly available catalog assets; passing
-        ``children`` makes the child set exactly that list. The machine-owned
+        Passing ``children`` makes a source's child asset set exactly that
+        list; omitting it leaves the current set as is. The machine-owned
         ``state`` column is never touched here.
 
         Returns:
@@ -173,7 +173,8 @@ class ComponentMixin(RelationMixin):
                 self._apply_config(db_component, config, encrypted)
             if db_component.kind == "source":
                 self._check_source_collision(session, db_component)
-                self._ensure_children(session, db_component, children)
+                if children is not None:
+                    self._ensure_children(session, db_component, children)
             elif children is not None:
                 raise ConfigError(f"Components of kind '{db_component.kind}' have no children")
             self._sync_relations(session, db_component, relations)
@@ -467,10 +468,10 @@ class ComponentMixin(RelationMixin):
         missing ones are created, extra ones are removed. Removal follows the
         delete guard's semantics: blocking relations from outside the source
         (a required cross-source dependency) raise ``InUseError``; detaching
-        ones and intra-source edges cascade. When ``None``, existing rows are
-        kept and newly available catalog assets are added. Existing rows keep
-        their IDs (and therefore their cross-source deps, event references,
-        and per-asset overrides).
+        ones and intra-source edges cascade. ``None`` is the source-creation
+        default and enables every asset the catalog class declares. Existing
+        rows keep their IDs (and therefore their cross-source deps, event
+        references, and per-asset overrides).
         """
         source_cls = resolve_source_cls(self._catalog, db_source.key)
         if source_cls is None:
@@ -485,9 +486,9 @@ class ComponentMixin(RelationMixin):
             child.key: child
             for child in session.exec(select(Component).where(Component.parent_id == db_source.id)).all()
         }
-        # An explicit list is the exact child set; None keeps existing rows
-        # (drifted keys included) and tops up new catalog assets.
-        target = set(child_keys) if child_keys is not None else set(existing) | all_keys
+        # An explicit list is the exact child set; None (creation) is all
+        # catalog assets.
+        target = set(child_keys) if child_keys is not None else all_keys
         to_create = target - set(existing)
         to_remove = set(existing) - target
 

--- a/packages/interloper-db/tests/store/test_components.py
+++ b/packages/interloper-db/tests/store/test_components.py
@@ -288,6 +288,11 @@ class TestIntraSourceWiring:
         demo_store.update_component(source.id, children=["a", "b", "c", "d", "e"])
         assert len(demo_store.list_relations(_ORG, type="dependency")) == 6
 
+    def test_update_without_children_leaves_child_set_untouched(self, demo_store: Store):
+        source = demo_store.create_component(_ORG, kind="source", key="demo_source", children=["b", "e"])
+        updated = demo_store.update_component(source.id, name="renamed")
+        assert {child.key for child in updated.children} == {"b", "e"}
+
 
 class TestChildRemovalGuard:
     """Narrowing a source's child set honors the delete guard's semantics."""


### PR DESCRIPTION
## Problem

Updating a source without passing `children` kept existing child assets **and silently added every newly available catalog asset** (`_ensure_children`'s `None` branch computed `existing ∪ all_keys`). This contradicted two documented contracts:

- `PUT /components/{id}`: *"Omitted facets are untouched"*
- Agent `update_component` tool: *"Omit to leave it unchanged"*

In practice, any rename or config-only edit (agent edits, raw API PUTs) could grow a source's child set after a catalog upgrade. Git archaeology shows the behaviour is an artifact of the original unified-store commit reusing create's "None = all" semantics on the update path — nothing in the product relies on it (the UI always sends an explicit list; no test pinned it).

## Change

- `update_component` only syncs children when the caller passes them; an omitted list leaves the child set strictly untouched.
- `None` keeps its meaning **only at creation**: enable everything the catalog class declares (`_ensure_children`'s `None` branch simplified accordingly).
- Test pinning the new contract: a children-less update leaves a partial child set untouched.

Assets are now fully opt-in: the child set only ever changes through an explicit list. This is a precursor to the org-quota work — the asset-per-source quota will only ever gate explicit user action.

BREAKING CHANGE: `PUT /components/{id}` without `children` no longer adds newly available catalog assets to a source.

By Digitl