### PR TITLE
feat: organisation quota schema and usage metering

### DIFF
--- a/packages/interloper-api/src/interloper_api/app.py
+++ b/packages/interloper-api/src/interloper_api/app.py
@@ -17,6 +17,7 @@ from interloper_api.dependencies import (
     set_auth_config,
     set_catalog,
     set_features,
+    set_quota_defaults,
     set_smtp_config,
     set_store,
 )
@@ -92,6 +93,7 @@ def create_app(
     if settings:
         set_auth_config(settings.auth)
         set_smtp_config(settings.smtp)
+        set_quota_defaults(settings.quota)
 
     api = APIRouter(prefix="/api")
     api.include_router(auth.router)

--- a/packages/interloper-api/src/interloper_api/dependencies.py
+++ b/packages/interloper-api/src/interloper_api/dependencies.py
@@ -18,6 +18,7 @@ _auth_config: Any | None = None
 _smtp_config: Any | None = None
 _features: dict[str, bool] = {}
 _admin_config: Any | None = None
+_quota_defaults: Any | None = None
 
 # Role hierarchy: admin > editor > viewer
 _ROLE_RANK = {"viewer": 0, "editor": 1, "admin": 2}
@@ -152,6 +153,25 @@ def get_admin_config() -> Any:
         The AdminConfigResponse snapshot, or None if not configured.
     """
     return _admin_config
+
+
+def set_quota_defaults(defaults: Any) -> None:
+    """Set the global default quota limits (from settings, at app creation).
+
+    Args:
+        defaults: The QuotaSettings instance.
+    """
+    global _quota_defaults  # noqa: PLW0603
+    _quota_defaults = defaults
+
+
+def get_quota_defaults() -> Any:
+    """Return the global default quota limits.
+
+    Returns:
+        The QuotaSettings instance, or None if not configured.
+    """
+    return _quota_defaults
 
 
 # -- Auth dependencies -------------------------------------------------------

--- a/packages/interloper-api/src/interloper_api/routes/admin.py
+++ b/packages/interloper-api/src/interloper_api/routes/admin.py
@@ -8,6 +8,7 @@ no access to org-scoped *data* (sources, jobs, runs, …).
 
 from __future__ import annotations
 
+import datetime as dt
 import inspect
 import logging
 from datetime import datetime
@@ -17,9 +18,10 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from interloper_db import Organisation, Profile, Store
+from interloper_db.store.quotas import METRIC_SUCCESSFUL_RUNS
 from pydantic import BaseModel
 
-from interloper_api.dependencies import get_admin_config, get_store, require_super_admin
+from interloper_api.dependencies import get_admin_config, get_quota_defaults, get_store, require_super_admin
 from interloper_api.email import send_invite_email
 
 logger = logging.getLogger(__name__)
@@ -223,6 +225,38 @@ class AdminDataConfig(BaseModel):
     catalog: dict[str, list[str]]
 
 
+class AdminQuotaLimits(BaseModel):
+    """One set of quota limits; null means unlimited (or unset, for overrides)."""
+
+    max_sources: int | None = None
+    max_assets_per_source: int | None = None
+    max_successful_runs_per_month: int | None = None
+
+
+class AdminOrgQuotaStatus(BaseModel):
+    """One organisation's quota limits and current usage."""
+
+    id: UUID
+    name: str
+    limits: AdminQuotaLimits
+    effective: AdminQuotaLimits
+    sources: int
+    max_assets_per_source: int
+    successful_runs: int
+    reserved_runs: int
+    #: Recomputed from the runs table; a mismatch with ``successful_runs``
+    #: (the ledger) signals counter drift.
+    recomputed_successful_runs: int
+
+
+class AdminQuotasResponse(BaseModel):
+    """Quota overview: global defaults plus per-organisation status."""
+
+    period_start: dt.date
+    defaults: AdminQuotaLimits
+    organisations: list[AdminOrgQuotaStatus]
+
+
 class AdminConfigResponse(BaseModel):
     """Read-only, secrets-redacted snapshot of the instance configuration."""
 
@@ -230,6 +264,7 @@ class AdminConfigResponse(BaseModel):
     auth: AdminAuthConfig
     services: AdminServicesConfig
     data: AdminDataConfig
+    quotas: AdminQuotaLimits
 
 
 # Non-secret launcher/runner config keys exposed on /admin/config. Anything not
@@ -400,10 +435,37 @@ def build_config_snapshot(settings: Any, features: dict[str, bool], catalog: Any
             encryption_configured=bool(settings.secrets.encryption_key),
             catalog=_catalog_by_kind(catalog) if catalog is not None else {},
         ),
+        quotas=_quota_limits(settings.quota),
     )
 
 
 # -- Helpers ------------------------------------------------------------------
+
+
+def _quota_limits(limits: Any) -> AdminQuotaLimits:
+    """Map any limits-shaped object (settings, Quota row, None) to the model."""
+    return AdminQuotaLimits(
+        max_sources=getattr(limits, "max_sources", None),
+        max_assets_per_source=getattr(limits, "max_assets_per_source", None),
+        max_successful_runs_per_month=getattr(limits, "max_successful_runs_per_month", None),
+    )
+
+
+def _effective_limits(overrides: AdminQuotaLimits, defaults: AdminQuotaLimits) -> AdminQuotaLimits:
+    """Per-org overrides win field-by-field over the global defaults."""
+    return AdminQuotaLimits(
+        max_sources=overrides.max_sources if overrides.max_sources is not None else defaults.max_sources,
+        max_assets_per_source=(
+            overrides.max_assets_per_source
+            if overrides.max_assets_per_source is not None
+            else defaults.max_assets_per_source
+        ),
+        max_successful_runs_per_month=(
+            overrides.max_successful_runs_per_month
+            if overrides.max_successful_runs_per_month is not None
+            else defaults.max_successful_runs_per_month
+        ),
+    )
 
 
 def _require_org(store: Store, org_id: UUID) -> Organisation:
@@ -464,6 +526,48 @@ def get_instance_config(
     if config is None:
         raise HTTPException(status_code=503, detail="Instance configuration not available")
     return config
+
+
+# -- Quotas ---------------------------------------------------------------------
+
+
+@router.get("/quotas")
+def get_quotas(
+    user: Profile = Depends(require_super_admin),
+    store: Store = Depends(get_store),
+    quota_defaults: Any = Depends(get_quota_defaults),
+) -> AdminQuotasResponse:
+    """Quota limits and current-period usage for every organisation."""
+    defaults = _quota_limits(quota_defaults)
+    period_start = store.current_period_start()
+    overrides = {quota.org_id: quota for quota in store.list_quotas()}
+    usage = {
+        row.org_id: row
+        for row in store.list_usage(period_start=period_start)
+        if row.metric == METRIC_SUCCESSFUL_RUNS
+    }
+    sources = store.count_sources_by_org()
+    max_assets = store.max_assets_per_source_by_org()
+    recomputed = store.count_successful_runs_by_org(period_start)
+
+    organisations = []
+    for org, _member_count in store.list_all_organisations():
+        limits = _quota_limits(overrides.get(org.id))
+        org_usage = usage.get(org.id)
+        organisations.append(
+            AdminOrgQuotaStatus(
+                id=org.id,
+                name=org.name,
+                limits=limits,
+                effective=_effective_limits(limits, defaults),
+                sources=sources.get(org.id, 0),
+                max_assets_per_source=max_assets.get(org.id, 0),
+                successful_runs=org_usage.used if org_usage else 0,
+                reserved_runs=org_usage.reserved if org_usage else 0,
+                recomputed_successful_runs=recomputed.get(org.id, 0),
+            )
+        )
+    return AdminQuotasResponse(period_start=period_start, defaults=defaults, organisations=organisations)
 
 
 # -- Users --------------------------------------------------------------------

--- a/packages/interloper-api/tests/conftest.py
+++ b/packages/interloper-api/tests/conftest.py
@@ -51,5 +51,6 @@ def fake_settings() -> SimpleNamespace:
         mcp=SimpleNamespace(external_url="", token="mcp-secret"),
         secrets=SimpleNamespace(encryption_key="key-material"),
         postgres=SimpleNamespace(password="pg-secret"),
+        quota=SimpleNamespace(max_sources=None, max_assets_per_source=None, max_successful_runs_per_month=25),
         catalog=["interloper_assets.demo.source.DemoSource"],
     )

--- a/packages/interloper-api/tests/test_admin.py
+++ b/packages/interloper-api/tests/test_admin.py
@@ -112,6 +112,37 @@ class FakeStore:
     def delete_invitation(self, invitation_id: UUID) -> None:
         pass
 
+    # -- quotas --
+    def current_period_start(self):
+        import datetime as dt
+
+        return dt.date(2026, 8, 1)
+
+    def list_quotas(self):
+        return [SimpleNamespace(org_id=self.org.id, max_sources=5, max_assets_per_source=None)]
+
+    def list_usage(self, *, period_start=None, org_id=None):
+        import datetime as dt
+
+        return [
+            SimpleNamespace(
+                org_id=self.org.id,
+                metric="successful_runs",
+                period_start=dt.date(2026, 8, 1),
+                used=7,
+                reserved=1,
+            )
+        ]
+
+    def count_sources_by_org(self):
+        return {self.org.id: 2}
+
+    def max_assets_per_source_by_org(self):
+        return {self.org.id: 4}
+
+    def count_successful_runs_by_org(self, period_start):
+        return {self.org.id: 8}
+
 
 def _profile(*, is_super_admin: bool):
     return SimpleNamespace(
@@ -219,6 +250,53 @@ def test_super_admin_reads_config(store: FakeStore, fake_settings: SimpleNamespa
 def test_config_unavailable_returns_503(store: FakeStore) -> None:
     resp = _client(store, is_super_admin=True).get("/admin/config")
     assert resp.status_code == 503
+
+
+def test_non_super_admin_cannot_read_quotas(store: FakeStore) -> None:
+    resp = _client(store, is_super_admin=False).get("/admin/quotas")
+    assert resp.status_code == 403
+
+
+def test_super_admin_reads_quota_overview(store: FakeStore) -> None:
+    from interloper_api.dependencies import get_quota_defaults
+
+    client = _client(store, is_super_admin=True)
+    client.app.dependency_overrides[get_quota_defaults] = lambda: SimpleNamespace(
+        max_sources=10, max_assets_per_source=20, max_successful_runs_per_month=100
+    )
+    resp = client.get("/admin/quotas")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["period_start"] == "2026-08-01"
+    assert body["defaults"]["max_successful_runs_per_month"] == 100
+
+    (org,) = body["organisations"]
+    assert org["limits"]["max_sources"] == 5
+    # Overrides win field-by-field; unset fields fall back to the defaults.
+    assert org["effective"]["max_sources"] == 5
+    assert org["effective"]["max_assets_per_source"] == 20
+    assert org["sources"] == 2
+    assert org["max_assets_per_source"] == 4
+    assert org["successful_runs"] == 7
+    assert org["reserved_runs"] == 1
+    assert org["recomputed_successful_runs"] == 8
+
+
+def test_quota_overview_defaults_absent_means_unlimited(store: FakeStore) -> None:
+    from interloper_api.dependencies import get_quota_defaults
+
+    client = _client(store, is_super_admin=True)
+    client.app.dependency_overrides[get_quota_defaults] = lambda: None
+    resp = client.get("/admin/quotas")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["defaults"] == {
+        "max_sources": None,
+        "max_assets_per_source": None,
+        "max_successful_runs_per_month": None,
+    }
+    (org,) = body["organisations"]
+    assert org["effective"]["max_assets_per_source"] is None
 
 
 def test_non_super_admin_cannot_list_users(store: FakeStore) -> None:

--- a/packages/interloper-app/app/app/layouts/admin.vue
+++ b/packages/interloper-app/app/app/layouts/admin.vue
@@ -36,6 +36,12 @@ const items = computed<NavigationMenuItem[]>(() => [
         active: route.path.startsWith('/admin/users'),
     },
     {
+        label: 'Quotas',
+        icon: 'i-lucide-gauge',
+        to: '/admin/quotas',
+        active: route.path.startsWith('/admin/quotas'),
+    },
+    {
         label: 'Config',
         icon: 'i-lucide-settings-2',
         to: '/admin/config',

--- a/packages/interloper-app/app/app/pages/admin/config.vue
+++ b/packages/interloper-app/app/app/pages/admin/config.vue
@@ -66,7 +66,7 @@ function configAttrs(config: Record<string, unknown>, prefix = ''): { key: strin
 
 const sections = computed<ConfigSection[]>(() => {
     if (!config.value) return []
-    const { deployment, auth, services, data } = config.value
+    const { deployment, auth, services, data, quotas } = config.value
     const launcher = deployment.launcher
 
     const deploymentRows: ConfigRow[] = [
@@ -178,11 +178,19 @@ const sections = computed<ConfigSection[]>(() => {
         ...(catalogRows.length ? catalogRows : [{ label: 'Catalog', value: 'empty' }]),
     ]
 
+    const limitValue = (limit: number | null) => (limit != null ? String(limit) : 'unlimited')
+    const quotaRows: ConfigRow[] = [
+        { label: 'Max sources', value: limitValue(quotas.max_sources) },
+        { label: 'Max assets per source', value: limitValue(quotas.max_assets_per_source) },
+        { label: 'Max successful runs / month', value: limitValue(quotas.max_successful_runs_per_month) },
+    ]
+
     return [
         { title: 'Deployment', icon: 'i-lucide-server', rows: deploymentRows },
         { title: 'Authentication', icon: 'i-lucide-key-round', rows: authRows },
         { title: 'Services', icon: 'i-lucide-cog', rows: serviceRows },
         { title: 'Data', icon: 'i-lucide-database', rows: dataRows },
+        { title: 'Quota defaults', icon: 'i-lucide-gauge', rows: quotaRows },
     ]
 })
 </script>

--- a/packages/interloper-app/app/app/pages/admin/quotas.vue
+++ b/packages/interloper-app/app/app/pages/admin/quotas.vue
@@ -1,0 +1,123 @@
+<script setup lang="ts">
+import { h, resolveComponent } from 'vue'
+import type { TableColumn } from '@nuxt/ui'
+import type { AdminOrgQuotaStatus, AdminQuotas } from '~/types/admin'
+
+definePageMeta({
+    title: 'Quotas',
+    layout: 'admin',
+    middleware: 'super-admin',
+    pageHeader: {
+        title: 'Quotas',
+        description: 'Per-organisation limits and current-period usage. Limits are read-only for now; defaults come from the instance configuration.',
+    },
+})
+
+const UBadge = resolveComponent('UBadge')
+
+const adminStore = useAdminStore()
+
+const quotas = ref<AdminQuotas | null>(null)
+const loading = ref(true)
+
+onMounted(async () => {
+    try {
+        quotas.value = await adminStore.getQuotas()
+    }
+    catch (err) {
+        console.error('[Admin] Failed to load quotas', err)
+    }
+    finally {
+        loading.value = false
+    }
+})
+
+const rows = computed(() => quotas.value?.organisations ?? [])
+
+const periodLabel = computed(() => {
+    if (!quotas.value) return ''
+    return new Date(quotas.value.period_start).toLocaleDateString(undefined, { month: 'long', year: 'numeric' })
+})
+
+/** "used / limit" with unlimited limits shown as a plain count. */
+function usageText(used: number, limit: number | null): string {
+    return limit != null ? `${used} / ${limit}` : String(used)
+}
+
+function usageCell(used: number, limit: number | null) {
+    const over = limit != null && used >= limit
+    return h('span', { class: over ? 'font-semibold text-error' : undefined }, usageText(used, limit))
+}
+
+const columns: TableColumn<AdminOrgQuotaStatus>[] = [
+    {
+        accessorKey: 'name',
+        header: 'Organisation',
+        cell: ({ row }) => h('span', { class: 'font-semibold text-highlighted' }, row.original.name),
+    },
+    {
+        id: 'sources',
+        header: 'Sources',
+        cell: ({ row }) => usageCell(row.original.sources, row.original.effective.max_sources),
+    },
+    {
+        id: 'assets',
+        header: 'Assets / source (max)',
+        cell: ({ row }) => usageCell(row.original.max_assets_per_source, row.original.effective.max_assets_per_source),
+    },
+    {
+        id: 'runs',
+        header: 'Successful runs',
+        cell: ({ row }) => {
+            const org = row.original
+            const parts = [usageCell(org.successful_runs, org.effective.max_successful_runs_per_month)]
+            if (org.reserved_runs > 0)
+                parts.push(h('span', { class: 'text-dimmed text-xs' }, ` +${org.reserved_runs} reserved`))
+            return h('span', parts)
+        },
+    },
+    {
+        id: 'ledger',
+        header: 'Ledger',
+        cell: ({ row }) => {
+            const org = row.original
+            return org.successful_runs === org.recomputed_successful_runs
+                ? h(UBadge, { label: 'In sync', color: 'success', variant: 'subtle' })
+                : h(UBadge, {
+                        label: `Drift (runs table: ${org.recomputed_successful_runs})`,
+                        color: 'warning',
+                        variant: 'subtle',
+                    })
+        },
+    },
+    {
+        id: 'overrides',
+        header: 'Overrides',
+        cell: ({ row }) => {
+            const limits = row.original.limits
+            const set = Object.entries(limits).filter(([, value]) => value != null)
+            if (!set.length) return h('span', { class: 'text-dimmed' }, '—')
+            return h('div', { class: 'flex flex-wrap gap-1' }, set.map(([key, value]) =>
+                h('span', { key, class: 'rounded-[5px] bg-elevated px-1.5 py-0.5 font-mono text-xs' }, `${key}=${value}`),
+            ))
+        },
+    },
+]
+</script>
+
+<template>
+    <div class="flex flex-col flex-1 min-h-0 gap-3">
+        <div v-if="quotas"
+             class="flex items-center gap-2 text-sm text-muted">
+            <UIcon name="i-lucide-calendar"
+                   class="size-4" />
+            <span>Current period: {{ periodLabel }}</span>
+        </div>
+
+        <DataTable :columns="columns"
+                   :data="rows"
+                   :loading="loading"
+                   no-actions
+                   search-placeholder="Search organisations..." />
+    </div>
+</template>

--- a/packages/interloper-app/app/app/stores/admin.ts
+++ b/packages/interloper-app/app/app/stores/admin.ts
@@ -1,4 +1,4 @@
-import type { AdminConfig, AdminOrganisation, AdminUser } from '~/types/admin'
+import type { AdminConfig, AdminOrganisation, AdminQuotas, AdminUser } from '~/types/admin'
 
 interface MemberResponse {
     id: string
@@ -22,6 +22,10 @@ export const useAdminStore = defineStore('admin', () => {
 
     function getConfig() {
         return apiFetch<AdminConfig>('/admin/config')
+    }
+
+    function getQuotas() {
+        return apiFetch<AdminQuotas>('/admin/quotas')
     }
 
     function listUsers() {
@@ -101,6 +105,7 @@ export const useAdminStore = defineStore('admin', () => {
 
     return {
         getConfig,
+        getQuotas,
         listUsers,
         deleteUser,
         listOrganisations,

--- a/packages/interloper-app/app/app/types/admin.ts
+++ b/packages/interloper-app/app/app/types/admin.ts
@@ -45,6 +45,32 @@ export interface AdminConfig {
         encryption_configured: boolean
         catalog: Record<string, string[]>
     }
+    quotas: AdminQuotaLimits
+}
+
+export interface AdminQuotaLimits {
+    max_sources: number | null
+    max_assets_per_source: number | null
+    max_successful_runs_per_month: number | null
+}
+
+export interface AdminOrgQuotaStatus {
+    id: string
+    name: string
+    limits: AdminQuotaLimits
+    effective: AdminQuotaLimits
+    sources: number
+    max_assets_per_source: number
+    successful_runs: number
+    reserved_runs: number
+    /** Recomputed from the runs table; differing from successful_runs signals ledger drift. */
+    recomputed_successful_runs: number
+}
+
+export interface AdminQuotas {
+    period_start: string
+    defaults: AdminQuotaLimits
+    organisations: AdminOrgQuotaStatus[]
 }
 
 export interface AdminUser {

--- a/packages/interloper-core/src/interloper/settings.py
+++ b/packages/interloper-core/src/interloper/settings.py
@@ -240,6 +240,20 @@ class ReaperSettings(BaseSettings):
     poll_interval: int = 60
 
 
+class QuotaSettings(BaseSettings):
+    """Default per-organisation quota limits; null means unlimited.
+
+    Per-organisation overrides live in the ``quotas`` table and win over
+    these defaults.
+    """
+
+    model_config = SettingsConfigDict(env_prefix=f"{PREFIX}QUOTA_")
+
+    max_sources: int | None = None
+    max_assets_per_source: int | None = None
+    max_successful_runs_per_month: int | None = None
+
+
 class AppSettings(BaseSettings):
     """Top-level runtime settings for the CLI."""
 
@@ -262,6 +276,7 @@ class AppSettings(BaseSettings):
     launcher: LauncherSettings = Field(default_factory=LauncherSettings)
     runner: RunnerSettings = Field(default_factory=RunnerSettings)
     otel: TelemetrySettings = Field(default_factory=TelemetrySettings)
+    quota: QuotaSettings = Field(default_factory=QuotaSettings)
     catalog: list[str] = Field(default_factory=list)
 
     _active: ClassVar[AppSettings | None] = None

--- a/packages/interloper-db/src/interloper_db/__init__.py
+++ b/packages/interloper-db/src/interloper_db/__init__.py
@@ -11,7 +11,9 @@ from interloper_db.models import (
     Organisation,
     PersonalAccessToken,
     Profile,
+    Quota,
     Run,
+    Usage,
     UserOrganisation,
 )
 from interloper_db.provision import create_all, downgrade, ensure_database, upgrade
@@ -30,8 +32,10 @@ __all__ = [
     "Organisation",
     "PersonalAccessToken",
     "Profile",
+    "Quota",
     "Run",
     "Store",
+    "Usage",
     "UserOrganisation",
     "create_all",
     "downgrade",

--- a/packages/interloper-db/src/interloper_db/migrations/versions/007_quotas.py
+++ b/packages/interloper-db/src/interloper_db/migrations/versions/007_quotas.py
@@ -1,0 +1,74 @@
+"""Quota limits, the usage ledger, and the run reservation marker.
+
+``create_all()`` provisions the two new tables on fresh databases; this
+migration covers upgrade-only paths (tables) and existing databases (the
+``runs.quota_reserved_at`` column, which ``create_all`` never adds to an
+already-existing table). Idempotent: every step checks before acting.
+
+Revision ID: 007
+Revises: 006
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "007"
+down_revision: str | None = "006"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if not inspector.has_table("quotas"):
+        op.create_table(
+            "quotas",
+            sa.Column("org_id", sa.Uuid(), primary_key=True),
+            sa.Column("max_sources", sa.Integer(), nullable=True),
+            sa.Column("max_assets_per_source", sa.Integer(), nullable=True),
+            sa.Column("max_successful_runs_per_month", sa.Integer(), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("CURRENT_TIMESTAMP")),
+        )
+
+    if not inspector.has_table("usage"):
+        op.create_table(
+            "usage",
+            sa.Column("org_id", sa.Uuid(), primary_key=True),
+            sa.Column("metric", sa.String(), primary_key=True),
+            sa.Column("period_start", sa.Date(), primary_key=True),
+            sa.Column("used", sa.Integer(), nullable=False),
+            sa.Column("reserved", sa.Integer(), nullable=False),
+        )
+
+    # Seed the ledger from run history so reconciliation is meaningful from
+    # day one — without this, months containing runs that succeeded before
+    # metering existed under-count forever. ON CONFLICT keeps any rows live
+    # charging already wrote (re-runs and mixed-version upgrades).
+    if bind.dialect.name == "postgresql":
+        op.execute(
+            """
+            INSERT INTO usage (org_id, metric, period_start, used, reserved)
+            SELECT org_id, 'successful_runs',
+                   (date_trunc('month', completed_at AT TIME ZONE 'UTC'))::date,
+                   count(*), 0
+            FROM runs
+            WHERE status = 'success' AND completed_at IS NOT NULL
+            GROUP BY org_id, 3
+            ON CONFLICT (org_id, metric, period_start) DO NOTHING
+            """
+        )
+
+    run_columns = {column["name"] for column in inspector.get_columns("runs")}
+    if "quota_reserved_at" not in run_columns:
+        op.add_column("runs", sa.Column("quota_reserved_at", sa.DateTime(timezone=True), nullable=True))
+
+
+def downgrade() -> None:
+    # The usage table is the billing ledger and is deliberately kept.
+    op.drop_column("runs", "quota_reserved_at")
+    op.drop_table("quotas")

--- a/packages/interloper-db/src/interloper_db/models.py
+++ b/packages/interloper-db/src/interloper_db/models.py
@@ -159,6 +159,46 @@ class PersonalAccessToken(SQLModel, table=True):
     created_at: datetime | None = _ts()
 
 
+# -- Quotas --------------------------------------------------------------------
+
+
+class Quota(SQLModel, table=True):
+    """Per-organisation quota limits, one row per organisation, created lazily.
+
+    A null limit falls back to the global default (``QuotaSettings``); null
+    there means unlimited. Bare ``org_id`` (no FK) like every org-scoped data
+    table.
+    """
+
+    __tablename__: ClassVar[str] = "quotas"
+
+    org_id: UUID = SQLField(primary_key=True)
+    max_sources: int | None = None
+    max_assets_per_source: int | None = None
+    max_successful_runs_per_month: int | None = None
+    created_at: datetime | None = _ts()
+
+
+class Usage(SQLModel, table=True):
+    """Per-period usage counters — the append-only ledger billing reads.
+
+    ``used`` counts successful runs, charged at completion; ``reserved``
+    holds dispatch-time reservations not yet settled. Rows are never
+    deleted — deliberately not even with their organisation — so billing
+    history survives everything. Counters are only ever moved by atomic
+    increments; drift against the ``runs`` table is a bug signal, not
+    something to clamp away.
+    """
+
+    __tablename__: ClassVar[str] = "usage"
+
+    org_id: UUID = SQLField(primary_key=True)
+    metric: str = SQLField(primary_key=True)
+    period_start: dt.date = SQLField(primary_key=True)
+    used: int = 0
+    reserved: int = 0
+
+
 # -- Components ----------------------------------------------------------------
 
 
@@ -351,6 +391,9 @@ class Run(SQLModel, table=True):
     )
     attempt: int = 1
     retry_scope: str | None = None
+    # Set when a dispatch-time quota reservation was taken; its month tells
+    # settlement which usage period to release.
+    quota_reserved_at: datetime | None = SQLField(default=None, sa_column=Column(TZDateTime))
     started_at: datetime | None = SQLField(default=None, sa_column=Column(TZDateTime))
     completed_at: datetime | None = SQLField(default=None, sa_column=Column(TZDateTime))
     created_at: datetime | None = _ts()

--- a/packages/interloper-db/src/interloper_db/store/__init__.py
+++ b/packages/interloper-db/src/interloper_db/store/__init__.py
@@ -27,6 +27,7 @@ and hydration for any kind, with the semantics a kind genuinely owns
 - ``ComponentMixin`` — component CRUD, hydration (all kinds); builds on
   ``RelationMixin``, the vocabulary-validated relation read/write layer
 - ``RunMixin`` — runs, events, backfills
+- ``QuotaMixin`` — per-org quota limits and the usage ledger
 - ``DriftMixin`` — catalog-resolution status for stored keys
 """
 
@@ -43,13 +44,14 @@ from interloper_db.hydration import Hydrator
 from interloper_db.store.auth import AuthMixin
 from interloper_db.store.components import ComponentMixin
 from interloper_db.store.drift import DriftMixin
+from interloper_db.store.quotas import QuotaMixin
 from interloper_db.store.runs import RunMixin
 from interloper_db.store.tokens import TokenMixin
 
 logger = logging.getLogger(__name__)
 
 
-class Store(AuthMixin, TokenMixin, ComponentMixin, RunMixin, DriftMixin):
+class Store(AuthMixin, TokenMixin, ComponentMixin, RunMixin, QuotaMixin, DriftMixin):
     """Framework-level persistence layer.
 
     Bridges catalog definitions and database rows to hydrate and persist

--- a/packages/interloper-db/src/interloper_db/store/auth.py
+++ b/packages/interloper-db/src/interloper_db/store/auth.py
@@ -21,6 +21,7 @@ from interloper_db.models import (
     Organisation,
     PersonalAccessToken,
     Profile,
+    Quota,
     Run,
     UserOrganisation,
 )
@@ -401,6 +402,9 @@ class AuthMixin(StoreBase):
                 delete(ComponentRelation).where(ComponentRelation.org_id == org_id),  # ty: ignore[invalid-argument-type]
                 delete(Component).where(Component.org_id == org_id),  # ty: ignore[invalid-argument-type]
                 delete(PersonalAccessToken).where(PersonalAccessToken.organisation_id == org_id),  # ty: ignore[invalid-argument-type]
+                delete(Quota).where(Quota.org_id == org_id),  # ty: ignore[invalid-argument-type]
+                # Usage is deliberately NOT deleted: it is the billing ledger
+                # and must survive its organisation.
                 delete(Invitation).where(Invitation.organisation_id == org_id),  # ty: ignore[invalid-argument-type]
                 delete(UserOrganisation).where(UserOrganisation.organisation_id == org_id),  # ty: ignore[invalid-argument-type]
                 update(AuthSession).where(AuthSession.organisation_id == org_id).values(organisation_id=None),  # ty: ignore[invalid-argument-type]

--- a/packages/interloper-db/src/interloper_db/store/quotas.py
+++ b/packages/interloper-db/src/interloper_db/store/quotas.py
@@ -1,0 +1,183 @@
+"""Quota limits and usage metering.
+
+``quotas`` holds per-organisation limits (null falls back to the global
+default). ``usage`` is the append-only ledger of per-period counters billing
+reads: successful runs are charged into ``used`` inside ``complete_run``'s
+transaction, and ``reserved`` holds dispatch-time reservations until they
+settle. Periods are calendar months in UTC, resolved with the database clock
+so every writer (API, scheduler, child pods) agrees on the boundary.
+
+The ledger is the admission primitive; the ``runs`` table is the audit
+source of truth. ``count_successful_runs_by_org`` recomputes the ledger from
+it so drift is always visible.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from datetime import datetime, timezone
+from uuid import UUID
+
+from sqlalchemy import func
+from sqlalchemy import select as sa_select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlmodel import Session, col, select
+
+from interloper_db.models import Component, Quota, Run, Usage
+from interloper_db.store.base import StoreBase
+
+METRIC_SUCCESSFUL_RUNS = "successful_runs"
+
+#: The closed set of valid usage metrics — the column is a free string in the
+#: DB, so writers must go through this to keep the ledger free of typo rows.
+USAGE_METRICS = frozenset({METRIC_SUCCESSFUL_RUNS})
+
+
+def month_start(moment: datetime) -> dt.date:
+    """The first day of the UTC calendar month a moment falls in.
+
+    Naive values are treated as UTC (SQLite round-trips columns naive).
+    """
+    if moment.tzinfo is not None:
+        moment = moment.astimezone(timezone.utc)
+    return dt.date(moment.year, moment.month, 1)
+
+
+def next_month_start(period_start: dt.date) -> dt.date:
+    """The first day of the month after ``period_start``."""
+    if period_start.month == 12:
+        return dt.date(period_start.year + 1, 1, 1)
+    return dt.date(period_start.year, period_start.month + 1, 1)
+
+
+def db_now(session: Session) -> datetime:
+    """The database server's current time, as an aware UTC datetime.
+
+    The DB clock is the single billing clock: completions are written by
+    whatever process executes the run (for docker/k8s a child pod), whose
+    wall clock is not trusted for month attribution.
+    """
+    value = session.scalar(sa_select(func.current_timestamp()))
+    if isinstance(value, str):  # SQLite returns text
+        value = datetime.fromisoformat(value)
+    assert value is not None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value
+
+
+def increment_usage(
+    session: Session,
+    org_id: UUID,
+    metric: str,
+    period_start: dt.date,
+    *,
+    used: int = 0,
+    reserved: int = 0,
+) -> None:
+    """Atomically add to a usage row, creating it on first touch.
+
+    Upsert-based so concurrent writers never lose an increment; part of the
+    caller's transaction (the caller commits).
+    """
+    if metric not in USAGE_METRICS:
+        raise ValueError(f"Unknown usage metric: {metric}")
+    table = Usage.__table__  # ty: ignore[unresolved-attribute]
+    insert_fn = pg_insert if session.get_bind().dialect.name == "postgresql" else sqlite_insert
+    statement = (
+        insert_fn(table)
+        .values(org_id=org_id, metric=metric, period_start=period_start, used=used, reserved=reserved)
+        .on_conflict_do_update(
+            index_elements=["org_id", "metric", "period_start"],
+            set_={"used": table.c.used + used, "reserved": table.c.reserved + reserved},
+        )
+    )
+    session.execute(statement)  # ty: ignore[deprecated]
+
+
+def settle_run_usage(session: Session, db_run: Run, *, success: bool) -> None:
+    """Charge or release a completing run's usage, in the caller's transaction.
+
+    A successful run charges ``used`` in the month it completes (DB clock);
+    a dispatch-time reservation is released in the month it was taken —
+    those can differ across a month boundary.
+    """
+    reserved_period = month_start(db_run.quota_reserved_at) if db_run.quota_reserved_at else None
+    charge_period = month_start(db_now(session)) if success else None
+
+    if charge_period is not None and charge_period == reserved_period:
+        increment_usage(session, db_run.org_id, METRIC_SUCCESSFUL_RUNS, charge_period, used=1, reserved=-1)
+        return
+    if charge_period is not None:
+        increment_usage(session, db_run.org_id, METRIC_SUCCESSFUL_RUNS, charge_period, used=1)
+    if reserved_period is not None:
+        increment_usage(session, db_run.org_id, METRIC_SUCCESSFUL_RUNS, reserved_period, reserved=-1)
+
+
+class QuotaMixin(StoreBase):
+    """Store methods for quota limits and usage reads."""
+
+    def get_quota(self, org_id: UUID) -> Quota | None:
+        """The organisation's quota overrides, or None if none are set."""
+        with self._session() as session:
+            return session.get(Quota, org_id)
+
+    def list_quotas(self) -> list[Quota]:
+        """All per-organisation quota override rows."""
+        with self._session() as session:
+            return list(session.exec(select(Quota)).all())
+
+    def list_usage(self, *, period_start: dt.date | None = None, org_id: UUID | None = None) -> list[Usage]:
+        """Usage ledger rows, optionally filtered by period and organisation."""
+        with self._session() as session:
+            statement = select(Usage)
+            if period_start is not None:
+                statement = statement.where(Usage.period_start == period_start)
+            if org_id is not None:
+                statement = statement.where(Usage.org_id == org_id)
+            return list(session.exec(statement).all())
+
+    def current_period_start(self) -> dt.date:
+        """The current UTC calendar month, per the database clock."""
+        with self._session() as session:
+            return month_start(db_now(session))
+
+    def count_sources_by_org(self) -> dict[UUID, int]:
+        """Current number of sources per organisation."""
+        with self._session() as session:
+            rows = session.exec(
+                select(Component.org_id, func.count())
+                .where(Component.kind == "source")
+                .group_by(Component.org_id)  # ty: ignore[invalid-argument-type]
+            ).all()
+            return dict(rows)
+
+    def max_assets_per_source_by_org(self) -> dict[UUID, int]:
+        """The largest child-asset count of any single source, per organisation."""
+        with self._session() as session:
+            per_source = (
+                sa_select(col(Component.org_id).label("org_id"), func.count().label("n"))
+                .where(col(Component.kind) == "asset", col(Component.parent_id).is_not(None))
+                .group_by(col(Component.org_id), col(Component.parent_id))
+            ).subquery()
+            rows = session.execute(  # ty: ignore[deprecated]
+                sa_select(per_source.c.org_id, func.max(per_source.c.n)).group_by(per_source.c.org_id)
+            ).all()
+            return {org_id: count for org_id, count in rows}
+
+    def count_successful_runs_by_org(self, period_start: dt.date) -> dict[UUID, int]:
+        """Recompute the ledger's truth: successful runs completed in the period.
+
+        Counts on ``completed_at`` — the nearest column to the charge moment.
+        Reconciliation compares this against ``usage.used``.
+        """
+        lower = datetime.combine(period_start, dt.time.min, tzinfo=timezone.utc)
+        upper = datetime.combine(next_month_start(period_start), dt.time.min, tzinfo=timezone.utc)
+        with self._session() as session:
+            rows = session.exec(
+                select(Run.org_id, func.count())
+                .where(Run.status == "success", col(Run.completed_at) >= lower, col(Run.completed_at) < upper)
+                .group_by(Run.org_id)  # ty: ignore[invalid-argument-type]
+            ).all()
+            return dict(rows)

--- a/packages/interloper-db/src/interloper_db/store/runs.py
+++ b/packages/interloper-db/src/interloper_db/store/runs.py
@@ -19,6 +19,7 @@ from sqlmodel import Session, col, select
 from interloper_db.models import AssetExecution, Backfill, Component, Event, Run
 from interloper_db.store.base import StoreBase
 from interloper_db.store.components import stamp_component_state
+from interloper_db.store.quotas import settle_run_usage
 
 logger = logging.getLogger(__name__)
 
@@ -423,6 +424,8 @@ class RunMixin(StoreBase):
             db_run.status = "success" if success else "failed"
             db_run.completed_at = datetime.now(timezone.utc)
             session.add(db_run)
+
+            settle_run_usage(session, db_run, success=success)
 
             if db_run.component_id:
                 db_component = session.get(Component, db_run.component_id)

--- a/packages/interloper-db/tests/store/test_auth.py
+++ b/packages/interloper-db/tests/store/test_auth.py
@@ -27,7 +27,9 @@ from interloper_db.models import (
     Organisation,
     PersonalAccessToken,
     Profile,
+    Quota,
     Run,
+    Usage,
     UserOrganisation,
 )
 from interloper_db.store import Store
@@ -50,7 +52,7 @@ def auth_db() -> Iterator[Engine]:
         dbapi_connection.create_function("gen_random_uuid", 0, lambda: uuid4().hex)
 
     auth_models = (Profile, Organisation, UserOrganisation, Invitation, AuthSession, PersonalAccessToken)
-    org_data_models = (Component, ComponentRelation, Backfill, Run, Event)
+    org_data_models = (Component, ComponentRelation, Backfill, Run, Event, Quota, Usage)
     for model in auth_models + org_data_models:
         model.__table__.create(eng)  # ty: ignore[unresolved-attribute]
     try:

--- a/packages/interloper-db/tests/store/test_quotas.py
+++ b/packages/interloper-db/tests/store/test_quotas.py
@@ -1,0 +1,204 @@
+"""Tests for quota limits and usage metering (``interloper_db.store.quotas``)."""
+
+from __future__ import annotations
+
+import datetime as dt
+from collections.abc import Iterator
+from datetime import datetime, timezone
+from typing import Any
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import event
+from sqlalchemy.pool import StaticPool
+from sqlmodel import Session, select
+
+from interloper_db import engine as engine_module
+from interloper_db.models import Backfill, Component, Quota, Run, Usage
+from interloper_db.store.quotas import (
+    METRIC_SUCCESSFUL_RUNS,
+    QuotaMixin,
+    increment_usage,
+    month_start,
+    next_month_start,
+    settle_run_usage,
+)
+from interloper_db.store.runs import RunMixin
+
+_ORG_ID = uuid4()
+
+
+class _Store(RunMixin, QuotaMixin):
+    """The run + quota slice of the full store, for integration tests."""
+
+
+@pytest.fixture
+def store() -> Iterator[_Store]:
+    """A quota-capable store over a fresh in-memory SQLite database."""
+    eng = engine_module.init_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(eng, "connect")
+    def _sqlite_uuid(dbapi_connection: Any, _record: Any) -> None:
+        dbapi_connection.create_function("gen_random_uuid", 0, lambda: uuid4().hex)
+
+    for model in (Component, Backfill, Run, Quota, Usage):
+        model.__table__.create(eng)  # ty: ignore[unresolved-attribute]
+    try:
+        mixin = _Store()
+        mixin._engine = eng
+        yield mixin
+    finally:
+        eng.dispose()
+        engine_module._engine = None
+
+
+def _usage_rows(store: _Store) -> dict[dt.date, tuple[int, int]]:
+    with Session(store._engine) as session:
+        rows = session.exec(select(Usage).where(Usage.org_id == _ORG_ID)).all()
+        return {row.period_start: (row.used, row.reserved) for row in rows}
+
+
+def _run(store: _Store, *, quota_reserved_at: datetime | None = None) -> Run:
+    with Session(store._engine) as session:
+        run = Run(id=uuid4(), org_id=_ORG_ID, status="running", quota_reserved_at=quota_reserved_at)
+        session.add(run)
+        session.commit()
+        session.refresh(run)
+        return run
+
+
+class TestPeriods:
+    def test_month_start_normalizes_to_utc(self):
+        # 00:30 Berlin on July 1st is still June in UTC.
+        berlin = timezone(dt.timedelta(hours=2))
+        assert month_start(datetime(2026, 7, 1, 0, 30, tzinfo=berlin)) == dt.date(2026, 6, 1)
+        assert month_start(datetime(2026, 7, 1, 0, 30)) == dt.date(2026, 7, 1)  # naive = UTC
+
+    def test_next_month_start_rolls_the_year(self):
+        assert next_month_start(dt.date(2026, 12, 1)) == dt.date(2027, 1, 1)
+        assert next_month_start(dt.date(2026, 1, 1)) == dt.date(2026, 2, 1)
+
+
+class TestIncrementUsage:
+    def test_creates_then_increments(self, store: _Store):
+        period = dt.date(2026, 8, 1)
+        with Session(store._engine) as session:
+            increment_usage(session, _ORG_ID, METRIC_SUCCESSFUL_RUNS, period, used=1)
+            increment_usage(session, _ORG_ID, METRIC_SUCCESSFUL_RUNS, period, used=1, reserved=2)
+            session.commit()
+        assert _usage_rows(store) == {period: (2, 2)}
+
+    def test_unknown_metric_rejected(self, store: _Store):
+        with Session(store._engine) as session:
+            with pytest.raises(ValueError, match="Unknown usage metric"):
+                increment_usage(session, _ORG_ID, "sucessful_runs", dt.date(2026, 8, 1), used=1)
+
+
+class TestSettleRunUsage:
+    def test_success_without_reservation_charges_used(self, store: _Store):
+        run = _run(store)
+        with Session(store._engine) as session:
+            settle_run_usage(session, run, success=True)
+            session.commit()
+        (counts,) = _usage_rows(store).values()
+        assert counts == (1, 0)
+
+    def test_success_with_same_month_reservation_converts_it(self, store: _Store):
+        now = datetime.now(timezone.utc)
+        run = _run(store, quota_reserved_at=now)
+        with Session(store._engine) as session:
+            increment_usage(session, _ORG_ID, METRIC_SUCCESSFUL_RUNS, month_start(now), reserved=1)
+            settle_run_usage(session, run, success=True)
+            session.commit()
+        assert _usage_rows(store) == {month_start(now): (1, 0)}
+
+    def test_failure_with_reservation_releases_it(self, store: _Store):
+        now = datetime.now(timezone.utc)
+        run = _run(store, quota_reserved_at=now)
+        with Session(store._engine) as session:
+            increment_usage(session, _ORG_ID, METRIC_SUCCESSFUL_RUNS, month_start(now), reserved=1)
+            settle_run_usage(session, run, success=False)
+            session.commit()
+        assert _usage_rows(store) == {month_start(now): (0, 0)}
+
+    def test_failure_without_reservation_is_a_no_op(self, store: _Store):
+        run = _run(store)
+        with Session(store._engine) as session:
+            settle_run_usage(session, run, success=False)
+            session.commit()
+        assert _usage_rows(store) == {}
+
+    def test_cross_month_reservation_settles_both_periods(self, store: _Store):
+        reserved_at = datetime(2026, 7, 31, 23, 59, tzinfo=timezone.utc)
+        run = _run(store, quota_reserved_at=reserved_at)
+        with Session(store._engine) as session:
+            increment_usage(session, _ORG_ID, METRIC_SUCCESSFUL_RUNS, dt.date(2026, 7, 1), reserved=1)
+            settle_run_usage(session, run, success=True)
+            session.commit()
+        rows = _usage_rows(store)
+        assert rows[dt.date(2026, 7, 1)] == (0, 0)  # reservation released where taken
+        current = month_start(datetime.now(timezone.utc))
+        assert rows[current] == (1, 0)  # charge lands in the completion month
+
+    def test_complete_run_charges_the_ledger(self, store: _Store):
+        run = _run(store)
+        completed = store.complete_run(run.id, success=True)
+        assert completed.status == "success"
+        (counts,) = _usage_rows(store).values()
+        assert counts == (1, 0)
+
+
+class TestQuotaReads:
+    def test_get_and_list_quotas(self, store: _Store):
+        assert store.get_quota(_ORG_ID) is None
+        with Session(store._engine) as session:
+            session.add(Quota(org_id=_ORG_ID, max_sources=3))
+            session.commit()
+        quota = store.get_quota(_ORG_ID)
+        assert quota is not None and quota.max_sources == 3
+        assert [q.org_id for q in store.list_quotas()] == [_ORG_ID]
+
+    def test_list_usage_filters(self, store: _Store):
+        other_org = uuid4()
+        with Session(store._engine) as session:
+            increment_usage(session, _ORG_ID, METRIC_SUCCESSFUL_RUNS, dt.date(2026, 7, 1), used=1)
+            increment_usage(session, _ORG_ID, METRIC_SUCCESSFUL_RUNS, dt.date(2026, 8, 1), used=2)
+            increment_usage(session, other_org, METRIC_SUCCESSFUL_RUNS, dt.date(2026, 8, 1), used=3)
+            session.commit()
+        august = store.list_usage(period_start=dt.date(2026, 8, 1))
+        assert {(row.org_id, row.used) for row in august} == {(_ORG_ID, 2), (other_org, 3)}
+        assert [row.used for row in store.list_usage(org_id=_ORG_ID, period_start=dt.date(2026, 7, 1))] == [1]
+
+    def test_capacity_counts(self, store: _Store):
+        other_org = uuid4()
+        with Session(store._engine) as session:
+            big = Component(org_id=_ORG_ID, kind="source", key="s1")
+            small = Component(org_id=_ORG_ID, kind="source", key="s2")
+            other = Component(org_id=other_org, kind="source", key="s3")
+            session.add_all([big, small, other])
+            session.flush()
+            for key in ("a", "b", "c"):
+                session.add(Component(org_id=_ORG_ID, kind="asset", key=key, parent_id=big.id))
+            session.add(Component(org_id=_ORG_ID, kind="asset", key="a", parent_id=small.id))
+            session.commit()
+
+        assert store.count_sources_by_org() == {_ORG_ID: 2, other_org: 1}
+        assert store.max_assets_per_source_by_org() == {_ORG_ID: 3}
+
+    def test_count_successful_runs_by_org(self, store: _Store):
+        period = dt.date(2026, 8, 1)
+        inside = datetime(2026, 8, 10, 12, 0, tzinfo=timezone.utc)
+        outside = datetime(2026, 7, 31, 12, 0, tzinfo=timezone.utc)
+        with Session(store._engine) as session:
+            session.add(Run(id=uuid4(), org_id=_ORG_ID, status="success", completed_at=inside))
+            session.add(Run(id=uuid4(), org_id=_ORG_ID, status="success", completed_at=outside))
+            session.add(Run(id=uuid4(), org_id=_ORG_ID, status="failed", completed_at=inside))
+            session.commit()
+        assert store.count_successful_runs_by_org(period) == {_ORG_ID: 1}
+
+    def test_current_period_start_is_this_month(self, store: _Store):
+        assert store.current_period_start() == month_start(datetime.now(timezone.utc))

--- a/packages/interloper-db/tests/store/test_runs.py
+++ b/packages/interloper-db/tests/store/test_runs.py
@@ -18,7 +18,7 @@ from sqlalchemy.pool import StaticPool
 from sqlmodel import Session, select
 
 from interloper_db import engine as engine_module
-from interloper_db.models import Backfill, Run
+from interloper_db.models import Backfill, Run, Usage
 from interloper_db.store.runs import RunMixin
 
 _ORG_ID = uuid4()
@@ -39,6 +39,7 @@ def store() -> Iterator[RunMixin]:
 
     Backfill.__table__.create(eng)  # ty: ignore[unresolved-attribute]
     Run.__table__.create(eng)  # ty: ignore[unresolved-attribute]
+    Usage.__table__.create(eng)  # ty: ignore[unresolved-attribute]  (complete_run settles usage)
     try:
         mixin = RunMixin()
         mixin._engine = eng

--- a/packages/interloper-db/tests/test_run_events.py
+++ b/packages/interloper-db/tests/test_run_events.py
@@ -201,8 +201,8 @@ def test_asset_filter_accepts_multiple_assets(store: RunMixin) -> None:
 
 @pytest.fixture
 def run_store() -> Iterator[RunMixin]:
-    """A RunMixin over a database with runs and components tables."""
-    from interloper_db.models import Component, Run
+    """A RunMixin over a database with runs, components, and usage tables."""
+    from interloper_db.models import Component, Run, Usage
 
     eng = engine_module.init_engine(
         "sqlite://",
@@ -211,6 +211,7 @@ def run_store() -> Iterator[RunMixin]:
     )
     Component.__table__.create(eng)  # ty: ignore[unresolved-attribute]
     Run.__table__.create(eng)  # ty: ignore[unresolved-attribute]
+    Usage.__table__.create(eng)  # ty: ignore[unresolved-attribute]  (complete_run settles usage)
     try:
         mixin = RunMixin()
         mixin._engine = eng


### PR DESCRIPTION
## What

PR 2 of the org-quota plan: schema + metering + admin visibility. **No enforcement yet** — defaults ship as null (unlimited), so this observes a full cycle of real usage before limits go live (meter-first rollout).

### Schema (SQLModel + idempotent migration `007`)
- **`quotas`** — one row per org, nullable limits (`max_sources`, `max_assets_per_source`, `max_successful_runs_per_month`) over `QuotaSettings` defaults (`INTERLOPER_QUOTA_*`). Deleted with its org.
- **`usage`** — the append-only billing ledger: PK `(org_id, metric, period_start)`, `used`/`reserved` counters moved only by atomic upserts. **Deliberately excluded from org deletion** and seeded from run history by the migration, so reconciliation is meaningful from day one.
- **`runs.quota_reserved_at`** — marks dispatch-time reservations (taken by the enforcement PR); its month tells settlement which period to release, correct across month boundaries.

### Metering
- `complete_run` charges `used += 1` for successful runs in the same transaction, attributed to the **UTC calendar month per the DB clock** (`db_now`) — not the child pod's wall clock. Failures/cancels charge nothing; reservation release is wired and dormant.
- Metric names go through a closed set (`USAGE_METRICS`) so a typo can't open a stray ledger row.

### Visibility
- `GET /admin/quotas` (super-admin): per org — override + effective limits, live capacity counts, current-period `used`/`reserved`, and `recomputed_successful_runs` straight from the runs table so **ledger drift is visible immediately**.
- New admin **Quotas** page (drift badge, override chips); quota defaults section on the admin config page.

## Verified live (Postgres, dev instance)

- Migration applied cleanly on an existing DB (`alembic_version` → 007; tables + column present); ledger seeded from history.
- Triggered a run via the API against a tracked fixture source/job: on success, `usage.used` incremented by exactly 1 through the PG `ON CONFLICT` path; a failed run charged nothing.
- `/admin/quotas` returns matching ledger vs recompute; page renders with the "In sync" badge.
- Fixtures and minted session cleaned up.

## Tests

- Store: month/period helpers, upsert increment, all four settle branches (incl. cross-month reservation), `complete_run` integration, capacity counts, recompute query, unknown-metric guard.
- API: super-admin gating, overview shape, field-by-field effective-limit fallback, absent defaults = unlimited.

By Digitl