### PR TITLE
refactor(app): drop the Overrides column from the quotas overview

### DIFF
--- a/packages/interloper-app/app/app/pages/admin/quotas.vue
+++ b/packages/interloper-app/app/app/pages/admin/quotas.vue
@@ -171,18 +171,6 @@ const columns: TableColumn<AdminOrgQuotaStatus>[] = [
             }))
         },
     },
-    {
-        id: 'overrides',
-        header: 'Overrides',
-        cell: ({ row }) => {
-            const limits = row.original.limits
-            const set = Object.entries(limits).filter(([, value]) => value != null)
-            if (!set.length) return dash()
-            return h('div', { class: 'flex flex-wrap gap-1' }, set.map(([key, value]) =>
-                h('span', { key, class: 'rounded-[5px] bg-elevated px-1.5 py-0.5 font-mono text-xs' }, `${key}=${value}`),
-            ))
-        },
-    },
 ]
 </script>
 

--- a/packages/interloper-db/src/interloper_db/store/quotas.py
+++ b/packages/interloper-db/src/interloper_db/store/quotas.py
@@ -175,7 +175,7 @@ def check_source_quota(session: Session, org_id: UUID, defaults: Any) -> None:
     ).one()
     if used >= limit:
         raise QuotaExceededError(
-            f"Organisation is at its source limit ({used}/{limit}); delete a source or raise the quota",
+            f"Organisation is at its source limit ({used}/{limit})",
             quota="max_sources",
             limit=limit,
             used=used,


### PR DESCRIPTION
Removes the Overrides chip column from the admin Quotas table. The per-org overrides remain visible where they're actionable — the edit drawer's inherit/override hints and the org detail Limits card (Override/Inherited tags with the instance default) — and the usage columns already render against the effective limits.

By Digitl