### PR TITLE
refactor(app): redesign the admin list pages

### DIFF
--- a/packages/interloper-api/src/interloper_api/routes/admin.py
+++ b/packages/interloper-api/src/interloper_api/routes/admin.py
@@ -241,6 +241,8 @@ class AdminOrgQuotaStatus(BaseModel):
 
     id: UUID
     name: str
+    #: Soft-deleted orgs keep their ledger visible but are read-only.
+    deleted_at: datetime | None = None
     limits: AdminQuotaLimits
     effective: AdminQuotaLimits
     sources: int
@@ -578,6 +580,7 @@ def get_quotas(
             AdminOrgQuotaStatus(
                 id=org.id,
                 name=org.name,
+                deleted_at=org.deleted_at,
                 limits=limits,
                 effective=_effective_limits(limits, defaults),
                 sources=sources.get(org.id, 0),

--- a/packages/interloper-app/app/app/pages/admin/organisations/index.vue
+++ b/packages/interloper-app/app/app/pages/admin/organisations/index.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { h, resolveComponent } from 'vue'
-import type { TableColumn, DropdownMenuItem } from '@nuxt/ui'
-import type { AdminOrganisation } from '~/types/admin'
+import type { TableColumn } from '@nuxt/ui'
+import type { AdminOrganisation, AdminOrgQuotaStatus, AdminQuotas } from '~/types/admin'
 
 definePageMeta({
     title: 'Organisations',
@@ -10,24 +10,27 @@ definePageMeta({
 })
 
 const UBadge = resolveComponent('UBadge')
+const AdminUsageMeter = resolveComponent('AdminUsageMeter')
 
 const adminStore = useAdminStore()
 const toast = useToast()
 
 const rows = ref<AdminOrganisation[]>([])
+const quotas = ref<AdminQuotas | null>(null)
 const loading = ref(false)
 
-// Create / rename modal state
-const formOpen = ref(false)
-const formMode = ref<'create' | 'rename'>('create')
-const formName = ref('')
-const formTarget = ref<AdminOrganisation | null>(null)
-const submitting = ref(false)
+// Create modal state — rename and delete live on the detail page's Settings tab.
+const createOpen = ref(false)
+const createName = ref('')
+const creating = ref(false)
 
 async function loadData() {
     loading.value = true
     try {
-        rows.value = await adminStore.listOrganisations()
+        [rows.value, quotas.value] = await Promise.all([
+            adminStore.listOrganisations(),
+            adminStore.getQuotas(),
+        ])
     }
     catch (err) {
         console.error('[Admin] Failed to load organisations', err)
@@ -37,73 +40,36 @@ async function loadData() {
     }
 }
 
-// Delete modal state — confirmed by typing the organisation's exact name.
-const deleteOpen = ref(false)
-const deleteTarget = ref<AdminOrganisation | null>(null)
-const deleteConfirmName = ref('')
-const deleting = ref(false)
+/** Usage columns come from the quotas overview; the rest from the org row. */
+const usageByOrg = computed(() => new Map<string, AdminOrgQuotaStatus>(
+    (quotas.value?.organisations ?? []).map(row => [row.id, row])))
+
+const periodLabel = computed(() => {
+    if (!quotas.value) return ''
+    return new Date(quotas.value.period_start).toLocaleDateString(undefined, { month: 'long', year: 'numeric' })
+})
 
 function openCreate() {
-    formMode.value = 'create'
-    formName.value = ''
-    formTarget.value = null
-    formOpen.value = true
+    createName.value = ''
+    createOpen.value = true
 }
 
-function openDelete(org: AdminOrganisation) {
-    deleteTarget.value = org
-    deleteConfirmName.value = ''
-    deleteOpen.value = true
-}
-
-async function submitDelete() {
-    const target = deleteTarget.value
-    if (!target || deleteConfirmName.value !== target.name) return
-
-    deleting.value = true
-    try {
-        await adminStore.deleteOrganisation(target.id, deleteConfirmName.value)
-        toast.add({ title: `Organisation "${target.name}" deleted`, color: 'success' })
-        deleteOpen.value = false
-        await loadData()
-    }
-    catch (err) {
-        toast.add(errorToast(err, 'Failed to delete organisation'))
-    }
-    finally {
-        deleting.value = false
-    }
-}
-
-function openRename(org: AdminOrganisation) {
-    formMode.value = 'rename'
-    formName.value = org.name
-    formTarget.value = org
-    formOpen.value = true
-}
-
-async function submitForm() {
-    const name = formName.value.trim()
+async function submitCreate() {
+    const name = createName.value.trim()
     if (!name) return
 
-    submitting.value = true
+    creating.value = true
     try {
-        if (formMode.value === 'create') {
-            await adminStore.createOrganisation(name)
-            toast.add({ title: `Organisation "${name}" created`, color: 'success' })
-        }
-        else if (formTarget.value) {
-            await adminStore.renameOrganisation(formTarget.value.id, name)
-            toast.add({ title: 'Organisation renamed', color: 'success' })
-        }
-        formOpen.value = false
+        await adminStore.createOrganisation(name)
+        toast.add({ title: `Organisation "${name}" created`, color: 'success' })
+        createOpen.value = false
         await loadData()
     }
     catch (err) {
-        toast.add(errorToast(err, 'Operation failed'))
+        toast.add(errorToast(err, 'Failed to create organisation'))
     }
     finally {
-        submitting.value = false
+        creating.value = false
     }
 }
 
@@ -112,31 +78,7 @@ function openOrg(org: AdminOrganisation) {
     navigateTo(`/admin/organisations/${org.id}`)
 }
 
-function rowActions(org: AdminOrganisation): DropdownMenuItem[][] {
-    if (org.deleted_at) return []
-    return [
-        [
-            {
-                label: 'Manage members',
-                icon: 'i-lucide-users',
-                onSelect: () => navigateTo(`/admin/organisations/${org.id}`),
-            },
-            {
-                label: 'Rename',
-                icon: 'i-lucide-pencil',
-                onSelect: () => openRename(org),
-            },
-        ],
-        [
-            {
-                label: 'Delete organisation',
-                icon: 'i-lucide-trash-2',
-                color: 'error' as const,
-                onSelect: () => openDelete(org),
-            },
-        ],
-    ]
-}
+const dash = () => h('span', { class: 'text-dimmed' }, '—')
 
 const columns: TableColumn<AdminOrganisation>[] = [
     {
@@ -144,24 +86,52 @@ const columns: TableColumn<AdminOrganisation>[] = [
         header: 'Name',
         cell: ({ row }) => {
             const org = row.original
-            if (!org.deleted_at) return org.name
+            if (!org.deleted_at) return h('span', { class: 'font-medium' }, org.name)
             return h('div', { class: 'flex items-center gap-2' }, [
                 h('span', { class: 'text-dimmed line-through' }, org.name),
-                h(UBadge, { label: 'Deleted', color: 'neutral', size: 'sm' }),
+                h(UBadge, { label: 'Deleted', color: 'neutral', variant: 'subtle', size: 'sm' }),
             ])
         },
     },
     {
         accessorKey: 'member_count',
         header: 'Members',
-        cell: ({ row }) => row.original.member_count,
+        cell: ({ row }) => row.original.deleted_at
+            ? dash()
+            : h('span', { class: 'text-muted' }, String(row.original.member_count)),
+    },
+    {
+        id: 'sources',
+        header: 'Sources',
+        cell: ({ row }) => {
+            const usage = usageByOrg.value.get(row.original.id)
+            if (row.original.deleted_at || !usage) return dash()
+            return h('span', { class: 'text-muted' }, String(usage.sources))
+        },
+    },
+    {
+        id: 'runs',
+        header: 'Runs',
+        cell: ({ row }) => {
+            const usage = usageByOrg.value.get(row.original.id)
+            if (row.original.deleted_at || !usage) return dash()
+            return h('span', { class: 'text-muted tabular-nums' }, usage.successful_runs.toLocaleString())
+        },
+    },
+    {
+        id: 'quota',
+        header: 'Run quota used',
+        cell: ({ row }) => {
+            const usage = usageByOrg.value.get(row.original.id)
+            const limit = usage?.effective.max_successful_runs_per_month ?? null
+            if (row.original.deleted_at || !usage || limit == null) return dash()
+            return h('div', { class: 'w-32' }, h(AdminUsageMeter, { used: usage.successful_runs, limit }))
+        },
     },
     {
         accessorKey: 'created_at',
         header: 'Created',
-        cell: ({ row }) => row.original.created_at
-            ? new Date(row.original.created_at).toLocaleDateString()
-            : '—',
+        cell: ({ row }) => h('span', { class: 'text-muted' }, formatDay(row.original.created_at)),
     },
 ]
 
@@ -169,11 +139,17 @@ onMounted(loadData)
 </script>
 
 <template>
-    <div class="flex flex-col flex-1 min-h-0">
+    <div class="flex flex-col flex-1 min-h-0 gap-3">
+        <div v-if="quotas"
+             class="flex items-center gap-2 text-sm text-muted shrink-0">
+            <UIcon name="i-lucide-calendar"
+                   class="size-4" />
+            <span>Runs and usage shown for the current quota period, <b class="text-default font-semibold">{{ periodLabel }}</b></span>
+        </div>
+
         <DataTable :columns="columns"
                    :data="rows"
                    :loading="loading"
-                   :row-actions="rowActions"
                    no-actions
                    search-placeholder="Search organisations..."
                    @edit="openOrg">
@@ -184,57 +160,25 @@ onMounted(loadData)
             </template>
         </DataTable>
 
-        <UModal v-model:open="deleteOpen"
-                title="Delete organisation"
+        <UModal v-model:open="createOpen"
+                title="New organisation"
                 :ui="{ footer: 'justify-end' }">
             <template #body>
-                <div class="flex flex-col gap-3">
-                    <p class="text-sm text-muted">
-                        This permanently deletes
-                        <EntityBadge icon="i-lucide-building-2"
-                                     :label="deleteTarget?.name ?? ''" />
-                        with all its members, invitations, components, and execution history.
-                        This action cannot be undone.
-                    </p>
-                    <UInput v-model="deleteConfirmName"
-                            :placeholder="`Type “${deleteTarget?.name}” to confirm`"
-                            autofocus
-                            class="w-full"
-                            @keydown.enter="submitDelete" />
-                </div>
-            </template>
-            <template #footer>
-                <UButton label="Cancel"
-                         color="neutral"
-                         variant="outline"
-                         @click="deleteOpen = false" />
-                <UButton label="Delete"
-                         color="error"
-                         :disabled="deleteConfirmName !== deleteTarget?.name || deleting"
-                         :loading="deleting"
-                         @click="submitDelete" />
-            </template>
-        </UModal>
-
-        <UModal v-model:open="formOpen"
-                :title="formMode === 'create' ? 'New organisation' : 'Rename organisation'"
-                :ui="{ footer: 'justify-end' }">
-            <template #body>
-                <UInput v-model="formName"
+                <UInput v-model="createName"
                         placeholder="Organisation name"
                         autofocus
                         class="w-full"
-                        @keydown.enter="submitForm" />
+                        @keydown.enter="submitCreate" />
             </template>
             <template #footer>
                 <UButton label="Cancel"
                          color="neutral"
                          variant="outline"
-                         @click="formOpen = false" />
-                <UButton :label="formMode === 'create' ? 'Create' : 'Save'"
-                         :disabled="!formName.trim() || submitting"
-                         :loading="submitting"
-                         @click="submitForm" />
+                         @click="createOpen = false" />
+                <UButton label="Create"
+                         :disabled="!createName.trim() || creating"
+                         :loading="creating"
+                         @click="submitCreate" />
             </template>
         </UModal>
     </div>

--- a/packages/interloper-app/app/app/pages/admin/quotas.vue
+++ b/packages/interloper-app/app/app/pages/admin/quotas.vue
@@ -14,13 +14,14 @@ definePageMeta({
 })
 
 const UBadge = resolveComponent('UBadge')
+const UButton = resolveComponent('UButton')
 
 const adminStore = useAdminStore()
 
 const quotas = ref<AdminQuotas | null>(null)
 const loading = ref(true)
 
-onMounted(async () => {
+async function loadData() {
     try {
         quotas.value = await adminStore.getQuotas()
     }
@@ -30,7 +31,18 @@ onMounted(async () => {
     finally {
         loading.value = false
     }
-})
+}
+
+onMounted(loadData)
+
+// Edit drawer — the AdminQuotaDrawer owns the form; rows open it via the pencil.
+const editOpen = ref(false)
+const editTarget = ref<AdminOrgQuotaStatus | null>(null)
+
+function openEdit(org: AdminOrgQuotaStatus) {
+    editTarget.value = org
+    editOpen.value = true
+}
 
 const rows = computed(() => quotas.value?.organisations ?? [])
 
@@ -139,6 +151,26 @@ const columns: TableColumn<AdminOrgQuotaStatus>[] = [
         },
     },
     {
+        id: 'edit',
+        header: '',
+        cell: ({ row }) => {
+            const org = row.original
+            if (org.deleted_at) return null
+            return h('div', { class: 'flex justify-end' }, h(UButton, {
+                'icon': 'i-lucide-pencil',
+                'color': 'neutral',
+                'variant': 'ghost',
+                'size': 'sm',
+                'aria-label': 'Edit quotas',
+                // Row click navigates to the org page; the pencil must not.
+                'onClick': (event: MouseEvent) => {
+                    event.stopPropagation()
+                    openEdit(org)
+                },
+            }))
+        },
+    },
+    {
         id: 'overrides',
         header: 'Overrides',
         cell: ({ row }) => {
@@ -177,5 +209,12 @@ const columns: TableColumn<AdminOrgQuotaStatus>[] = [
                    no-actions
                    search-placeholder="Search organisations..."
                    @edit="openOrg" />
+
+        <AdminQuotaDrawer v-model:open="editOpen"
+                          :org-id="editTarget?.id ?? ''"
+                          :org-name="editTarget?.name ?? ''"
+                          :limits="editTarget?.limits ?? null"
+                          :defaults="quotas?.defaults ?? null"
+                          @saved="loadData" />
     </div>
 </template>

--- a/packages/interloper-app/app/app/pages/admin/quotas.vue
+++ b/packages/interloper-app/app/app/pages/admin/quotas.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { h, resolveComponent } from 'vue'
-import type { TableColumn, DropdownMenuItem } from '@nuxt/ui'
+import type { TableColumn } from '@nuxt/ui'
 import type { AdminOrgQuotaStatus, AdminQuotas } from '~/types/admin'
 
 definePageMeta({
@@ -9,19 +9,18 @@ definePageMeta({
     middleware: 'super-admin',
     pageHeader: {
         title: 'Quotas',
-        description: 'Per-organisation limits and current-period usage. Empty limits inherit the instance defaults.',
+        description: 'Per-organisation limits and current-period usage. Empty limits inherit the instance defaults; edit them on the organisation page.',
     },
 })
 
 const UBadge = resolveComponent('UBadge')
 
 const adminStore = useAdminStore()
-const toast = useToast()
 
 const quotas = ref<AdminQuotas | null>(null)
 const loading = ref(true)
 
-async function loadData() {
+onMounted(async () => {
     try {
         quotas.value = await adminStore.getQuotas()
     }
@@ -31,75 +30,7 @@ async function loadData() {
     finally {
         loading.value = false
     }
-}
-
-onMounted(loadData)
-
-// Edit modal state — string-typed fields so an emptied input means "inherit".
-const editOpen = ref(false)
-const editTarget = ref<AdminOrgQuotaStatus | null>(null)
-const editForm = ref({ max_sources: '', max_assets_per_source: '', max_successful_runs_per_month: '' })
-const saving = ref(false)
-
-const LIMIT_FIELDS = [
-    { key: 'max_sources', label: 'Max sources' },
-    { key: 'max_assets_per_source', label: 'Max assets per source' },
-    { key: 'max_successful_runs_per_month', label: 'Max successful runs / month' },
-] as const
-
-function defaultPlaceholder(key: keyof typeof editForm.value): string {
-    const value = quotas.value?.defaults[key]
-    return value != null ? `default: ${value}` : 'default: unlimited'
-}
-
-function openEdit(org: AdminOrgQuotaStatus) {
-    editTarget.value = org
-    editForm.value = {
-        max_sources: org.limits.max_sources?.toString() ?? '',
-        max_assets_per_source: org.limits.max_assets_per_source?.toString() ?? '',
-        max_successful_runs_per_month: org.limits.max_successful_runs_per_month?.toString() ?? '',
-    }
-    editOpen.value = true
-}
-
-async function submitEdit() {
-    const target = editTarget.value
-    if (!target) return
-
-    saving.value = true
-    try {
-        await adminStore.updateOrgQuota(target.id, {
-            max_sources: editForm.value.max_sources === '' ? null : Number(editForm.value.max_sources),
-            max_assets_per_source: editForm.value.max_assets_per_source === ''
-                ? null
-                : Number(editForm.value.max_assets_per_source),
-            max_successful_runs_per_month: editForm.value.max_successful_runs_per_month === ''
-                ? null
-                : Number(editForm.value.max_successful_runs_per_month),
-        })
-        toast.add({ title: `Quota limits updated for ${target.name}`, color: 'success' })
-        editOpen.value = false
-        await loadData()
-    }
-    catch (err) {
-        toast.add(errorToast(err, 'Failed to update quota limits'))
-    }
-    finally {
-        saving.value = false
-    }
-}
-
-function rowActions(org: AdminOrgQuotaStatus): DropdownMenuItem[][] {
-    return [
-        [
-            {
-                label: 'Edit limits',
-                icon: 'i-lucide-pencil',
-                onSelect: () => openEdit(org),
-            },
-        ],
-    ]
-}
+})
 
 const rows = computed(() => quotas.value?.organisations ?? [])
 
@@ -108,38 +39,86 @@ const periodLabel = computed(() => {
     return new Date(quotas.value.period_start).toLocaleDateString(undefined, { month: 'long', year: 'numeric' })
 })
 
-/** "used / limit" with unlimited limits shown as a plain count. */
-function usageText(used: number, limit: number | null): string {
-    return limit != null ? `${used} / ${limit}` : String(used)
+const defaultChips = computed(() => {
+    const defaults = quotas.value?.defaults
+    if (!defaults) return []
+    return Object.entries(defaults).map(([key, value]) => ({
+        key,
+        value: value != null ? value.toLocaleString() : 'unlimited',
+    }))
+})
+
+function openOrg(org: AdminOrgQuotaStatus) {
+    if (org.deleted_at) return
+    navigateTo(`/admin/organisations/${org.id}`)
 }
 
-function usageCell(used: number, limit: number | null) {
-    const over = limit != null && used >= limit
-    return h('span', { class: over ? 'font-semibold text-error' : undefined }, usageText(used, limit))
+/** Threshold tone: ink below 75%, amber from 75%, red from 90%. */
+function usageClass(used: number, limit: number | null): string {
+    if (limit == null || limit <= 0) return ''
+    const pct = (used / limit) * 100
+    if (pct >= 90) return 'text-error font-semibold'
+    if (pct >= 75) return 'text-warning font-semibold'
+    return ''
 }
+
+function usageText(used: number, limit: number | null): string {
+    return limit != null ? `${used.toLocaleString()} / ${limit.toLocaleString()}` : used.toLocaleString()
+}
+
+const dash = () => h('span', { class: 'text-dimmed' }, '—')
 
 const columns: TableColumn<AdminOrgQuotaStatus>[] = [
     {
         accessorKey: 'name',
         header: 'Organisation',
-        cell: ({ row }) => h('span', { class: 'font-semibold text-highlighted' }, row.original.name),
+        cell: ({ row }) => {
+            const org = row.original
+            const tint = h('span', {
+                class: 'w-[5px] h-[22px] rounded shrink-0',
+                style: { background: avatarColor(org.id) },
+            })
+            const name = org.deleted_at
+                ? h('span', { class: 'text-dimmed line-through truncate' }, org.name)
+                : h('span', { class: 'font-semibold text-highlighted truncate' }, org.name)
+            const parts = [tint, name]
+            if (org.deleted_at)
+                parts.push(h(UBadge, { label: 'Deleted', color: 'neutral', variant: 'subtle', size: 'sm' }))
+            return h('div', { class: 'flex items-center gap-2.5 min-w-0' }, parts)
+        },
     },
     {
         id: 'sources',
         header: 'Sources',
-        cell: ({ row }) => usageCell(row.original.sources, row.original.effective.max_sources),
+        cell: ({ row }) => {
+            const org = row.original
+            if (org.deleted_at) return dash()
+            return h('span', {
+                class: `font-mono text-xs ${usageClass(org.sources, org.effective.max_sources)}`,
+            }, usageText(org.sources, org.effective.max_sources))
+        },
     },
     {
         id: 'assets',
         header: 'Assets / source (max)',
-        cell: ({ row }) => usageCell(row.original.max_assets_per_source, row.original.effective.max_assets_per_source),
+        cell: ({ row }) => {
+            const org = row.original
+            if (org.deleted_at) return dash()
+            // Deliberately never threshold-colored: the largest source is
+            // informational, not a pressure signal.
+            return h('span', { class: 'font-mono text-xs text-muted' },
+                usageText(org.max_assets_per_source, org.effective.max_assets_per_source))
+        },
     },
     {
         id: 'runs',
         header: 'Successful runs',
         cell: ({ row }) => {
             const org = row.original
-            const parts = [usageCell(org.successful_runs, org.effective.max_successful_runs_per_month)]
+            const limit = org.effective.max_successful_runs_per_month
+            const parts = [h('span', {
+                class: `font-mono text-xs ${usageClass(org.successful_runs, limit)}`,
+            }, usageText(org.successful_runs, limit))]
             if (org.reserved_runs > 0)
                 parts.push(h('span', { class: 'text-dimmed text-xs' }, ` +${org.reserved_runs} reserved`))
             return h('span', parts)
@@ -151,10 +130,11 @@ const columns: TableColumn<AdminOrgQuotaStatus>[] = [
         cell: ({ row }) => {
             const org = row.original
             return org.successful_runs === org.recomputed_successful_runs
-                ? h(UBadge, { label: 'In sync', color: 'success' })
+                ? h(UBadge, { label: 'In sync', color: 'success', variant: 'subtle' })
                 : h(UBadge, {
-                        label: `Drift (runs table: ${org.recomputed_successful_runs})`,
+                        label: `Drift (runs table: ${org.recomputed_successful_runs.toLocaleString()})`,
                         color: 'warning',
+                        variant: 'subtle',
                     })
         },
     },
@@ -164,7 +144,7 @@ const columns: TableColumn<AdminOrgQuotaStatus>[] = [
         cell: ({ row }) => {
             const limits = row.original.limits
             const set = Object.entries(limits).filter(([, value]) => value != null)
-            if (!set.length) return h('span', { class: 'text-dimmed' }, '—')
+            if (!set.length) return dash()
             return h('div', { class: 'flex flex-wrap gap-1' }, set.map(([key, value]) =>
                 h('span', { key, class: 'rounded-[5px] bg-elevated px-1.5 py-0.5 font-mono text-xs' }, `${key}=${value}`),
             ))
@@ -176,50 +156,26 @@ const columns: TableColumn<AdminOrgQuotaStatus>[] = [
 <template>
     <div class="flex flex-col flex-1 min-h-0 gap-3">
         <div v-if="quotas"
-             class="flex items-center gap-2 text-sm text-muted">
-            <UIcon name="i-lucide-calendar"
-                   class="size-4" />
-            <span>Current period: {{ periodLabel }}</span>
+             class="flex flex-wrap items-center gap-2.5 text-sm text-muted shrink-0">
+            <span class="flex items-center gap-1.5">
+                <UIcon name="i-lucide-calendar"
+                       class="size-4" />
+                Current period: <b class="text-default font-semibold">{{ periodLabel }}</b>
+            </span>
+            <span class="size-[3px] rounded-full bg-accented" />
+            <span>Instance defaults</span>
+            <span v-for="chip in defaultChips"
+                  :key="chip.key"
+                  class="rounded-md border border-default bg-default px-2 py-0.5 font-mono text-xs text-toned">
+                {{ chip.key }}=<b class="font-semibold">{{ chip.value }}</b>
+            </span>
         </div>
 
         <DataTable :columns="columns"
                    :data="rows"
                    :loading="loading"
-                   :row-actions="rowActions"
                    no-actions
                    search-placeholder="Search organisations..."
-                   @edit="openEdit" />
-
-        <UModal v-model:open="editOpen"
-                :title="`Quota limits — ${editTarget?.name}`"
-                :ui="{ footer: 'justify-end' }">
-            <template #body>
-                <div class="flex flex-col gap-3">
-                    <p class="text-sm text-muted">
-                        Overrides for this organisation. Leave a field empty to inherit the instance default.
-                    </p>
-                    <UFormField v-for="field in LIMIT_FIELDS"
-                                :key="field.key"
-                                :label="field.label">
-                        <UInput v-model="editForm[field.key]"
-                                type="number"
-                                min="0"
-                                :placeholder="defaultPlaceholder(field.key)"
-                                class="w-full"
-                                @keydown.enter="submitEdit" />
-                    </UFormField>
-                </div>
-            </template>
-            <template #footer>
-                <UButton label="Cancel"
-                         color="neutral"
-                         variant="outline"
-                         @click="editOpen = false" />
-                <UButton label="Save"
-                         :disabled="saving"
-                         :loading="saving"
-                         @click="submitEdit" />
-            </template>
-        </UModal>
+                   @edit="openOrg" />
     </div>
 </template>

--- a/packages/interloper-app/app/app/pages/admin/quotas.vue
+++ b/packages/interloper-app/app/app/pages/admin/quotas.vue
@@ -156,17 +156,18 @@ const columns: TableColumn<AdminOrgQuotaStatus>[] = [
         cell: ({ row }) => {
             const org = row.original
             if (org.deleted_at) return null
-            return h('div', { class: 'flex justify-end' }, h(UButton, {
+            // The wrapper's native listener stops the click before the row's
+            // select handler navigates to the org page.
+            return h('div', {
+                class: 'flex justify-end',
+                onClick: (event: Event) => event.stopPropagation(),
+            }, h(UButton, {
                 'icon': 'i-lucide-pencil',
                 'color': 'neutral',
                 'variant': 'ghost',
                 'size': 'sm',
                 'aria-label': 'Edit quotas',
-                // Row click navigates to the org page; the pencil must not.
-                'onClick': (event: MouseEvent) => {
-                    event.stopPropagation()
-                    openEdit(org)
-                },
+                'onClick': () => openEdit(org),
             }))
         },
     },

--- a/packages/interloper-app/app/app/pages/admin/users/index.vue
+++ b/packages/interloper-app/app/app/pages/admin/users/index.vue
@@ -88,29 +88,18 @@ function rowActions(user: AdminUser): DropdownMenuItem[][] {
     ]
 }
 
-function initials(user: AdminUser): string {
-    const name = user.name?.trim()
-    if (name) {
-        const parts = name.split(/\s+/)
-        const first = parts[0]?.[0] ?? ''
-        const last = parts.length > 1 ? (parts[parts.length - 1]?.[0] ?? '') : ''
-        return (last ? first + last : first).toUpperCase()
-    }
-    return user.email?.charAt(0).toUpperCase() ?? '?'
-}
-
 const columns: TableColumn<AdminUser>[] = [
     {
         accessorKey: 'name',
         header: 'Name',
         cell: ({ row }) => {
             const user = row.original
-            const avatar = h(UAvatar, {
-                src: user.avatar_url ?? undefined,
-                alt: user.name ?? user.email,
-                text: initials(user),
-                size: 'sm',
-            })
+            const avatar = user.avatar_url
+                ? h(UAvatar, { src: user.avatar_url, alt: user.name ?? user.email, size: 'sm' })
+                : h('div', {
+                        class: 'size-8 shrink-0 rounded-full flex items-center justify-center text-white text-xs font-semibold',
+                        style: { background: avatarColor(user.email || user.id) },
+                    }, getInitials(user.name, user.email))
             const name = user.name
                 ? h('span', { class: 'font-semibold text-highlighted' }, user.name)
                 : h('span', { class: 'text-dimmed' }, '—')
@@ -120,6 +109,7 @@ const columns: TableColumn<AdminUser>[] = [
     {
         accessorKey: 'email',
         header: 'Email',
+        cell: ({ row }) => h('span', { class: 'text-muted' }, row.original.email),
     },
     {
         id: 'organisations',
@@ -137,15 +127,13 @@ const columns: TableColumn<AdminUser>[] = [
         accessorKey: 'is_super_admin',
         header: 'Super admin',
         cell: ({ row }) => row.original.is_super_admin
-            ? h(UBadge, { label: 'Super admin', icon: 'i-lucide-shield', color: 'primary' })
+            ? h(UBadge, { label: 'Super admin', icon: 'i-lucide-shield', color: 'primary', variant: 'subtle' })
             : h('span', { class: 'text-dimmed' }, '—'),
     },
     {
         accessorKey: 'created_at',
         header: 'Joined',
-        cell: ({ row }) => row.original.created_at
-            ? new Date(row.original.created_at).toLocaleDateString()
-            : '—',
+        cell: ({ row }) => h('span', { class: 'text-muted' }, formatDay(row.original.created_at)),
     },
 ]
 

--- a/packages/interloper-app/app/app/types/admin.ts
+++ b/packages/interloper-app/app/app/types/admin.ts
@@ -59,6 +59,8 @@ export interface AdminQuotaLimits {
 export interface AdminOrgQuotaStatus {
     id: string
     name: string
+    /** Soft-deleted orgs keep their ledger visible but are read-only. */
+    deleted_at: string | null
     limits: AdminQuotaLimits
     effective: AdminQuotaLimits
     sources: number


### PR DESCRIPTION
PR 3/4 of the admin panel redesign. **Stacked on the org-detail PR** (it moves quota editing there).

- **Organisations**: usage columns (sources, runs, run-quota meter) joined client-side from the quotas overview per the design's own note, plus the current-period line. Rename/delete move exclusively to the detail page's Settings tab; the list keeps creation and navigation. Soft-deleted rows show dashes for usage.
- **Quotas**: now a **read-only overview** — instance-defaults chips beside the period, org tint bars, monospace thousands-separated numbers with 75/90% threshold tones (assets column deliberately uncolored — informational, not pressure), drift labels localized, rows navigate to the org page. Soft-deleted orgs stay listed for their ledger, struck through.
- **Users**: colored-initial avatars (shared palette), muted email/joined styling, subtle super-admin badge.
- Backend: `deleted_at` added to `AdminOrgQuotaStatus` so both pages mark deleted orgs without a second lookup.

By Digitl