### PR TITLE
feat(app): organisation detail page

### DIFF
--- a/packages/interloper-api/src/interloper_api/routes/admin.py
+++ b/packages/interloper-api/src/interloper_api/routes/admin.py
@@ -268,6 +268,15 @@ class AdminQuotaUpdateRequest(BaseModel):
     max_successful_runs_per_month: int | None = Field(default=None, ge=0)
 
 
+class AdminActivityEntry(BaseModel):
+    """One event in an organisation's derived activity feed."""
+
+    kind: str
+    when: datetime
+    title: str
+    detail: str | None = None
+
+
 class AdminConfigResponse(BaseModel):
     """Read-only, secrets-redacted snapshot of the instance configuration."""
 
@@ -579,6 +588,44 @@ def get_quotas(
             )
         )
     return AdminQuotasResponse(period_start=period_start, defaults=defaults, organisations=organisations)
+
+
+def _activity_title(entry: dict[str, Any]) -> tuple[str, str | None]:
+    """Presentation strings for a derived activity entry."""
+    kind, subject, extra = entry["kind"], entry["subject"], entry["extra"]
+    if kind == "org_created":
+        return "Organisation created", None
+    if kind == "org_deleted":
+        return "Organisation deleted", "Retained read-only for billing history."
+    if kind == "member_joined":
+        return f"{subject} joined the organisation", f"Role: {extra}" if extra else None
+    if kind == "invitation_sent":
+        return f"Invitation sent to {subject}", f"Invited by {extra}" if extra else None
+    if kind == "source_added":
+        return f"Source added — {subject}", None
+    if kind == "runs_completed":
+        count = int(subject)
+        return f"{count:,} run{'' if count == 1 else 's'} completed successfully", None
+    return kind, None
+
+
+@router.get("/organisations/{org_id}/activity")
+def get_organisation_activity(
+    org_id: UUID,
+    user: Profile = Depends(require_super_admin),
+    store: Store = Depends(get_store),
+) -> list[AdminActivityEntry]:
+    """Derived activity feed for one organisation, newest first.
+
+    Composed from existing records (memberships, pending invitations,
+    sources, run aggregates, the org row itself) — there is no audit
+    trail, so actor attribution is limited to what those rows carry.
+    """
+    entries = []
+    for entry in store.list_organisation_activity(org_id):
+        title, detail = _activity_title(entry)
+        entries.append(AdminActivityEntry(kind=entry["kind"], when=entry["when"], title=title, detail=detail))
+    return entries
 
 
 @router.patch("/organisations/{org_id}/quota")

--- a/packages/interloper-api/tests/test_admin.py
+++ b/packages/interloper-api/tests/test_admin.py
@@ -518,3 +518,29 @@ def test_deleted_org_is_listed_but_not_manageable(store: FakeStore) -> None:
     resp = client.patch(f"/admin/organisations/{store.org.id}/quota", json={"max_sources": 1})
     assert resp.status_code == 404
     assert store.quota_updates == []
+
+
+def test_non_super_admin_cannot_read_activity(store: FakeStore) -> None:
+    resp = _client(store, is_super_admin=False).get(f"/admin/organisations/{uuid4()}/activity")
+    assert resp.status_code == 403
+
+
+def test_activity_feed_composes_titles(store: FakeStore) -> None:
+    when = datetime(2026, 8, 10, 12, 0, tzinfo=timezone.utc)
+    store.activity = [  # ty: ignore[unresolved-attribute]
+        {"kind": "runs_completed", "when": when, "subject": "1204", "extra": None},
+        {"kind": "invitation_sent", "when": when, "subject": "a@b.io", "extra": "Root"},
+        {"kind": "member_joined", "when": when, "subject": "Jonas", "extra": "editor"},
+        {"kind": "org_created", "when": when, "subject": None, "extra": None},
+    ]
+    store.list_organisation_activity = lambda org_id: store.activity  # ty: ignore[unresolved-attribute]
+
+    resp = _client(store, is_super_admin=True).get(f"/admin/organisations/{store.org.id}/activity")
+    assert resp.status_code == 200
+    titles = [(entry["kind"], entry["title"], entry["detail"]) for entry in resp.json()]
+    assert titles == [
+        ("runs_completed", "1,204 runs completed successfully", None),
+        ("invitation_sent", "Invitation sent to a@b.io", "Invited by Root"),
+        ("member_joined", "Jonas joined the organisation", "Role: editor"),
+        ("org_created", "Organisation created", None),
+    ]

--- a/packages/interloper-app/app/app/components/admin/QuotaDrawer.vue
+++ b/packages/interloper-app/app/app/components/admin/QuotaDrawer.vue
@@ -1,0 +1,132 @@
+<script setup lang="ts">
+/**
+ * Right drawer for editing an organisation's quota overrides.
+ * String-typed fields so an emptied input means "inherit the instance
+ * default"; each field hints whether it inherits or overrides.
+ */
+import type { AdminQuotaLimits } from '~/types/admin'
+
+const open = defineModel<boolean>('open', { required: true })
+
+const props = defineProps<{
+    orgId: string
+    orgName: string
+    /** The org's current overrides (nulls where inherited). */
+    limits: AdminQuotaLimits | null
+    /** The instance defaults the empty fields fall back to. */
+    defaults: AdminQuotaLimits | null
+}>()
+
+const emit = defineEmits<{ saved: [] }>()
+
+const adminStore = useAdminStore()
+const toast = useToast()
+
+const LIMIT_FIELDS = [
+    { key: 'max_sources', label: 'Max sources' },
+    { key: 'max_assets_per_source', label: 'Max assets per source' },
+    { key: 'max_successful_runs_per_month', label: 'Max successful runs / month' },
+] as const
+
+type LimitKey = typeof LIMIT_FIELDS[number]['key']
+
+const form = ref<Record<LimitKey, string>>({
+    max_sources: '',
+    max_assets_per_source: '',
+    max_successful_runs_per_month: '',
+})
+const saving = ref(false)
+
+watch(open, (opened) => {
+    if (!opened) return
+    form.value = {
+        max_sources: props.limits?.max_sources?.toString() ?? '',
+        max_assets_per_source: props.limits?.max_assets_per_source?.toString() ?? '',
+        max_successful_runs_per_month: props.limits?.max_successful_runs_per_month?.toString() ?? '',
+    }
+})
+
+function defaultLabel(key: LimitKey): string {
+    const value = props.defaults?.[key]
+    return value != null ? value.toLocaleString() : 'unlimited'
+}
+
+function hint(key: LimitKey): string {
+    return form.value[key] === ''
+        ? `Inheriting ${defaultLabel(key)}`
+        : `Overrides the instance default of ${defaultLabel(key)}`
+}
+
+async function submit() {
+    saving.value = true
+    try {
+        await adminStore.updateOrgQuota(props.orgId, {
+            max_sources: form.value.max_sources === '' ? null : Number(form.value.max_sources),
+            max_assets_per_source: form.value.max_assets_per_source === ''
+                ? null
+                : Number(form.value.max_assets_per_source),
+            max_successful_runs_per_month: form.value.max_successful_runs_per_month === ''
+                ? null
+                : Number(form.value.max_successful_runs_per_month),
+        })
+        toast.add({ title: `Quota limits updated for ${props.orgName}`, color: 'success' })
+        open.value = false
+        emit('saved')
+    }
+    catch (err) {
+        toast.add(errorToast(err, 'Failed to update quota limits'))
+    }
+    finally {
+        saving.value = false
+    }
+}
+</script>
+
+<template>
+    <UDrawer v-model:open="open"
+             direction="right"
+             :handle="false"
+             :handle-only="true"
+             title="Edit quotas"
+             :description="orgName"
+             :ui="{ content: 'w-[420px] max-w-[92vw]' }">
+        <template #body>
+            <UButton icon="i-lucide-x"
+                     color="neutral"
+                     variant="soft"
+                     size="md"
+                     class="absolute top-[22px] right-[26px] rounded-[9px] text-muted"
+                     aria-label="Close"
+                     @click="open = false" />
+            <p class="text-[13px] text-muted leading-normal mb-4">
+                Leave a field empty to inherit the instance default.
+            </p>
+            <div class="flex flex-col gap-4">
+                <div v-for="field in LIMIT_FIELDS"
+                     :key="field.key"
+                     class="flex flex-col gap-1.5">
+                    <label class="text-[13px] font-semibold">{{ field.label }}</label>
+                    <UInput v-model="form[field.key]"
+                            type="number"
+                            min="0"
+                            :placeholder="`Instance default (${defaultLabel(field.key)})`"
+                            class="w-full font-mono"
+                            @keydown.enter="submit" />
+                    <span class="text-xs text-dimmed">{{ hint(field.key) }}</span>
+                </div>
+            </div>
+        </template>
+        <template #footer>
+            <div class="flex justify-end gap-2 w-full">
+                <UButton label="Cancel"
+                         color="neutral"
+                         variant="outline"
+                         @click="open = false" />
+                <UButton label="Save"
+                         :disabled="saving"
+                         :loading="saving"
+                         @click="submit" />
+            </div>
+        </template>
+    </UDrawer>
+</template>

--- a/packages/interloper-app/app/app/layouts/admin.vue
+++ b/packages/interloper-app/app/app/layouts/admin.vue
@@ -94,8 +94,7 @@ const items = computed<NavigationMenuItem[]>(() => [
                          :ui="{ body: '!p-0 !gap-0 overflow-hidden [&>*]:flex-1 [&>*]:flex [&>*]:flex-col [&>*]:min-h-0' }">
             <template #body>
                 <div class="flex-1 min-h-0 w-full overflow-y-auto">
-                    <div class="p-4 w-full"
-                         :class="pageHeader && 'max-w-[1040px] mx-auto'">
+                    <div class="p-4 w-full max-w-[1040px] mx-auto">
                         <div v-if="pageTitle"
                              class="mb-4">
                             <PageBreadcrumb :items="[titleCrumb(pageTitle)]" />

--- a/packages/interloper-app/app/app/pages/admin/index.vue
+++ b/packages/interloper-app/app/app/pages/admin/index.vue
@@ -48,11 +48,6 @@ const periodLabel = computed(() => {
     return new Date(quotas.value.period_start).toLocaleDateString(undefined, { month: 'long', year: 'numeric' })
 })
 
-function shortDate(value: string | null): string {
-    if (!value) return '—'
-    return new Date(value).toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' })
-}
-
 // -- Stat tiles ---------------------------------------------------------------
 
 const tiles = computed(() => {
@@ -142,7 +137,7 @@ const attention = computed<AttentionItem[]>(() => {
                 icon: 'i-lucide-user-minus',
                 tone: 'neutral',
                 title: `${user.name || user.email} belongs to no organisation`,
-                detail: `Signed up ${shortDate(user.created_at)} and was never invited anywhere — `
+                detail: `Signed up ${formatDay(user.created_at)} and was never invited anywhere — `
                     + 'cannot reach any workspace.',
                 action: 'Review',
                 to: '/admin/users',

--- a/packages/interloper-app/app/app/pages/admin/organisations/[id].vue
+++ b/packages/interloper-app/app/app/pages/admin/organisations/[id].vue
@@ -186,8 +186,6 @@ const LIMIT_FIELDS = [
     { key: 'max_successful_runs_per_month', label: 'Max successful runs / month' },
 ] as const
 
-type LimitKey = typeof LIMIT_FIELDS[number]['key']
-
 const limitRows = computed(() => {
     const row = quotaRow.value
     const defaults = quotas.value?.defaults
@@ -210,52 +208,11 @@ const limitRows = computed(() => {
 const ledgerInSync = computed(() =>
     quotaRow.value != null && quotaRow.value.successful_runs === quotaRow.value.recomputed_successful_runs)
 
-// Edit modal — string-typed fields so an emptied input means "inherit".
+// Edit drawer — the AdminQuotaDrawer owns the form; we just open it.
 const editOpen = ref(false)
-const editForm = ref<Record<LimitKey, string>>({
-    max_sources: '',
-    max_assets_per_source: '',
-    max_successful_runs_per_month: '',
-})
-const saving = ref(false)
 
-function defaultPlaceholder(key: LimitKey): string {
-    const value = quotas.value?.defaults[key]
-    return value != null ? `default: ${value}` : 'default: unlimited'
-}
-
-function openEdit() {
-    const limits = quotaRow.value?.limits
-    editForm.value = {
-        max_sources: limits?.max_sources?.toString() ?? '',
-        max_assets_per_source: limits?.max_assets_per_source?.toString() ?? '',
-        max_successful_runs_per_month: limits?.max_successful_runs_per_month?.toString() ?? '',
-    }
-    editOpen.value = true
-}
-
-async function submitEdit() {
-    saving.value = true
-    try {
-        await adminStore.updateOrgQuota(orgId.value, {
-            max_sources: editForm.value.max_sources === '' ? null : Number(editForm.value.max_sources),
-            max_assets_per_source: editForm.value.max_assets_per_source === ''
-                ? null
-                : Number(editForm.value.max_assets_per_source),
-            max_successful_runs_per_month: editForm.value.max_successful_runs_per_month === ''
-                ? null
-                : Number(editForm.value.max_successful_runs_per_month),
-        })
-        toast.add({ title: 'Quota limits updated', color: 'success' })
-        editOpen.value = false
-        quotas.value = await adminStore.getQuotas()
-    }
-    catch (err) {
-        toast.add(errorToast(err, 'Failed to update quota limits'))
-    }
-    finally {
-        saving.value = false
-    }
+async function reloadQuotas() {
+    quotas.value = await adminStore.getQuotas()
 }
 
 // -- Activity ---------------------------------------------------------------------
@@ -405,7 +362,7 @@ watch(orgId, loadData)
                              variant="outline"
                              size="sm"
                              class="ml-auto"
-                             @click="openEdit" />
+                             @click="editOpen = true" />
                 </div>
                 <div v-for="row in limitRows"
                      :key="row.key"
@@ -531,36 +488,11 @@ watch(orgId, loadData)
             </section>
         </div>
 
-        <UModal v-model:open="editOpen"
-                :title="`Quota limits — ${org?.name}`"
-                :ui="{ footer: 'justify-end' }">
-            <template #body>
-                <div class="flex flex-col gap-3">
-                    <p class="text-sm text-muted">
-                        Overrides for this organisation. Leave a field empty to inherit the instance default.
-                    </p>
-                    <UFormField v-for="field in LIMIT_FIELDS"
-                                :key="field.key"
-                                :label="field.label">
-                        <UInput v-model="editForm[field.key]"
-                                type="number"
-                                min="0"
-                                :placeholder="defaultPlaceholder(field.key)"
-                                class="w-full"
-                                @keydown.enter="submitEdit" />
-                    </UFormField>
-                </div>
-            </template>
-            <template #footer>
-                <UButton label="Cancel"
-                         color="neutral"
-                         variant="outline"
-                         @click="editOpen = false" />
-                <UButton label="Save"
-                         :disabled="saving"
-                         :loading="saving"
-                         @click="submitEdit" />
-            </template>
-        </UModal>
+        <AdminQuotaDrawer v-model:open="editOpen"
+                          :org-id="orgId"
+                          :org-name="org?.name ?? ''"
+                          :limits="quotaRow?.limits ?? null"
+                          :defaults="quotas?.defaults ?? null"
+                          @saved="reloadQuotas" />
     </div>
 </template>

--- a/packages/interloper-app/app/app/pages/admin/organisations/[id].vue
+++ b/packages/interloper-app/app/app/pages/admin/organisations/[id].vue
@@ -381,7 +381,7 @@ watch(orgId, loadData)
         </div>
 
         <div v-else-if="tab === 'usage'"
-             class="flex flex-col gap-3">
+             class="flex flex-col gap-3 w-full max-w-[1040px] mx-auto">
             <div class="grid grid-cols-2 xl:grid-cols-4 gap-3">
                 <div v-for="tile in usageTiles"
                      :key="tile.label"
@@ -436,7 +436,7 @@ watch(orgId, loadData)
         </div>
 
         <div v-else-if="tab === 'activity'"
-             class="overflow-hidden rounded-lg border border-default bg-default">
+             class="overflow-hidden rounded-lg border border-default bg-default w-full max-w-[1040px] mx-auto">
             <div class="border-b border-default px-4 py-3">
                 <div class="text-sm font-semibold">Activity</div>
                 <div class="text-xs text-dimmed mt-0.5">
@@ -466,8 +466,8 @@ watch(orgId, loadData)
         </div>
 
         <div v-else-if="tab === 'settings'"
-             class="flex flex-col gap-3 max-w-[660px]">
-            <section class="rounded-lg border border-default bg-default p-4">
+             class="flex flex-col gap-3 w-full max-w-[1040px] mx-auto">
+            <section class="rounded-lg border border-default bg-default p-4 max-w-[660px] w-full">
                 <div class="text-sm font-semibold">Organisation name</div>
                 <p class="text-[13px] text-muted leading-normal mt-1">
                     Shown across the app and in invitation emails.
@@ -483,7 +483,7 @@ watch(orgId, loadData)
                 </div>
             </section>
 
-            <section class="rounded-lg border border-default bg-default p-4">
+            <section class="rounded-lg border border-default bg-default p-4 max-w-[660px] w-full">
                 <div class="text-sm font-semibold">Your membership</div>
                 <p class="text-[13px] text-muted leading-normal mt-1">
                     <template v-if="isMember">
@@ -507,7 +507,7 @@ watch(orgId, loadData)
                 </div>
             </section>
 
-            <section class="rounded-lg border border-error/40 bg-error/5 p-4">
+            <section class="rounded-lg border border-error/40 bg-error/5 p-4 max-w-[660px] w-full">
                 <div class="flex items-center gap-2 text-sm font-semibold text-error">
                     <UIcon name="i-lucide-octagon-alert"
                            class="size-4" />

--- a/packages/interloper-app/app/app/pages/admin/organisations/[id].vue
+++ b/packages/interloper-app/app/app/pages/admin/organisations/[id].vue
@@ -381,7 +381,7 @@ watch(orgId, loadData)
         </div>
 
         <div v-else-if="tab === 'usage'"
-             class="flex flex-col gap-3 w-full max-w-[1040px] mx-auto">
+             class="flex flex-col gap-3">
             <div class="grid grid-cols-2 xl:grid-cols-4 gap-3">
                 <div v-for="tile in usageTiles"
                      :key="tile.label"
@@ -436,7 +436,7 @@ watch(orgId, loadData)
         </div>
 
         <div v-else-if="tab === 'activity'"
-             class="overflow-hidden rounded-lg border border-default bg-default w-full max-w-[1040px] mx-auto">
+             class="overflow-hidden rounded-lg border border-default bg-default">
             <div class="border-b border-default px-4 py-3">
                 <div class="text-sm font-semibold">Activity</div>
                 <div class="text-xs text-dimmed mt-0.5">
@@ -466,7 +466,7 @@ watch(orgId, loadData)
         </div>
 
         <div v-else-if="tab === 'settings'"
-             class="flex flex-col gap-3 w-full max-w-[1040px] mx-auto">
+             class="flex flex-col gap-3">
             <section class="rounded-lg border border-default bg-default p-4 max-w-[660px] w-full">
                 <div class="text-sm font-semibold">Organisation name</div>
                 <p class="text-[13px] text-muted leading-normal mt-1">

--- a/packages/interloper-app/app/app/pages/admin/organisations/[id].vue
+++ b/packages/interloper-app/app/app/pages/admin/organisations/[id].vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import type { BreadcrumbItem } from '@nuxt/ui'
-import type { OrgMember } from '~/types/organisation'
+import type { BreadcrumbItem, TabsItem } from '@nuxt/ui'
+import type { AdminActivityEntry, AdminOrganisation, AdminOrgQuotaStatus, AdminQuotas } from '~/types/admin'
+import type { Organisation, OrgMember } from '~/types/organisation'
 
 definePageMeta({ title: 'Manage organisation', layout: 'admin', middleware: 'super-admin', titleInBreadcrumb: true })
 
@@ -10,9 +11,12 @@ const orgId = computed(() => route.params.id as string)
 const adminStore = useAdminStore()
 const userStore = useUserStore()
 const toast = useToast()
+const { switchToOrg } = useOrgSwitch()
 
 const rows = ref<OrgMember[]>([])
-const orgName = ref<string | null>(null)
+const org = ref<AdminOrganisation | null>(null)
+const quotas = ref<AdminQuotas | null>(null)
+const activity = ref<AdminActivityEntry[]>([])
 const loading = ref(false)
 const inviteOpen = ref(false)
 
@@ -23,19 +27,26 @@ const inviteEndpoint = computed(() => `/admin/organisations/${orgId.value}/invit
 
 const breadcrumbs = computed<BreadcrumbItem[]>(() => [
     titleCrumb('Organisations', '/admin/organisations'),
-    entityCrumb(orgName.value ?? '…', 'i-lucide-building-2'),
+    entityCrumb(org.value?.name ?? '…', 'i-lucide-building-2'),
 ])
+
+const quotaRow = computed<AdminOrgQuotaStatus | null>(() =>
+    quotas.value?.organisations.find(row => row.id === orgId.value) ?? null)
 
 async function loadData() {
     loading.value = true
     try {
-        const [members, invitations, organisations] = await Promise.all([
+        const [members, invitations, organisations, quotasResp, activityResp] = await Promise.all([
             adminStore.listMembers(orgId.value),
             adminStore.listInvitations(orgId.value),
             adminStore.listOrganisations(),
+            adminStore.getQuotas(),
+            adminStore.getOrgActivity(orgId.value),
         ])
 
-        orgName.value = organisations.find(o => o.id === orgId.value)?.name ?? null
+        org.value = organisations.find(o => o.id === orgId.value) ?? null
+        quotas.value = quotasResp
+        activity.value = activityResp
 
         const memberRows: OrgMember[] = members.map(m => ({
             id: m.id,
@@ -58,12 +69,24 @@ async function loadData() {
         rows.value = [...memberRows, ...inviteRows]
     }
     catch (err) {
-        console.error('[Admin] Failed to load members', err)
+        console.error('[Admin] Failed to load organisation', err)
     }
     finally {
         loading.value = false
     }
 }
+
+// -- Tabs -----------------------------------------------------------------------
+
+const tab = ref('members')
+const tabItems = computed<TabsItem[]>(() => [
+    { label: `Members (${rows.value.length})`, icon: 'i-lucide-users', value: 'members' },
+    { label: 'Usage & quotas', icon: 'i-lucide-gauge', value: 'usage' },
+    { label: 'Activity', icon: 'i-lucide-activity', value: 'activity' },
+    { label: 'Settings', icon: 'i-lucide-sliders-horizontal', value: 'settings' },
+])
+
+// -- Members --------------------------------------------------------------------
 
 async function removeMember(member: OrgMember) {
     try {
@@ -90,7 +113,7 @@ async function cancelInvite(member: OrgMember) {
 async function joinOrganisation() {
     try {
         await adminStore.joinOrganisation(orgId.value)
-        toast.add({ title: `Joined ${orgName.value ?? 'organisation'}`, color: 'success' })
+        toast.add({ title: `Joined ${org.value?.name ?? 'organisation'}`, color: 'success' })
         await loadData()
     }
     catch (err) {
@@ -110,6 +133,193 @@ async function resendInvite(member: OrgMember) {
     }
 }
 
+// -- Usage & quotas ---------------------------------------------------------------
+
+const periodLabel = computed(() => {
+    if (!quotas.value) return ''
+    return new Date(quotas.value.period_start).toLocaleDateString(undefined, { month: 'long', year: 'numeric' })
+})
+
+const usageTiles = computed(() => {
+    const row = quotaRow.value
+    if (!row) return []
+    const eff = row.effective
+    return [
+        {
+            label: 'Sources',
+            value: row.sources.toLocaleString(),
+            sub: eff.max_sources != null ? `of ${eff.max_sources.toLocaleString()} allowed` : 'no limit set',
+            used: row.sources,
+            limit: eff.max_sources,
+        },
+        {
+            label: 'Assets / source',
+            value: row.max_assets_per_source.toLocaleString(),
+            sub: eff.max_assets_per_source != null
+                ? `largest source, of ${eff.max_assets_per_source.toLocaleString()}`
+                : 'largest source',
+            used: row.max_assets_per_source,
+            limit: eff.max_assets_per_source,
+        },
+        {
+            label: 'Successful runs',
+            value: row.successful_runs.toLocaleString(),
+            sub: eff.max_successful_runs_per_month != null
+                ? `of ${eff.max_successful_runs_per_month.toLocaleString()} this period`
+                : 'this period',
+            used: row.successful_runs,
+            limit: eff.max_successful_runs_per_month,
+        },
+        {
+            label: 'Reserved runs',
+            value: row.reserved_runs.toLocaleString(),
+            sub: 'queued against the ledger',
+            used: row.reserved_runs,
+            limit: null,
+        },
+    ]
+})
+
+const LIMIT_FIELDS = [
+    { key: 'max_sources', label: 'Max sources' },
+    { key: 'max_assets_per_source', label: 'Max assets per source' },
+    { key: 'max_successful_runs_per_month', label: 'Max successful runs / month' },
+] as const
+
+type LimitKey = typeof LIMIT_FIELDS[number]['key']
+
+const limitRows = computed(() => {
+    const row = quotaRow.value
+    const defaults = quotas.value?.defaults
+    if (!row || !defaults) return []
+    return LIMIT_FIELDS.map(({ key, label }) => {
+        const override = row.limits[key]
+        const effective = row.effective[key]
+        return {
+            key,
+            label,
+            value: effective != null ? effective.toLocaleString() : 'Unlimited',
+            overridden: override != null,
+            note: override != null
+                ? `Instance default is ${defaults[key] != null ? defaults[key]!.toLocaleString() : 'unlimited'}`
+                : 'Follows the instance default',
+        }
+    })
+})
+
+const ledgerInSync = computed(() =>
+    quotaRow.value != null && quotaRow.value.successful_runs === quotaRow.value.recomputed_successful_runs)
+
+// Edit modal — string-typed fields so an emptied input means "inherit".
+const editOpen = ref(false)
+const editForm = ref<Record<LimitKey, string>>({
+    max_sources: '',
+    max_assets_per_source: '',
+    max_successful_runs_per_month: '',
+})
+const saving = ref(false)
+
+function defaultPlaceholder(key: LimitKey): string {
+    const value = quotas.value?.defaults[key]
+    return value != null ? `default: ${value}` : 'default: unlimited'
+}
+
+function openEdit() {
+    const limits = quotaRow.value?.limits
+    editForm.value = {
+        max_sources: limits?.max_sources?.toString() ?? '',
+        max_assets_per_source: limits?.max_assets_per_source?.toString() ?? '',
+        max_successful_runs_per_month: limits?.max_successful_runs_per_month?.toString() ?? '',
+    }
+    editOpen.value = true
+}
+
+async function submitEdit() {
+    saving.value = true
+    try {
+        await adminStore.updateOrgQuota(orgId.value, {
+            max_sources: editForm.value.max_sources === '' ? null : Number(editForm.value.max_sources),
+            max_assets_per_source: editForm.value.max_assets_per_source === ''
+                ? null
+                : Number(editForm.value.max_assets_per_source),
+            max_successful_runs_per_month: editForm.value.max_successful_runs_per_month === ''
+                ? null
+                : Number(editForm.value.max_successful_runs_per_month),
+        })
+        toast.add({ title: 'Quota limits updated', color: 'success' })
+        editOpen.value = false
+        quotas.value = await adminStore.getQuotas()
+    }
+    catch (err) {
+        toast.add(errorToast(err, 'Failed to update quota limits'))
+    }
+    finally {
+        saving.value = false
+    }
+}
+
+// -- Activity ---------------------------------------------------------------------
+
+const ACTIVITY_ICONS: Record<string, string> = {
+    org_created: 'i-lucide-building-2',
+    org_deleted: 'i-lucide-trash-2',
+    member_joined: 'i-lucide-user-plus',
+    invitation_sent: 'i-lucide-mail',
+    source_added: 'i-lucide-plug',
+    runs_completed: 'i-lucide-check-circle',
+}
+
+// -- Settings ----------------------------------------------------------------------
+
+const renameValue = ref('')
+watch(org, value => {
+    renameValue.value = value?.name ?? ''
+})
+const renaming = ref(false)
+
+async function submitRename() {
+    const name = renameValue.value.trim()
+    if (!name || name === org.value?.name) return
+    renaming.value = true
+    try {
+        await adminStore.renameOrganisation(orgId.value, name)
+        toast.add({ title: 'Organisation renamed', color: 'success' })
+        await loadData()
+    }
+    catch (err) {
+        toast.add(errorToast(err, 'Failed to rename organisation'))
+    }
+    finally {
+        renaming.value = false
+    }
+}
+
+async function openWorkspace() {
+    if (!org.value) return
+    await switchToOrg({ id: org.value.id, name: org.value.name } as Organisation)
+    await navigateTo('/')
+}
+
+const deleteConfirmName = ref('')
+const deleting = ref(false)
+
+async function submitDelete() {
+    const target = org.value
+    if (!target || deleteConfirmName.value !== target.name) return
+    deleting.value = true
+    try {
+        await adminStore.deleteOrganisation(target.id, deleteConfirmName.value)
+        toast.add({ title: `Organisation "${target.name}" deleted`, color: 'success' })
+        await navigateTo('/admin/organisations')
+    }
+    catch (err) {
+        toast.add(errorToast(err, 'Failed to delete organisation'))
+    }
+    finally {
+        deleting.value = false
+    }
+}
+
 onMounted(loadData)
 watch(orgId, loadData)
 </script>
@@ -119,26 +329,238 @@ watch(orgId, loadData)
         <div class="pb-4 shrink-0">
             <PageBreadcrumb :items="breadcrumbs" />
         </div>
-        <OrganizationMembersTable :members="rows"
-                                  :loading="loading"
-                                  is-admin
-                                  @remove-member="removeMember"
-                                  @cancel-invite="cancelInvite"
-                                  @resend-invite="resendInvite">
-            <template #toolbar>
-                <UButton v-if="!loading && !isMember"
-                         icon="i-lucide-log-in"
-                         label="Join"
-                         variant="outline"
-                         @click="joinOrganisation" />
-                <UButton icon="i-lucide-user-plus"
-                         label="Invite"
-                         @click="inviteOpen = true" />
-            </template>
-        </OrganizationMembersTable>
 
-        <OrganizationInviteModal v-model:open="inviteOpen"
-                                 :endpoint="inviteEndpoint"
-                                 @invited="loadData" />
+        <div class="flex items-center gap-3.5 mb-5">
+            <span class="flex size-11 shrink-0 items-center justify-center rounded-xl text-white text-[17px] font-bold"
+                  :style="{ background: avatarColor(orgId) }">
+                {{ (org?.name ?? '?').charAt(0).toUpperCase() }}
+            </span>
+            <div class="min-w-0">
+                <h1 class="text-[21px] font-bold tracking-tight truncate">{{ org?.name ?? '…' }}</h1>
+                <div class="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[13px] text-muted mt-0.5">
+                    <span>{{ rows.filter(r => r.status === 'active').length }} members</span>
+                    <span class="size-[3px] rounded-full bg-accented" />
+                    <span>{{ quotaRow?.sources ?? 0 }} sources</span>
+                    <span class="size-[3px] rounded-full bg-accented" />
+                    <span>Created {{ formatDay(org?.created_at) }}</span>
+                    <span class="size-[3px] rounded-full bg-accented" />
+                    <span class="font-mono text-xs">{{ orgId.slice(0, 8) }}</span>
+                </div>
+            </div>
+        </div>
+
+        <UTabs v-model="tab"
+               :items="tabItems"
+               :content="false"
+               variant="link"
+               class="mb-5 shrink-0" />
+
+        <div v-if="tab === 'members'"
+             class="flex flex-col flex-1 min-h-0">
+            <OrganizationMembersTable :members="rows"
+                                      :loading="loading"
+                                      is-admin
+                                      @remove-member="removeMember"
+                                      @cancel-invite="cancelInvite"
+                                      @resend-invite="resendInvite">
+                <template #toolbar>
+                    <UButton v-if="!loading && !isMember"
+                             icon="i-lucide-log-in"
+                             label="Join"
+                             variant="outline"
+                             @click="joinOrganisation" />
+                    <UButton icon="i-lucide-user-plus"
+                             label="Invite"
+                             @click="inviteOpen = true" />
+                </template>
+            </OrganizationMembersTable>
+
+            <OrganizationInviteModal v-model:open="inviteOpen"
+                                     :endpoint="inviteEndpoint"
+                                     @invited="loadData" />
+        </div>
+
+        <div v-else-if="tab === 'usage'"
+             class="flex flex-col gap-3">
+            <div class="grid grid-cols-2 xl:grid-cols-4 gap-3">
+                <div v-for="tile in usageTiles"
+                     :key="tile.label"
+                     class="rounded-lg border border-default bg-default px-4 py-3.5">
+                    <div class="text-[11.5px] font-semibold uppercase tracking-wider text-dimmed">{{ tile.label }}</div>
+                    <div class="text-[23px] font-bold tracking-tight tabular-nums mt-1.5">{{ tile.value }}</div>
+                    <div class="text-xs text-muted mt-0.5">{{ tile.sub }}</div>
+                    <AdminUsageMeter :used="tile.used"
+                                     :limit="tile.limit"
+                                     :show-label="false"
+                                     class="mt-2.5" />
+                </div>
+            </div>
+
+            <section class="overflow-hidden rounded-lg border border-default bg-default">
+                <div class="flex items-center gap-2 border-b border-default px-4 py-3">
+                    <span class="text-sm font-semibold">Limits</span>
+                    <span class="text-xs text-dimmed">Current period: {{ periodLabel }}</span>
+                    <UButton icon="i-lucide-pencil"
+                             label="Edit limits"
+                             variant="outline"
+                             size="sm"
+                             class="ml-auto"
+                             @click="openEdit" />
+                </div>
+                <div v-for="row in limitRows"
+                     :key="row.key"
+                     class="flex items-center gap-4 px-4 py-3 border-b border-muted">
+                    <span class="w-64 shrink-0 text-[13.5px] text-muted">{{ row.label }}</span>
+                    <span class="font-mono text-[13px] font-semibold">{{ row.value }}</span>
+                    <UBadge :label="row.overridden ? 'Override' : 'Inherited'"
+                            :color="row.overridden ? 'info' : 'neutral'"
+                            variant="subtle"
+                            size="sm" />
+                    <span class="text-xs text-dimmed">{{ row.note }}</span>
+                </div>
+                <div v-if="quotaRow"
+                     class="flex items-center gap-2.5 px-4 py-3 bg-elevated/40 text-[13.5px]">
+                    <UIcon :name="ledgerInSync ? 'i-lucide-check-circle' : 'i-lucide-triangle-alert'"
+                           class="size-4 shrink-0"
+                           :class="ledgerInSync ? 'text-success' : 'text-warning'" />
+                    <span v-if="ledgerInSync">
+                        Ledger in sync — the runs counter and the runs table both report
+                        <b>{{ quotaRow.successful_runs.toLocaleString() }}</b> successful runs.
+                    </span>
+                    <span v-else>
+                        Ledger drift — the counter reads <b>{{ quotaRow.successful_runs.toLocaleString() }}</b>,
+                        the runs table gives <b>{{ quotaRow.recomputed_successful_runs.toLocaleString() }}</b>.
+                    </span>
+                </div>
+            </section>
+        </div>
+
+        <div v-else-if="tab === 'activity'"
+             class="overflow-hidden rounded-lg border border-default bg-default">
+            <div class="border-b border-default px-4 py-3">
+                <div class="text-sm font-semibold">Activity</div>
+                <div class="text-xs text-dimmed mt-0.5">
+                    Derived from membership, invitation, source and run records
+                </div>
+            </div>
+            <div v-if="activity.length === 0"
+                 class="px-4 py-6 text-sm text-muted">
+                Nothing recorded yet.
+            </div>
+            <div v-for="entry in activity"
+                 :key="entry.kind + entry.when"
+                 class="flex items-start gap-3 px-4 py-3 border-b border-muted last:border-b-0">
+                <span class="flex size-6.5 shrink-0 items-center justify-center rounded-lg bg-elevated text-muted mt-0.5">
+                    <UIcon :name="ACTIVITY_ICONS[entry.kind] ?? 'i-lucide-circle'"
+                           class="size-3.5" />
+                </span>
+                <div class="flex-1 min-w-0">
+                    <div class="text-[13.5px] leading-snug">{{ entry.title }}</div>
+                    <div v-if="entry.detail"
+                         class="text-xs text-dimmed mt-0.5">{{ entry.detail }}</div>
+                </div>
+                <span class="shrink-0 text-xs text-dimmed whitespace-nowrap mt-0.5">
+                    {{ timeSince(new Date(entry.when)) }} ago
+                </span>
+            </div>
+        </div>
+
+        <div v-else-if="tab === 'settings'"
+             class="flex flex-col gap-3 max-w-[660px]">
+            <section class="rounded-lg border border-default bg-default p-4">
+                <div class="text-sm font-semibold">Organisation name</div>
+                <p class="text-[13px] text-muted leading-normal mt-1">
+                    Shown across the app and in invitation emails.
+                </p>
+                <div class="flex items-center gap-2 mt-3">
+                    <UInput v-model="renameValue"
+                            class="flex-1"
+                            @keydown.enter="submitRename" />
+                    <UButton label="Save"
+                             :disabled="!renameValue.trim() || renameValue.trim() === org?.name || renaming"
+                             :loading="renaming"
+                             @click="submitRename" />
+                </div>
+            </section>
+
+            <section class="rounded-lg border border-default bg-default p-4">
+                <div class="text-sm font-semibold">Your membership</div>
+                <p class="text-[13px] text-muted leading-normal mt-1">
+                    <template v-if="isMember">
+                        You are an active member of this organisation, so you can open its workspace directly.
+                    </template>
+                    <template v-else>
+                        You are not a member of this organisation. Join it to open its workspace.
+                    </template>
+                </p>
+                <div class="mt-3">
+                    <UButton v-if="isMember"
+                             icon="i-lucide-log-in"
+                             label="Open workspace"
+                             variant="outline"
+                             @click="openWorkspace" />
+                    <UButton v-else
+                             icon="i-lucide-log-in"
+                             label="Join"
+                             variant="outline"
+                             @click="joinOrganisation" />
+                </div>
+            </section>
+
+            <section class="rounded-lg border border-error/40 bg-error/5 p-4">
+                <div class="flex items-center gap-2 text-sm font-semibold text-error">
+                    <UIcon name="i-lucide-octagon-alert"
+                           class="size-4" />
+                    Delete organisation
+                </div>
+                <p class="text-[13px] leading-relaxed mt-1 text-error/90">
+                    This permanently deletes {{ org?.name ?? 'this organisation' }} with all its members,
+                    invitations, components, and execution history. This action cannot be undone.
+                </p>
+                <div class="flex items-center gap-2 mt-3">
+                    <UInput v-model="deleteConfirmName"
+                            :placeholder="`Type “${org?.name}” to confirm`"
+                            class="flex-1"
+                            @keydown.enter="submitDelete" />
+                    <UButton label="Delete"
+                             color="error"
+                             :disabled="deleteConfirmName !== org?.name || deleting"
+                             :loading="deleting"
+                             @click="submitDelete" />
+                </div>
+            </section>
+        </div>
+
+        <UModal v-model:open="editOpen"
+                :title="`Quota limits — ${org?.name}`"
+                :ui="{ footer: 'justify-end' }">
+            <template #body>
+                <div class="flex flex-col gap-3">
+                    <p class="text-sm text-muted">
+                        Overrides for this organisation. Leave a field empty to inherit the instance default.
+                    </p>
+                    <UFormField v-for="field in LIMIT_FIELDS"
+                                :key="field.key"
+                                :label="field.label">
+                        <UInput v-model="editForm[field.key]"
+                                type="number"
+                                min="0"
+                                :placeholder="defaultPlaceholder(field.key)"
+                                class="w-full"
+                                @keydown.enter="submitEdit" />
+                    </UFormField>
+                </div>
+            </template>
+            <template #footer>
+                <UButton label="Cancel"
+                         color="neutral"
+                         variant="outline"
+                         @click="editOpen = false" />
+                <UButton label="Save"
+                         :disabled="saving"
+                         :loading="saving"
+                         @click="submitEdit" />
+            </template>
+        </UModal>
     </div>
 </template>

--- a/packages/interloper-app/app/app/stores/admin.ts
+++ b/packages/interloper-app/app/app/stores/admin.ts
@@ -1,4 +1,11 @@
-import type { AdminConfig, AdminOrganisation, AdminQuotaLimits, AdminQuotas, AdminUser } from '~/types/admin'
+import type {
+    AdminActivityEntry,
+    AdminConfig,
+    AdminOrganisation,
+    AdminQuotaLimits,
+    AdminQuotas,
+    AdminUser,
+} from '~/types/admin'
 
 interface MemberResponse {
     id: string
@@ -26,6 +33,11 @@ export const useAdminStore = defineStore('admin', () => {
 
     function getQuotas() {
         return apiFetch<AdminQuotas>('/admin/quotas')
+    }
+
+    /** Derived activity feed for one organisation, newest first. */
+    function getOrgActivity(orgId: string) {
+        return apiFetch<AdminActivityEntry[]>(`/admin/organisations/${orgId}/activity`)
     }
 
     /** Set an org's quota overrides; null clears a field (falls back to the default). */
@@ -114,6 +126,7 @@ export const useAdminStore = defineStore('admin', () => {
     return {
         getConfig,
         getQuotas,
+        getOrgActivity,
         updateOrgQuota,
         listUsers,
         deleteUser,

--- a/packages/interloper-app/app/app/types/admin.ts
+++ b/packages/interloper-app/app/app/types/admin.ts
@@ -75,6 +75,13 @@ export interface AdminQuotas {
     organisations: AdminOrgQuotaStatus[]
 }
 
+export interface AdminActivityEntry {
+    kind: string
+    when: string
+    title: string
+    detail: string | null
+}
+
 export interface AdminUser {
     id: string
     email: string

--- a/packages/interloper-app/app/app/utils/time.ts
+++ b/packages/interloper-app/app/app/utils/time.ts
@@ -24,6 +24,13 @@ export function timeSince(date: Date): string {
     return Math.floor(seconds) + " seconds"
 }
 
+/** Date-only label, e.g. "4 Feb 2026". */
+export function formatDay(value: string | Date | null | undefined): string {
+    if (!value) return '—'
+    const date = typeof value === 'string' ? new Date(value) : value
+    return date.toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' })
+}
+
 export function formatDate(value: string | Date | null | undefined) {
     if (!value) return ''
     const date = typeof value === 'string' ? new Date(value) : value

--- a/packages/interloper-db/src/interloper_db/store/auth.py
+++ b/packages/interloper-db/src/interloper_db/store/auth.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 import hashlib
 import secrets
 from datetime import datetime, timedelta, timezone
+from typing import Any
 from uuid import UUID
 
 from interloper.errors import NotFoundError
 from sqlalchemy import delete, func, update
-from sqlmodel import Session, select
+from sqlmodel import Session, col, select
 
 from interloper_db.models import (
     AuthSession,
@@ -20,6 +21,7 @@ from interloper_db.models import (
     PersonalAccessToken,
     Profile,
     Quota,
+    Run,
     UserOrganisation,
 )
 from interloper_db.store.base import StoreBase
@@ -429,6 +431,94 @@ class AuthMixin(StoreBase):
             if organisation and organisation.deleted_at is not None and not include_deleted:
                 return None
             return organisation
+
+    def list_organisation_activity(self, org_id: UUID, *, limit: int = 20) -> list[dict[str, Any]]:
+        """A derived activity feed for one organisation, newest first.
+
+        Composed purely from existing records — the organisation row,
+        memberships, pending invitations, source components, and daily
+        successful-run aggregates. There is no audit table, so events whose
+        source rows are gone (accepted invitations' inviters, quota-change
+        history) are not reconstructible and deliberately absent.
+
+        Returns:
+            Entries as ``{kind, when, subject, extra}`` dicts, ``when``
+            always an aware UTC datetime.
+
+        Raises:
+            NotFoundError: If the organisation is not found.
+        """
+
+        def as_utc(value: Any) -> datetime:
+            if isinstance(value, str):  # SQLite aggregates come back as text
+                value = datetime.fromisoformat(value)
+            return value.replace(tzinfo=timezone.utc) if value.tzinfo is None else value
+
+        entries: list[dict[str, Any]] = []
+        with self._session() as session:
+            organisation = session.get(Organisation, org_id)
+            if not organisation:
+                raise NotFoundError(f"Organisation {org_id} not found")
+            if organisation.created_at:
+                entries.append({"kind": "org_created", "when": organisation.created_at, "subject": None, "extra": None})
+            if organisation.deleted_at:
+                entries.append({"kind": "org_deleted", "when": organisation.deleted_at, "subject": None, "extra": None})
+
+            memberships = session.exec(
+                select(UserOrganisation, Profile)
+                .where(UserOrganisation.organisation_id == org_id, col(Profile.id) == UserOrganisation.user_id)
+            ).all()
+            for membership, profile in memberships:
+                if membership.created_at:
+                    entries.append({
+                        "kind": "member_joined",
+                        "when": membership.created_at,
+                        "subject": profile.name or profile.email,
+                        "extra": membership.role,
+                    })
+
+            invitations = session.exec(select(Invitation).where(Invitation.organisation_id == org_id)).all()
+            inviter_ids = [invitation.invited_by for invitation in invitations]
+            inviters = {
+                profile.id: profile
+                for profile in session.exec(select(Profile).where(col(Profile.id).in_(inviter_ids))).all()
+            } if inviter_ids else {}
+            for invitation in invitations:
+                if invitation.created_at:
+                    inviter = inviters.get(invitation.invited_by)
+                    entries.append({
+                        "kind": "invitation_sent",
+                        "when": invitation.created_at,
+                        "subject": invitation.email,
+                        "extra": (inviter.name or inviter.email) if inviter else None,
+                    })
+
+            sources = session.exec(
+                select(Component).where(col(Component.org_id) == org_id, col(Component.kind) == "source")
+            ).all()
+            for source in sources:
+                if source.created_at:
+                    entries.append({
+                        "kind": "source_added",
+                        "when": source.created_at,
+                        "subject": source.name or source.key,
+                        "extra": None,
+                    })
+
+            # func.date() buckets per calendar day on both Postgres and SQLite.
+            day = func.date(col(Run.completed_at)).label("day")
+            run_days = session.exec(
+                select(day, func.count(), func.max(col(Run.completed_at)))
+                .where(col(Run.org_id) == org_id, col(Run.status) == "success")
+                .group_by(day)
+            ).all()
+            for _day, count, latest in run_days:
+                entries.append({"kind": "runs_completed", "when": latest, "subject": str(count), "extra": None})
+
+        for entry in entries:
+            entry["when"] = as_utc(entry["when"])
+        entries.sort(key=lambda entry: entry["when"], reverse=True)
+        return entries[:limit]
 
     def list_user_organisations(self, user_id: UUID) -> list[Organisation]:
         """List all organisations a user belongs to.

--- a/packages/interloper-db/tests/store/test_auth.py
+++ b/packages/interloper-db/tests/store/test_auth.py
@@ -258,3 +258,55 @@ class TestHasPendingInvitation:
             session.commit()
 
         assert not store.has_pending_invitation("new@example.com")
+
+
+class TestOrganisationActivity:
+    def test_composes_and_sorts_the_derived_feed(self, store: Store, auth_db: Engine):
+        admin = store.upsert_profile(google_id="g-act", email="act@example.com", name="Act Min")
+        org = store.create_organisation(name="Busy", creator_id=admin.id)
+        store.add_org_member(org.id, admin.id, "admin")
+        store.create_invitation(org_id=org.id, email="new@example.com", role="viewer", invited_by=admin.id)
+        with SQLSession(auth_db) as session:
+            session.add(Component(org_id=org.id, kind="source", key="bing_ads", name="Bing"))
+            session.add(
+                Run(
+                    id=uuid4(),
+                    org_id=org.id,
+                    status="success",
+                    completed_at=datetime(2026, 8, 10, 12, 0, tzinfo=timezone.utc),
+                )
+            )
+            session.add(
+                Run(
+                    id=uuid4(),
+                    org_id=org.id,
+                    status="success",
+                    completed_at=datetime(2026, 8, 10, 13, 0, tzinfo=timezone.utc),
+                )
+            )
+            session.add(Run(id=uuid4(), org_id=org.id, status="failed"))
+            session.commit()
+
+        entries = store.list_organisation_activity(org.id)
+
+        kinds = [entry["kind"] for entry in entries]
+        assert set(kinds) == {"org_created", "member_joined", "invitation_sent", "source_added", "runs_completed"}
+        whens = [entry["when"] for entry in entries]
+        assert whens == sorted(whens, reverse=True)
+        assert all(when.tzinfo is not None for when in whens)
+        joined = next(entry for entry in entries if entry["kind"] == "member_joined")
+        assert joined["subject"] == "Act Min" and joined["extra"] == "admin"
+        invited = next(entry for entry in entries if entry["kind"] == "invitation_sent")
+        assert invited["subject"] == "new@example.com" and invited["extra"] == "Act Min"
+        runs = next(entry for entry in entries if entry["kind"] == "runs_completed")
+        assert runs["subject"] == "2"  # only the successful runs, aggregated per day
+
+    def test_limit_caps_the_feed(self, store: Store):
+        admin = store.upsert_profile(google_id="g-cap", email="cap@example.com", name="Cap")
+        org = store.create_organisation(name="Capped", creator_id=admin.id)
+        store.add_org_member(org.id, admin.id, "admin")
+        assert len(store.list_organisation_activity(org.id, limit=1)) == 1
+
+    def test_unknown_org_raises(self, store: Store):
+        with pytest.raises(NotFoundError):
+            store.list_organisation_activity(uuid4())


### PR DESCRIPTION
PR 2/4 of the admin panel redesign. **Stacked on the overview PR.**

The admin org page grows from a bare members table into the designed detail view: identity header (colored tile + member/source/created/id meta) and four tabs —

- **Members**: existing table, invite/join unchanged.
- **Usage & quotas**: stat tiles with usage bars; a Limits card showing each limit's effective value with Override/Inherited tags and the instance default; the quota **edit modal now lives here** (the quotas list goes read-only in the next PR); the ledger in-sync/drift strip.
- **Activity**: derived feed from the new `GET /admin/organisations/{id}/activity` — composed purely from existing records (org row, memberships, pending invitations, sources, daily successful-run aggregates). No audit table exists, so events whose source rows are gone (accepted invitations' inviters, quota-change history) are deliberately absent — building a real audit trail is a separate future feature.
- **Settings**: rename, open-workspace/join, and the inline type-to-confirm danger delete card.

Tests: store feed composition/sorting/limit/404 (SQLite `func.date` day-bucketing), route title composition + super-admin gate.

By Digitl