### PR TITLE
feat!: soft-delete organisations, keeping the billing ledger

### DIFF
--- a/packages/interloper-api/src/interloper_api/routes/admin.py
+++ b/packages/interloper-api/src/interloper_api/routes/admin.py
@@ -41,6 +41,9 @@ class AdminOrganisationResponse(BaseModel):
     name: str
     member_count: int
     created_at: datetime | None = None
+    #: Soft-deleted orgs stay listed (their retained history and ledger are
+    #: still attributable) but are no longer manageable.
+    deleted_at: datetime | None = None
 
 
 class AdminUserOrganisation(BaseModel):
@@ -635,13 +638,14 @@ def list_all_organisations(
     user: Profile = Depends(require_super_admin),
     store: Store = Depends(get_store),
 ) -> list[AdminOrganisationResponse]:
-    """List every organisation with its member count."""
+    """List every organisation with its member count, soft-deleted ones included."""
     return [
         AdminOrganisationResponse(
             id=org.id,
             name=org.name,
             member_count=count,
             created_at=org.created_at,
+            deleted_at=org.deleted_at,
         )
         for org, count in store.list_all_organisations()
     ]
@@ -688,7 +692,11 @@ def delete_organisation(
     user: Profile = Depends(require_super_admin),
     store: Store = Depends(get_store),
 ) -> dict[str, str]:
-    """Delete an organisation and all its data. The body must repeat the exact name."""
+    """Soft-delete an organisation: purges its data, keeps execution history and the usage ledger.
+
+    The body must repeat the exact name. Deleted organisations stay in the
+    list (read-only) and read as missing everywhere else.
+    """
     org = _require_org(store, org_id)
     if body.name != org.name:
         raise HTTPException(status_code=400, detail="Organisation name does not match")

--- a/packages/interloper-api/tests/test_admin.py
+++ b/packages/interloper-api/tests/test_admin.py
@@ -24,7 +24,7 @@ class FakeStore:
     """In-memory stand-in implementing only the methods admin routes call."""
 
     def __init__(self) -> None:
-        self.org = SimpleNamespace(id=uuid4(), name="Acme", created_at=datetime.now(timezone.utc))
+        self.org = SimpleNamespace(id=uuid4(), name="Acme", created_at=datetime.now(timezone.utc), deleted_at=None)
         self.member = SimpleNamespace(
             id=uuid4(), email="member@acme.test", name="Member", avatar_url=None
         )
@@ -502,4 +502,19 @@ def test_update_quota_rejects_negative_limits(store: FakeStore) -> None:
         json={"max_sources": -1},
     )
     assert resp.status_code == 422
+    assert store.quota_updates == []
+
+
+def test_deleted_org_is_listed_but_not_manageable(store: FakeStore) -> None:
+    """Soft-deleted orgs surface in the list (billing history) but 404 on management routes."""
+    store.org.deleted_at = datetime.now(timezone.utc)
+    store.get_organisation = lambda org_id: None  # ty: ignore[invalid-assignment]  (deleted orgs read as missing)
+    client = _client(store, is_super_admin=True)
+
+    listed = client.get("/admin/organisations")
+    assert listed.status_code == 200
+    assert listed.json()[0]["deleted_at"] is not None
+
+    resp = client.patch(f"/admin/organisations/{store.org.id}/quota", json={"max_sources": 1})
+    assert resp.status_code == 404
     assert store.quota_updates == []

--- a/packages/interloper-app/app/app/pages/admin/organisations/index.vue
+++ b/packages/interloper-app/app/app/pages/admin/organisations/index.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { h, resolveComponent } from 'vue'
 import type { TableColumn, DropdownMenuItem } from '@nuxt/ui'
 import type { AdminOrganisation } from '~/types/admin'
 
@@ -7,6 +8,8 @@ definePageMeta({
     layout: 'admin',
     middleware: 'super-admin',
 })
+
+const UBadge = resolveComponent('UBadge')
 
 const adminStore = useAdminStore()
 const toast = useToast()
@@ -105,10 +108,12 @@ async function submitForm() {
 }
 
 function openOrg(org: AdminOrganisation) {
+    if (org.deleted_at) return
     navigateTo(`/admin/organisations/${org.id}`)
 }
 
 function rowActions(org: AdminOrganisation): DropdownMenuItem[][] {
+    if (org.deleted_at) return []
     return [
         [
             {
@@ -137,6 +142,14 @@ const columns: TableColumn<AdminOrganisation>[] = [
     {
         accessorKey: 'name',
         header: 'Name',
+        cell: ({ row }) => {
+            const org = row.original
+            if (!org.deleted_at) return org.name
+            return h('div', { class: 'flex items-center gap-2' }, [
+                h('span', { class: 'text-dimmed line-through' }, org.name),
+                h(UBadge, { label: 'Deleted', color: 'neutral', variant: 'subtle', size: 'sm' }),
+            ])
+        },
     },
     {
         accessorKey: 'member_count',

--- a/packages/interloper-app/app/app/types/admin.ts
+++ b/packages/interloper-app/app/app/types/admin.ts
@@ -3,6 +3,8 @@ export interface AdminOrganisation {
     name: string
     member_count: number
     created_at: string | null
+    /** Soft-deleted orgs stay listed for billing history but are read-only. */
+    deleted_at: string | null
 }
 
 export interface AdminUserOrganisation {

--- a/packages/interloper-db/src/interloper_db/migrations/versions/008_org_soft_delete.py
+++ b/packages/interloper-db/src/interloper_db/migrations/versions/008_org_soft_delete.py
@@ -1,0 +1,30 @@
+"""Soft-delete marker for organisations.
+
+``create_all()`` provisions the column on fresh databases; this migration
+adds it to existing ones (``create_all`` never alters a table). Idempotent.
+
+Revision ID: 008
+Revises: 007
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "008"
+down_revision: str | None = "007"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    columns = {column["name"] for column in sa.inspect(bind).get_columns("organisations")}
+    if "deleted_at" not in columns:
+        op.add_column("organisations", sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("organisations", "deleted_at")

--- a/packages/interloper-db/src/interloper_db/models.py
+++ b/packages/interloper-db/src/interloper_db/models.py
@@ -68,7 +68,13 @@ class Profile(SQLModel, table=True):
 
 
 class Organisation(SQLModel, table=True):
-    """A tenant organisation."""
+    """A tenant organisation.
+
+    Deletion is soft (``deleted_at``): the row survives so retained
+    execution history and the usage ledger stay attributable for billing,
+    while the org's sensitive payload (components, tokens, memberships)
+    is purged.
+    """
 
     __tablename__: ClassVar[str] = "organisations"
 
@@ -78,6 +84,7 @@ class Organisation(SQLModel, table=True):
         sa_column_kwargs={"server_default": text("gen_random_uuid()")},
     )
     name: str
+    deleted_at: datetime | None = SQLField(default=None, sa_column=Column(TZDateTime))
     created_at: datetime | None = _ts()
 
 

--- a/packages/interloper-db/src/interloper_db/store/auth.py
+++ b/packages/interloper-db/src/interloper_db/store/auth.py
@@ -13,16 +13,13 @@ from sqlmodel import Session, select
 
 from interloper_db.models import (
     AuthSession,
-    Backfill,
     Component,
     ComponentRelation,
-    Event,
     Invitation,
     Organisation,
     PersonalAccessToken,
     Profile,
     Quota,
-    Run,
     UserOrganisation,
 )
 from interloper_db.store.base import StoreBase
@@ -344,11 +341,11 @@ class AuthMixin(StoreBase):
             The updated Organisation.
 
         Raises:
-            NotFoundError: If the organisation is not found.
+            NotFoundError: If the organisation is not found or deleted.
         """
         with self._session() as session:
             db_organisation = session.get(Organisation, org_id)
-            if not db_organisation:
+            if not db_organisation or db_organisation.deleted_at is not None:
                 raise NotFoundError(f"Organisation {org_id} not found")
             db_organisation.name = name
             session.add(db_organisation)
@@ -374,37 +371,36 @@ class AuthMixin(StoreBase):
             return [(org, counts.get(org.id, 0)) for org in organisations]
 
     def delete_organisation(self, org_id: UUID) -> None:
-        """Delete an organisation and everything it owns.
+        """Soft-delete an organisation: purge its payload, keep the ledger.
 
-        Removes the org's execution history (events, runs, backfills), its
-        components and their relations, and its tokens, invitations, and
-        memberships. Live sessions and profiles pointing at the org are
-        detached (org reference cleared), not deleted. Bulk statements —
-        ordered children-first — so the cascade never depends on ORM-loaded
-        state. The ``asset_executions`` view follows the events.
+        The org row survives with ``deleted_at`` stamped, and so do its
+        runs, events, and backfills — execution history and the usage
+        ledger must stay attributable for billing, even after the org is
+        gone. Everything sensitive or live is removed: components and
+        their relations (encrypted credentials, client config), tokens,
+        quota overrides, invitations, and memberships; sessions and
+        profiles pointing at the org are detached. Retained runs and
+        backfills lose their component reference via the FK's SET NULL.
+        Bulk statements — ordered children-first — so the cascade never
+        depends on ORM-loaded state.
 
         Args:
             org_id: Organisation UUID.
 
         Raises:
-            NotFoundError: If the organisation is not found.
+            NotFoundError: If the organisation is not found or already deleted.
         """
         with self._session() as session:
             db_organisation = session.get(Organisation, org_id)
-            if not db_organisation:
+            if not db_organisation or db_organisation.deleted_at is not None:
                 raise NotFoundError(f"Organisation {org_id} not found")
 
             # ty misreads SQLModel column comparisons in DML where() as plain bools.
             statements = (
-                delete(Event).where(Event.org_id == org_id),  # ty: ignore[invalid-argument-type]
-                delete(Run).where(Run.org_id == org_id),  # ty: ignore[invalid-argument-type]
-                delete(Backfill).where(Backfill.org_id == org_id),  # ty: ignore[invalid-argument-type]
                 delete(ComponentRelation).where(ComponentRelation.org_id == org_id),  # ty: ignore[invalid-argument-type]
                 delete(Component).where(Component.org_id == org_id),  # ty: ignore[invalid-argument-type]
                 delete(PersonalAccessToken).where(PersonalAccessToken.organisation_id == org_id),  # ty: ignore[invalid-argument-type]
                 delete(Quota).where(Quota.org_id == org_id),  # ty: ignore[invalid-argument-type]
-                # Usage is deliberately NOT deleted: it is the billing ledger
-                # and must survive its organisation.
                 delete(Invitation).where(Invitation.organisation_id == org_id),  # ty: ignore[invalid-argument-type]
                 delete(UserOrganisation).where(UserOrganisation.organisation_id == org_id),  # ty: ignore[invalid-argument-type]
                 update(AuthSession).where(AuthSession.organisation_id == org_id).values(organisation_id=None),  # ty: ignore[invalid-argument-type]
@@ -414,20 +410,25 @@ class AuthMixin(StoreBase):
             for statement in statements:
                 connection.execute(statement)
 
-            session.delete(db_organisation)
+            db_organisation.deleted_at = datetime.now(timezone.utc)
+            session.add(db_organisation)
             session.commit()
 
-    def get_organisation(self, org_id: UUID) -> Organisation | None:
-        """Get an organisation by ID.
+    def get_organisation(self, org_id: UUID, *, include_deleted: bool = False) -> Organisation | None:
+        """Get an organisation by ID; soft-deleted orgs read as missing by default.
 
         Args:
             org_id: Organisation UUID.
+            include_deleted: Also return soft-deleted organisations.
 
         Returns:
             The Organisation or None.
         """
         with self._session() as session:
-            return session.get(Organisation, org_id)
+            organisation = session.get(Organisation, org_id)
+            if organisation and organisation.deleted_at is not None and not include_deleted:
+                return None
+            return organisation
 
     def list_user_organisations(self, user_id: UUID) -> list[Organisation]:
         """List all organisations a user belongs to.

--- a/packages/interloper-db/tests/store/test_auth.py
+++ b/packages/interloper-db/tests/store/test_auth.py
@@ -128,7 +128,7 @@ class TestDeleteOrganisation:
         session.add(Event(org_id=org_id, run_id=run.id, event_type="run_started", timestamp=datetime.now(timezone.utc)))
         session.commit()
 
-    def test_deletes_org_and_everything_it_owns(self, store: Store, auth_db: Engine):
+    def test_purges_payload_but_keeps_the_ledger(self, store: Store, auth_db: Engine):
         admin = store.upsert_profile(google_id="g-admin", email="admin@example.com", name="Admin")
         org = store.create_organisation(name="Doomed", creator_id=admin.id)
         keeper = store.create_organisation(name="Keeper", creator_id=admin.id)
@@ -147,9 +147,13 @@ class TestDeleteOrganisation:
 
         store.delete_organisation(org.id)
 
+        # The org reads as missing everywhere but the row survives, stamped.
         assert store.get_organisation(org.id) is None
+        retained = store.get_organisation(org.id, include_deleted=True)
+        assert retained is not None and retained.deleted_at is not None
         with SQLSession(auth_db) as session:
-            for model in (Component, ComponentRelation, Backfill, Run, Event):
+            # Sensitive payload is purged...
+            for model in (Component, ComponentRelation):
                 assert session.exec(select(model).where(model.org_id == org.id)).first() is None
             assert (
                 session.exec(select(UserOrganisation).where(UserOrganisation.organisation_id == org.id)).first()
@@ -160,6 +164,12 @@ class TestDeleteOrganisation:
                 session.exec(select(PersonalAccessToken).where(PersonalAccessToken.organisation_id == org.id)).first()
                 is None
             )
+            # ...but execution history survives for billing, detached from
+            # the purged components via the FK's SET NULL.
+            surviving_run = session.exec(select(Run).where(Run.org_id == org.id)).one()
+            assert surviving_run.component_id is None
+            assert session.exec(select(Backfill).where(Backfill.org_id == org.id)).first() is not None
+            assert session.exec(select(Event).where(Event.org_id == org.id)).first() is not None
         # The user, their session, and the other organisation survive; org refs are cleared.
         resolved = store.resolve_session(session_token)
         assert resolved is not None
@@ -168,6 +178,14 @@ class TestDeleteOrganisation:
         assert profile.last_organisation_id is None
         assert store.get_organisation(keeper.id) is not None
         assert store.get_user_role(admin.id, keeper.id) == "admin"
+
+    def test_double_delete_reads_as_missing(self, store: Store):
+        org = store.create_organisation(name="Once")
+        store.delete_organisation(org.id)
+        with pytest.raises(NotFoundError):
+            store.delete_organisation(org.id)
+        with pytest.raises(NotFoundError):
+            store.update_organisation(org.id, "Renamed")
 
     def test_missing_organisation_raises(self, store: Store):
         with pytest.raises(NotFoundError):


### PR DESCRIPTION
## What

PR 5 — the final piece of the org-quota plan: **the ledger can no longer be destroyed**. Deleting an organisation stamps `deleted_at` instead of erasing it.

### Retained (billing needs it attributable)
- The `organisations` row itself (name survives for historical usage).
- `runs`, `events`, `backfills` — execution history; retained runs/backfills lose their component reference via the existing FK `SET NULL`.
- `usage` — already delete-proof since #237.

### Still purged (sensitive or live)
- `components` + `component_relations` (Fernet-encrypted credentials, client config — GDPR data minimisation), personal access tokens, quota overrides, invitations, memberships.
- Sessions and profiles pointing at the org are detached, as before.

### Visibility semantics
- `get_organisation` filters soft-deleted orgs by default (`include_deleted=True` opts in), so org resolution (`get_current_org`), admin management routes (`_require_org`), renames, and quota PATCHes all read a deleted org as missing → 404. Double-delete 404s too.
- The one exception: `GET /admin/organisations` keeps deleted orgs listed — read-only, struck through with a **Deleted** badge, row actions and navigation disabled — so the quota overview and billing history keep a name to point at.

Schema: `organisations.deleted_at` via idempotent migration `008` (fresh DBs get it from `create_all`).

BREAKING CHANGE: `DELETE /admin/organisations/{id}` now retains the organisation row and its execution history instead of erasing all data.

## Verified live (dev instance)

Created a throwaway org with a quota override and a seeded ledger row, deleted it via the API: row stamped, ledger row survived, quota override purged, admin list shows it with `deleted_at`, quota PATCH and second delete both 404. Migration 008 applied cleanly on the existing dev DB. Throwaway rows cleaned up.

## Tests

- Store: full retention contract (payload purged / history + ledger kept / refs detached / other org untouched), `include_deleted` read, double-delete + rename-after-delete raise.
- API: deleted org listed with `deleted_at` but 404 on management routes.

This completes the quota plan: metering (#237) → enforcement (#239) → per-org administration (#240) → ledger protection (this PR).

By Digitl