### PR TITLE
refactor(app): flatten table, drawer, and badge chrome

### DIFF
--- a/packages/interloper-app/app/app/app.config.ts
+++ b/packages/interloper-app/app/app/app.config.ts
@@ -9,6 +9,10 @@ export default defineAppConfig({
       info: 'blue',
     },
     badge: {
+      // `soft` = tinted fill, no ring: badges carry no border. Statuses, tags,
+      // counts and log levels all ride this default; EntityBadge is the one
+      // documented exception, opting into `outline` so object references read
+      // as references.
       defaultVariants: {
         size: 'md',
         variant: 'soft'
@@ -109,20 +113,20 @@ export default defineAppConfig({
     },
     table: {
       slots: {
-        // Design table treatment: bordered card, #FAFAFB header band,
-        // #86868b header text, #F2F3F5 row dividers (lighter than the
-        // card border).
-        root: 'border border-default rounded-xl bg-default',
-        thead: 'bg-(--ui-bg-band)',
-        th: 'text-gray-700',
-        tbody: 'divide-(--ui-border-muted)'
+        // Borderless table treatment: no card frame and no header band — the
+        // header rule (#E8E8EC) and #F2F3F5 row dividers carry the structure,
+        // closed off by a rule under the last row.
+        root: 'bg-default',
+        thead: 'bg-default',
+        th: 'text-toned',
+        tbody: 'divide-(--ui-border-muted) [&>tr:last-child]:border-b [&>tr:last-child]:border-(--ui-border-muted)'
       },
       variants: {
         sticky: {
           true: {
             // The sticky variant's own bg-default/75 wins the class merge
-            // over slots.thead, so restate the header band here (opaque).
-            thead: 'bg-(--ui-bg-band) backdrop-blur-none'
+            // over slots.thead, so restate an opaque header background here.
+            thead: 'bg-default backdrop-blur-none'
           }
         }
       }
@@ -181,7 +185,18 @@ export default defineAppConfig({
         header: 'border-b border-default -mx-[30px] px-[30px] pb-5',
         title: 'text-[22px] font-bold tracking-[-0.01em]',
         footer: 'border-t border-default -mx-[30px] -mb-[30px] px-[30px] py-4'
-      }
+      },
+      compoundVariants: [
+        // Square edges: the theme rounds the drawer's inner edge per direction
+        // (`rounded-l-lg` for a right drawer). Those per-direction compounds win
+        // the class merge over `slots.content`, so the reset has to be one too.
+        {
+          inset: false,
+          class: {
+            content: 'rounded-none'
+          }
+        }
+      ]
     }
   }
 })

--- a/packages/interloper-app/app/app/components/collection/Table.vue
+++ b/packages/interloper-app/app/app/components/collection/Table.vue
@@ -278,8 +278,7 @@ function onRowClick(row: any) {
                     </span>
                     <UBadge v-if="sourceDriftBadge(row.original.sourceId)"
                             :color="sourceDriftBadge(row.original.sourceId)!.color"
-                            :icon="sourceDriftBadge(row.original.sourceId)!.icon"
-                            variant="subtle">
+                            :icon="sourceDriftBadge(row.original.sourceId)!.icon">
                         {{ sourceDriftBadge(row.original.sourceId)!.label }}
                     </UBadge>
                 </div>
@@ -296,8 +295,7 @@ function onRowClick(row: any) {
                     <span>{{ row.original.name }}</span>
                     <UBadge v-if="statusBadge(row.original.assetStatus)"
                             :color="statusBadge(row.original.assetStatus)!.color"
-                            :icon="statusBadge(row.original.assetStatus)!.icon"
-                            variant="subtle">
+                            :icon="statusBadge(row.original.assetStatus)!.icon">
                         {{ statusBadge(row.original.assetStatus)!.label }}
                     </UBadge>
                 </div>
@@ -320,8 +318,7 @@ function onRowClick(row: any) {
                      class="flex items-center justify-center gap-1 flex-wrap">
                     <UBadge v-for="tag in row.original.tags"
                             :key="tag"
-                            color="neutral"
-                            variant="subtle">
+                            color="neutral">
                         {{ tag }}
                     </UBadge>
                 </div>
@@ -483,8 +480,7 @@ function onRowClick(row: any) {
                     <div v-else
                          class="flex items-center justify-center">
                         <UBadge :color="statusColor[row.original.lastRunStatus] ?? 'neutral'"
-                                :icon="statusIcon[row.original.lastRunStatus] ?? 'i-lucide-circle'"
-                                variant="subtle">
+                                :icon="statusIcon[row.original.lastRunStatus] ?? 'i-lucide-circle'">
                             {{ timeSince(new Date(row.original.lastRunAt)) }} ago
                         </UBadge>
                     </div>

--- a/packages/interloper-app/app/app/components/executions/BackfillsTable.vue
+++ b/packages/interloper-app/app/app/components/executions/BackfillsTable.vue
@@ -55,7 +55,7 @@ const columns: TableColumn<Backfill>[] = withSortableHeaders([
         header: 'Status',
         cell: ({ row }) => {
             const status = row.getValue<string>('status')
-            return h(UBadge, { color: statusColor(status), variant: 'subtle' }, () => statusLabel(status))
+            return h(UBadge, { color: statusColor(status) }, () => statusLabel(status))
         },
     },
     {
@@ -109,6 +109,7 @@ const columns: TableColumn<Backfill>[] = withSortableHeaders([
                     :loading="loading"
                     :pagination-options="{ getPaginationRowModel: getPaginationRowModel() }"
                     sticky
+                    :ui="{ tr: 'cursor-pointer' }"
                     @select="(_e: Event, row: any) => navigateTo(`/executions/backfills/${row.original.id}`)" />
 
             <TableFooter class="py-3"

--- a/packages/interloper-app/app/app/components/executions/EventsTable.vue
+++ b/packages/interloper-app/app/app/components/executions/EventsTable.vue
@@ -96,14 +96,13 @@ const columns: TableColumn<RunEvent>[] = [
             const et = row.getValue<EventType>('event_type')
             const badge = h(UBadge, {
                 color: eventTypeColor(et),
-                variant: 'subtle',
                 icon: eventTypeIcon(et),
             }, () => eventTypeLabel(et))
             const level = row.original.level
             if (et !== 'log' || !level) return badge
             return h('div', { class: 'flex items-center gap-1.5' }, [
                 badge,
-                h(UBadge, { color: logLevelColor(level), variant: 'subtle' }, () => level),
+                h(UBadge, { color: logLevelColor(level) }, () => level),
             ])
         },
     },
@@ -145,7 +144,7 @@ const columns: TableColumn<RunEvent>[] = [
             :columns="columns"
             :loading="loading"
             sticky
-            :ui="{ tr: 'h-10', root: 'border-0 rounded-none' }"
+            :ui="{ tr: 'h-10' }"
             class="h-full"
             :on-hover="onRowHover">
         <template #body-bottom>

--- a/packages/interloper-app/app/app/components/executions/RunModal.vue
+++ b/packages/interloper-app/app/app/components/executions/RunModal.vue
@@ -170,7 +170,6 @@ async function onSubmit() {
         <template #title>
             <span>Run</span>
             <UBadge color="neutral"
-                    variant="subtle"
                     class="ml-1.5">
                 {{ props.target.name ?? props.target.key }}
             </UBadge>

--- a/packages/interloper-app/app/app/components/executions/RunsTable.vue
+++ b/packages/interloper-app/app/app/components/executions/RunsTable.vue
@@ -55,7 +55,7 @@ const columns: TableColumn<Run>[] = [
         header: 'Status',
         cell: ({ row }) => {
             const status = row.getValue<string>('status')
-            return h(UBadge, { color: statusColor(status), variant: 'subtle' }, () => statusLabel(status))
+            return h(UBadge, { color: statusColor(status) }, () => statusLabel(status))
         },
     },
     {
@@ -104,6 +104,7 @@ function onPageChange(page: number) {
                     :loading="loading"
                     :sorting="[{ id: 'created_at', desc: true }]"
                     sticky
+                    :ui="{ tr: 'cursor-pointer' }"
                     @select="(_e: Event, row: any) => navigateTo(`/executions/runs/${row.original.id}`)" />
 
             <TableFooter class="py-3"

--- a/packages/interloper-app/app/app/components/graph/AssetNode.vue
+++ b/packages/interloper-app/app/app/components/graph/AssetNode.vue
@@ -251,7 +251,6 @@ const contextMenuItems = computed<ContextMenuItem[][]>(() => {
                     <UBadge v-for="tag in tags"
                             :key="tag"
                             :color="tagColor(tag)"
-                            variant="subtle"
                             size="sm"
                             :label="tag" />
                 </div>

--- a/packages/interloper-app/app/app/components/graph/AssetPanel.vue
+++ b/packages/interloper-app/app/app/components/graph/AssetPanel.vue
@@ -282,7 +282,6 @@ const dependencyRows = computed(() => {
                 <UBadge v-for="tag in assetDefn.tags"
                         :key="tag"
                         :color="tagColor(tag)"
-                        variant="subtle"
                         size="sm"
                         :label="tag" />
             </div>
@@ -392,7 +391,6 @@ const dependencyRows = computed(() => {
                     <span class="text-xs font-semibold text-muted uppercase tracking-wide">Destinations</span>
                     <UBadge v-if="destinations.length"
                             color="neutral"
-                            variant="subtle"
                             class="ml-auto">
                         {{ destinations.length }}
                     </UBadge>
@@ -431,7 +429,6 @@ const dependencyRows = computed(() => {
                     <span class="text-xs font-semibold text-muted uppercase tracking-wide">Partitions</span>
                     <UBadge v-if="partitionData.length"
                             color="neutral"
-                            variant="subtle"
                             class="ml-auto">
                         {{ partitionData.length }}
                     </UBadge>
@@ -482,7 +479,6 @@ const dependencyRows = computed(() => {
                            class="size-3.5 shrink-0 text-dimmed group-data-[state=open]:rotate-90 transition-transform duration-200" />
                     <span class="text-xs font-semibold text-muted uppercase tracking-wide">Upstream dependencies</span>
                     <UBadge color="neutral"
-                            variant="subtle"
                             class="ml-auto">
                         {{ dependencyRows.length }}
                     </UBadge>
@@ -500,7 +496,6 @@ const dependencyRows = computed(() => {
                                 <div class="truncate text-xs text-muted">{{ dep.sourceName }}</div>
                             </div>
                             <UBadge color="neutral"
-                                    variant="subtle"
                                     size="sm"
                                     class="shrink-0 font-mono">
                                 {{ dep.param }}
@@ -519,7 +514,6 @@ const dependencyRows = computed(() => {
                            class="size-3.5 shrink-0 text-dimmed group-data-[state=open]:rotate-90 transition-transform duration-200" />
                     <span class="text-xs font-semibold text-muted uppercase tracking-wide">Schema</span>
                     <UBadge color="neutral"
-                            variant="subtle"
                             class="ml-auto">
                         {{ schemaFields.length }}
                     </UBadge>
@@ -542,8 +536,7 @@ const dependencyRows = computed(() => {
                                         class="border-b border-default last:border-0">
                                         <td class="p-1.5 font-mono text-xs whitespace-nowrap">{{ field.name }}</td>
                                         <td class="p-1.5 whitespace-nowrap">
-                                            <UBadge color="neutral"
-                                                    variant="subtle">
+                                            <UBadge color="neutral">
                                                 {{ field.type }}
                                             </UBadge>
                                         </td>

--- a/packages/interloper-app/app/app/components/hooks/ComponentSelect.vue
+++ b/packages/interloper-app/app/app/components/hooks/ComponentSelect.vue
@@ -51,7 +51,6 @@ function toggle(id: string) {
                     <span class="text-xs text-dimmed truncate">{{ component.key }}</span>
                 </div>
                 <UBadge color="neutral"
-                        variant="subtle"
                         size="xs"
                         class="ml-auto capitalize">
                     {{ component.kind }}

--- a/packages/interloper-app/app/app/components/jobs/Selector.vue
+++ b/packages/interloper-app/app/app/components/jobs/Selector.vue
@@ -125,7 +125,6 @@ defineExpose({ title })
                 <div class="flex items-center gap-2">
                     <UBadge v-if="jobPartitioned(item)"
                             color="neutral"
-                            variant="subtle"
                             size="xs">
                         <UIcon name="i-lucide-calendar-days"
                                class="size-3" />
@@ -133,12 +132,10 @@ defineExpose({ title })
                     </UBadge>
                     <UBadge v-if="!jobEnabled(item)"
                             color="warning"
-                            variant="subtle"
                             size="xs">
                         Disabled
                     </UBadge>
                     <UBadge color="neutral"
-                            variant="subtle"
                             size="xs">
                         {{ jobTargetIds(item, 'source').length }} source{{ jobTargetIds(item, 'source').length !== 1 ? 's' : '' }}
                     </UBadge>

--- a/packages/interloper-app/app/app/components/jobs/SourceSelect.vue
+++ b/packages/interloper-app/app/app/components/jobs/SourceSelect.vue
@@ -72,7 +72,6 @@ function deselectAll() {
                     <span class="text-xs text-dimmed truncate">{{ source.key }}</span>
                 </div>
                 <UBadge color="neutral"
-                        variant="subtle"
                         size="xs"
                         class="ml-auto">
                     {{ source.children.length }} asset{{ source.children.length !== 1 ? 's' : '' }}

--- a/packages/interloper-app/app/app/components/organization/MembersTable.vue
+++ b/packages/interloper-app/app/app/components/organization/MembersTable.vue
@@ -157,6 +157,7 @@ const columns = computed<TableColumn<OrgMember>[]>(() => {
                    :loading="loading"
                    :row-actions="isAdmin ? getRowMenuItems : undefined"
                    no-actions
+                   no-row-click
                    search-placeholder="Search members...">
             <template #toolbar>
                 <slot name="toolbar" />

--- a/packages/interloper-app/app/app/components/sources/AssetSelect.vue
+++ b/packages/interloper-app/app/app/components/sources/AssetSelect.vue
@@ -207,7 +207,6 @@ function depSelectionKey(assetKey: string, paramName: string): string {
                             <UBadge v-for="tag in asset.tags"
                                     :key="tag"
                                     :color="tagColor(tag)"
-                                    variant="subtle"
                                     size="sm">
                                 {{ tag }}
                             </UBadge>
@@ -222,7 +221,6 @@ function depSelectionKey(assetKey: string, paramName: string): string {
                         </UTooltip>
                         <UBadge v-if="depsByAsset.get(asset.key)?.length"
                                 color="info"
-                                variant="subtle"
                                 size="sm">
                             {{ depsByAsset.get(asset.key)!.length }} dep{{ depsByAsset.get(asset.key)!.length > 1 ? 's' : '' }}
                         </UBadge>
@@ -264,7 +262,6 @@ function depSelectionKey(assetKey: string, paramName: string): string {
 
                         <UBadge v-if="dep.isOptional"
                                 color="neutral"
-                                variant="outline"
                                 size="xs">
                             optional
                         </UBadge>

--- a/packages/interloper-app/app/app/components/ui/DataTable.vue
+++ b/packages/interloper-app/app/app/components/ui/DataTable.vue
@@ -14,6 +14,8 @@ const props = defineProps<{
     rowActions?: (item: TData) => DropdownMenuItem[][]
     /** When true, suppresses the built-in actions column and row menus. */
     noActions?: boolean
+    /** When true, rows are read-only: no pointer cursor, since clicking one leads nowhere. */
+    noRowClick?: boolean
     /**
      * Impact preview for deleting the given ids (e.g.
      * `componentsStore.deleteImpact`). `blocking` referrers disable the
@@ -176,6 +178,7 @@ const showEmpty = computed(() => hasLoaded.value && props.data.length === 0 && !
                 :global-filter="globalFilter"
                 :pagination-options="{ getPaginationRowModel: getPaginationRowModel() }"
                 sticky
+                :ui="{ tr: noRowClick ? '' : 'cursor-pointer' }"
                 class="max-h-[calc(100vh-16rem)]"
                 @select="(_e: Event, row: any) => emit('edit', row.original)"
                 @contextmenu="onRowContextMenu">

--- a/packages/interloper-app/app/app/layouts/admin.vue
+++ b/packages/interloper-app/app/app/layouts/admin.vue
@@ -63,7 +63,6 @@ const items = computed<NavigationMenuItem[]>(() => [
             <template #default="{ collapsed }">
                 <UBadge v-if="!collapsed"
                         color="primary"
-                        variant="subtle"
                         size="lg"
                         class="eyebrow w-full justify-center py-2"
                         label="Admin portal" />

--- a/packages/interloper-app/app/app/pages/admin/config.vue
+++ b/packages/interloper-app/app/app/pages/admin/config.vue
@@ -228,14 +228,12 @@ const sections = computed<ConfigSection[]>(() => {
                             <div v-if="row.pill || row.badges || row.value || row.attrs"
                                  class="flex flex-wrap items-center gap-1.5">
                                 <UBadge v-if="row.pill"
-                                        :color="row.pill.color"
-                                        variant="subtle">
+                                        :color="row.pill.color">
                                     {{ row.pill.label }}
                                 </UBadge>
                                 <UBadge v-for="badge in row.badges"
                                         :key="badge"
-                                        color="neutral"
-                                        variant="outline">
+                                        color="neutral">
                                     {{ badge }}
                                 </UBadge>
                                 <span v-if="row.value"

--- a/packages/interloper-app/app/app/pages/admin/organisations/index.vue
+++ b/packages/interloper-app/app/app/pages/admin/organisations/index.vue
@@ -147,7 +147,7 @@ const columns: TableColumn<AdminOrganisation>[] = [
             if (!org.deleted_at) return org.name
             return h('div', { class: 'flex items-center gap-2' }, [
                 h('span', { class: 'text-dimmed line-through' }, org.name),
-                h(UBadge, { label: 'Deleted', color: 'neutral', variant: 'subtle', size: 'sm' }),
+                h(UBadge, { label: 'Deleted', color: 'neutral', size: 'sm' }),
             ])
         },
     },

--- a/packages/interloper-app/app/app/pages/admin/quotas.vue
+++ b/packages/interloper-app/app/app/pages/admin/quotas.vue
@@ -151,11 +151,10 @@ const columns: TableColumn<AdminOrgQuotaStatus>[] = [
         cell: ({ row }) => {
             const org = row.original
             return org.successful_runs === org.recomputed_successful_runs
-                ? h(UBadge, { label: 'In sync', color: 'success', variant: 'subtle' })
+                ? h(UBadge, { label: 'In sync', color: 'success' })
                 : h(UBadge, {
                         label: `Drift (runs table: ${org.recomputed_successful_runs})`,
                         color: 'warning',
-                        variant: 'subtle',
                     })
         },
     },

--- a/packages/interloper-app/app/app/pages/admin/users/index.vue
+++ b/packages/interloper-app/app/app/pages/admin/users/index.vue
@@ -137,7 +137,7 @@ const columns: TableColumn<AdminUser>[] = [
         accessorKey: 'is_super_admin',
         header: 'Super admin',
         cell: ({ row }) => row.original.is_super_admin
-            ? h(UBadge, { label: 'Super admin', icon: 'i-lucide-shield', color: 'primary', variant: 'subtle' })
+            ? h(UBadge, { label: 'Super admin', icon: 'i-lucide-shield', color: 'primary' })
             : h('span', { class: 'text-dimmed' }, '—'),
     },
     {
@@ -159,6 +159,7 @@ onMounted(loadData)
                    :loading="loading"
                    :row-actions="rowActions"
                    no-actions
+                   no-row-click
                    search-placeholder="Search users...">
             <template #toolbar>
                 <USelect v-model="orgFilter"

--- a/packages/interloper-app/app/app/pages/executions/backfills/[backfill].vue
+++ b/packages/interloper-app/app/app/pages/executions/backfills/[backfill].vue
@@ -98,7 +98,7 @@ const columns: TableColumn<Run>[] = withSortableHeaders([
         header: 'Status',
         cell: ({ row }) => {
             const status = row.getValue<string>('status')
-            return h(UBadge, { color: statusColor(status), variant: 'subtle' }, () => statusLabel(status))
+            return h(UBadge, { color: statusColor(status) }, () => statusLabel(status))
         },
     },
     {
@@ -131,8 +131,7 @@ const columns: TableColumn<Run>[] = withSortableHeaders([
             <div class="flex items-center gap-3 mb-4 shrink-0">
             <PageBreadcrumb :items="breadcrumbs" />
             <UBadge v-if="backfill"
-                    :color="statusColor(backfill.status)"
-                    variant="subtle">
+                    :color="statusColor(backfill.status)">
                 {{ statusLabel(backfill.status) }}
             </UBadge>
             <UButton v-if="cancellable"
@@ -177,6 +176,7 @@ const columns: TableColumn<Run>[] = withSortableHeaders([
                 :columns="columns"
                 :loading="runsLoading"
                 sticky
+                :ui="{ tr: 'cursor-pointer' }"
                 class="flex-1"
                 @select="(_e: Event, row: any) => navigateTo(`/executions/runs/${row.original.id}`)" />
         </div>

--- a/packages/interloper-app/app/app/pages/executions/runs/[run].vue
+++ b/packages/interloper-app/app/app/pages/executions/runs/[run].vue
@@ -220,7 +220,6 @@ onUnmounted(() => {
                         <span class="ml-auto text-xs font-medium uppercase tracking-wide text-muted">Events</span>
                         <UBadge v-if="!eventsStore.loading"
                                 color="neutral"
-                                variant="subtle"
                                 size="sm">
                             {{ eventsStore.hasMore ? `${eventsStore.events.length} / ${eventsStore.total}` : eventsStore.events.length }}
                         </UBadge>

--- a/packages/interloper-app/app/app/pages/hooks.vue
+++ b/packages/interloper-app/app/app/pages/hooks.vue
@@ -51,7 +51,6 @@ const columns = computed<TableColumn<ComponentRecord>[]>(() => [
             h(UBadge, {
                 key: event,
                 color: 'neutral',
-                variant: 'subtle',
             }, () => event),
         )),
     },
@@ -76,7 +75,6 @@ const columns = computed<TableColumn<ComponentRecord>[]>(() => [
         header: 'Status',
         cell: ({ row }) => h(UBadge, {
             color: hookEnabled(row.original) ? 'success' : 'neutral',
-            variant: 'subtle',
         }, () => hookEnabled(row.original) ? 'Enabled' : 'Disabled'),
     },
     ...stateSchemaColumns(catalogStore.definitionsForKind('hook')[0]),

--- a/packages/interloper-app/app/app/pages/jobs.vue
+++ b/packages/interloper-app/app/app/pages/jobs.vue
@@ -93,7 +93,6 @@ const columns = computed<TableColumn<ComponentRecord>[]>(() => [
         header: 'Status',
         cell: ({ row }) => h(UBadge, {
             color: jobEnabled(row.original) ? 'success' : 'neutral',
-            variant: 'subtle',
         }, () => jobEnabled(row.original) ? 'Enabled' : 'Disabled'),
     },
     ...stateSchemaColumns(catalogStore.definitionsForKind('job')[0]),

--- a/packages/interloper-app/app/app/pages/sources.vue
+++ b/packages/interloper-app/app/app/pages/sources.vue
@@ -95,7 +95,6 @@ const columns: TableColumn<ComponentRecord>[] = [
             if (badge) {
                 children.push(h(UBadge, {
                     color: badge.color,
-                    variant: 'subtle',
                     size: 'sm',
                     class: 'ml-1',
                 }, () => h('span', { class: 'flex items-center gap-1' }, [


### PR DESCRIPTION
A UI polish pass that flattens the chrome around tables, drawers, and badges, and gives clickable rows a pointer cursor.

## Tables — borderless

The table theme drew a card frame (`border border-default rounded-xl`) plus a `#FAFAFB` header band. Both are gone; the structure now comes from the header rule Nuxt UI already renders (its `separator` slot, `#E8E8EC`) and the `#F2F3F5` row dividers, closed off by a matching rule under the last row so the table ends cleanly above the "N row(s) total." caption. Header labels move from `text-gray-700` (#86868b) to `text-toned` (#3f3f44), since they no longer have the band to set them off.

One theme change covers every table: the `DataTable` pages (sources, destinations, jobs, hooks, resources, admin users/orgs/quotas, org members), the collection table, runs/backfills/events, and the backfill detail table. `EventsTable`'s local `border-0 rounded-none` override — which only existed to strip that frame inside the run-detail panel — is now redundant and removed. Bordered panels that *contain* tables (run detail's timeline/events panes, admin config) keep their frames: those belong to the panel and its header bar.

## Drawers — square edges

The theme rounds a drawer's inner edge per direction (`rounded-l-lg` for a right-side drawer) from a compound variant, and those outrank anything set on `slots.content` in the class merge — so the reset has to be a compound variant too. Note for anyone touching this later: `inset: [true, false]` silently fails to match (tailwind-variants doesn't resolve boolean arrays there), which produces no error, just no effect. The single `inset: false` form works. An `inset` drawer would still round its corners; nothing in the app uses that variant, and rounding is intrinsic to the inset look.

## Badges — no rings

`badge.defaultVariants.variant` was already `soft` (tinted fill, no ring), but 37 call sites overrode it with `subtle` (same tint plus `ring ring-inset ring-<color>/25`). Rather than redefining what `subtle` means, this removes the overrides and lets badges fall to the default; the app.config block now records the convention.

`EntityBadge` is the one exception and keeps `variant="outline"`, so object references still read as references against the flat status pills. Two other `outline` badges that aren't entity references also lost their border — the `optional` marker in `AssetSelect` and the `row.badges` chips in admin config (allowed domains, super-admin emails). Both are value labels; **flagging in case you'd rather they stayed outlined**, it's a one-word revert each.

## Pointer cursor on clickable rows

Applied per table rather than in the theme. Nuxt UI sets `data-selectable` for `onSelect` **or** `onHover` **or** `onContextmenu`, so a theme-level rule keyed on it would have put a pointer on the run events table, whose rows only highlight on hover (its error detail opens from a button inside the cell) — and a tbody-level selector outranks any per-table opt-out on specificity.

`DataTable` gets a `noRowClick` prop for the two read-only consumers whose rows do nothing on click (admin users, org members — both have row menus via ⋮/right-click, but no left-click target). `RunsTable`, `BackfillsTable`, and the backfill detail table opt in directly; the collection table already had it.

## Verification

Driven headlessly against a seeded dev instance (Chrome via playwright-core, minted session, torn down after):

- **Cursors** — read the computed `cursor` after a real hover on 9 pages: `pointer` on sources, destinations, jobs, collection, executions, admin organisations; `auto` on admin users, org members, run events.
- **Drawers** — computed corner radii on all three wizard drawers (New source / destination / job): `0px` on all four corners, previously `12.8px` on the left pair.
- **Badges** — read the computed `box-shadow` of every chip across 6 pages: 63 badges, and the only ringed ones were the 25 EntityBadges.
- **Tables** — screenshotted sources, collection, executions, run detail, admin users/orgs, jobs, destinations.

`pnpm run lint` clean (one pre-existing `v-html` warning in `ErrorDetailModal.vue`) and `nuxt exec typecheck` passes. No Python touched, so the pre-commit Python gate had nothing to check.

One process note: I made the badge sweep with a script, and it corrupted the markup in `pages/executions/backfills/[backfill].vue` — the edit list wasn't sorted by file offset, so in the one file with both a template badge and a render-function badge, the second rewrite used stale offsets. Lint caught it and I repaired it by hand, then re-scanned every `.vue`/`.ts` to confirm no bordered badge survived.

By Digitl
