### PR TITLE
refactor: store quota limits as one row per quota key

### DIFF
--- a/packages/interloper-api/src/interloper_api/routes/admin.py
+++ b/packages/interloper-api/src/interloper_api/routes/admin.py
@@ -465,7 +465,9 @@ def build_config_snapshot(settings: Any, features: dict[str, bool], catalog: Any
 
 
 def _quota_limits(limits: Any) -> AdminQuotaLimits:
-    """Map any limits-shaped object (settings, Quota row, None) to the model."""
+    """Map limits from a ``{key: limit}`` dict (store) or attributes (settings)."""
+    if isinstance(limits, dict):
+        return AdminQuotaLimits(**{key: limits.get(key) for key in AdminQuotaLimits.model_fields})
     return AdminQuotaLimits(
         max_sources=getattr(limits, "max_sources", None),
         max_assets_per_source=getattr(limits, "max_assets_per_source", None),
@@ -562,7 +564,7 @@ def get_quotas(
     """Quota limits and current-period usage for every organisation."""
     defaults = _quota_limits(quota_defaults)
     period_start = store.current_period_start()
-    overrides = {quota.org_id: quota for quota in store.list_quotas()}
+    overrides = store.list_quota_overrides()
     usage = {
         row.org_id: row
         for row in store.list_usage(period_start=period_start)
@@ -574,7 +576,7 @@ def get_quotas(
 
     organisations = []
     for org, _member_count in store.list_all_organisations():
-        limits = _quota_limits(overrides.get(org.id))
+        limits = _quota_limits(overrides.get(org.id, {}))
         org_usage = usage.get(org.id)
         organisations.append(
             AdminOrgQuotaStatus(
@@ -640,8 +642,8 @@ def update_org_quota(
 ) -> AdminQuotaLimits:
     """Set an organisation's quota overrides; omitted fields keep their value, null clears one."""
     _require_org(store, org_id)
-    quota = store.set_quota(org_id, body.model_dump(exclude_unset=True))
-    return _quota_limits(quota)
+    overrides = store.set_quota(org_id, body.model_dump(exclude_unset=True))
+    return _quota_limits(overrides)
 
 
 # -- Users --------------------------------------------------------------------

--- a/packages/interloper-api/tests/test_admin.py
+++ b/packages/interloper-api/tests/test_admin.py
@@ -119,8 +119,8 @@ class FakeStore:
 
         return dt.date(2026, 8, 1)
 
-    def list_quotas(self):
-        return [SimpleNamespace(org_id=self.org.id, max_sources=5, max_assets_per_source=None)]
+    def list_quota_overrides(self):
+        return {self.org.id: {"max_sources": 5}}
 
     def list_usage(self, *, period_start=None, org_id=None):
         import datetime as dt
@@ -146,11 +146,7 @@ class FakeStore:
 
     def set_quota(self, org_id: UUID, limits: dict):
         self.quota_updates.append((org_id, limits))
-        return SimpleNamespace(
-            max_sources=limits.get("max_sources"),
-            max_assets_per_source=limits.get("max_assets_per_source"),
-            max_successful_runs_per_month=limits.get("max_successful_runs_per_month"),
-        )
+        return {key: value for key, value in limits.items() if value is not None}
 
 
 def _profile(*, is_super_admin: bool):

--- a/packages/interloper-db/src/interloper_db/migrations/versions/009_quota_rows.py
+++ b/packages/interloper-db/src/interloper_db/migrations/versions/009_quota_rows.py
@@ -1,0 +1,72 @@
+"""Quota limits become one row per quota key.
+
+The ``quotas`` table changes from one column per limit to
+``(org_id, key, limit)`` so new quotas need no schema change. Existing
+per-column overrides are unpivoted into rows. Idempotent: a no-op on
+fresh databases (``create_all`` provisions the new shape) and on re-runs.
+
+Revision ID: 009
+Revises: 008
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "009"
+down_revision: str | None = "008"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+_LEGACY_COLUMNS = ("max_sources", "max_assets_per_source", "max_successful_runs_per_month")
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if not inspector.has_table("quotas"):
+        return
+    columns = {column["name"] for column in inspector.get_columns("quotas")}
+    if "key" in columns:
+        return
+
+    op.create_table(
+        "quotas_new",
+        sa.Column("org_id", sa.Uuid(), primary_key=True),
+        sa.Column("key", sa.String(), primary_key=True),
+        sa.Column("limit", sa.Integer(), nullable=True),
+    )
+    for key in _LEGACY_COLUMNS:
+        op.execute(
+            sa.text(
+                f'INSERT INTO quotas_new (org_id, key, "limit") '  # noqa: S608 - keys are module constants
+                f"SELECT org_id, '{key}', {key} FROM quotas WHERE {key} IS NOT NULL"
+            )
+        )
+    op.drop_table("quotas")
+    op.rename_table("quotas_new", "quotas")
+
+
+def downgrade() -> None:
+    op.create_table(
+        "quotas_old",
+        sa.Column("org_id", sa.Uuid(), primary_key=True),
+        sa.Column("max_sources", sa.Integer(), nullable=True),
+        sa.Column("max_assets_per_source", sa.Integer(), nullable=True),
+        sa.Column("max_successful_runs_per_month", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("CURRENT_TIMESTAMP")),
+    )
+    op.execute(
+        sa.text(
+            "INSERT INTO quotas_old (org_id, max_sources, max_assets_per_source, max_successful_runs_per_month) "
+            "SELECT org_id, "
+            "MAX(CASE WHEN key = 'max_sources' THEN \"limit\" END), "
+            "MAX(CASE WHEN key = 'max_assets_per_source' THEN \"limit\" END), "
+            "MAX(CASE WHEN key = 'max_successful_runs_per_month' THEN \"limit\" END) "
+            "FROM quotas GROUP BY org_id"
+        )
+    )
+    op.drop_table("quotas")
+    op.rename_table("quotas_old", "quotas")

--- a/packages/interloper-db/src/interloper_db/models.py
+++ b/packages/interloper-db/src/interloper_db/models.py
@@ -170,20 +170,20 @@ class PersonalAccessToken(SQLModel, table=True):
 
 
 class Quota(SQLModel, table=True):
-    """Per-organisation quota limits, one row per organisation, created lazily.
+    """Per-organisation quota limit overrides, one row per quota key.
 
-    A null limit falls back to the global default (``QuotaSettings``); null
-    there means unlimited. Bare ``org_id`` (no FK) like every org-scoped data
-    table.
+    Rows are created lazily; a null ``limit`` is a cleared override (and the
+    enforcement lock anchor) — resolution falls back to the global default
+    (``QuotaSettings``), and null there means unlimited. New quota keys need
+    no schema change; the valid set is ``QUOTA_KEYS`` in the store. Bare
+    ``org_id`` (no FK) like every org-scoped data table.
     """
 
     __tablename__: ClassVar[str] = "quotas"
 
     org_id: UUID = SQLField(primary_key=True)
-    max_sources: int | None = None
-    max_assets_per_source: int | None = None
-    max_successful_runs_per_month: int | None = None
-    created_at: datetime | None = _ts()
+    key: str = SQLField(primary_key=True)
+    limit: int | None = None
 
 
 class Usage(SQLModel, table=True):

--- a/packages/interloper-db/src/interloper_db/store/quotas.py
+++ b/packages/interloper-db/src/interloper_db/store/quotas.py
@@ -35,6 +35,15 @@ METRIC_SUCCESSFUL_RUNS = "successful_runs"
 #: DB, so writers must go through this to keep the ledger free of typo rows.
 USAGE_METRICS = frozenset({METRIC_SUCCESSFUL_RUNS})
 
+QUOTA_MAX_SOURCES = "max_sources"
+QUOTA_MAX_ASSETS_PER_SOURCE = "max_assets_per_source"
+QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH = "max_successful_runs_per_month"
+
+#: The closed set of quota keys. Limits are stored one row per key, so
+#: adding a quota is a new entry here (plus its enforcement site) — no
+#: schema change.
+QUOTA_KEYS = frozenset({QUOTA_MAX_SOURCES, QUOTA_MAX_ASSETS_PER_SOURCE, QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH})
+
 
 def month_start(moment: datetime) -> dt.date:
     """The first day of the UTC calendar month a moment falls in.
@@ -132,29 +141,36 @@ def settle_run_usage(session: Session, db_run: Run, *, success: bool) -> None:
 # ``try_reserve_run``; the creation-time checks are advisory fail-fasts.
 
 
-def _effective_limit(session: Session, org_id: UUID, field: str, defaults: Any) -> int | None:
+def _effective_limit(session: Session, org_id: UUID, key: str, defaults: Any) -> int | None:
     """Resolve a limit: org override wins over the global default; None = unlimited."""
-    override = session.get(Quota, org_id)
-    value = getattr(override, field, None) if override else None
+    override = session.get(Quota, (org_id, key))
+    value = override.limit if override else None
     if value is None:
-        value = getattr(defaults, field, None)
+        value = getattr(defaults, key, None)
     return value
 
 
-def _locked_effective_limit(session: Session, org_id: UUID, field: str, defaults: Any) -> int | None:
-    """Resolve a limit while holding the org's quota-row lock.
+def _locked_effective_limit(session: Session, org_id: UUID, key: str, defaults: Any) -> int | None:
+    """Resolve a limit while holding the ``(org, key)`` quota-row lock.
 
-    Upserts the (all-null) row first so there is always something to lock;
-    the lock is released with the caller's transaction and serializes
-    capacity checks per organisation.
+    Upserts the (null-limit) row first so there is always something to
+    lock; the lock is released with the caller's transaction and
+    serializes checks per organisation *and* key, so independent quotas
+    never block each other.
     """
     table = Quota.__table__  # ty: ignore[unresolved-attribute]
-    statement = _insert_fn(session)(table).values(org_id=org_id).on_conflict_do_nothing(index_elements=["org_id"])
+    statement = (
+        _insert_fn(session)(table)
+        .values(org_id=org_id, key=key)
+        .on_conflict_do_nothing(index_elements=["org_id", "key"])
+    )
     session.execute(statement)  # ty: ignore[deprecated]
-    override = session.exec(select(Quota).where(Quota.org_id == org_id).with_for_update()).first()
-    value = getattr(override, field, None) if override else None
+    override = session.exec(
+        select(Quota).where(Quota.org_id == org_id, Quota.key == key).with_for_update()
+    ).first()
+    value = override.limit if override else None
     if value is None:
-        value = getattr(defaults, field, None)
+        value = getattr(defaults, key, None)
     return value
 
 
@@ -163,9 +179,9 @@ def check_source_quota(session: Session, org_id: UUID, defaults: Any) -> None:
 
     Part of the caller's transaction; call before inserting the new source.
     """
-    if _effective_limit(session, org_id, "max_sources", defaults) is None:
+    if _effective_limit(session, org_id, QUOTA_MAX_SOURCES, defaults) is None:
         return
-    limit = _locked_effective_limit(session, org_id, "max_sources", defaults)
+    limit = _locked_effective_limit(session, org_id, QUOTA_MAX_SOURCES, defaults)
     if limit is None:
         return
     used = session.exec(
@@ -176,7 +192,7 @@ def check_source_quota(session: Session, org_id: UUID, defaults: Any) -> None:
     if used >= limit:
         raise QuotaExceededError(
             f"Organisation is at its source limit ({used}/{limit})",
-            quota="max_sources",
+            quota=QUOTA_MAX_SOURCES,
             limit=limit,
             used=used,
         )
@@ -188,15 +204,15 @@ def check_asset_quota(session: Session, db_source: Component, asset_count: int, 
     ``asset_count`` is the size of the *desired* final set, so the check is
     declarative — no counting race regardless of what the set is today.
     """
-    if _effective_limit(session, db_source.org_id, "max_assets_per_source", defaults) is None:
+    if _effective_limit(session, db_source.org_id, QUOTA_MAX_ASSETS_PER_SOURCE, defaults) is None:
         return
-    limit = _locked_effective_limit(session, db_source.org_id, "max_assets_per_source", defaults)
+    limit = _locked_effective_limit(session, db_source.org_id, QUOTA_MAX_ASSETS_PER_SOURCE, defaults)
     if limit is None or asset_count <= limit:
         return
     raise QuotaExceededError(
         f"Source '{db_source.name or db_source.key}' would have {asset_count} assets, "
         f"exceeding the limit of {limit}",
-        quota="max_assets_per_source",
+        quota=QUOTA_MAX_ASSETS_PER_SOURCE,
         limit=limit,
         used=asset_count,
     )
@@ -207,7 +223,7 @@ def run_quota_status(session: Session, org_id: UUID, defaults: Any) -> tuple[int
 
     Limit None means unlimited (and the ledger is not read at all).
     """
-    limit = _effective_limit(session, org_id, "max_successful_runs_per_month", defaults)
+    limit = _effective_limit(session, org_id, QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH, defaults)
     if limit is None:
         return 0, None
     period_start = month_start(db_now(session))
@@ -226,7 +242,7 @@ def check_run_quota(session: Session, org_id: UUID, defaults: Any, *, source: st
     if limit is not None and committed >= limit:
         raise QuotaExceededError(
             f"Cannot queue {source}: the monthly successful-run quota is exhausted ({committed}/{limit})",
-            quota="max_successful_runs_per_month",
+            quota=QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH,
             limit=limit,
             used=committed,
         )
@@ -243,7 +259,7 @@ def try_reserve_run(session: Session, db_run: Run, defaults: Any) -> bool:
     Returns:
         True if the run may dispatch, False when the quota is exhausted.
     """
-    limit = _effective_limit(session, db_run.org_id, "max_successful_runs_per_month", defaults)
+    limit = _effective_limit(session, db_run.org_id, QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH, defaults)
     if limit is None:
         return True
     if limit <= 0:
@@ -271,37 +287,49 @@ def try_reserve_run(session: Session, db_run: Run, defaults: Any) -> bool:
 class QuotaMixin(StoreBase):
     """Store methods for quota limits and usage reads."""
 
-    def get_quota(self, org_id: UUID) -> Quota | None:
-        """The organisation's quota overrides, or None if none are set."""
+    def get_quota_overrides(self, org_id: UUID) -> dict[str, int]:
+        """The organisation's set overrides as ``{key: limit}`` (null rows excluded)."""
         with self._session() as session:
-            return session.get(Quota, org_id)
+            rows = session.exec(select(Quota).where(Quota.org_id == org_id)).all()
+            return {row.key: row.limit for row in rows if row.limit is not None}
 
-    def list_quotas(self) -> list[Quota]:
-        """All per-organisation quota override rows."""
+    def list_quota_overrides(self) -> dict[UUID, dict[str, int]]:
+        """Every organisation's set overrides, keyed by org id."""
         with self._session() as session:
-            return list(session.exec(select(Quota)).all())
+            rows = session.exec(select(Quota)).all()
+            overrides: dict[UUID, dict[str, int]] = {}
+            for row in rows:
+                if row.limit is not None:
+                    overrides.setdefault(row.org_id, {})[row.key] = row.limit
+            return overrides
 
-    def set_quota(self, org_id: UUID, limits: dict[str, int | None]) -> Quota:
-        """Set an organisation's quota overrides; only the given fields change.
+    def set_quota(self, org_id: UUID, limits: dict[str, int | None]) -> dict[str, int]:
+        """Set an organisation's quota overrides; only the given keys change.
 
-        ``None`` clears a field so it falls back to the global default.
+        ``None`` clears a key so it falls back to the global default (the
+        row is kept as a null-limit lock anchor).
+
+        Returns:
+            The organisation's overrides after the update.
 
         Raises:
-            ValueError: On an unknown limit field or a negative value.
+            ValueError: On an unknown quota key or a negative value.
         """
-        allowed = {"max_sources", "max_assets_per_source", "max_successful_runs_per_month"}
-        if unknown := set(limits) - allowed:
+        if unknown := set(limits) - QUOTA_KEYS:
             raise ValueError(f"Unknown quota limit(s): {sorted(unknown)}")
-        if negative := {field for field, value in limits.items() if value is not None and value < 0}:
+        if negative := {key for key, value in limits.items() if value is not None and value < 0}:
             raise ValueError(f"Quota limit(s) must be >= 0: {sorted(negative)}")
+        table = Quota.__table__  # ty: ignore[unresolved-attribute]
         with self._session() as session:
-            quota = session.get(Quota, org_id) or Quota(org_id=org_id)
-            for field, value in limits.items():
-                setattr(quota, field, value)
-            session.add(quota)
+            for key, value in limits.items():
+                statement = (
+                    _insert_fn(session)(table)
+                    .values(org_id=org_id, key=key, limit=value)
+                    .on_conflict_do_update(index_elements=["org_id", "key"], set_={"limit": value})
+                )
+                session.execute(statement)  # ty: ignore[deprecated]
             session.commit()
-            session.refresh(quota)
-            return quota
+        return self.get_quota_overrides(org_id)
 
     def list_usage(self, *, period_start: dt.date | None = None, org_id: UUID | None = None) -> list[Usage]:
         """Usage ledger rows, optionally filtered by period and organisation."""

--- a/packages/interloper-db/tests/store/test_components.py
+++ b/packages/interloper-db/tests/store/test_components.py
@@ -462,7 +462,7 @@ class TestQuotaGates:
 
         store = self._store(max_sources=1)
         with Session(component_db) as session:
-            session.add(Quota(org_id=_ORG, max_sources=2))
+            session.add(Quota(org_id=_ORG, key="max_sources", limit=2))
             session.commit()
         store.create_component(_ORG, kind="source", key="demo_source", children=["a"], config={"dataset": "one"})
         store.create_component(_ORG, kind="source", key="demo_source", children=["a"], config={"dataset": "two"})

--- a/packages/interloper-db/tests/store/test_quotas.py
+++ b/packages/interloper-db/tests/store/test_quotas.py
@@ -156,14 +156,14 @@ class TestSettleRunUsage:
 
 
 class TestQuotaReads:
-    def test_get_and_list_quotas(self, store: _Store):
-        assert store.get_quota(_ORG_ID) is None
+    def test_get_and_list_overrides(self, store: _Store):
+        assert store.get_quota_overrides(_ORG_ID) == {}
         with Session(store._engine) as session:
-            session.add(Quota(org_id=_ORG_ID, max_sources=3))
+            session.add(Quota(org_id=_ORG_ID, key="max_sources", limit=3))
+            session.add(Quota(org_id=_ORG_ID, key="max_assets_per_source", limit=None))  # cleared/anchor row
             session.commit()
-        quota = store.get_quota(_ORG_ID)
-        assert quota is not None and quota.max_sources == 3
-        assert [q.org_id for q in store.list_quotas()] == [_ORG_ID]
+        assert store.get_quota_overrides(_ORG_ID) == {"max_sources": 3}
+        assert store.list_quota_overrides() == {_ORG_ID: {"max_sources": 3}}
 
     def test_list_usage_filters(self, store: _Store):
         other_org = uuid4()
@@ -237,7 +237,7 @@ class TestRunCreationGate:
     def test_org_override_wins_over_default(self, store: _Store):
         store._quota_defaults = _defaults(max_successful_runs_per_month=1)
         with Session(store._engine) as session:
-            session.add(Quota(org_id=_ORG_ID, max_successful_runs_per_month=3))
+            session.add(Quota(org_id=_ORG_ID, key="max_successful_runs_per_month", limit=3))
             session.commit()
         self._exhaust(store, used=2)
         assert store.create_run(_ORG_ID).status == "queued"
@@ -329,16 +329,15 @@ class TestReconcileUsage:
 
 class TestSetQuota:
     def test_creates_then_partially_updates(self, store: _Store):
-        quota = store.set_quota(_ORG_ID, {"max_sources": 5})
-        assert (quota.max_sources, quota.max_successful_runs_per_month) == (5, None)
-
-        quota = store.set_quota(_ORG_ID, {"max_successful_runs_per_month": 100})
-        assert (quota.max_sources, quota.max_successful_runs_per_month) == (5, 100)
+        assert store.set_quota(_ORG_ID, {"max_sources": 5}) == {"max_sources": 5}
+        assert store.set_quota(_ORG_ID, {"max_successful_runs_per_month": 100}) == {
+            "max_sources": 5,
+            "max_successful_runs_per_month": 100,
+        }
 
     def test_none_clears_an_override(self, store: _Store):
         store.set_quota(_ORG_ID, {"max_sources": 5})
-        quota = store.set_quota(_ORG_ID, {"max_sources": None})
-        assert quota.max_sources is None
+        assert store.set_quota(_ORG_ID, {"max_sources": None}) == {}
 
     def test_rejects_unknown_and_negative(self, store: _Store):
         with pytest.raises(ValueError, match="Unknown quota limit"):


### PR DESCRIPTION
Replaces #251 (closed by the branch recreation while resolving its conflict with 4f50730 — the resolution keeps main's shortened error message together with this PR's key constant).

## What

Restructures the `quotas` table from one-column-per-limit to **one row per quota key** — `(org_id, key, limit)`, composite PK — per the scaling analysis: the enforcement core already resolved limits by string key (`getattr` over column names), so the column shape paid a hand-written migration + five layers of per-field plumbing for every new quota while using none of its type-safety benefits in the middle. It also mirrors the `usage` table's row-per-metric shape.

- **`QUOTA_KEYS` registry** (with per-key constants adopted at the enforcement sites) is the closed vocabulary — same pattern as `USAGE_METRICS`. Adding a quota = registry entry + enforcement site, **no schema change**.
- **Finer locking for free**: the `FOR UPDATE` anchor is now the `(org, key)` row, so a source-capacity check no longer serializes against an asset-capacity check. Null-limit rows are cleared overrides doubling as lock anchors.
- **Store surface**: `get_quota_overrides`/`list_quota_overrides` return `{key: limit}` dicts; `set_quota` upserts per key (`None` clears) and returns the org's overrides.
- **Wire format unchanged** — the route pivots dicts into the existing `AdminQuotaLimits` shape; frontend, drawer, and TS types untouched. `QuotaSettings` stays typed fields for env-var ergonomics.
- **Migration `009`** unpivots existing per-column overrides into rows (idempotent, full downgrade).

## Verified

- Full suite green; store tests reshaped to the dict surface.
- On real Postgres (throwaway DB): composite-key upserts incl. clear-to-null, locked effective resolution with override-over-default, anchor rows staying invisible as overrides, and a replay of migration 009 against a hand-built legacy-shape table with data.

By Digitl