### PR TITLE
feat: cancel a backfill

### DIFF
--- a/packages/interloper-api/src/interloper_api/routes/backfills.py
+++ b/packages/interloper-api/src/interloper_api/routes/backfills.py
@@ -1,4 +1,4 @@
-"""Backfills API: read endpoints for backfill state."""
+"""Backfills API: queue, inspect, and cancel backfills."""
 
 from __future__ import annotations
 
@@ -123,4 +123,25 @@ def get_backfill(
     except NotFoundError:
         raise HTTPException(status_code=404, detail=f"Backfill {backfill_id} not found")
     authorize_org_member(user, backfill.org_id, store, detail=f"Backfill {backfill_id} not found")
+    return _backfill_to_response(backfill)
+
+
+@router.post("/{backfill_id}/cancel")
+def cancel_backfill(
+    backfill_id: UUID,
+    user: Profile = Depends(get_current_user),
+    store: Store = Depends(get_store),
+) -> BackfillResponse:
+    """Cancel a backfill: pending and queued runs are canceled, in-flight runs drain."""
+    try:
+        backfill = store.get_backfill(backfill_id)
+    except NotFoundError:
+        raise HTTPException(status_code=404, detail=f"Backfill {backfill_id} not found")
+    authorize_org_member(
+        user, backfill.org_id, store, minimum="editor", detail=f"Backfill {backfill_id} not found"
+    )
+    try:
+        backfill = store.cancel_backfill(backfill_id)
+    except ValueError as e:
+        raise HTTPException(status_code=409, detail=str(e))
     return _backfill_to_response(backfill)

--- a/packages/interloper-api/tests/test_backfills.py
+++ b/packages/interloper-api/tests/test_backfills.py
@@ -1,0 +1,115 @@
+"""Tests for ``interloper_api.routes.backfills`` — cancel endpoint and org-membership scoping.
+
+A lightweight fake store stands in for persistence so these stay pure unit
+tests, matching the style of ``test_runs.py``.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from types import SimpleNamespace
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from interloper.errors import NotFoundError
+
+from interloper_api.dependencies import get_current_user, get_store
+from interloper_api.routes import backfills as backfills_module
+
+_ORG_ID = uuid4()
+
+
+def _fake_backfill(backfill_id: UUID, status: str = "running") -> SimpleNamespace:
+    return SimpleNamespace(
+        id=backfill_id,
+        org_id=_ORG_ID,
+        component_id=None,
+        status=status,
+        start_date=dt.date(2026, 1, 1),
+        end_date=dt.date(2026, 1, 3),
+        concurrency=1,
+        fail_fast=False,
+        partitions=3,
+        started_at=None,
+        completed_at=None,
+        created_at=None,
+    )
+
+
+class FakeStore:
+    """In-memory stand-in implementing only what the backfill routes call."""
+
+    def __init__(self) -> None:
+        self.cancel_calls: list[UUID] = []
+        self.raise_not_found = False
+        self.raise_value_error: str | None = None
+        #: Role the fake user holds in the backfill's org. None = not a member.
+        self.role: str | None = "editor"
+
+    def get_backfill(self, backfill_id: UUID):
+        if self.raise_not_found:
+            raise NotFoundError(f"Backfill {backfill_id} not found")
+        return _fake_backfill(backfill_id)
+
+    def get_user_role(self, user_id: UUID, org_id: UUID) -> str | None:
+        return self.role
+
+    def cancel_backfill(self, backfill_id: UUID):
+        self.cancel_calls.append(backfill_id)
+        if self.raise_value_error is not None:
+            raise ValueError(self.raise_value_error)
+        return _fake_backfill(backfill_id, status="canceled")
+
+
+def _client(store: FakeStore) -> TestClient:
+    app = FastAPI()
+    app.include_router(backfills_module.router)
+    app.dependency_overrides[get_store] = lambda: store
+    app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(id=uuid4())
+    return TestClient(app)
+
+
+@pytest.fixture
+def store() -> FakeStore:
+    return FakeStore()
+
+
+# -- Cancel ---------------------------------------------------------------------
+
+
+def test_cancel_returns_the_canceled_backfill(store: FakeStore) -> None:
+    backfill_id = uuid4()
+    resp = _client(store).post(f"/backfills/{backfill_id}/cancel")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "canceled"
+    assert store.cancel_calls == [backfill_id]
+
+
+def test_cancel_missing_backfill_returns_404(store: FakeStore) -> None:
+    store.raise_not_found = True
+    resp = _client(store).post(f"/backfills/{uuid4()}/cancel")
+    assert resp.status_code == 404
+    assert store.cancel_calls == []
+
+
+def test_cancel_terminal_backfill_returns_409(store: FakeStore) -> None:
+    store.raise_value_error = "Backfill is already canceled"
+    resp = _client(store).post(f"/backfills/{uuid4()}/cancel")
+    assert resp.status_code == 409
+    assert "already canceled" in resp.json()["detail"]
+
+
+def test_cancel_requires_editor_in_owning_org(store: FakeStore) -> None:
+    store.role = "viewer"
+    resp = _client(store).post(f"/backfills/{uuid4()}/cancel")
+    assert resp.status_code == 403
+    assert store.cancel_calls == []
+
+
+def test_cancel_returns_404_for_non_member(store: FakeStore) -> None:
+    store.role = None
+    resp = _client(store).post(f"/backfills/{uuid4()}/cancel")
+    assert resp.status_code == 404
+    assert store.cancel_calls == []

--- a/packages/interloper-app/app/app/pages/executions/backfills/[backfill].vue
+++ b/packages/interloper-app/app/app/pages/executions/backfills/[backfill].vue
@@ -21,11 +21,40 @@ const breadcrumbs: BreadcrumbItem[] = [
 const { apiFetch } = useApi()
 const backfillsStore = useBackfillsStore()
 const componentsStore = useComponentsStore()
+const toast = useToast()
+const { confirm } = useConfirm()
 
 const backfill = ref<Backfill | null>(null)
 const backfillRuns = ref<Run[]>([])
 const runsLoading = ref(false)
 const sorting = ref([{ id: 'partition_date', desc: false }])
+
+const cancellable = computed(() => backfill.value != null && ['running', 'queued'].includes(backfill.value.status))
+const cancelling = ref(false)
+
+async function onCancel() {
+    const confirmed = await confirm({
+        title: 'Cancel backfill',
+        description: 'Runs that have not started yet will be canceled. Runs already in flight finish on their own.',
+        confirmLabel: 'Cancel backfill',
+        confirmColor: 'error',
+        icon: 'i-lucide-ban',
+    })
+    if (!confirmed) return
+
+    cancelling.value = true
+    try {
+        backfill.value = await backfillsStore.cancelBackfill(backfillId)
+        backfillRuns.value = await apiFetch<Run[]>(`/runs?backfill_id=${backfillId}`)
+        toast.add({ title: 'Backfill canceled', color: 'success' })
+    }
+    catch (e) {
+        toast.add(errorToast(e, 'Failed to cancel backfill'))
+    }
+    finally {
+        cancelling.value = false
+    }
+}
 
 const backfillTargetName = computed(() => {
     const target = componentsStore.byId(backfill.value?.component_id ?? '')
@@ -106,6 +135,16 @@ const columns: TableColumn<Run>[] = withSortableHeaders([
                     variant="subtle">
                 {{ statusLabel(backfill.status) }}
             </UBadge>
+            <UButton v-if="cancellable"
+                     color="error"
+                     variant="subtle"
+                     size="xs"
+                     icon="i-lucide-ban"
+                     :loading="cancelling"
+                     class="ml-auto"
+                     @click="onCancel">
+                Cancel
+            </UButton>
         </div>
 
         <div v-if="backfill"

--- a/packages/interloper-app/app/app/stores/backfills.ts
+++ b/packages/interloper-app/app/app/stores/backfills.ts
@@ -78,6 +78,13 @@ export const useBackfillsStore = defineStore('backfills', () => {
         return backfill.id
     }
 
+    /** Cancel a backfill: pending and queued runs stop, in-flight runs drain. */
+    async function cancelBackfill(id: string): Promise<Backfill> {
+        const backfill = await apiFetch<Backfill>(`/backfills/${id}/cancel`, { method: 'POST' })
+        _upsert(backfill)
+        return backfill
+    }
+
     /**********************
      * Lookups
      **********************/
@@ -100,6 +107,7 @@ export const useBackfillsStore = defineStore('backfills', () => {
         fetch,
         fetchOne,
         createBackfill,
+        cancelBackfill,
         findById,
         _upsert,
         _remove,

--- a/packages/interloper-db/src/interloper_db/store/runs.py
+++ b/packages/interloper-db/src/interloper_db/store/runs.py
@@ -545,6 +545,49 @@ class RunMixin(StoreBase):
             session.refresh(db_backfill)
             return db_backfill
 
+    def cancel_backfill(self, backfill_id: UUID) -> Backfill:
+        """Cancel a backfill: runs not yet dispatched will never execute.
+
+        Pending and queued runs flip to ``"canceled"``; runs already
+        dispatched or running drain to their own terminal state (their late
+        completions are no-ops on the now-terminal backfill).
+
+        Args:
+            backfill_id: The backfill UUID.
+
+        Returns:
+            The updated Backfill row.
+
+        Raises:
+            NotFoundError: If the backfill is not found.
+            ValueError: If the backfill is already terminal.
+        """
+        with self._session() as session:
+            db_backfill = session.get(Backfill, backfill_id)
+            if not db_backfill:
+                raise NotFoundError(f"Backfill {backfill_id} not found")
+            if db_backfill.status not in ("running", "queued"):
+                raise ValueError(f"Backfill {backfill_id} is already {db_backfill.status}")
+
+            # skip_locked leaves runs the worker is claiming right now to the
+            # worker — they are effectively dispatched and drain like any
+            # other in-flight run.
+            cancellable = session.exec(
+                select(Run)
+                .where(Run.backfill_id == backfill_id, col(Run.status).in_(["pending", "queued"]))
+                .with_for_update(skip_locked=True)
+            ).all()
+            for db_run in cancellable:
+                db_run.status = "canceled"
+                session.add(db_run)
+
+            db_backfill.status = "canceled"
+            db_backfill.completed_at = datetime.now(timezone.utc)
+            session.add(db_backfill)
+            session.commit()
+            session.refresh(db_backfill)
+            return db_backfill
+
     def get_backfill(self, backfill_id: UUID) -> Backfill:
         """Load a backfill by ID.
 

--- a/packages/interloper-db/tests/store/test_runs.py
+++ b/packages/interloper-db/tests/store/test_runs.py
@@ -1,0 +1,112 @@
+"""Tests for the run/backfill lifecycle methods in ``RunMixin`` (``store/runs.py``).
+
+These run against an in-memory SQLite database (only the runs/backfills
+tables) so status transitions are exercised against real SQL.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from collections.abc import Iterator
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+from interloper.errors import NotFoundError
+from sqlalchemy import event
+from sqlalchemy.pool import StaticPool
+from sqlmodel import Session, select
+
+from interloper_db import engine as engine_module
+from interloper_db.models import Backfill, Run
+from interloper_db.store.runs import RunMixin
+
+_ORG_ID = uuid4()
+
+
+@pytest.fixture
+def store() -> Iterator[RunMixin]:
+    """A RunMixin wired to a fresh in-memory SQLite database."""
+    eng = engine_module.init_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(eng, "connect")
+    def _sqlite_uuid(dbapi_connection: Any, _record: Any) -> None:
+        dbapi_connection.create_function("gen_random_uuid", 0, lambda: uuid4().hex)
+
+    Backfill.__table__.create(eng)  # ty: ignore[unresolved-attribute]
+    Run.__table__.create(eng)  # ty: ignore[unresolved-attribute]
+    try:
+        mixin = RunMixin()
+        mixin._engine = eng
+        yield mixin
+    finally:
+        eng.dispose()
+        engine_module._engine = None
+
+
+def _backfill(store: RunMixin, *, days: int = 4, concurrency: int = 2) -> Backfill:
+    return store.create_backfill(
+        _ORG_ID,
+        start_date=dt.date(2026, 1, 1),
+        end_date=dt.date(2026, 1, days),
+        concurrency=concurrency,
+    )
+
+
+def _mark_dispatched(store: RunMixin, backfill_id: UUID) -> UUID:
+    """Flip one queued run to dispatched, simulating a worker claim."""
+    with Session(store._engine) as session:
+        run = session.exec(select(Run).where(Run.backfill_id == backfill_id, Run.status == "queued")).first()
+        assert run is not None and run.id is not None
+        run.status = "dispatched"
+        session.add(run)
+        session.commit()
+        return run.id
+
+
+def _run_statuses(store: RunMixin, backfill_id: UUID) -> dict[UUID, str]:
+    with Session(store._engine) as session:
+        runs = session.exec(select(Run).where(Run.backfill_id == backfill_id)).all()
+        return {run.id: run.status for run in runs if run.id}
+
+
+class TestCancelBackfill:
+    def test_cancels_pending_and_queued_runs_only(self, store: RunMixin):
+        backfill = _backfill(store)  # 2 queued + 2 pending
+        dispatched_id = _mark_dispatched(store, backfill.id)
+
+        canceled = store.cancel_backfill(backfill.id)
+
+        assert canceled.status == "canceled"
+        assert canceled.completed_at is not None
+        statuses = _run_statuses(store, backfill.id)
+        assert statuses.pop(dispatched_id) == "dispatched"
+        assert set(statuses.values()) == {"canceled"}
+
+    def test_late_completion_does_not_resurrect_canceled_backfill(self, store: RunMixin):
+        backfill = _backfill(store)
+        dispatched_id = _mark_dispatched(store, backfill.id)
+        store.cancel_backfill(backfill.id)
+
+        completed = store.complete_run(dispatched_id, success=True)
+
+        assert completed.status == "success"
+        assert store.get_backfill(backfill.id).status == "canceled"
+        # The completion must not promote canceled runs back to queued.
+        statuses = _run_statuses(store, backfill.id)
+        statuses.pop(dispatched_id)
+        assert set(statuses.values()) == {"canceled"}
+
+    def test_cancel_terminal_backfill_raises(self, store: RunMixin):
+        backfill = _backfill(store)
+        store.cancel_backfill(backfill.id)
+        with pytest.raises(ValueError, match="already canceled"):
+            store.cancel_backfill(backfill.id)
+
+    def test_cancel_missing_backfill_raises(self, store: RunMixin):
+        with pytest.raises(NotFoundError):
+            store.cancel_backfill(uuid4())


### PR DESCRIPTION
## What

Backfills can now be canceled — a standalone feature, and a prerequisite for the upcoming org-quota mechanism (a quota-tripped backfill will be canceled through this same machinery).

- **Store**: `cancel_backfill` flips `pending` + `queued` runs to `canceled` and terminalizes the backfill (`status="canceled"`, `completed_at` stamped). Runs already `dispatched`/`running` drain to their own terminal state; `_advance_backfill`'s status guard makes their late completions no-ops on the terminal backfill, and the fixed-up runs are never promoted back to `queued`. Runs mid-claim by the queue worker are skipped (`FOR UPDATE SKIP LOCKED`, same idiom as the worker) and drain as in-flight.
- **API**: `POST /api/backfills/{id}/cancel` (editor in the owning org; 404 for non-members, 409 when already terminal) returning the updated backfill.
- **App**: cancel button (with confirm) on the backfill page while it is running/queued; `canceled` already exists in the status vocabulary.

## Tests

- Store: cancels pending+queued only; late completion doesn't resurrect a canceled backfill; 409/404 paths.
- API: happy path, 404 missing, 404 non-member, 403 viewer, 409 terminal.

By Digitl