### PR TITLE
feat: administer per-organisation quota limits

### DIFF
--- a/packages/interloper-api/src/interloper_api/routes/admin.py
+++ b/packages/interloper-api/src/interloper_api/routes/admin.py
@@ -19,7 +19,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Request
 from interloper_db import Organisation, Profile, Store
 from interloper_db.store.quotas import METRIC_SUCCESSFUL_RUNS
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from interloper_api.dependencies import get_admin_config, get_quota_defaults, get_store, require_super_admin
 from interloper_api.email import send_invite_email
@@ -255,6 +255,14 @@ class AdminQuotasResponse(BaseModel):
     period_start: dt.date
     defaults: AdminQuotaLimits
     organisations: list[AdminOrgQuotaStatus]
+
+
+class AdminQuotaUpdateRequest(BaseModel):
+    """Per-org quota overrides. Omitted fields keep their value; null clears one."""
+
+    max_sources: int | None = Field(default=None, ge=0)
+    max_assets_per_source: int | None = Field(default=None, ge=0)
+    max_successful_runs_per_month: int | None = Field(default=None, ge=0)
 
 
 class AdminConfigResponse(BaseModel):
@@ -568,6 +576,19 @@ def get_quotas(
             )
         )
     return AdminQuotasResponse(period_start=period_start, defaults=defaults, organisations=organisations)
+
+
+@router.patch("/organisations/{org_id}/quota")
+def update_org_quota(
+    org_id: UUID,
+    body: AdminQuotaUpdateRequest,
+    user: Profile = Depends(require_super_admin),
+    store: Store = Depends(get_store),
+) -> AdminQuotaLimits:
+    """Set an organisation's quota overrides; omitted fields keep their value, null clears one."""
+    _require_org(store, org_id)
+    quota = store.set_quota(org_id, body.model_dump(exclude_unset=True))
+    return _quota_limits(quota)
 
 
 # -- Users --------------------------------------------------------------------

--- a/packages/interloper-api/tests/test_admin.py
+++ b/packages/interloper-api/tests/test_admin.py
@@ -35,6 +35,7 @@ class FakeStore:
         self.already_member = False
         self.deleted_profiles: list[UUID] = []
         self.deleted_organisations: list[UUID] = []
+        self.quota_updates: list[tuple[UUID, dict]] = []
 
     def delete_profile(self, user_id: UUID) -> None:
         self.deleted_profiles.append(user_id)
@@ -142,6 +143,14 @@ class FakeStore:
 
     def count_successful_runs_by_org(self, period_start):
         return {self.org.id: 8}
+
+    def set_quota(self, org_id: UUID, limits: dict):
+        self.quota_updates.append((org_id, limits))
+        return SimpleNamespace(
+            max_sources=limits.get("max_sources"),
+            max_assets_per_source=limits.get("max_assets_per_source"),
+            max_successful_runs_per_month=limits.get("max_successful_runs_per_month"),
+        )
 
 
 def _profile(*, is_super_admin: bool):
@@ -466,3 +475,31 @@ def test_invite_into_any_org(store: FakeStore) -> None:
     )
     assert resp.status_code == 201
     assert store.created_invites[0]["email"] == "x@acme.test"
+
+
+def test_non_super_admin_cannot_update_quota(store: FakeStore) -> None:
+    resp = _client(store, is_super_admin=False).patch(f"/admin/organisations/{uuid4()}/quota", json={})
+    assert resp.status_code == 403
+
+
+def test_update_quota_passes_only_provided_fields(store: FakeStore) -> None:
+    resp = _client(store, is_super_admin=True).patch(
+        f"/admin/organisations/{store.org.id}/quota",
+        json={"max_sources": 5, "max_successful_runs_per_month": None},
+    )
+    assert resp.status_code == 200
+    assert store.quota_updates == [
+        (store.org.id, {"max_sources": 5, "max_successful_runs_per_month": None})
+    ]
+    body = resp.json()
+    assert body["max_sources"] == 5
+    assert body["max_successful_runs_per_month"] is None
+
+
+def test_update_quota_rejects_negative_limits(store: FakeStore) -> None:
+    resp = _client(store, is_super_admin=True).patch(
+        f"/admin/organisations/{store.org.id}/quota",
+        json={"max_sources": -1},
+    )
+    assert resp.status_code == 422
+    assert store.quota_updates == []

--- a/packages/interloper-app/app/app/pages/admin/quotas.vue
+++ b/packages/interloper-app/app/app/pages/admin/quotas.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { h, resolveComponent } from 'vue'
-import type { TableColumn } from '@nuxt/ui'
+import type { TableColumn, DropdownMenuItem } from '@nuxt/ui'
 import type { AdminOrgQuotaStatus, AdminQuotas } from '~/types/admin'
 
 definePageMeta({
@@ -9,18 +9,19 @@ definePageMeta({
     middleware: 'super-admin',
     pageHeader: {
         title: 'Quotas',
-        description: 'Per-organisation limits and current-period usage. Limits are read-only for now; defaults come from the instance configuration.',
+        description: 'Per-organisation limits and current-period usage. Empty limits inherit the instance defaults.',
     },
 })
 
 const UBadge = resolveComponent('UBadge')
 
 const adminStore = useAdminStore()
+const toast = useToast()
 
 const quotas = ref<AdminQuotas | null>(null)
 const loading = ref(true)
 
-onMounted(async () => {
+async function loadData() {
     try {
         quotas.value = await adminStore.getQuotas()
     }
@@ -30,7 +31,75 @@ onMounted(async () => {
     finally {
         loading.value = false
     }
-})
+}
+
+onMounted(loadData)
+
+// Edit modal state — string-typed fields so an emptied input means "inherit".
+const editOpen = ref(false)
+const editTarget = ref<AdminOrgQuotaStatus | null>(null)
+const editForm = ref({ max_sources: '', max_assets_per_source: '', max_successful_runs_per_month: '' })
+const saving = ref(false)
+
+const LIMIT_FIELDS = [
+    { key: 'max_sources', label: 'Max sources' },
+    { key: 'max_assets_per_source', label: 'Max assets per source' },
+    { key: 'max_successful_runs_per_month', label: 'Max successful runs / month' },
+] as const
+
+function defaultPlaceholder(key: keyof typeof editForm.value): string {
+    const value = quotas.value?.defaults[key]
+    return value != null ? `default: ${value}` : 'default: unlimited'
+}
+
+function openEdit(org: AdminOrgQuotaStatus) {
+    editTarget.value = org
+    editForm.value = {
+        max_sources: org.limits.max_sources?.toString() ?? '',
+        max_assets_per_source: org.limits.max_assets_per_source?.toString() ?? '',
+        max_successful_runs_per_month: org.limits.max_successful_runs_per_month?.toString() ?? '',
+    }
+    editOpen.value = true
+}
+
+async function submitEdit() {
+    const target = editTarget.value
+    if (!target) return
+
+    saving.value = true
+    try {
+        await adminStore.updateOrgQuota(target.id, {
+            max_sources: editForm.value.max_sources === '' ? null : Number(editForm.value.max_sources),
+            max_assets_per_source: editForm.value.max_assets_per_source === ''
+                ? null
+                : Number(editForm.value.max_assets_per_source),
+            max_successful_runs_per_month: editForm.value.max_successful_runs_per_month === ''
+                ? null
+                : Number(editForm.value.max_successful_runs_per_month),
+        })
+        toast.add({ title: `Quota limits updated for ${target.name}`, color: 'success' })
+        editOpen.value = false
+        await loadData()
+    }
+    catch (err) {
+        toast.add(errorToast(err, 'Failed to update quota limits'))
+    }
+    finally {
+        saving.value = false
+    }
+}
+
+function rowActions(org: AdminOrgQuotaStatus): DropdownMenuItem[][] {
+    return [
+        [
+            {
+                label: 'Edit limits',
+                icon: 'i-lucide-pencil',
+                onSelect: () => openEdit(org),
+            },
+        ],
+    ]
+}
 
 const rows = computed(() => quotas.value?.organisations ?? [])
 
@@ -117,7 +186,41 @@ const columns: TableColumn<AdminOrgQuotaStatus>[] = [
         <DataTable :columns="columns"
                    :data="rows"
                    :loading="loading"
+                   :row-actions="rowActions"
                    no-actions
-                   search-placeholder="Search organisations..." />
+                   search-placeholder="Search organisations..."
+                   @edit="openEdit" />
+
+        <UModal v-model:open="editOpen"
+                :title="`Quota limits — ${editTarget?.name}`"
+                :ui="{ footer: 'justify-end' }">
+            <template #body>
+                <div class="flex flex-col gap-3">
+                    <p class="text-sm text-muted">
+                        Overrides for this organisation. Leave a field empty to inherit the instance default.
+                    </p>
+                    <UFormField v-for="field in LIMIT_FIELDS"
+                                :key="field.key"
+                                :label="field.label">
+                        <UInput v-model="editForm[field.key]"
+                                type="number"
+                                min="0"
+                                :placeholder="defaultPlaceholder(field.key)"
+                                class="w-full"
+                                @keydown.enter="submitEdit" />
+                    </UFormField>
+                </div>
+            </template>
+            <template #footer>
+                <UButton label="Cancel"
+                         color="neutral"
+                         variant="outline"
+                         @click="editOpen = false" />
+                <UButton label="Save"
+                         :disabled="saving"
+                         :loading="saving"
+                         @click="submitEdit" />
+            </template>
+        </UModal>
     </div>
 </template>

--- a/packages/interloper-app/app/app/stores/admin.ts
+++ b/packages/interloper-app/app/app/stores/admin.ts
@@ -1,4 +1,4 @@
-import type { AdminConfig, AdminOrganisation, AdminQuotas, AdminUser } from '~/types/admin'
+import type { AdminConfig, AdminOrganisation, AdminQuotaLimits, AdminQuotas, AdminUser } from '~/types/admin'
 
 interface MemberResponse {
     id: string
@@ -26,6 +26,14 @@ export const useAdminStore = defineStore('admin', () => {
 
     function getQuotas() {
         return apiFetch<AdminQuotas>('/admin/quotas')
+    }
+
+    /** Set an org's quota overrides; null clears a field (falls back to the default). */
+    function updateOrgQuota(orgId: string, limits: AdminQuotaLimits) {
+        return apiFetch<AdminQuotaLimits>(`/admin/organisations/${orgId}/quota`, {
+            method: 'PATCH',
+            body: limits,
+        })
     }
 
     function listUsers() {
@@ -106,6 +114,7 @@ export const useAdminStore = defineStore('admin', () => {
     return {
         getConfig,
         getQuotas,
+        updateOrgQuota,
         listUsers,
         deleteUser,
         listOrganisations,

--- a/packages/interloper-db/src/interloper_db/store/quotas.py
+++ b/packages/interloper-db/src/interloper_db/store/quotas.py
@@ -281,6 +281,28 @@ class QuotaMixin(StoreBase):
         with self._session() as session:
             return list(session.exec(select(Quota)).all())
 
+    def set_quota(self, org_id: UUID, limits: dict[str, int | None]) -> Quota:
+        """Set an organisation's quota overrides; only the given fields change.
+
+        ``None`` clears a field so it falls back to the global default.
+
+        Raises:
+            ValueError: On an unknown limit field or a negative value.
+        """
+        allowed = {"max_sources", "max_assets_per_source", "max_successful_runs_per_month"}
+        if unknown := set(limits) - allowed:
+            raise ValueError(f"Unknown quota limit(s): {sorted(unknown)}")
+        if negative := {field for field, value in limits.items() if value is not None and value < 0}:
+            raise ValueError(f"Quota limit(s) must be >= 0: {sorted(negative)}")
+        with self._session() as session:
+            quota = session.get(Quota, org_id) or Quota(org_id=org_id)
+            for field, value in limits.items():
+                setattr(quota, field, value)
+            session.add(quota)
+            session.commit()
+            session.refresh(quota)
+            return quota
+
     def list_usage(self, *, period_start: dt.date | None = None, org_id: UUID | None = None) -> list[Usage]:
         """Usage ledger rows, optionally filtered by period and organisation."""
         with self._session() as session:

--- a/packages/interloper-db/tests/store/test_quotas.py
+++ b/packages/interloper-db/tests/store/test_quotas.py
@@ -325,3 +325,23 @@ class TestReconcileUsage:
         run = _run(store)
         store.complete_run(run.id, success=True)
         assert store.reconcile_usage() == []
+
+
+class TestSetQuota:
+    def test_creates_then_partially_updates(self, store: _Store):
+        quota = store.set_quota(_ORG_ID, {"max_sources": 5})
+        assert (quota.max_sources, quota.max_successful_runs_per_month) == (5, None)
+
+        quota = store.set_quota(_ORG_ID, {"max_successful_runs_per_month": 100})
+        assert (quota.max_sources, quota.max_successful_runs_per_month) == (5, 100)
+
+    def test_none_clears_an_override(self, store: _Store):
+        store.set_quota(_ORG_ID, {"max_sources": 5})
+        quota = store.set_quota(_ORG_ID, {"max_sources": None})
+        assert quota.max_sources is None
+
+    def test_rejects_unknown_and_negative(self, store: _Store):
+        with pytest.raises(ValueError, match="Unknown quota limit"):
+            store.set_quota(_ORG_ID, {"max_bananas": 1})
+        with pytest.raises(ValueError, match=">= 0"):
+            store.set_quota(_ORG_ID, {"max_sources": -1})


### PR DESCRIPTION
## What

PR 4 of the org-quota plan: per-org limits become editable.

- **Store**: `set_quota(org_id, limits)` — partial update, `None` clears a field back to the instance default; validates field names and non-negativity.
- **API**: `PATCH /admin/organisations/{org_id}/quota` (super-admin) with true PATCH semantics via `exclude_unset` — omitted fields untouched, explicit null clears. `ge=0` validation at the model.
- **App**: clicking a row on the admin Quotas page opens an edit modal (also in the row context menu). Empty inputs inherit the instance defaults, which are shown as placeholders (`default: 25` / `default: unlimited`); the overview reloads with the new effective limits and override chips.

## Verified live (dev instance)

Set `max_sources=4` on Dev Org through the modal: success toast, override chip, usage column switches to `1 / 4`; cleared the field and the override dropped back to inherit (quotas row confirmed all-null in the DB afterwards). Session and fixtures cleaned up.

## Tests

- Store: create-then-partial-update, null-clears, unknown/negative rejection.
- API: super-admin gate, `exclude_unset` pass-through (provided null vs omitted), 422 on negative.

With this, the rollout lever is complete: set `INTERLOPER_QUOTA_*` defaults when metering has been observed, and tune individual orgs from the UI. Remaining from the plan: PR 5 (org soft-deletion protecting the ledger).

By Digitl