### PR TITLE
feat(scheduler): per-loop liveness gauge

### DIFF
--- a/docs/features/telemetry.md
+++ b/docs/features/telemetry.md
@@ -223,6 +223,7 @@ value (e.g. `http/dup` to emit both during a migration).
 | `interloper.asset.duration` | histogram (s) | `status`, `asset_key` |
 | `interloper.destination.io` | counter | `operation`, `status`, `destination_key` |
 | `interloper.runs.launched` | counter | `outcome` |
+| `interloper.scheduler.tick` | gauge (unix s) | `loop` (`cron`, `hook`, `queue`, `reaper`) |
 
 † **Platform identity** — `org_id`, `target_kind`, `target_key` — appears on
 run-level instruments when the run goes through the scheduler, which threads

--- a/packages/interloper-scheduler/src/interloper_scheduler/controller.py
+++ b/packages/interloper-scheduler/src/interloper_scheduler/controller.py
@@ -3,10 +3,44 @@
 from __future__ import annotations
 
 import logging
+import time
 from abc import ABC, abstractmethod
 from threading import Event
 
+from interloper.telemetry.tracer import meter
+from opentelemetry.metrics import CallbackOptions, Observation
+
 logger = logging.getLogger(__name__)
+
+#: Unix timestamp of each loop's last successful tick, keyed by loop name.
+#: One process hosts each controller as a singleton thread, so a plain dict
+#: (guarded by the GIL for single-key writes) is enough.
+_last_tick: dict[str, float] = {}
+_gauge_registered = False
+
+
+def _observe_ticks(_options: CallbackOptions) -> list[Observation]:
+    return [Observation(ts, {"loop": name}) for name, ts in _last_tick.items()]
+
+
+def _register_tick_gauge() -> None:
+    """Register the liveness gauge once per process.
+
+    A gauge (a level, not a flow) survives every sparse-counter pitfall:
+    dashboards and alerts read staleness as ``time() - value`` per loop.
+    Only *successful* ticks are recorded, so a loop that keeps failing goes
+    stale even though its thread is alive.
+    """
+    global _gauge_registered
+    if _gauge_registered:
+        return
+    _gauge_registered = True
+    meter().create_observable_gauge(
+        "interloper.scheduler.tick",
+        callbacks=[_observe_ticks],
+        unit="s",
+        description="Unix time of each scheduler loop's last successful tick",
+    )
 
 
 class Controller(ABC):
@@ -27,6 +61,12 @@ class Controller(ABC):
         """
         self._poll_interval = poll_interval
         self._stop_event = Event()
+        _register_tick_gauge()
+
+    @property
+    def _loop_name(self) -> str:
+        """This loop's name on the liveness gauge (``CronController`` -> ``cron``)."""
+        return type(self).__name__.removesuffix("Controller").lower()
 
     def start(self) -> None:
         """Run the loop until stopped."""
@@ -35,6 +75,7 @@ class Controller(ABC):
             while not self._stop_event.is_set():
                 try:
                     self._tick()
+                    _last_tick[self._loop_name] = time.time()
                 except Exception:
                     logger.exception("%s tick failed", type(self).__name__)
 

--- a/packages/interloper-scheduler/tests/test_controller.py
+++ b/packages/interloper-scheduler/tests/test_controller.py
@@ -1,0 +1,58 @@
+"""Tests for ``interloper_scheduler.controller``."""
+
+from __future__ import annotations
+
+import time
+
+from interloper_scheduler import controller
+from interloper_scheduler.controller import Controller
+
+
+class _StubLoopController(Controller):
+    def __init__(self) -> None:
+        super().__init__(poll_interval=0)
+
+    def _tick(self) -> None:
+        self.stop()
+
+
+class _FailingLoopController(Controller):
+    def __init__(self) -> None:
+        super().__init__(poll_interval=0)
+        self.ticks = 0
+
+    def _tick(self) -> None:
+        self.ticks += 1
+        if self.ticks >= 2:
+            self.stop()
+        raise RuntimeError("boom")
+
+
+class TestTickLiveness:
+    def test_successful_tick_records_timestamp(self):
+        before = time.time()
+        _StubLoopController().start()
+        assert controller._last_tick["_stubloop"] >= before
+
+    def test_failing_ticks_never_record(self):
+        controller._last_tick.pop("_failingloop", None)
+        _FailingLoopController().start()
+        assert "_failingloop" not in controller._last_tick
+
+    def test_loop_name_derivation(self):
+        assert _StubLoopController()._loop_name == "_stubloop"
+
+    def test_gauge_reports_per_loop(self, metric_reader):
+        _StubLoopController().start()
+        data = metric_reader.get_metrics_data()
+        points = [
+            (point.attributes.get("loop"), point.value)
+            for rm in data.resource_metrics
+            for sm in rm.scope_metrics
+            for metric in sm.metrics
+            if metric.name == "interloper.scheduler.tick"
+            for point in metric.data.data_points
+        ]
+        loops = dict(points)
+        assert "_stubloop" in loops
+        assert loops["_stubloop"] > 0


### PR DESCRIPTION
## What

`interloper.scheduler.tick` — an observable gauge holding the unix timestamp of each scheduler loop's last **successful** tick, labeled `loop=cron|hook|queue|reaper`. One instrumentation point in the `Controller` base covers all four (loop name derived from the class name); failing ticks don't record, so a permanently-erroring loop goes stale instead of looking alive.

## Why

The dashboard's scheduler heartbeat currently reads db pool activity, which conflates the four loops — any one can wedge while the others keep the tile green. A last-tick gauge per loop is the standard liveness pattern (cf. `kube_cronjob_status_last_schedule_time`): dashboards and alerts read `time() - gauge` as per-loop staleness. Gauges are levels, so none of the sparse-counter pitfalls (baseline swallow, extrapolation, restart resets) apply.

## Verification

- 4 new tests: successful ticks record, failing ticks don't, loop-name derivation, gauge observes per-loop datapoints through the SDK reader.
- Full suite: ruff, ty, all tests green.

## Follow-up (interloper-kubernetes, after release)

Repoint the Overview scheduler stat tile and the Scheduler section heartbeat panel to `time() - interloper_scheduler_tick` per loop; the db-tick heartbeat can retire.

By Digitl