### PR TITLE
feat: enforce organisation quotas

### DIFF
--- a/packages/interloper-api/src/interloper_api/app.py
+++ b/packages/interloper-api/src/interloper_api/app.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from interloper.catalog.base import Catalog
-from interloper.errors import ComponentDriftError, NotFoundError
+from interloper.errors import ComponentDriftError, NotFoundError, QuotaExceededError
 from interloper_db import Store
 
 from interloper_api.dependencies import (
@@ -76,6 +76,14 @@ def create_app(
         user resolves the drift, so surface it as a clean 409 the UI can act on.
         """
         return JSONResponse(status_code=409, content={"detail": str(exc)})
+
+    @app.exception_handler(QuotaExceededError)
+    async def _quota_exceeded_handler(_request: Request, exc: QuotaExceededError) -> JSONResponse:
+        """Store-level quota enforcement surfaces as 429 with structured context."""
+        return JSONResponse(
+            status_code=429,
+            content={"detail": {"message": str(exc), "quota": exc.quota, "limit": exc.limit, "used": exc.used}},
+        )
 
     if cors_origins:
         app.add_middleware(

--- a/packages/interloper-api/src/interloper_api/routes/backfills.py
+++ b/packages/interloper-api/src/interloper_api/routes/backfills.py
@@ -100,14 +100,17 @@ def create_backfill(
     job = load_authorized(
         lambda i: store.get_component(i, kind="job"), body.component_id, user, store, label="Job", minimum="editor"
     )
-    backfill = store.create_backfill(
-        job.org_id,
-        component_id=body.component_id,
-        start_date=body.start_date,
-        end_date=body.end_date,
-        concurrency=body.concurrency,
-        fail_fast=body.fail_fast,
-    )
+    try:
+        backfill = store.create_backfill(
+            job.org_id,
+            component_id=body.component_id,
+            start_date=body.start_date,
+            end_date=body.end_date,
+            concurrency=body.concurrency,
+            fail_fast=body.fail_fast,
+        )
+    except ValueError as e:  # span cap
+        raise HTTPException(status_code=400, detail=str(e))
     return _backfill_to_response(backfill)
 
 

--- a/packages/interloper-api/tests/test_backfills.py
+++ b/packages/interloper-api/tests/test_backfills.py
@@ -113,3 +113,17 @@ def test_cancel_returns_404_for_non_member(store: FakeStore) -> None:
     resp = _client(store).post(f"/backfills/{uuid4()}/cancel")
     assert resp.status_code == 404
     assert store.cancel_calls == []
+
+
+def test_create_backfill_span_cap_returns_400(store: FakeStore) -> None:
+    def _raise(org_id, **kwargs):
+        raise ValueError("Backfill spans 31 days; the instance caps backfills at 30 days")
+
+    store.get_component = lambda component_id, kind=None: _fake_backfill(component_id)  # ty: ignore[unresolved-attribute]
+    store.create_backfill = _raise  # ty: ignore[unresolved-attribute]
+    resp = _client(store).post(
+        "/backfills/",
+        json={"component_id": str(uuid4()), "start_date": "2026-01-01", "end_date": "2026-01-31"},
+    )
+    assert resp.status_code == 400
+    assert "caps backfills" in resp.json()["detail"]

--- a/packages/interloper-api/tests/test_runs.py
+++ b/packages/interloper-api/tests/test_runs.py
@@ -160,3 +160,35 @@ def test_asset_executions_return_404_for_non_member(store: FakeStore) -> None:
     store.role = None
     resp = _client(store).get(f"/runs/{uuid4()}/asset-executions")
     assert resp.status_code == 404
+
+
+# -- Quota ---------------------------------------------------------------------
+
+
+def test_quota_exceeded_maps_to_429(store: FakeStore) -> None:
+    """The app-level handler turns QuotaExceededError into a structured 429."""
+    from interloper.errors import QuotaExceededError
+
+    def _raise(org_id, **kwargs):
+        raise QuotaExceededError("quota exhausted (3/3)", quota="max_successful_runs_per_month", limit=3, used=3)
+
+    store.get_component = lambda component_id: SimpleNamespace(  # ty: ignore[unresolved-attribute]
+        id=component_id, org_id=_ORG_ID, kind="job"
+    )
+    store.create_run = _raise  # ty: ignore[unresolved-attribute]
+    client = _client(store)
+
+    @client.app.exception_handler(QuotaExceededError)  # mirrors create_app's handler
+    async def _quota_handler(_request, exc: QuotaExceededError):
+        from fastapi.responses import JSONResponse
+
+        return JSONResponse(
+            status_code=429,
+            content={"detail": {"message": str(exc), "quota": exc.quota, "limit": exc.limit, "used": exc.used}},
+        )
+
+    resp = client.post("/runs/", json={"component_id": str(uuid4())})
+    assert resp.status_code == 429
+    detail = resp.json()["detail"]
+    assert detail["quota"] == "max_successful_runs_per_month"
+    assert (detail["limit"], detail["used"]) == (3, 3)

--- a/packages/interloper-core/src/interloper/errors.py
+++ b/packages/interloper-core/src/interloper/errors.py
@@ -150,6 +150,21 @@ class InUseError(InterloperError):
         self.referrers = referrers or []
 
 
+class QuotaExceededError(InterloperError):
+    """An organisation quota does not allow the requested operation.
+
+    Raised by the store layer; API routes surface it as HTTP 429 with the
+    structured fields so clients can show limit and usage.
+    """
+
+    def __init__(self, message: str, *, quota: str, limit: int, used: int) -> None:
+        """Initialize with a user-facing message and the quota context."""
+        super().__init__(message)
+        self.quota = quota
+        self.limit = limit
+        self.used = used
+
+
 # -- Hydration / Catalog -------------------------------------------------------
 
 

--- a/packages/interloper-core/src/interloper/settings.py
+++ b/packages/interloper-core/src/interloper/settings.py
@@ -252,6 +252,9 @@ class QuotaSettings(BaseSettings):
     max_sources: int | None = None
     max_assets_per_source: int | None = None
     max_successful_runs_per_month: int | None = None
+    # Global guard, not a per-org quota: caps how many runs one backfill
+    # request may create.
+    max_backfill_days: int | None = None
 
 
 class AppSettings(BaseSettings):

--- a/packages/interloper-db/src/interloper_db/store/__init__.py
+++ b/packages/interloper-db/src/interloper_db/store/__init__.py
@@ -67,6 +67,7 @@ class Store(AuthMixin, TokenMixin, ComponentMixin, RunMixin, QuotaMixin, DriftMi
         engine: Engine | None = None,
         encrypt: Any | None = None,
         decrypt: Any | None = None,
+        quota_defaults: Any | None = None,
     ) -> None:
         """Initialize the store.
 
@@ -76,11 +77,14 @@ class Store(AuthMixin, TokenMixin, ComponentMixin, RunMixin, QuotaMixin, DriftMi
                 already-initialized process engine.
             encrypt: Optional callable ``(data: bytes) -> bytes`` for resource encryption.
             decrypt: Optional callable ``(data: bytes) -> bytes`` for resource decryption.
+            quota_defaults: QuotaSettings-shaped default limits enforced when
+                an organisation has no override. None = everything unlimited.
         """
         self._catalog = catalog
         self._engine = engine or get_engine()
         self._encrypt = encrypt
         self._decrypt = decrypt
+        self._quota_defaults = quota_defaults
         self._hydrator = Hydrator(catalog, decrypt=decrypt)
 
     @classmethod
@@ -110,16 +114,17 @@ class Store(AuthMixin, TokenMixin, ComponentMixin, RunMixin, QuotaMixin, DriftMi
 
         catalog = catalog if catalog is not None else Catalog.from_settings()
         engine = engine_from_settings()
-        key = AppSettings.get().secrets.encryption_key
+        settings = AppSettings.get()
+        key = settings.secrets.encryption_key
         if not key:
             logger.warning(
                 "INTERLOPER_ENCRYPTION_KEY is not configured; resource persistence will "
                 "fail closed (writes are rejected rather than stored in plaintext). Set it "
                 "to enable encrypted resources at rest."
             )
-            return cls(catalog=catalog, engine=engine)
+            return cls(catalog=catalog, engine=engine, quota_defaults=settings.quota)
 
         from interloper_db.crypto import make_cipher
 
         encrypt, decrypt = make_cipher(key)
-        return cls(catalog=catalog, engine=engine, encrypt=encrypt, decrypt=decrypt)
+        return cls(catalog=catalog, engine=engine, encrypt=encrypt, decrypt=decrypt, quota_defaults=settings.quota)

--- a/packages/interloper-db/src/interloper_db/store/base.py
+++ b/packages/interloper-db/src/interloper_db/store/base.py
@@ -29,6 +29,18 @@ class StoreBase:
     _hydrator: Hydrator
     _encrypt: Any
     _decrypt: Any
+    # QuotaSettings-shaped defaults for quota limits; None = everything
+    # unlimited (quota checks short-circuit without touching the DB).
+    _quota_defaults: Any = None
+
+    @property
+    def quota_defaults(self) -> Any:
+        """The global default quota limits (QuotaSettings-shaped, or None).
+
+        Exposed so co-located machinery (the scheduler's claim/cron SQL)
+        enforces against the same defaults as the store.
+        """
+        return self._quota_defaults
 
     @property
     def engine(self) -> Engine:

--- a/packages/interloper-db/src/interloper_db/store/components.py
+++ b/packages/interloper-db/src/interloper_db/store/components.py
@@ -37,6 +37,7 @@ from sqlmodel import Session, col, select
 
 from interloper_db.drift import ComponentStatus, asset_status, resolve_component_cls, resolve_source_cls, source_status
 from interloper_db.models import Component, ComponentRelation
+from interloper_db.store.quotas import check_asset_quota, check_source_quota
 from interloper_db.store.relations import Binding, RelationMixin, _add_relation
 
 # Eager-load set for rows returned to API consumers: the parent, children
@@ -88,6 +89,8 @@ class ComponentMixin(RelationMixin):
             The created component row, eager-loaded.
         """
         with self._session() as session:
+            if kind == "source":
+                check_source_quota(session, org_id, self._quota_defaults)
             db_component = Component(org_id=org_id, kind=kind, key=key, name=name)
             self._apply_config(db_component, config, encrypted)
             if name is None:
@@ -489,6 +492,7 @@ class ComponentMixin(RelationMixin):
         # An explicit list is the exact child set; None (creation) is all
         # catalog assets.
         target = set(child_keys) if child_keys is not None else all_keys
+        check_asset_quota(session, db_source, len(target), self._quota_defaults)
         to_create = target - set(existing)
         to_remove = set(existing) - target
 

--- a/packages/interloper-db/src/interloper_db/store/quotas.py
+++ b/packages/interloper-db/src/interloper_db/store/quotas.py
@@ -16,8 +16,10 @@ from __future__ import annotations
 
 import datetime as dt
 from datetime import datetime, timezone
+from typing import Any
 from uuid import UUID
 
+from interloper.errors import QuotaExceededError
 from sqlalchemy import func
 from sqlalchemy import select as sa_select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
@@ -67,6 +69,11 @@ def db_now(session: Session) -> datetime:
     return value
 
 
+def _insert_fn(session: Session) -> Any:
+    """The dialect's upsert-capable insert constructor."""
+    return pg_insert if session.get_bind().dialect.name == "postgresql" else sqlite_insert
+
+
 def increment_usage(
     session: Session,
     org_id: UUID,
@@ -84,9 +91,8 @@ def increment_usage(
     if metric not in USAGE_METRICS:
         raise ValueError(f"Unknown usage metric: {metric}")
     table = Usage.__table__  # ty: ignore[unresolved-attribute]
-    insert_fn = pg_insert if session.get_bind().dialect.name == "postgresql" else sqlite_insert
     statement = (
-        insert_fn(table)
+        _insert_fn(session)(table)
         .values(org_id=org_id, metric=metric, period_start=period_start, used=used, reserved=reserved)
         .on_conflict_do_update(
             index_elements=["org_id", "metric", "period_start"],
@@ -113,6 +119,153 @@ def settle_run_usage(session: Session, db_run: Run, *, success: bool) -> None:
         increment_usage(session, db_run.org_id, METRIC_SUCCESSFUL_RUNS, charge_period, used=1)
     if reserved_period is not None:
         increment_usage(session, db_run.org_id, METRIC_SUCCESSFUL_RUNS, reserved_period, reserved=-1)
+
+
+# -- Enforcement ----------------------------------------------------------------
+#
+# All checks short-circuit without touching the database when neither the
+# organisation nor the defaults set a limit, so unconfigured instances pay
+# nothing. Capacity checks (sources, assets per source) serialize on the
+# org's quotas row via SELECT FOR UPDATE — the count-then-insert race is
+# the reason a plain count in application code is not enough. The run
+# quota's authoritative gate is the atomic dispatch-time reservation in
+# ``try_reserve_run``; the creation-time checks are advisory fail-fasts.
+
+
+def _effective_limit(session: Session, org_id: UUID, field: str, defaults: Any) -> int | None:
+    """Resolve a limit: org override wins over the global default; None = unlimited."""
+    override = session.get(Quota, org_id)
+    value = getattr(override, field, None) if override else None
+    if value is None:
+        value = getattr(defaults, field, None)
+    return value
+
+
+def _locked_effective_limit(session: Session, org_id: UUID, field: str, defaults: Any) -> int | None:
+    """Resolve a limit while holding the org's quota-row lock.
+
+    Upserts the (all-null) row first so there is always something to lock;
+    the lock is released with the caller's transaction and serializes
+    capacity checks per organisation.
+    """
+    table = Quota.__table__  # ty: ignore[unresolved-attribute]
+    statement = _insert_fn(session)(table).values(org_id=org_id).on_conflict_do_nothing(index_elements=["org_id"])
+    session.execute(statement)  # ty: ignore[deprecated]
+    override = session.exec(select(Quota).where(Quota.org_id == org_id).with_for_update()).first()
+    value = getattr(override, field, None) if override else None
+    if value is None:
+        value = getattr(defaults, field, None)
+    return value
+
+
+def check_source_quota(session: Session, org_id: UUID, defaults: Any) -> None:
+    """Reject creating a source when the organisation is at its source limit.
+
+    Part of the caller's transaction; call before inserting the new source.
+    """
+    if _effective_limit(session, org_id, "max_sources", defaults) is None:
+        return
+    limit = _locked_effective_limit(session, org_id, "max_sources", defaults)
+    if limit is None:
+        return
+    used = session.exec(
+        select(func.count())
+        .select_from(Component)
+        .where(col(Component.org_id) == org_id, col(Component.kind) == "source")
+    ).one()
+    if used >= limit:
+        raise QuotaExceededError(
+            f"Organisation is at its source limit ({used}/{limit}); delete a source or raise the quota",
+            quota="max_sources",
+            limit=limit,
+            used=used,
+        )
+
+
+def check_asset_quota(session: Session, db_source: Component, asset_count: int, defaults: Any) -> None:
+    """Reject a source child set larger than the assets-per-source limit.
+
+    ``asset_count`` is the size of the *desired* final set, so the check is
+    declarative — no counting race regardless of what the set is today.
+    """
+    if _effective_limit(session, db_source.org_id, "max_assets_per_source", defaults) is None:
+        return
+    limit = _locked_effective_limit(session, db_source.org_id, "max_assets_per_source", defaults)
+    if limit is None or asset_count <= limit:
+        return
+    raise QuotaExceededError(
+        f"Source '{db_source.name or db_source.key}' would have {asset_count} assets, "
+        f"exceeding the limit of {limit}",
+        quota="max_assets_per_source",
+        limit=limit,
+        used=asset_count,
+    )
+
+
+def run_quota_status(session: Session, org_id: UUID, defaults: Any) -> tuple[int, int | None]:
+    """The org's committed run usage this period: ``(used + reserved, limit)``.
+
+    Limit None means unlimited (and the ledger is not read at all).
+    """
+    limit = _effective_limit(session, org_id, "max_successful_runs_per_month", defaults)
+    if limit is None:
+        return 0, None
+    period_start = month_start(db_now(session))
+    row = session.get(Usage, (org_id, METRIC_SUCCESSFUL_RUNS, period_start))
+    committed = (row.used + row.reserved) if row else 0
+    return committed, limit
+
+
+def check_run_quota(session: Session, org_id: UUID, defaults: Any, *, source: str = "run") -> None:
+    """Advisory creation-time gate: reject new runs once the quota is exhausted.
+
+    Fail-fast only — runs admitted here can still be denied at dispatch by
+    ``try_reserve_run``, the authoritative gate.
+    """
+    committed, limit = run_quota_status(session, org_id, defaults)
+    if limit is not None and committed >= limit:
+        raise QuotaExceededError(
+            f"Cannot queue {source}: the monthly successful-run quota is exhausted ({committed}/{limit})",
+            quota="max_successful_runs_per_month",
+            limit=limit,
+            used=committed,
+        )
+
+
+def try_reserve_run(session: Session, db_run: Run, defaults: Any) -> bool:
+    """Atomically reserve a run-quota slot at dispatch time.
+
+    The reservation is a conditional upsert (``used + reserved < limit``),
+    so concurrent claimers can never overshoot; on success the run is
+    stamped with ``quota_reserved_at`` so settlement releases the right
+    period. Unlimited orgs are admitted without touching the ledger.
+
+    Returns:
+        True if the run may dispatch, False when the quota is exhausted.
+    """
+    limit = _effective_limit(session, db_run.org_id, "max_successful_runs_per_month", defaults)
+    if limit is None:
+        return True
+    if limit <= 0:
+        return False
+    now = db_now(session)
+    period_start = month_start(now)
+    table = Usage.__table__  # ty: ignore[unresolved-attribute]
+    statement = (
+        _insert_fn(session)(table)
+        .values(org_id=db_run.org_id, metric=METRIC_SUCCESSFUL_RUNS, period_start=period_start, used=0, reserved=1)
+        .on_conflict_do_update(
+            index_elements=["org_id", "metric", "period_start"],
+            set_={"reserved": table.c.reserved + 1},
+            where=(table.c.used + table.c.reserved < limit),
+        )
+    )
+    result = session.execute(statement)  # ty: ignore[deprecated]
+    if result.rowcount != 1:  # ty: ignore[unresolved-attribute]
+        return False
+    db_run.quota_reserved_at = now
+    session.add(db_run)
+    return True
 
 
 class QuotaMixin(StoreBase):
@@ -181,3 +334,31 @@ class QuotaMixin(StoreBase):
                 .group_by(Run.org_id)  # ty: ignore[invalid-argument-type]
             ).all()
             return dict(rows)
+
+    def reconcile_usage(self) -> list[dict[str, Any]]:
+        """Compare the current period's ledger against the runs table.
+
+        Returns one entry per organisation whose ``usage.used`` differs from
+        the recomputed successful-run count. Both sides move in the same
+        transaction on completion, so persistent drift is a bug signal;
+        transient off-by-ones are possible (the two reads are separate
+        queries, and charge months are DB-clock while ``completed_at`` is
+        the executor's clock at the boundary).
+        """
+        period_start = self.current_period_start()
+        recomputed = self.count_successful_runs_by_org(period_start)
+        ledger = {
+            row.org_id: row.used
+            for row in self.list_usage(period_start=period_start)
+            if row.metric == METRIC_SUCCESSFUL_RUNS
+        }
+        return [
+            {
+                "org_id": org_id,
+                "period_start": period_start,
+                "ledger": ledger.get(org_id, 0),
+                "recomputed": recomputed.get(org_id, 0),
+            }
+            for org_id in sorted(set(recomputed) | set(ledger), key=str)
+            if recomputed.get(org_id, 0) != ledger.get(org_id, 0)
+        ]

--- a/packages/interloper-db/src/interloper_db/store/runs.py
+++ b/packages/interloper-db/src/interloper_db/store/runs.py
@@ -19,7 +19,7 @@ from sqlmodel import Session, col, select
 from interloper_db.models import AssetExecution, Backfill, Component, Event, Run
 from interloper_db.store.base import StoreBase
 from interloper_db.store.components import stamp_component_state
-from interloper_db.store.quotas import settle_run_usage
+from interloper_db.store.quotas import check_run_quota, settle_run_usage
 
 logger = logging.getLogger(__name__)
 
@@ -312,6 +312,7 @@ class RunMixin(StoreBase):
             The created Run row.
         """
         with self._session() as session:
+            check_run_quota(session, org_id, self._quota_defaults)
             db_run = Run(
                 org_id=org_id,
                 component_id=component_id,
@@ -468,6 +469,7 @@ class RunMixin(StoreBase):
             if src.status != "failed":
                 raise ValueError(f"Run {run_id} is not failed (status={src.status!r}); only failed runs can be retried")
 
+            check_run_quota(session, src.org_id, self._quota_defaults, source="retry")
             db_run = Run(
                 org_id=src.org_id,
                 component_id=src.component_id,
@@ -510,7 +512,13 @@ class RunMixin(StoreBase):
         Returns:
             The created Backfill row with runs.
         """
+        max_days = getattr(self._quota_defaults, "max_backfill_days", None)
+        span = (end_date - start_date).days + 1
+        if max_days is not None and span > max_days:
+            raise ValueError(f"Backfill spans {span} days; the instance caps backfills at {max_days} days")
+
         with self._session() as session:
+            check_run_quota(session, org_id, self._quota_defaults, source="backfill")
             db_backfill = Backfill(
                 org_id=org_id,
                 component_id=component_id,
@@ -572,21 +580,7 @@ class RunMixin(StoreBase):
             if db_backfill.status not in ("running", "queued"):
                 raise ValueError(f"Backfill {backfill_id} is already {db_backfill.status}")
 
-            # skip_locked leaves runs the worker is claiming right now to the
-            # worker — they are effectively dispatched and drain like any
-            # other in-flight run.
-            cancellable = session.exec(
-                select(Run)
-                .where(Run.backfill_id == backfill_id, col(Run.status).in_(["pending", "queued"]))
-                .with_for_update(skip_locked=True)
-            ).all()
-            for db_run in cancellable:
-                db_run.status = "canceled"
-                session.add(db_run)
-
-            db_backfill.status = "canceled"
-            db_backfill.completed_at = datetime.now(timezone.utc)
-            session.add(db_backfill)
+            cancel_backfill_runs(session, db_backfill)
             session.commit()
             session.refresh(db_backfill)
             return db_backfill
@@ -637,6 +631,27 @@ class RunMixin(StoreBase):
                 col(Backfill.status).in_(["running", "queued"]),
             )
             return list(session.exec(statement).all())
+
+
+def cancel_backfill_runs(session: Session, db_backfill: Backfill) -> None:
+    """Cancel a backfill's not-yet-dispatched runs and terminalize it.
+
+    Part of the caller's transaction (the caller commits). ``skip_locked``
+    leaves runs the worker is claiming right now to the worker — they are
+    effectively dispatched and drain like any other in-flight run.
+    """
+    cancellable = session.exec(
+        select(Run)
+        .where(Run.backfill_id == db_backfill.id, col(Run.status).in_(["pending", "queued"]))
+        .with_for_update(skip_locked=True)
+    ).all()
+    for db_run in cancellable:
+        db_run.status = "canceled"
+        session.add(db_run)
+
+    db_backfill.status = "canceled"
+    db_backfill.completed_at = datetime.now(timezone.utc)
+    session.add(db_backfill)
 
 
 def _advance_backfill(session: Session, backfill_id: UUID, *, failed: bool) -> None:

--- a/packages/interloper-db/tests/conftest.py
+++ b/packages/interloper-db/tests/conftest.py
@@ -15,7 +15,7 @@ from sqlalchemy import Engine, event
 from sqlalchemy.pool import StaticPool
 
 from interloper_db import engine as engine_module
-from interloper_db.models import Component, ComponentRelation
+from interloper_db.models import Component, ComponentRelation, Quota, Usage
 
 
 @pytest.fixture
@@ -31,8 +31,8 @@ def component_db() -> Iterator[Engine]:
     def _enable_foreign_keys(dbapi_connection: Any, _record: Any) -> None:
         dbapi_connection.execute("PRAGMA foreign_keys=ON")
 
-    Component.__table__.create(eng)  # ty: ignore[unresolved-attribute]
-    ComponentRelation.__table__.create(eng)  # ty: ignore[unresolved-attribute]
+    for model in (Component, ComponentRelation, Quota, Usage):
+        model.__table__.create(eng)  # ty: ignore[unresolved-attribute]
     try:
         yield eng
     finally:

--- a/packages/interloper-db/tests/store/test_components.py
+++ b/packages/interloper-db/tests/store/test_components.py
@@ -433,3 +433,57 @@ class TestDerivedNames:
         assert row.name is None
 
 
+
+
+class TestQuotaGates:
+    """Capacity quotas gate source creation and the child-asset set size."""
+
+    def _store(self, **limits: int | None) -> Store:
+        from types import SimpleNamespace
+
+        from interloper_assets.demo.source import DemoSource
+
+        return Store(catalog=il.Catalog.from_assets([DemoSource]), quota_defaults=SimpleNamespace(**limits))
+
+    def test_source_limit_blocks_creation(self, component_db: Engine):
+        from interloper.errors import QuotaExceededError
+
+        store = self._store(max_sources=1)
+        store.create_component(_ORG, kind="source", key="demo_source", children=["a"])
+        with pytest.raises(QuotaExceededError) as excinfo:
+            store.create_component(_ORG, kind="source", key="demo_source", children=["a"])
+        assert excinfo.value.quota == "max_sources"
+        assert (excinfo.value.limit, excinfo.value.used) == (1, 1)
+
+    def test_source_limit_org_override_wins(self, component_db: Engine):
+        from interloper.errors import QuotaExceededError
+
+        from interloper_db.models import Quota
+
+        store = self._store(max_sources=1)
+        with Session(component_db) as session:
+            session.add(Quota(org_id=_ORG, max_sources=2))
+            session.commit()
+        store.create_component(_ORG, kind="source", key="demo_source", children=["a"], config={"dataset": "one"})
+        store.create_component(_ORG, kind="source", key="demo_source", children=["a"], config={"dataset": "two"})
+        with pytest.raises(QuotaExceededError):
+            store.create_component(_ORG, kind="source", key="demo_source", children=["a"], config={"dataset": "3"})
+
+    def test_asset_limit_blocks_large_child_set(self, component_db: Engine):
+        from interloper.errors import QuotaExceededError
+
+        store = self._store(max_assets_per_source=2)
+        source = store.create_component(_ORG, kind="source", key="demo_source", children=["a", "b"])
+        with pytest.raises(QuotaExceededError) as excinfo:
+            store.update_component(source.id, children=["a", "b", "c"])
+        assert excinfo.value.quota == "max_assets_per_source"
+        # Creation with the full catalog set (children=None -> 5 assets) is also gated.
+        with pytest.raises(QuotaExceededError):
+            store.create_component(_ORG, kind="source", key="demo_source", config={"dataset": "full"})
+        # Shrinking or staying within the limit is fine.
+        assert {c.key for c in store.update_component(source.id, children=["a"]).children} == {"a"}
+
+    def test_unconfigured_quotas_gate_nothing(self, component_db: Engine):
+        store = self._store()
+        for dataset in ("one", "two", "three"):
+            store.create_component(_ORG, kind="source", key="demo_source", config={"dataset": dataset})

--- a/packages/interloper-db/tests/store/test_quotas.py
+++ b/packages/interloper-db/tests/store/test_quotas.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import datetime as dt
 from collections.abc import Iterator
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from typing import Any
 from uuid import uuid4
 
 import pytest
+from interloper.errors import QuotaExceededError
 from sqlalchemy import event
 from sqlalchemy.pool import StaticPool
 from sqlmodel import Session, select
@@ -22,6 +24,7 @@ from interloper_db.store.quotas import (
     month_start,
     next_month_start,
     settle_run_usage,
+    try_reserve_run,
 )
 from interloper_db.store.runs import RunMixin
 
@@ -202,3 +205,123 @@ class TestQuotaReads:
 
     def test_current_period_start_is_this_month(self, store: _Store):
         assert store.current_period_start() == month_start(datetime.now(timezone.utc))
+
+
+# -- Enforcement ------------------------------------------------------------------
+
+
+def _defaults(**limits: int | None) -> SimpleNamespace:
+    return SimpleNamespace(**limits)
+
+
+class TestRunCreationGate:
+    def _exhaust(self, store: _Store, *, used: int = 0, reserved: int = 0) -> None:
+        with Session(store._engine) as session:
+            period = month_start(datetime.now(timezone.utc))
+            increment_usage(session, _ORG_ID, METRIC_SUCCESSFUL_RUNS, period, used=used, reserved=reserved)
+            session.commit()
+
+    def test_create_run_blocked_at_limit(self, store: _Store):
+        store._quota_defaults = _defaults(max_successful_runs_per_month=2)
+        self._exhaust(store, used=1, reserved=1)  # reserved counts against the limit
+        with pytest.raises(QuotaExceededError) as excinfo:
+            store.create_run(_ORG_ID)
+        assert excinfo.value.quota == "max_successful_runs_per_month"
+        assert (excinfo.value.limit, excinfo.value.used) == (2, 2)
+
+    def test_create_run_allowed_below_limit(self, store: _Store):
+        store._quota_defaults = _defaults(max_successful_runs_per_month=2)
+        self._exhaust(store, used=1)
+        assert store.create_run(_ORG_ID).status == "queued"
+
+    def test_org_override_wins_over_default(self, store: _Store):
+        store._quota_defaults = _defaults(max_successful_runs_per_month=1)
+        with Session(store._engine) as session:
+            session.add(Quota(org_id=_ORG_ID, max_successful_runs_per_month=3))
+            session.commit()
+        self._exhaust(store, used=2)
+        assert store.create_run(_ORG_ID).status == "queued"
+
+    def test_retry_blocked_at_limit(self, store: _Store):
+        run = store.create_run(_ORG_ID)
+        store.complete_run(run.id, success=False)
+        store._quota_defaults = _defaults(max_successful_runs_per_month=1)
+        self._exhaust(store, used=1)
+        with pytest.raises(QuotaExceededError, match="retry"):
+            store.retry_run(run.id)
+
+    def test_backfill_blocked_at_limit(self, store: _Store):
+        store._quota_defaults = _defaults(max_successful_runs_per_month=1)
+        self._exhaust(store, used=1)
+        with pytest.raises(QuotaExceededError, match="backfill"):
+            store.create_backfill(_ORG_ID, start_date=dt.date(2026, 1, 1), end_date=dt.date(2026, 1, 2))
+
+    def test_backfill_span_cap(self, store: _Store):
+        store._quota_defaults = _defaults(max_backfill_days=2)
+        with pytest.raises(ValueError, match="caps backfills at 2 days"):
+            store.create_backfill(_ORG_ID, start_date=dt.date(2026, 1, 1), end_date=dt.date(2026, 1, 3))
+        backfill = store.create_backfill(_ORG_ID, start_date=dt.date(2026, 1, 1), end_date=dt.date(2026, 1, 2))
+        assert backfill.partitions == 2
+
+
+class TestTryReserveRun:
+    def test_unlimited_admits_without_ledger(self, store: _Store):
+        run = _run(store)
+        with Session(store._engine) as session:
+            db_run = session.get(Run, run.id)
+            assert db_run is not None
+            assert try_reserve_run(session, db_run, None) is True
+            session.commit()
+        assert _usage_rows(store) == {}
+
+    def test_reserves_and_stamps(self, store: _Store):
+        run = _run(store)
+        with Session(store._engine) as session:
+            db_run = session.get(Run, run.id)
+            assert db_run is not None
+            assert try_reserve_run(session, db_run, _defaults(max_successful_runs_per_month=1)) is True
+            session.commit()
+        (counts,) = _usage_rows(store).values()
+        assert counts == (0, 1)
+        with Session(store._engine) as session:
+            reserved = session.get(Run, run.id)
+            assert reserved is not None and reserved.quota_reserved_at is not None
+
+    def test_denies_when_exhausted(self, store: _Store):
+        with Session(store._engine) as session:
+            period = month_start(datetime.now(timezone.utc))
+            increment_usage(session, _ORG_ID, METRIC_SUCCESSFUL_RUNS, period, used=1)
+            session.commit()
+        run = _run(store)
+        with Session(store._engine) as session:
+            db_run = session.get(Run, run.id)
+            assert db_run is not None
+            assert try_reserve_run(session, db_run, _defaults(max_successful_runs_per_month=1)) is False
+            session.commit()
+        (counts,) = _usage_rows(store).values()
+        assert counts == (1, 0)
+        with Session(store._engine) as session:
+            released = session.get(Run, run.id)
+            assert released is not None and released.quota_reserved_at is None
+
+    def test_zero_limit_denies(self, store: _Store):
+        run = _run(store)
+        with Session(store._engine) as session:
+            db_run = session.get(Run, run.id)
+            assert db_run is not None
+            assert try_reserve_run(session, db_run, _defaults(max_successful_runs_per_month=0)) is False
+
+
+class TestReconcileUsage:
+    def test_reports_drift_both_ways(self, store: _Store):
+        period = month_start(datetime.now(timezone.utc))
+        with Session(store._engine) as session:
+            increment_usage(session, _ORG_ID, METRIC_SUCCESSFUL_RUNS, period, used=5)
+            session.commit()
+        drifts = store.reconcile_usage()
+        assert drifts == [{"org_id": _ORG_ID, "period_start": period, "ledger": 5, "recomputed": 0}]
+
+    def test_in_sync_reports_nothing(self, store: _Store):
+        run = _run(store)
+        store.complete_run(run.id, success=True)
+        assert store.reconcile_usage() == []

--- a/packages/interloper-db/tests/store/test_runs.py
+++ b/packages/interloper-db/tests/store/test_runs.py
@@ -18,7 +18,7 @@ from sqlalchemy.pool import StaticPool
 from sqlmodel import Session, select
 
 from interloper_db import engine as engine_module
-from interloper_db.models import Backfill, Run, Usage
+from interloper_db.models import Backfill, Quota, Run, Usage
 from interloper_db.store.runs import RunMixin
 
 _ORG_ID = uuid4()
@@ -37,9 +37,8 @@ def store() -> Iterator[RunMixin]:
     def _sqlite_uuid(dbapi_connection: Any, _record: Any) -> None:
         dbapi_connection.create_function("gen_random_uuid", 0, lambda: uuid4().hex)
 
-    Backfill.__table__.create(eng)  # ty: ignore[unresolved-attribute]
-    Run.__table__.create(eng)  # ty: ignore[unresolved-attribute]
-    Usage.__table__.create(eng)  # ty: ignore[unresolved-attribute]  (complete_run settles usage)
+    for model in (Backfill, Run, Quota, Usage):
+        model.__table__.create(eng)  # ty: ignore[unresolved-attribute]
     try:
         mixin = RunMixin()
         mixin._engine = eng

--- a/packages/interloper-scheduler/src/interloper_scheduler/cron.py
+++ b/packages/interloper-scheduler/src/interloper_scheduler/cron.py
@@ -23,6 +23,7 @@ from croniter import croniter
 from interloper.errors import ConfigError
 from interloper_db import Store, stamp_component_state
 from interloper_db.models import Backfill, Component, Run
+from interloper_db.store.quotas import run_quota_status
 from sqlalchemy import or_
 from sqlmodel import Session, select
 
@@ -119,6 +120,20 @@ class CronController(Controller):
                     continue
 
                 self._set_state(session, job, next_run_at=next_run)
+
+                # Quota-exhausted orgs skip run creation but still advance
+                # next_run_at (committed with this session) — otherwise the
+                # blocked job would re-fire every tick forever.
+                committed, limit = run_quota_status(session, job.org_id, self._store.quota_defaults)
+                if limit is not None and committed >= limit:
+                    logger.warning(
+                        "Skipping job '%s' - monthly successful-run quota exhausted (%d/%d) for org %s",
+                        job.name,
+                        committed,
+                        limit,
+                        job.org_id,
+                    )
+                    continue
 
                 # Create runs. The backfill is built inline rather than via
                 # Store.create_backfill: it must commit atomically with the

--- a/packages/interloper-scheduler/src/interloper_scheduler/queue.py
+++ b/packages/interloper-scheduler/src/interloper_scheduler/queue.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import logging
-from uuid import UUID
+from datetime import datetime, timezone
+from uuid import UUID, uuid4
 
 from interloper.telemetry import attributes
 from interloper.telemetry.tracer import meter, tracer
 from interloper_db import Store
-from interloper_db.models import Run
+from interloper_db.models import Backfill, Event, Run
+from interloper_db.store.quotas import try_reserve_run
+from interloper_db.store.runs import cancel_backfill_runs
 from sqlmodel import Session, col, select
 
 from interloper_scheduler.controller import Controller
@@ -74,25 +77,64 @@ class QueueController(Controller):
                 self._store.complete_run(run_id, success=False)
 
     def _claim_next(self) -> UUID | None:
-        """Claim the oldest queued run and mark it dispatched.
+        """Claim the oldest queued run, reserve its quota slot, and mark it dispatched.
+
+        This is the authoritative run-quota gate: dispatch requires an atomic
+        reservation, so an exhausted organisation can never execute past its
+        limit. Denied runs are canceled (their whole backfill with them) and
+        the loop moves on to the next queued run — canceling rather than
+        skipping keeps an exhausted org from head-of-line-blocking the queue.
 
         Returns:
             The claimed run id, or ``None`` when the queue is empty.
         """
-        with Session(self._store.engine) as session:
-            statement = (
-                select(Run)
-                .where(Run.status == "queued")
-                .order_by(col(Run.created_at).asc())
-                .limit(1)
-                .with_for_update(skip_locked=True)
-            )
-            run = session.exec(statement).first()
-            if not run or not run.id:
-                return None
+        while True:
+            with Session(self._store.engine) as session:
+                statement = (
+                    select(Run)
+                    .where(Run.status == "queued")
+                    .order_by(col(Run.created_at).asc())
+                    .limit(1)
+                    .with_for_update(skip_locked=True)
+                )
+                run = session.exec(statement).first()
+                if not run or not run.id:
+                    return None
 
-            run.status = "dispatched"
-            session.add(run)
-            session.commit()
-            logger.info("Dispatched run %s", run.id)
-            return run.id
+                if try_reserve_run(session, run, self._store.quota_defaults):
+                    run.status = "dispatched"
+                    session.add(run)
+                    session.commit()
+                    logger.info("Dispatched run %s", run.id)
+                    return run.id
+
+                self._cancel_over_quota(session, run)
+                session.commit()
+                logger.warning(
+                    "Canceled run %s: monthly successful-run quota exhausted for org %s", run.id, run.org_id
+                )
+
+    @staticmethod
+    def _cancel_over_quota(session: Session, run: Run) -> None:
+        """Cancel a quota-denied run (and its backfill), with an explanatory event.
+
+        A canceled run is never claimed again, so the event cannot double-write.
+        """
+        run.status = "canceled"
+        session.add(run)
+        if run.backfill_id:
+            backfill = session.get(Backfill, run.backfill_id)
+            if backfill and backfill.status in ("running", "queued"):
+                cancel_backfill_runs(session, backfill)
+        session.add(
+            Event(
+                id=uuid4(),
+                org_id=run.org_id,
+                run_id=run.id,
+                component_id=run.component_id,
+                event_type="log",
+                level="warning",
+                message="Run canceled: the organisation's monthly successful-run quota is exhausted",
+                timestamp=datetime.now(timezone.utc),
+            )
+        )

--- a/packages/interloper-scheduler/src/interloper_scheduler/reaper.py
+++ b/packages/interloper-scheduler/src/interloper_scheduler/reaper.py
@@ -76,12 +76,42 @@ class Reaper(Controller):
         self._store = store
         self._launcher = launcher
         self._timeout = timeout
+        # Usage reconciliation rides the reaper's loop (the singleton
+        # housekeeping process) roughly hourly.
+        self._reconcile_every = max(1, 3600 // max(1, poll_interval))
+        self._ticks_since_reconcile = self._reconcile_every  # reconcile on first tick
 
     def _tick(self) -> None:
         """Scan once and log when anything was reaped."""
         reaped = self._reap()
         if reaped:
             logger.info("Reaped %d dispatched run(s)", reaped)
+
+        self._ticks_since_reconcile += 1
+        if self._ticks_since_reconcile >= self._reconcile_every:
+            self._ticks_since_reconcile = 0
+            self._reconcile_usage()
+
+    def _reconcile_usage(self) -> None:
+        """Warn when the usage ledger drifts from the runs table.
+
+        Advisory only — nothing is corrected automatically. Transient
+        off-by-ones can appear while runs are completing; drift that
+        persists across cycles is a bug in the charging path.
+        """
+        try:
+            drifts = self._store.reconcile_usage()
+        except Exception:
+            logger.exception("Usage reconciliation failed")
+            return
+        for drift in drifts:
+            logger.warning(
+                "Usage ledger drift for org %s (period %s): ledger=%d, runs table=%d",
+                drift["org_id"],
+                drift["period_start"],
+                drift["ledger"],
+                drift["recomputed"],
+            )
 
     def _reap(self) -> int:
         """Scan dispatched runs and reap any that have terminated.

--- a/packages/interloper-scheduler/tests/test_cron.py
+++ b/packages/interloper-scheduler/tests/test_cron.py
@@ -17,7 +17,7 @@ import pytest
 from interloper.errors import ConfigError
 from interloper_db import Store
 from interloper_db import engine as engine_module
-from interloper_db.models import Backfill, Component, ComponentRelation, Run
+from interloper_db.models import Backfill, Component, ComponentRelation, Quota, Run, Usage
 from sqlalchemy import event
 from sqlalchemy.pool import StaticPool
 from sqlmodel import Session, select
@@ -40,7 +40,7 @@ def store() -> Iterator[Store]:
     def _sqlite_uuid(dbapi_connection: Any, _record: Any) -> None:
         dbapi_connection.create_function("gen_random_uuid", 0, lambda: uuid4().hex)
 
-    for model in (Component, ComponentRelation, Run, Backfill):
+    for model in (Component, ComponentRelation, Run, Backfill, Quota, Usage):
         model.__table__.create(eng)  # ty: ignore[unresolved-attribute]
     try:
         yield Store(catalog=il.Catalog(components={}))
@@ -134,3 +134,27 @@ class TestConfig:
     def test_delay_must_cover_the_reconcile_interval(self, store: Store) -> None:
         with pytest.raises(ConfigError, match="max_execution_delay"):
             CronController(store=store, reconcile_interval=10, max_execution_delay=5)
+
+
+class TestRunQuota:
+    def test_exhausted_org_skips_run_but_advances_schedule(self, store: Store) -> None:
+        from types import SimpleNamespace
+
+        from interloper_db.store.quotas import METRIC_SUCCESSFUL_RUNS, db_now, increment_usage, month_start
+
+        store._quota_defaults = SimpleNamespace(max_successful_runs_per_month=1)
+        with Session(store.engine) as session:
+            increment_usage(session, _ORG, METRIC_SUCCESSFUL_RUNS, month_start(db_now(session)), used=1)
+            session.commit()
+
+        now = dt.datetime.now(dt.timezone.utc)
+        job_id = _job(
+            store,
+            config={"cron": "0 * * * *", "enabled": True},
+            state={"next_run_at": now.isoformat()},
+        )
+        CronController(store=store)._tick()
+
+        assert _runs(store) == []
+        # The schedule still advances so the job doesn't re-fire every tick.
+        assert _state(store, job_id)["next_run_at"] > now.isoformat()

--- a/packages/interloper-scheduler/tests/test_hooks.py
+++ b/packages/interloper-scheduler/tests/test_hooks.py
@@ -16,7 +16,7 @@ import pytest
 from interloper_assets.demo.source import DemoSource, demo_asset
 from interloper_db import Store
 from interloper_db import engine as engine_module
-from interloper_db.models import Component, ComponentRelation, Run
+from interloper_db.models import Component, ComponentRelation, Quota, Run, Usage
 from interloper_db.models import Event as EventRow
 from interloper_db.store.runs import _event_values
 from sqlalchemy import event
@@ -42,7 +42,7 @@ def store(monkeypatch: pytest.MonkeyPatch) -> Iterator[Store]:
     def _sqlite_uuid(dbapi_connection: Any, _record: Any) -> None:
         dbapi_connection.create_function("gen_random_uuid", 0, lambda: uuid4().hex)
 
-    for model in (Component, ComponentRelation, Run, EventRow):
+    for model in (Component, ComponentRelation, Run, EventRow, Quota, Usage):
         model.__table__.create(eng)  # ty: ignore[unresolved-attribute]
 
     store = Store(catalog=il.Catalog.from_assets([DemoSource, demo_asset]))

--- a/packages/interloper-scheduler/tests/test_queue.py
+++ b/packages/interloper-scheduler/tests/test_queue.py
@@ -11,7 +11,7 @@ import interloper as il
 import pytest
 from interloper_db import Store
 from interloper_db import engine as engine_module
-from interloper_db.models import Backfill, Component, ComponentRelation, Run
+from interloper_db.models import Backfill, Component, ComponentRelation, Event, Quota, Run, Usage
 from sqlalchemy import event
 from sqlalchemy.pool import StaticPool
 from sqlmodel import Session, select
@@ -46,7 +46,7 @@ def store() -> Iterator[Store]:
     def _sqlite_uuid(dbapi_connection: Any, _record: Any) -> None:
         dbapi_connection.create_function("gen_random_uuid", 0, lambda: uuid4().hex)
 
-    for model in (Component, ComponentRelation, Run, Backfill):
+    for model in (Component, ComponentRelation, Run, Backfill, Event, Quota, Usage):
         model.__table__.create(eng)  # ty: ignore[unresolved-attribute]
     try:
         yield Store(catalog=il.Catalog(components={}))
@@ -114,3 +114,88 @@ def test_launch_emits_a_span_per_claimed_run(store: Store, span_exporter: Any) -
 def test_empty_tick_emits_no_launch_spans(store: Store, span_exporter: Any) -> None:
     QueueController(launcher=_FakeLauncher(), store=store)._tick()
     assert not [s for s in span_exporter.get_finished_spans() if s.name == "interloper.launcher.launch"]
+
+
+# -- Run quota at dispatch ------------------------------------------------------
+
+
+def _exhaust_quota(store: Store, limit: int = 1) -> None:
+    """Give the org a limit and a ledger already at it."""
+    from types import SimpleNamespace
+
+    from interloper_db.store.quotas import METRIC_SUCCESSFUL_RUNS, db_now, increment_usage, month_start
+
+    store._quota_defaults = SimpleNamespace(max_successful_runs_per_month=limit)
+    with Session(store.engine) as session:
+        increment_usage(session, _ORG, METRIC_SUCCESSFUL_RUNS, month_start(db_now(session)), used=limit)
+        session.commit()
+
+
+def test_dispatch_reserves_a_quota_slot(store: Store) -> None:
+    from types import SimpleNamespace
+
+    from interloper_db.models import Usage
+
+    store._quota_defaults = SimpleNamespace(max_successful_runs_per_month=5)
+    run = store.create_run(_ORG)
+    launcher = _FakeLauncher()
+
+    QueueController(launcher=launcher, store=store)._tick()
+
+    assert launcher.launched == [run.id]
+    with Session(store.engine) as session:
+        dispatched = session.get(Run, run.id)
+        assert dispatched is not None and dispatched.quota_reserved_at is not None
+        usage = session.exec(select(Usage)).one()
+        assert (usage.used, usage.reserved) == (0, 1)
+
+
+def test_quota_denied_claim_cancels_instead_of_blocking(store: Store) -> None:
+    first = store.create_run(_ORG)
+    second = store.create_run(_ORG)
+    _exhaust_quota(store)
+    launcher = _FakeLauncher()
+
+    QueueController(launcher=launcher, store=store)._tick()
+
+    assert launcher.launched == []
+    statuses = _statuses(store)
+    assert statuses[first.id] == "canceled"
+    assert statuses[second.id] == "canceled"
+    with Session(store.engine) as session:
+        from interloper_db.models import Event
+
+        messages = [e.message for e in session.exec(select(Event)).all()]
+    assert len(messages) == 2 and all(m and "quota" in m for m in messages)
+
+
+def test_quota_denied_backfill_run_cancels_the_whole_backfill(store: Store) -> None:
+    backfill = store.create_backfill(
+        _ORG,
+        start_date=dt.date(2026, 1, 1),
+        end_date=dt.date(2026, 1, 3),
+        concurrency=1,
+    )
+    _exhaust_quota(store)
+    launcher = _FakeLauncher()
+
+    QueueController(launcher=launcher, store=store)._tick()
+
+    assert launcher.launched == []
+    assert set(_statuses(store).values()) == {"canceled"}
+    refreshed = store.get_backfill(backfill.id)
+    assert refreshed.status == "canceled"
+    assert refreshed.completed_at is not None
+
+
+def test_unlimited_org_dispatches_without_touching_the_ledger(store: Store) -> None:
+    from interloper_db.models import Usage
+
+    run = store.create_run(_ORG)
+    launcher = _FakeLauncher()
+
+    QueueController(launcher=launcher, store=store)._tick()
+
+    assert launcher.launched == [run.id]
+    with Session(store.engine) as session:
+        assert session.exec(select(Usage)).all() == []

--- a/packages/interloper-scheduler/tests/test_reaper.py
+++ b/packages/interloper-scheduler/tests/test_reaper.py
@@ -11,7 +11,7 @@ import interloper as il
 import pytest
 from interloper_db import Store
 from interloper_db import engine as engine_module
-from interloper_db.models import Backfill, Component, ComponentRelation, Run
+from interloper_db.models import Backfill, Component, ComponentRelation, Quota, Run, Usage
 from interloper_db.models import Event as EventRow
 from interloper_db.store.runs import _event_values
 from sqlalchemy import event
@@ -50,7 +50,7 @@ def store(monkeypatch: pytest.MonkeyPatch) -> Iterator[Store]:
     def _sqlite_uuid(dbapi_connection: Any, _record: Any) -> None:
         dbapi_connection.create_function("gen_random_uuid", 0, lambda: uuid4().hex)
 
-    for model in (Component, ComponentRelation, Run, Backfill, EventRow):
+    for model in (Component, ComponentRelation, Run, Backfill, EventRow, Quota, Usage):
         model.__table__.create(eng)  # ty: ignore[unresolved-attribute]
 
     store = Store(catalog=il.Catalog(components={}))


### PR DESCRIPTION
## What

PR 3 of the org-quota plan: the metered quotas become hard limits. Enforcement is layered so every path is covered, with the store as the authority and the DB doing the atomic work. Everything short-circuits without touching the DB when no limit is configured — the meter-first rollout stays zero-cost until defaults get values.

### Capacity quotas (sources, assets per source)
Checked inside the creating store transaction under `SELECT FOR UPDATE` on the org's `quotas` row (lazily upserted), closing the count-then-insert race — the same shape `_check_source_collision` is exposed to. The asset check gates the *desired final child set* declaratively, covering create-with-all, explicit growth, and updates.

### Run quota (three gates + settle)
1. **Creation** (`create_run` / `retry_run` / `create_backfill` — covers API, agent tools, hook triggers): reject once `used + reserved` reaches the limit. Advisory fail-fast.
2. **Cron**: exhausted orgs skip run creation but `next_run_at` still advances in the same transaction (mirrors the too-late branch) — no per-tick re-fires.
3. **Dispatch — authoritative**: `_claim_next` atomically reserves a slot (conditional upsert `used + reserved < limit`, rowcount tells admission) and stamps `runs.quota_reserved_at`. Denied runs are **canceled with an explanatory event — their whole backfill with them** (reusing the cancel machinery from #236), and the claim loop moves to the next run, so an exhausted org can't head-of-line-block other orgs. Unlimited orgs never touch the ledger.
4. **Settlement** (from #237): success converts the reservation to `used`, failure releases it — each in the month it belongs to, correct across boundaries. Crashed runs release via the reaper's terminal path. Hard invariant: `used + reserved ≤ limit`, zero overshoot.

### Surfaces
- `QuotaExceededError` → **HTTP 429** with `{message, quota, limit, used}` (app-level handler; frontend `errorDetail` already renders it).
- The reaper reconciles ledger vs runs table hourly and warns on drift (advisory; transient off-by-ones documented).
- Global `max_backfill_days` cap (`INTERLOPER_QUOTA_MAX_BACKFILL_DAYS`) bounds the one-request run-amplification hole (400 at the API).

### Deliberately not here
The agent's `trigger_run`/`trigger_backfill` role check: ADK session state carries only `org_id`, no user identity — plumbing that through the agent session flow is its own change (Jira follow-up). The quota gates themselves do cover agent-triggered runs.

## Verified

- Full suite green (1321 tests). New coverage: capacity gates (limit, override-wins, declarative asset set, unconfigured = untouched), all three run gates, span cap, reserve success/denial/zero-limit/unlimited, backfill cancel cascade at claim, cron skip-and-advance, reconcile drift both ways, 429 shape.
- PG-specific semantics verified against a real Postgres (throwaway DB): fresh-insert reserve, conditional-update reserve, rowcount-0 denial at limit, settle both ways, locked override-over-default resolution.

By Digitl