### PR TITLE
refactor(app): trim jobs and hooks empty states

### DIFF
--- a/packages/interloper-app/app/app/pages/hooks.vue
+++ b/packages/interloper-app/app/app/pages/hooks.vue
@@ -122,17 +122,12 @@ async function handleDelete(ids: string[]) {
                 <template #empty>
                     <EmptyState icon="i-carbon-lightning"
                                 title="No hooks yet"
-                                description="A hook reacts to what your pipelines do. Watch a source, asset, or job and trigger downstream runs or notify an external system when runs complete or fail." />
-
-                    <div class="flex items-center gap-3 border border-default rounded-[14px] px-5 py-4 bg-(--ui-bg-band) mt-9">
-                        <div class="flex-1 text-sm text-toned">
-                            Create a hook to react to run outcomes on your components.
-                        </div>
+                                description="A hook reacts to what your pipelines do. Watch a source, asset, or job and trigger downstream runs or notify an external system when runs complete or fail.">
                         <UButton icon="i-lucide-plus"
                                  label="New hook"
-                                 size="md"
+                                 class="mt-5"
                                  @click="handleCreate" />
-                    </div>
+                    </EmptyState>
                 </template>
             </DataTable>
         </div>

--- a/packages/interloper-app/app/app/pages/jobs.vue
+++ b/packages/interloper-app/app/app/pages/jobs.vue
@@ -57,12 +57,6 @@ watchEffect(() => {
     router.replace({ query: { ...route.query, run: undefined } })
 })
 
-/** Onboarding cards shown in the empty state. */
-const SETUP_STEPS = [
-    { to: '/sources', icon: 'i-lucide-plug', title: 'Step 1 · Connect a source', sub: 'Pull from Google Ads, Meta, Bing & more', link: 'Go to Sources' },
-    { to: '/destinations', icon: 'i-lucide-database', title: 'Step 2 · Add a destination', sub: 'Choose where assets are materialized', link: 'Go to Destinations' },
-]
-
 const columns = computed<TableColumn<ComponentRecord>[]>(() => [
     { accessorKey: 'select' as any, header: '' },
     {
@@ -156,57 +150,12 @@ async function handleDelete(ids: string[]) {
                 <template #empty>
                     <EmptyState icon="i-lucide-calendar-clock"
                                 title="No jobs yet"
-                                description="A job is a scheduled pipeline. It runs your sources on a cron schedule and materializes the results into your destination — automatically, with no manual triggering. Every run is recorded under Executions." />
-
-                    <div class="mt-9">
-                        <div class="eyebrow text-primary">
-                            Before your first job
-                        </div>
-                        <h2 class="text-[19px] font-bold tracking-[-0.015em] text-highlighted mt-2">
-                            A job needs something to run
-                        </h2>
-                        <p class="text-[14.5px] text-muted leading-relaxed max-w-[640px] mt-2">
-                            Set up at least one source to pull from and one destination to write to.
-                            Once both exist, you can wire them into a scheduled job.
-                        </p>
-                    </div>
-
-                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-3.5 mt-5">
-                        <NuxtLink v-for="step in SETUP_STEPS"
-                                  :key="step.to"
-                                  :to="step.to"
-                                  class="block border border-default rounded-[14px] p-5 bg-default shadow-xs transition hover:border-primary/40 hover:shadow-md hover:-translate-y-0.5">
-                            <div class="flex items-center gap-3">
-                                <div class="size-[42px] rounded-[11px] bg-primary/10 text-primary flex items-center justify-center">
-                                    <UIcon :name="step.icon"
-                                           class="size-[21px]" />
-                                </div>
-                                <div>
-                                    <div class="text-[15.5px] font-semibold text-highlighted">{{ step.title }}</div>
-                                    <div class="text-[12.5px] text-dimmed mt-0.5">{{ step.sub }}</div>
-                                </div>
-                            </div>
-                            <div class="flex items-center gap-1.5 mt-3.5 text-primary text-[13.5px] font-semibold">
-                                {{ step.link }}
-                                <UIcon name="i-lucide-arrow-right"
-                                       class="size-3" />
-                            </div>
-                        </NuxtLink>
-                    </div>
-
-                    <div class="flex items-center gap-3 border border-default rounded-[14px] px-5 py-4 bg-(--ui-bg-band) mt-4">
-                        <div class="size-[30px] shrink-0 rounded-full bg-elevated flex items-center justify-center font-mono text-[13px] font-semibold text-muted">
-                            3
-                        </div>
-                        <div class="flex-1 text-sm text-toned">
-                            With a source and destination ready, create a job to run them on a schedule.
-                        </div>
+                                description="A job is a scheduled pipeline. It runs your sources on a cron schedule and materializes the results into your destination — automatically, with no manual triggering. Every run is recorded under Executions.">
                         <UButton icon="i-lucide-plus"
                                  label="New job"
-                                 size="md"
+                                 class="mt-5"
                                  @click="handleCreate" />
-                    </div>
-
+                    </EmptyState>
                 </template>
             </DataTable>
         </div>


### PR DESCRIPTION
## What

Simplifies the placeholder (no-data) content on the **Jobs** and **Hooks** pages so each shows a single hero panel with the create button inside it — the same shape the Sources page already uses.

**Jobs** — removed everything from the "Before your first job" heading down: the "A job needs something to run" copy, the two setup-step cards (Sources / Destinations), and the numbered step-3 band. The now-unused `SETUP_STEPS` constant went with it. `+ New job` moved into the `EmptyState` default slot.

**Hooks** — removed the trailing band ("Create a hook to react to run outcomes on your components.") and moved `+ New hook` into the `EmptyState` slot.

## Why

Both pages repeated the same call to action twice — hero panel, then a band that ended in another New job / New hook button — and the jobs page stacked three separate blocks of onboarding prose on top of that. The button belongs with the hero copy that introduces the concept, which is how Sources already does it.

## Notes for reviewers

- Presentational only — no store, API, or type changes. `handleCreate` is the same handler the toolbar button uses.
- Button uses `class="mt-5"` to match [`components/sources/EmptyState.vue`](packages/interloper-app/app/app/components/sources/EmptyState.vue) exactly.
- `pnpm run lint` and `pnpm exec nuxt typecheck` pass. Lint reports one pre-existing `v-html` warning in `executions/ErrorDetailModal.vue`, untouched here.
- Branch was renamed off the generated `claude/…` name to follow the repo's `<type>/<slug>` convention.

By Digitl