### PR TITLE
refactor: quota limits as registry-declared rows behind a QuotaService

### DIFF
--- a/packages/interloper-api/src/interloper_api/routes/admin.py
+++ b/packages/interloper-api/src/interloper_api/routes/admin.py
@@ -465,7 +465,9 @@ def build_config_snapshot(settings: Any, features: dict[str, bool], catalog: Any
 
 
 def _quota_limits(limits: Any) -> AdminQuotaLimits:
-    """Map any limits-shaped object (settings, Quota row, None) to the model."""
+    """Map limits from a ``{key: limit}`` dict (store) or attributes (settings)."""
+    if isinstance(limits, dict):
+        return AdminQuotaLimits(**{key: limits.get(key) for key in AdminQuotaLimits.model_fields})
     return AdminQuotaLimits(
         max_sources=getattr(limits, "max_sources", None),
         max_assets_per_source=getattr(limits, "max_assets_per_source", None),
@@ -562,7 +564,7 @@ def get_quotas(
     """Quota limits and current-period usage for every organisation."""
     defaults = _quota_limits(quota_defaults)
     period_start = store.current_period_start()
-    overrides = {quota.org_id: quota for quota in store.list_quotas()}
+    overrides = store.list_quota_overrides()
     usage = {
         row.org_id: row
         for row in store.list_usage(period_start=period_start)
@@ -574,7 +576,7 @@ def get_quotas(
 
     organisations = []
     for org, _member_count in store.list_all_organisations():
-        limits = _quota_limits(overrides.get(org.id))
+        limits = _quota_limits(overrides.get(org.id, {}))
         org_usage = usage.get(org.id)
         organisations.append(
             AdminOrgQuotaStatus(
@@ -640,8 +642,8 @@ def update_org_quota(
 ) -> AdminQuotaLimits:
     """Set an organisation's quota overrides; omitted fields keep their value, null clears one."""
     _require_org(store, org_id)
-    quota = store.set_quota(org_id, body.model_dump(exclude_unset=True))
-    return _quota_limits(quota)
+    overrides = store.set_quota(org_id, body.model_dump(exclude_unset=True))
+    return _quota_limits(overrides)
 
 
 # -- Users --------------------------------------------------------------------

--- a/packages/interloper-api/tests/test_admin.py
+++ b/packages/interloper-api/tests/test_admin.py
@@ -540,3 +540,10 @@ def test_activity_feed_composes_titles(store: FakeStore) -> None:
         ("member_joined", "Jonas joined the organisation", "Role: editor"),
         ("org_created", "Organisation created", None),
     ]
+
+
+def test_quota_wire_model_matches_the_registry() -> None:
+    """AdminQuotaLimits must expose exactly the registered quota keys."""
+    from interloper_db.store.quotas import QUOTAS
+
+    assert set(admin_module.AdminQuotaLimits.model_fields) == set(QUOTAS.keys())

--- a/packages/interloper-api/tests/test_admin.py
+++ b/packages/interloper-api/tests/test_admin.py
@@ -119,8 +119,8 @@ class FakeStore:
 
         return dt.date(2026, 8, 1)
 
-    def list_quotas(self):
-        return [SimpleNamespace(org_id=self.org.id, max_sources=5, max_assets_per_source=None)]
+    def list_quota_overrides(self):
+        return {self.org.id: {"max_sources": 5}}
 
     def list_usage(self, *, period_start=None, org_id=None):
         import datetime as dt
@@ -146,11 +146,7 @@ class FakeStore:
 
     def set_quota(self, org_id: UUID, limits: dict):
         self.quota_updates.append((org_id, limits))
-        return SimpleNamespace(
-            max_sources=limits.get("max_sources"),
-            max_assets_per_source=limits.get("max_assets_per_source"),
-            max_successful_runs_per_month=limits.get("max_successful_runs_per_month"),
-        )
+        return {key: value for key, value in limits.items() if value is not None}
 
 
 def _profile(*, is_super_admin: bool):

--- a/packages/interloper-db/src/interloper_db/migrations/versions/009_quota_rows.py
+++ b/packages/interloper-db/src/interloper_db/migrations/versions/009_quota_rows.py
@@ -1,0 +1,72 @@
+"""Quota limits become one row per quota key.
+
+The ``quotas`` table changes from one column per limit to
+``(org_id, key, limit)`` so new quotas need no schema change. Existing
+per-column overrides are unpivoted into rows. Idempotent: a no-op on
+fresh databases (``create_all`` provisions the new shape) and on re-runs.
+
+Revision ID: 009
+Revises: 008
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "009"
+down_revision: str | None = "008"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+_LEGACY_COLUMNS = ("max_sources", "max_assets_per_source", "max_successful_runs_per_month")
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if not inspector.has_table("quotas"):
+        return
+    columns = {column["name"] for column in inspector.get_columns("quotas")}
+    if "key" in columns:
+        return
+
+    op.create_table(
+        "quotas_new",
+        sa.Column("org_id", sa.Uuid(), primary_key=True),
+        sa.Column("key", sa.String(), primary_key=True),
+        sa.Column("limit", sa.Integer(), nullable=True),
+    )
+    for key in _LEGACY_COLUMNS:
+        op.execute(
+            sa.text(
+                f'INSERT INTO quotas_new (org_id, key, "limit") '  # noqa: S608 - keys are module constants
+                f"SELECT org_id, '{key}', {key} FROM quotas WHERE {key} IS NOT NULL"
+            )
+        )
+    op.drop_table("quotas")
+    op.rename_table("quotas_new", "quotas")
+
+
+def downgrade() -> None:
+    op.create_table(
+        "quotas_old",
+        sa.Column("org_id", sa.Uuid(), primary_key=True),
+        sa.Column("max_sources", sa.Integer(), nullable=True),
+        sa.Column("max_assets_per_source", sa.Integer(), nullable=True),
+        sa.Column("max_successful_runs_per_month", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("CURRENT_TIMESTAMP")),
+    )
+    op.execute(
+        sa.text(
+            "INSERT INTO quotas_old (org_id, max_sources, max_assets_per_source, max_successful_runs_per_month) "
+            "SELECT org_id, "
+            "MAX(CASE WHEN key = 'max_sources' THEN \"limit\" END), "
+            "MAX(CASE WHEN key = 'max_assets_per_source' THEN \"limit\" END), "
+            "MAX(CASE WHEN key = 'max_successful_runs_per_month' THEN \"limit\" END) "
+            "FROM quotas GROUP BY org_id"
+        )
+    )
+    op.drop_table("quotas")
+    op.rename_table("quotas_old", "quotas")

--- a/packages/interloper-db/src/interloper_db/models.py
+++ b/packages/interloper-db/src/interloper_db/models.py
@@ -170,20 +170,20 @@ class PersonalAccessToken(SQLModel, table=True):
 
 
 class Quota(SQLModel, table=True):
-    """Per-organisation quota limits, one row per organisation, created lazily.
+    """Per-organisation quota limit overrides, one row per quota key.
 
-    A null limit falls back to the global default (``QuotaSettings``); null
-    there means unlimited. Bare ``org_id`` (no FK) like every org-scoped data
-    table.
+    Rows are created lazily; a null ``limit`` is a cleared override (and the
+    enforcement lock anchor) — resolution falls back to the global default
+    (``QuotaSettings``), and null there means unlimited. New quota keys need
+    no schema change; the valid set is ``QUOTA_KEYS`` in the store. Bare
+    ``org_id`` (no FK) like every org-scoped data table.
     """
 
     __tablename__: ClassVar[str] = "quotas"
 
     org_id: UUID = SQLField(primary_key=True)
-    max_sources: int | None = None
-    max_assets_per_source: int | None = None
-    max_successful_runs_per_month: int | None = None
-    created_at: datetime | None = _ts()
+    key: str = SQLField(primary_key=True)
+    limit: int | None = None
 
 
 class Usage(SQLModel, table=True):

--- a/packages/interloper-db/src/interloper_db/store/base.py
+++ b/packages/interloper-db/src/interloper_db/store/base.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
     from interloper.catalog.base import Catalog
 
     from interloper_db.hydration import Hydrator
+    from interloper_db.store.quotas import QuotaService
 
 
 class StoreBase:
@@ -34,13 +35,20 @@ class StoreBase:
     _quota_defaults: Any = None
 
     @property
-    def quota_defaults(self) -> Any:
-        """The global default quota limits (QuotaSettings-shaped, or None).
+    def quotas(self) -> QuotaService:
+        """Quota limit resolution and enforcement gates.
 
         Exposed so co-located machinery (the scheduler's claim/cron SQL)
-        enforces against the same defaults as the store.
+        enforces against the same defaults as the store. Lazily built; the
+        defaults are read per call, so late configuration is visible.
         """
-        return self._quota_defaults
+        service: QuotaService | None = getattr(self, "_quota_service", None)
+        if service is None:
+            from interloper_db.store.quotas import QuotaService as _QuotaService
+
+            service = _QuotaService(lambda: self._quota_defaults)
+            self._quota_service = service
+        return service
 
     @property
     def engine(self) -> Engine:

--- a/packages/interloper-db/src/interloper_db/store/components.py
+++ b/packages/interloper-db/src/interloper_db/store/components.py
@@ -37,6 +37,7 @@ from sqlmodel import Session, col, select
 
 from interloper_db.drift import ComponentStatus, asset_status, resolve_component_cls, resolve_source_cls, source_status
 from interloper_db.models import Component, ComponentRelation
+from interloper_db.store.quotas import QUOTA_MAX_ASSETS_PER_SOURCE, QUOTA_MAX_SOURCES
 from interloper_db.store.relations import Binding, RelationMixin, _add_relation
 
 # Eager-load set for rows returned to API consumers: the parent, children
@@ -89,7 +90,7 @@ class ComponentMixin(RelationMixin):
         """
         with self._session() as session:
             if kind == "source":
-                self.quotas.check_source(session, org_id)
+                self.quotas.check(session, org_id, QUOTA_MAX_SOURCES)
             db_component = Component(org_id=org_id, kind=kind, key=key, name=name)
             self._apply_config(db_component, config, encrypted)
             if name is None:
@@ -491,7 +492,13 @@ class ComponentMixin(RelationMixin):
         # An explicit list is the exact child set; None (creation) is all
         # catalog assets.
         target = set(child_keys) if child_keys is not None else all_keys
-        self.quotas.check_assets(session, db_source, len(target))
+        self.quotas.check(
+            session,
+            db_source.org_id,
+            QUOTA_MAX_ASSETS_PER_SOURCE,
+            used=len(target),
+            subject=db_source.name or db_source.key,
+        )
         to_create = target - set(existing)
         to_remove = set(existing) - target
 

--- a/packages/interloper-db/src/interloper_db/store/components.py
+++ b/packages/interloper-db/src/interloper_db/store/components.py
@@ -37,7 +37,6 @@ from sqlmodel import Session, col, select
 
 from interloper_db.drift import ComponentStatus, asset_status, resolve_component_cls, resolve_source_cls, source_status
 from interloper_db.models import Component, ComponentRelation
-from interloper_db.store.quotas import check_asset_quota, check_source_quota
 from interloper_db.store.relations import Binding, RelationMixin, _add_relation
 
 # Eager-load set for rows returned to API consumers: the parent, children
@@ -90,7 +89,7 @@ class ComponentMixin(RelationMixin):
         """
         with self._session() as session:
             if kind == "source":
-                check_source_quota(session, org_id, self._quota_defaults)
+                self.quotas.check_source(session, org_id)
             db_component = Component(org_id=org_id, kind=kind, key=key, name=name)
             self._apply_config(db_component, config, encrypted)
             if name is None:
@@ -492,7 +491,7 @@ class ComponentMixin(RelationMixin):
         # An explicit list is the exact child set; None (creation) is all
         # catalog assets.
         target = set(child_keys) if child_keys is not None else all_keys
-        check_asset_quota(session, db_source, len(target), self._quota_defaults)
+        self.quotas.check_assets(session, db_source, len(target))
         to_create = target - set(existing)
         to_remove = set(existing) - target
 

--- a/packages/interloper-db/src/interloper_db/store/quotas.py
+++ b/packages/interloper-db/src/interloper_db/store/quotas.py
@@ -24,7 +24,7 @@ import datetime as dt
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, ClassVar
 from uuid import UUID
 
 from interloper.errors import QuotaExceededError
@@ -47,19 +47,124 @@ QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH = "max_successful_runs_per_month"
 
 @dataclass(frozen=True)
 class QuotaDefinition:
-    """One per-organisation quota: its key and how usage is measured.
+    """One per-organisation quota: its key and its check semantics.
 
-    Capacity quotas carry a ``count`` of current usage (a live query —
-    they are never metered); consumption quotas carry the ``metric`` their
-    usage is charged under in the ledger.
+    Subclasses own how usage is measured and compared; the
+    :class:`QuotaService` only resolves the effective limit and delegates.
+    ``subject`` is caller-supplied context interpolated into the rejection
+    message — the part only the call site knows (an entity label, the
+    operation being attempted).
     """
 
     key: str
-    #: Ledger metric for consumption quotas; None for capacity quotas.
-    metric: str | None = None
-    #: Live usage count for capacity quotas; None when the gate supplies
-    #: the prospective usage itself (declarative checks).
+    #: Capacity checks resolve the limit under the ``(org, key)`` row lock;
+    #: the consumption advisory check does not (its authoritative gate is
+    #: the atomic ledger reservation).
+    requires_lock: ClassVar[bool] = False
+
+    def check(
+        self,
+        session: Session,
+        org_id: UUID,
+        limit: int,
+        *,
+        used: int | None = None,
+        subject: str | None = None,
+    ) -> None:
+        """Raise :class:`QuotaExceededError` when the limit rejects the operation."""
+        raise NotImplementedError
+
+    def _reject(self, used: int, limit: int, subject: str | None) -> None:
+        raise QuotaExceededError(self.message(used, limit, subject), quota=self.key, limit=limit, used=used)
+
+    #: ``message(used, limit, subject)`` — the rejection text.
+    message: Callable[[int, int, str | None], str] = lambda used, limit, subject: ""
+
+
+@dataclass(frozen=True)
+class CapacityQuota(QuotaDefinition):
+    """Limits how many of something can exist right now (never metered).
+
+    Two check flavors: without ``used`` the current amount is measured via
+    ``count`` and admitting one more must stay within the limit; with
+    ``used`` the caller states the *desired final* amount (declarative —
+    no counting race regardless of what exists today).
+    """
+
+    requires_lock: ClassVar[bool] = True
+
+    #: Live usage count; None when every gate supplies ``used`` itself.
     count: Callable[[Session, UUID], int] | None = None
+
+    def check(
+        self,
+        session: Session,
+        org_id: UUID,
+        limit: int,
+        *,
+        used: int | None = None,
+        subject: str | None = None,
+    ) -> None:
+        if used is None:
+            assert self.count is not None  # capacity quota registered with its counter
+            current = self.count(session, org_id)
+            if current >= limit:
+                self._reject(current, limit, subject)
+        elif used > limit:
+            self._reject(used, limit, subject)
+
+
+@dataclass(frozen=True)
+class ConsumptionQuota(QuotaDefinition):
+    """Limits what accumulates per period, charged under ``metric`` in the ledger."""
+
+    #: Ledger metric this quota's usage is charged under.
+    metric: str = ""
+
+    def committed(self, session: Session, org_id: UUID) -> int:
+        """The org's committed usage this period: ledger ``used + reserved``."""
+        period_start = month_start(db_now(session))
+        row = session.get(Usage, (org_id, self.metric, period_start))
+        return (row.used + row.reserved) if row else 0
+
+    def check(
+        self,
+        session: Session,
+        org_id: UUID,
+        limit: int,
+        *,
+        used: int | None = None,
+        subject: str | None = None,
+    ) -> None:
+        committed = used if used is not None else self.committed(session, org_id)
+        if committed >= limit:
+            self._reject(committed, limit, subject)
+
+    def reserve(self, session: Session, org_id: UUID, limit: int) -> datetime | None:
+        """Atomically reserve one unit against the period's ledger row.
+
+        A conditional upsert (``used + reserved < limit``), so concurrent
+        reservers can never overshoot.
+
+        Returns:
+            The reservation timestamp (DB clock), or None when exhausted.
+        """
+        if limit <= 0:
+            return None
+        now = db_now(session)
+        period_start = month_start(now)
+        table = Usage.__table__  # ty: ignore[unresolved-attribute]
+        statement = (
+            _insert_fn(session)(table)
+            .values(org_id=org_id, metric=self.metric, period_start=period_start, used=0, reserved=1)
+            .on_conflict_do_update(
+                index_elements=["org_id", "metric", "period_start"],
+                set_={"reserved": table.c.reserved + 1},
+                where=(table.c.used + table.c.reserved < limit),
+            )
+        )
+        result = session.execute(statement)  # ty: ignore[deprecated]
+        return now if result.rowcount == 1 else None  # ty: ignore[unresolved-attribute]
 
 
 #: Every quota, by key. Adding one is a registration plus its enforcement
@@ -122,7 +227,7 @@ def increment_usage(
     Upsert-based so concurrent writers never lose an increment; part of the
     caller's transaction (the caller commits).
     """
-    if all(definition.metric != metric for definition in QUOTAS.values()):
+    if all(getattr(definition, "metric", None) != metric for definition in QUOTAS.values()):
         raise ValueError(f"Unknown usage metric: {metric}")
     table = Usage.__table__  # ty: ignore[unresolved-attribute]
     statement = (
@@ -220,115 +325,93 @@ class QuotaService:
             value = getattr(self._defaults(), key, None)
         return value
 
-    def check_source(self, session: Session, org_id: UUID) -> None:
-        """Reject creating a source when the organisation is at its source limit.
+    def check(
+        self,
+        session: Session,
+        org_id: UUID,
+        key: str,
+        *,
+        used: int | None = None,
+        subject: str | None = None,
+    ) -> None:
+        """The one enforcement gate: resolve the limit, delegate to the definition.
 
-        Part of the caller's transaction; call before inserting the new source.
+        Part of the caller's transaction. No-op while the quota is
+        unlimited; capacity definitions re-resolve under the ``(org, key)``
+        row lock before comparing. ``used`` and ``subject`` are forwarded to
+        :meth:`QuotaDefinition.check`.
         """
-        if self.effective(session, org_id, QUOTA_MAX_SOURCES) is None:
-            return
-        limit = self.effective(session, org_id, QUOTA_MAX_SOURCES, lock=True)
+        definition = QUOTAS[key]
+        limit = self.effective(session, org_id, key)
         if limit is None:
             return
-        count = QUOTAS[QUOTA_MAX_SOURCES].count
-        assert count is not None  # capacity quota, registered with its counter
-        used = count(session, org_id)
-        if used >= limit:
-            raise QuotaExceededError(
-                f"Organisation is at its source limit ({used}/{limit})",
-                quota=QUOTA_MAX_SOURCES,
-                limit=limit,
-                used=used,
-            )
-
-    def check_assets(self, session: Session, db_source: Component, asset_count: int) -> None:
-        """Reject a source child set larger than the assets-per-source limit.
-
-        ``asset_count`` is the size of the *desired* final set, so the check
-        is declarative — no counting race regardless of what the set is today.
-        """
-        if self.effective(session, db_source.org_id, QUOTA_MAX_ASSETS_PER_SOURCE) is None:
-            return
-        limit = self.effective(session, db_source.org_id, QUOTA_MAX_ASSETS_PER_SOURCE, lock=True)
-        if limit is None or asset_count <= limit:
-            return
-        raise QuotaExceededError(
-            f"Source '{db_source.name or db_source.key}' would have {asset_count} assets, "
-            f"exceeding the limit of {limit}",
-            quota=QUOTA_MAX_ASSETS_PER_SOURCE,
-            limit=limit,
-            used=asset_count,
-        )
+        if definition.requires_lock:
+            limit = self.effective(session, org_id, key, lock=True)
+            if limit is None:
+                return
+        definition.check(session, org_id, limit, used=used, subject=subject)
 
     def run_status(self, session: Session, org_id: UUID) -> tuple[int, int | None]:
         """The org's committed run usage this period: ``(used + reserved, limit)``.
 
         Limit None means unlimited (and the ledger is not read at all).
         """
+        definition = QUOTAS[QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH]
+        assert isinstance(definition, ConsumptionQuota)
         limit = self.effective(session, org_id, QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH)
         if limit is None:
             return 0, None
-        period_start = month_start(db_now(session))
-        row = session.get(Usage, (org_id, METRIC_SUCCESSFUL_RUNS, period_start))
-        committed = (row.used + row.reserved) if row else 0
-        return committed, limit
-
-    def check_run_admission(self, session: Session, org_id: UUID, *, source: str = "run") -> None:
-        """Advisory creation-time gate: reject new runs once the quota is exhausted.
-
-        Fail-fast only — runs admitted here can still be denied at dispatch
-        by :meth:`try_reserve_run`, the authoritative gate.
-        """
-        committed, limit = self.run_status(session, org_id)
-        if limit is not None and committed >= limit:
-            raise QuotaExceededError(
-                f"Cannot queue {source}: the monthly successful-run quota is exhausted ({committed}/{limit})",
-                quota=QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH,
-                limit=limit,
-                used=committed,
-            )
+        return definition.committed(session, org_id), limit
 
     def try_reserve_run(self, session: Session, db_run: Run) -> bool:
         """Atomically reserve a run-quota slot at dispatch time.
 
-        The reservation is a conditional upsert (``used + reserved < limit``),
-        so concurrent claimers can never overshoot; on success the run is
-        stamped with ``quota_reserved_at`` so settlement releases the right
-        period. Unlimited orgs are admitted without touching the ledger.
+        The authoritative run gate: on success the run is stamped with
+        ``quota_reserved_at`` so settlement releases the right period.
+        Unlimited orgs are admitted without touching the ledger.
 
         Returns:
             True if the run may dispatch, False when the quota is exhausted.
         """
+        definition = QUOTAS[QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH]
+        assert isinstance(definition, ConsumptionQuota)
         limit = self.effective(session, db_run.org_id, QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH)
         if limit is None:
             return True
-        if limit <= 0:
+        reserved_at = definition.reserve(session, db_run.org_id, limit)
+        if reserved_at is None:
             return False
-        now = db_now(session)
-        period_start = month_start(now)
-        table = Usage.__table__  # ty: ignore[unresolved-attribute]
-        statement = (
-            _insert_fn(session)(table)
-            .values(org_id=db_run.org_id, metric=METRIC_SUCCESSFUL_RUNS, period_start=period_start, used=0, reserved=1)
-            .on_conflict_do_update(
-                index_elements=["org_id", "metric", "period_start"],
-                set_={"reserved": table.c.reserved + 1},
-                where=(table.c.used + table.c.reserved < limit),
-            )
-        )
-        result = session.execute(statement)  # ty: ignore[deprecated]
-        if result.rowcount != 1:  # ty: ignore[unresolved-attribute]
-            return False
-        db_run.quota_reserved_at = now
+        db_run.quota_reserved_at = reserved_at
         session.add(db_run)
         return True
 
 
-QUOTAS.register(QUOTA_MAX_SOURCES, QuotaDefinition(key=QUOTA_MAX_SOURCES, count=_count_sources))
-QUOTAS.register(QUOTA_MAX_ASSETS_PER_SOURCE, QuotaDefinition(key=QUOTA_MAX_ASSETS_PER_SOURCE))
+QUOTAS.register(
+    QUOTA_MAX_SOURCES,
+    CapacityQuota(
+        key=QUOTA_MAX_SOURCES,
+        count=_count_sources,
+        message=lambda used, limit, _subject: f"Organisation is at its source limit ({used}/{limit})",
+    ),
+)
+QUOTAS.register(
+    QUOTA_MAX_ASSETS_PER_SOURCE,
+    CapacityQuota(
+        key=QUOTA_MAX_ASSETS_PER_SOURCE,
+        message=lambda used, limit, subject: (
+            f"Source '{subject}' would have {used} assets, exceeding the limit of {limit}"
+        ),
+    ),
+)
 QUOTAS.register(
     QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH,
-    QuotaDefinition(key=QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH, metric=METRIC_SUCCESSFUL_RUNS),
+    ConsumptionQuota(
+        key=QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH,
+        metric=METRIC_SUCCESSFUL_RUNS,
+        message=lambda used, limit, subject: (
+            f"Cannot queue {subject or 'run'}: the monthly successful-run quota is exhausted ({used}/{limit})"
+        ),
+    ),
 )
 
 

--- a/packages/interloper-db/src/interloper_db/store/quotas.py
+++ b/packages/interloper-db/src/interloper_db/store/quotas.py
@@ -35,6 +35,15 @@ METRIC_SUCCESSFUL_RUNS = "successful_runs"
 #: DB, so writers must go through this to keep the ledger free of typo rows.
 USAGE_METRICS = frozenset({METRIC_SUCCESSFUL_RUNS})
 
+QUOTA_MAX_SOURCES = "max_sources"
+QUOTA_MAX_ASSETS_PER_SOURCE = "max_assets_per_source"
+QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH = "max_successful_runs_per_month"
+
+#: The closed set of quota keys. Limits are stored one row per key, so
+#: adding a quota is a new entry here (plus its enforcement site) — no
+#: schema change.
+QUOTA_KEYS = frozenset({QUOTA_MAX_SOURCES, QUOTA_MAX_ASSETS_PER_SOURCE, QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH})
+
 
 def month_start(moment: datetime) -> dt.date:
     """The first day of the UTC calendar month a moment falls in.
@@ -132,29 +141,36 @@ def settle_run_usage(session: Session, db_run: Run, *, success: bool) -> None:
 # ``try_reserve_run``; the creation-time checks are advisory fail-fasts.
 
 
-def _effective_limit(session: Session, org_id: UUID, field: str, defaults: Any) -> int | None:
+def _effective_limit(session: Session, org_id: UUID, key: str, defaults: Any) -> int | None:
     """Resolve a limit: org override wins over the global default; None = unlimited."""
-    override = session.get(Quota, org_id)
-    value = getattr(override, field, None) if override else None
+    override = session.get(Quota, (org_id, key))
+    value = override.limit if override else None
     if value is None:
-        value = getattr(defaults, field, None)
+        value = getattr(defaults, key, None)
     return value
 
 
-def _locked_effective_limit(session: Session, org_id: UUID, field: str, defaults: Any) -> int | None:
-    """Resolve a limit while holding the org's quota-row lock.
+def _locked_effective_limit(session: Session, org_id: UUID, key: str, defaults: Any) -> int | None:
+    """Resolve a limit while holding the ``(org, key)`` quota-row lock.
 
-    Upserts the (all-null) row first so there is always something to lock;
-    the lock is released with the caller's transaction and serializes
-    capacity checks per organisation.
+    Upserts the (null-limit) row first so there is always something to
+    lock; the lock is released with the caller's transaction and
+    serializes checks per organisation *and* key, so independent quotas
+    never block each other.
     """
     table = Quota.__table__  # ty: ignore[unresolved-attribute]
-    statement = _insert_fn(session)(table).values(org_id=org_id).on_conflict_do_nothing(index_elements=["org_id"])
+    statement = (
+        _insert_fn(session)(table)
+        .values(org_id=org_id, key=key)
+        .on_conflict_do_nothing(index_elements=["org_id", "key"])
+    )
     session.execute(statement)  # ty: ignore[deprecated]
-    override = session.exec(select(Quota).where(Quota.org_id == org_id).with_for_update()).first()
-    value = getattr(override, field, None) if override else None
+    override = session.exec(
+        select(Quota).where(Quota.org_id == org_id, Quota.key == key).with_for_update()
+    ).first()
+    value = override.limit if override else None
     if value is None:
-        value = getattr(defaults, field, None)
+        value = getattr(defaults, key, None)
     return value
 
 
@@ -163,9 +179,9 @@ def check_source_quota(session: Session, org_id: UUID, defaults: Any) -> None:
 
     Part of the caller's transaction; call before inserting the new source.
     """
-    if _effective_limit(session, org_id, "max_sources", defaults) is None:
+    if _effective_limit(session, org_id, QUOTA_MAX_SOURCES, defaults) is None:
         return
-    limit = _locked_effective_limit(session, org_id, "max_sources", defaults)
+    limit = _locked_effective_limit(session, org_id, QUOTA_MAX_SOURCES, defaults)
     if limit is None:
         return
     used = session.exec(
@@ -176,7 +192,7 @@ def check_source_quota(session: Session, org_id: UUID, defaults: Any) -> None:
     if used >= limit:
         raise QuotaExceededError(
             f"Organisation is at its source limit ({used}/{limit})",
-            quota="max_sources",
+            quota=QUOTA_MAX_SOURCES,
             limit=limit,
             used=used,
         )
@@ -188,15 +204,15 @@ def check_asset_quota(session: Session, db_source: Component, asset_count: int, 
     ``asset_count`` is the size of the *desired* final set, so the check is
     declarative — no counting race regardless of what the set is today.
     """
-    if _effective_limit(session, db_source.org_id, "max_assets_per_source", defaults) is None:
+    if _effective_limit(session, db_source.org_id, QUOTA_MAX_ASSETS_PER_SOURCE, defaults) is None:
         return
-    limit = _locked_effective_limit(session, db_source.org_id, "max_assets_per_source", defaults)
+    limit = _locked_effective_limit(session, db_source.org_id, QUOTA_MAX_ASSETS_PER_SOURCE, defaults)
     if limit is None or asset_count <= limit:
         return
     raise QuotaExceededError(
         f"Source '{db_source.name or db_source.key}' would have {asset_count} assets, "
         f"exceeding the limit of {limit}",
-        quota="max_assets_per_source",
+        quota=QUOTA_MAX_ASSETS_PER_SOURCE,
         limit=limit,
         used=asset_count,
     )
@@ -207,7 +223,7 @@ def run_quota_status(session: Session, org_id: UUID, defaults: Any) -> tuple[int
 
     Limit None means unlimited (and the ledger is not read at all).
     """
-    limit = _effective_limit(session, org_id, "max_successful_runs_per_month", defaults)
+    limit = _effective_limit(session, org_id, QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH, defaults)
     if limit is None:
         return 0, None
     period_start = month_start(db_now(session))
@@ -226,7 +242,7 @@ def check_run_quota(session: Session, org_id: UUID, defaults: Any, *, source: st
     if limit is not None and committed >= limit:
         raise QuotaExceededError(
             f"Cannot queue {source}: the monthly successful-run quota is exhausted ({committed}/{limit})",
-            quota="max_successful_runs_per_month",
+            quota=QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH,
             limit=limit,
             used=committed,
         )
@@ -243,7 +259,7 @@ def try_reserve_run(session: Session, db_run: Run, defaults: Any) -> bool:
     Returns:
         True if the run may dispatch, False when the quota is exhausted.
     """
-    limit = _effective_limit(session, db_run.org_id, "max_successful_runs_per_month", defaults)
+    limit = _effective_limit(session, db_run.org_id, QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH, defaults)
     if limit is None:
         return True
     if limit <= 0:
@@ -271,37 +287,49 @@ def try_reserve_run(session: Session, db_run: Run, defaults: Any) -> bool:
 class QuotaMixin(StoreBase):
     """Store methods for quota limits and usage reads."""
 
-    def get_quota(self, org_id: UUID) -> Quota | None:
-        """The organisation's quota overrides, or None if none are set."""
+    def get_quota_overrides(self, org_id: UUID) -> dict[str, int]:
+        """The organisation's set overrides as ``{key: limit}`` (null rows excluded)."""
         with self._session() as session:
-            return session.get(Quota, org_id)
+            rows = session.exec(select(Quota).where(Quota.org_id == org_id)).all()
+            return {row.key: row.limit for row in rows if row.limit is not None}
 
-    def list_quotas(self) -> list[Quota]:
-        """All per-organisation quota override rows."""
+    def list_quota_overrides(self) -> dict[UUID, dict[str, int]]:
+        """Every organisation's set overrides, keyed by org id."""
         with self._session() as session:
-            return list(session.exec(select(Quota)).all())
+            rows = session.exec(select(Quota)).all()
+            overrides: dict[UUID, dict[str, int]] = {}
+            for row in rows:
+                if row.limit is not None:
+                    overrides.setdefault(row.org_id, {})[row.key] = row.limit
+            return overrides
 
-    def set_quota(self, org_id: UUID, limits: dict[str, int | None]) -> Quota:
-        """Set an organisation's quota overrides; only the given fields change.
+    def set_quota(self, org_id: UUID, limits: dict[str, int | None]) -> dict[str, int]:
+        """Set an organisation's quota overrides; only the given keys change.
 
-        ``None`` clears a field so it falls back to the global default.
+        ``None`` clears a key so it falls back to the global default (the
+        row is kept as a null-limit lock anchor).
+
+        Returns:
+            The organisation's overrides after the update.
 
         Raises:
-            ValueError: On an unknown limit field or a negative value.
+            ValueError: On an unknown quota key or a negative value.
         """
-        allowed = {"max_sources", "max_assets_per_source", "max_successful_runs_per_month"}
-        if unknown := set(limits) - allowed:
+        if unknown := set(limits) - QUOTA_KEYS:
             raise ValueError(f"Unknown quota limit(s): {sorted(unknown)}")
-        if negative := {field for field, value in limits.items() if value is not None and value < 0}:
+        if negative := {key for key, value in limits.items() if value is not None and value < 0}:
             raise ValueError(f"Quota limit(s) must be >= 0: {sorted(negative)}")
+        table = Quota.__table__  # ty: ignore[unresolved-attribute]
         with self._session() as session:
-            quota = session.get(Quota, org_id) or Quota(org_id=org_id)
-            for field, value in limits.items():
-                setattr(quota, field, value)
-            session.add(quota)
+            for key, value in limits.items():
+                statement = (
+                    _insert_fn(session)(table)
+                    .values(org_id=org_id, key=key, limit=value)
+                    .on_conflict_do_update(index_elements=["org_id", "key"], set_={"limit": value})
+                )
+                session.execute(statement)  # ty: ignore[deprecated]
             session.commit()
-            session.refresh(quota)
-            return quota
+        return self.get_quota_overrides(org_id)
 
     def list_usage(self, *, period_start: dt.date | None = None, org_id: UUID | None = None) -> list[Usage]:
         """Usage ledger rows, optionally filtered by period and organisation."""

--- a/packages/interloper-db/src/interloper_db/store/quotas.py
+++ b/packages/interloper-db/src/interloper_db/store/quotas.py
@@ -10,16 +10,25 @@ so every writer (API, scheduler, child pods) agrees on the boundary.
 The ledger is the admission primitive; the ``runs`` table is the audit
 source of truth. ``count_successful_runs_by_org`` recomputes the ledger from
 it so drift is always visible.
+
+Quotas themselves are declared in the :data:`QUOTAS` registry — one
+:class:`QuotaDefinition` per key — and enforced through the store's
+:class:`QuotaService` (``store.quotas``), which owns limit resolution and
+the gates. Metering stays in module functions: the ledger never depends on
+limits.
 """
 
 from __future__ import annotations
 
 import datetime as dt
+from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 from uuid import UUID
 
 from interloper.errors import QuotaExceededError
+from interloper.registry import Registry
 from sqlalchemy import func
 from sqlalchemy import select as sa_select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
@@ -31,18 +40,34 @@ from interloper_db.store.base import StoreBase
 
 METRIC_SUCCESSFUL_RUNS = "successful_runs"
 
-#: The closed set of valid usage metrics — the column is a free string in the
-#: DB, so writers must go through this to keep the ledger free of typo rows.
-USAGE_METRICS = frozenset({METRIC_SUCCESSFUL_RUNS})
-
 QUOTA_MAX_SOURCES = "max_sources"
 QUOTA_MAX_ASSETS_PER_SOURCE = "max_assets_per_source"
 QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH = "max_successful_runs_per_month"
 
-#: The closed set of quota keys. Limits are stored one row per key, so
-#: adding a quota is a new entry here (plus its enforcement site) — no
-#: schema change.
-QUOTA_KEYS = frozenset({QUOTA_MAX_SOURCES, QUOTA_MAX_ASSETS_PER_SOURCE, QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH})
+
+@dataclass(frozen=True)
+class QuotaDefinition:
+    """One per-organisation quota: its key and how usage is measured.
+
+    Capacity quotas carry a ``count`` of current usage (a live query —
+    they are never metered); consumption quotas carry the ``metric`` their
+    usage is charged under in the ledger.
+    """
+
+    key: str
+    #: Ledger metric for consumption quotas; None for capacity quotas.
+    metric: str | None = None
+    #: Live usage count for capacity quotas; None when the gate supplies
+    #: the prospective usage itself (declarative checks).
+    count: Callable[[Session, UUID], int] | None = None
+
+
+#: Every quota, by key. Adding one is a registration plus its enforcement
+#: site — limits are stored one row per key, so there is no schema change.
+#: Code-registered (no entry-point group): enforcement is welded into the
+#: store, so quotas are not a plugin surface. Instance defaults live as
+#: same-named optional fields on ``QuotaSettings``.
+QUOTAS: Registry[QuotaDefinition] = Registry()
 
 
 def month_start(moment: datetime) -> dt.date:
@@ -97,7 +122,7 @@ def increment_usage(
     Upsert-based so concurrent writers never lose an increment; part of the
     caller's transaction (the caller commits).
     """
-    if metric not in USAGE_METRICS:
+    if all(definition.metric != metric for definition in QUOTAS.values()):
         raise ValueError(f"Unknown usage metric: {metric}")
     table = Usage.__table__  # ty: ignore[unresolved-attribute]
     statement = (
@@ -131,157 +156,180 @@ def settle_run_usage(session: Session, db_run: Run, *, success: bool) -> None:
 
 
 # -- Enforcement ----------------------------------------------------------------
-#
-# All checks short-circuit without touching the database when neither the
-# organisation nor the defaults set a limit, so unconfigured instances pay
-# nothing. Capacity checks (sources, assets per source) serialize on the
-# org's quotas row via SELECT FOR UPDATE — the count-then-insert race is
-# the reason a plain count in application code is not enough. The run
-# quota's authoritative gate is the atomic dispatch-time reservation in
-# ``try_reserve_run``; the creation-time checks are advisory fail-fasts.
 
 
-def _effective_limit(session: Session, org_id: UUID, key: str, defaults: Any) -> int | None:
-    """Resolve a limit: org override wins over the global default; None = unlimited."""
-    override = session.get(Quota, (org_id, key))
-    value = override.limit if override else None
-    if value is None:
-        value = getattr(defaults, key, None)
-    return value
-
-
-def _locked_effective_limit(session: Session, org_id: UUID, key: str, defaults: Any) -> int | None:
-    """Resolve a limit while holding the ``(org, key)`` quota-row lock.
-
-    Upserts the (null-limit) row first so there is always something to
-    lock; the lock is released with the caller's transaction and
-    serializes checks per organisation *and* key, so independent quotas
-    never block each other.
-    """
-    table = Quota.__table__  # ty: ignore[unresolved-attribute]
-    statement = (
-        _insert_fn(session)(table)
-        .values(org_id=org_id, key=key)
-        .on_conflict_do_nothing(index_elements=["org_id", "key"])
-    )
-    session.execute(statement)  # ty: ignore[deprecated]
-    override = session.exec(
-        select(Quota).where(Quota.org_id == org_id, Quota.key == key).with_for_update()
-    ).first()
-    value = override.limit if override else None
-    if value is None:
-        value = getattr(defaults, key, None)
-    return value
-
-
-def check_source_quota(session: Session, org_id: UUID, defaults: Any) -> None:
-    """Reject creating a source when the organisation is at its source limit.
-
-    Part of the caller's transaction; call before inserting the new source.
-    """
-    if _effective_limit(session, org_id, QUOTA_MAX_SOURCES, defaults) is None:
-        return
-    limit = _locked_effective_limit(session, org_id, QUOTA_MAX_SOURCES, defaults)
-    if limit is None:
-        return
-    used = session.exec(
+def _count_sources(session: Session, org_id: UUID) -> int:
+    """Current number of sources — the usage side of ``max_sources``."""
+    return session.exec(
         select(func.count())
         .select_from(Component)
         .where(col(Component.org_id) == org_id, col(Component.kind) == "source")
     ).one()
-    if used >= limit:
+
+
+class QuotaService:
+    """Limit resolution and enforcement gates over the :data:`QUOTAS` registry.
+
+    Constructed by the store (exposed as ``store.quotas``) with a defaults
+    provider, read per call so reconfiguration is always visible. All gates
+    short-circuit without touching the database when neither the
+    organisation nor the defaults set a limit, so unconfigured instances
+    pay nothing. Capacity gates serialize on the ``(org, key)`` quota-row
+    lock — the count-then-insert race is the reason a plain count in
+    application code is not enough. The run quota's authoritative gate is
+    the atomic dispatch-time reservation in :meth:`try_reserve_run`; the
+    creation-time checks are advisory fail-fasts.
+    """
+
+    def __init__(self, defaults: Callable[[], Any]) -> None:
+        """Initialize the service.
+
+        Args:
+            defaults: Zero-arg provider of the QuotaSettings-shaped global
+                defaults (or None = everything unlimited).
+        """
+        self._defaults = defaults
+
+    def effective(self, session: Session, org_id: UUID, key: str, *, lock: bool = False) -> int | None:
+        """Resolve a limit: org override wins over the global default; None = unlimited.
+
+        With ``lock`` the ``(org, key)`` row is upserted (null-limit lock
+        anchor) and held ``FOR UPDATE`` until the caller's transaction ends,
+        serializing checks per organisation *and* key so independent quotas
+        never block each other.
+
+        Raises:
+            KeyError: If the key is not a registered quota.
+        """
+        QUOTAS[key]  # loud failure on unregistered keys  # noqa: B018
+        if lock:
+            table = Quota.__table__  # ty: ignore[unresolved-attribute]
+            statement = (
+                _insert_fn(session)(table)
+                .values(org_id=org_id, key=key)
+                .on_conflict_do_nothing(index_elements=["org_id", "key"])
+            )
+            session.execute(statement)  # ty: ignore[deprecated]
+            override = session.exec(
+                select(Quota).where(Quota.org_id == org_id, Quota.key == key).with_for_update()
+            ).first()
+        else:
+            override = session.get(Quota, (org_id, key))
+        value = override.limit if override else None
+        if value is None:
+            value = getattr(self._defaults(), key, None)
+        return value
+
+    def check_source(self, session: Session, org_id: UUID) -> None:
+        """Reject creating a source when the organisation is at its source limit.
+
+        Part of the caller's transaction; call before inserting the new source.
+        """
+        if self.effective(session, org_id, QUOTA_MAX_SOURCES) is None:
+            return
+        limit = self.effective(session, org_id, QUOTA_MAX_SOURCES, lock=True)
+        if limit is None:
+            return
+        count = QUOTAS[QUOTA_MAX_SOURCES].count
+        assert count is not None  # capacity quota, registered with its counter
+        used = count(session, org_id)
+        if used >= limit:
+            raise QuotaExceededError(
+                f"Organisation is at its source limit ({used}/{limit})",
+                quota=QUOTA_MAX_SOURCES,
+                limit=limit,
+                used=used,
+            )
+
+    def check_assets(self, session: Session, db_source: Component, asset_count: int) -> None:
+        """Reject a source child set larger than the assets-per-source limit.
+
+        ``asset_count`` is the size of the *desired* final set, so the check
+        is declarative — no counting race regardless of what the set is today.
+        """
+        if self.effective(session, db_source.org_id, QUOTA_MAX_ASSETS_PER_SOURCE) is None:
+            return
+        limit = self.effective(session, db_source.org_id, QUOTA_MAX_ASSETS_PER_SOURCE, lock=True)
+        if limit is None or asset_count <= limit:
+            return
         raise QuotaExceededError(
-            f"Organisation is at its source limit ({used}/{limit})",
-            quota=QUOTA_MAX_SOURCES,
+            f"Source '{db_source.name or db_source.key}' would have {asset_count} assets, "
+            f"exceeding the limit of {limit}",
+            quota=QUOTA_MAX_ASSETS_PER_SOURCE,
             limit=limit,
-            used=used,
+            used=asset_count,
         )
 
+    def run_status(self, session: Session, org_id: UUID) -> tuple[int, int | None]:
+        """The org's committed run usage this period: ``(used + reserved, limit)``.
 
-def check_asset_quota(session: Session, db_source: Component, asset_count: int, defaults: Any) -> None:
-    """Reject a source child set larger than the assets-per-source limit.
+        Limit None means unlimited (and the ledger is not read at all).
+        """
+        limit = self.effective(session, org_id, QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH)
+        if limit is None:
+            return 0, None
+        period_start = month_start(db_now(session))
+        row = session.get(Usage, (org_id, METRIC_SUCCESSFUL_RUNS, period_start))
+        committed = (row.used + row.reserved) if row else 0
+        return committed, limit
 
-    ``asset_count`` is the size of the *desired* final set, so the check is
-    declarative — no counting race regardless of what the set is today.
-    """
-    if _effective_limit(session, db_source.org_id, QUOTA_MAX_ASSETS_PER_SOURCE, defaults) is None:
-        return
-    limit = _locked_effective_limit(session, db_source.org_id, QUOTA_MAX_ASSETS_PER_SOURCE, defaults)
-    if limit is None or asset_count <= limit:
-        return
-    raise QuotaExceededError(
-        f"Source '{db_source.name or db_source.key}' would have {asset_count} assets, "
-        f"exceeding the limit of {limit}",
-        quota=QUOTA_MAX_ASSETS_PER_SOURCE,
-        limit=limit,
-        used=asset_count,
-    )
+    def check_run_admission(self, session: Session, org_id: UUID, *, source: str = "run") -> None:
+        """Advisory creation-time gate: reject new runs once the quota is exhausted.
 
+        Fail-fast only — runs admitted here can still be denied at dispatch
+        by :meth:`try_reserve_run`, the authoritative gate.
+        """
+        committed, limit = self.run_status(session, org_id)
+        if limit is not None and committed >= limit:
+            raise QuotaExceededError(
+                f"Cannot queue {source}: the monthly successful-run quota is exhausted ({committed}/{limit})",
+                quota=QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH,
+                limit=limit,
+                used=committed,
+            )
 
-def run_quota_status(session: Session, org_id: UUID, defaults: Any) -> tuple[int, int | None]:
-    """The org's committed run usage this period: ``(used + reserved, limit)``.
+    def try_reserve_run(self, session: Session, db_run: Run) -> bool:
+        """Atomically reserve a run-quota slot at dispatch time.
 
-    Limit None means unlimited (and the ledger is not read at all).
-    """
-    limit = _effective_limit(session, org_id, QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH, defaults)
-    if limit is None:
-        return 0, None
-    period_start = month_start(db_now(session))
-    row = session.get(Usage, (org_id, METRIC_SUCCESSFUL_RUNS, period_start))
-    committed = (row.used + row.reserved) if row else 0
-    return committed, limit
+        The reservation is a conditional upsert (``used + reserved < limit``),
+        so concurrent claimers can never overshoot; on success the run is
+        stamped with ``quota_reserved_at`` so settlement releases the right
+        period. Unlimited orgs are admitted without touching the ledger.
 
-
-def check_run_quota(session: Session, org_id: UUID, defaults: Any, *, source: str = "run") -> None:
-    """Advisory creation-time gate: reject new runs once the quota is exhausted.
-
-    Fail-fast only — runs admitted here can still be denied at dispatch by
-    ``try_reserve_run``, the authoritative gate.
-    """
-    committed, limit = run_quota_status(session, org_id, defaults)
-    if limit is not None and committed >= limit:
-        raise QuotaExceededError(
-            f"Cannot queue {source}: the monthly successful-run quota is exhausted ({committed}/{limit})",
-            quota=QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH,
-            limit=limit,
-            used=committed,
+        Returns:
+            True if the run may dispatch, False when the quota is exhausted.
+        """
+        limit = self.effective(session, db_run.org_id, QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH)
+        if limit is None:
+            return True
+        if limit <= 0:
+            return False
+        now = db_now(session)
+        period_start = month_start(now)
+        table = Usage.__table__  # ty: ignore[unresolved-attribute]
+        statement = (
+            _insert_fn(session)(table)
+            .values(org_id=db_run.org_id, metric=METRIC_SUCCESSFUL_RUNS, period_start=period_start, used=0, reserved=1)
+            .on_conflict_do_update(
+                index_elements=["org_id", "metric", "period_start"],
+                set_={"reserved": table.c.reserved + 1},
+                where=(table.c.used + table.c.reserved < limit),
+            )
         )
-
-
-def try_reserve_run(session: Session, db_run: Run, defaults: Any) -> bool:
-    """Atomically reserve a run-quota slot at dispatch time.
-
-    The reservation is a conditional upsert (``used + reserved < limit``),
-    so concurrent claimers can never overshoot; on success the run is
-    stamped with ``quota_reserved_at`` so settlement releases the right
-    period. Unlimited orgs are admitted without touching the ledger.
-
-    Returns:
-        True if the run may dispatch, False when the quota is exhausted.
-    """
-    limit = _effective_limit(session, db_run.org_id, QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH, defaults)
-    if limit is None:
+        result = session.execute(statement)  # ty: ignore[deprecated]
+        if result.rowcount != 1:  # ty: ignore[unresolved-attribute]
+            return False
+        db_run.quota_reserved_at = now
+        session.add(db_run)
         return True
-    if limit <= 0:
-        return False
-    now = db_now(session)
-    period_start = month_start(now)
-    table = Usage.__table__  # ty: ignore[unresolved-attribute]
-    statement = (
-        _insert_fn(session)(table)
-        .values(org_id=db_run.org_id, metric=METRIC_SUCCESSFUL_RUNS, period_start=period_start, used=0, reserved=1)
-        .on_conflict_do_update(
-            index_elements=["org_id", "metric", "period_start"],
-            set_={"reserved": table.c.reserved + 1},
-            where=(table.c.used + table.c.reserved < limit),
-        )
-    )
-    result = session.execute(statement)  # ty: ignore[deprecated]
-    if result.rowcount != 1:  # ty: ignore[unresolved-attribute]
-        return False
-    db_run.quota_reserved_at = now
-    session.add(db_run)
-    return True
+
+
+QUOTAS.register(QUOTA_MAX_SOURCES, QuotaDefinition(key=QUOTA_MAX_SOURCES, count=_count_sources))
+QUOTAS.register(QUOTA_MAX_ASSETS_PER_SOURCE, QuotaDefinition(key=QUOTA_MAX_ASSETS_PER_SOURCE))
+QUOTAS.register(
+    QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH,
+    QuotaDefinition(key=QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH, metric=METRIC_SUCCESSFUL_RUNS),
+)
 
 
 class QuotaMixin(StoreBase):
@@ -315,7 +363,7 @@ class QuotaMixin(StoreBase):
         Raises:
             ValueError: On an unknown quota key or a negative value.
         """
-        if unknown := set(limits) - QUOTA_KEYS:
+        if unknown := {key for key in limits if key not in QUOTAS}:
             raise ValueError(f"Unknown quota limit(s): {sorted(unknown)}")
         if negative := {key for key, value in limits.items() if value is not None and value < 0}:
             raise ValueError(f"Quota limit(s) must be >= 0: {sorted(negative)}")

--- a/packages/interloper-db/src/interloper_db/store/runs.py
+++ b/packages/interloper-db/src/interloper_db/store/runs.py
@@ -19,7 +19,7 @@ from sqlmodel import Session, col, select
 from interloper_db.models import AssetExecution, Backfill, Component, Event, Run
 from interloper_db.store.base import StoreBase
 from interloper_db.store.components import stamp_component_state
-from interloper_db.store.quotas import check_run_quota, settle_run_usage
+from interloper_db.store.quotas import settle_run_usage
 
 logger = logging.getLogger(__name__)
 
@@ -312,7 +312,7 @@ class RunMixin(StoreBase):
             The created Run row.
         """
         with self._session() as session:
-            check_run_quota(session, org_id, self._quota_defaults)
+            self.quotas.check_run_admission(session, org_id)
             db_run = Run(
                 org_id=org_id,
                 component_id=component_id,
@@ -469,7 +469,7 @@ class RunMixin(StoreBase):
             if src.status != "failed":
                 raise ValueError(f"Run {run_id} is not failed (status={src.status!r}); only failed runs can be retried")
 
-            check_run_quota(session, src.org_id, self._quota_defaults, source="retry")
+            self.quotas.check_run_admission(session, src.org_id, source="retry")
             db_run = Run(
                 org_id=src.org_id,
                 component_id=src.component_id,
@@ -518,7 +518,7 @@ class RunMixin(StoreBase):
             raise ValueError(f"Backfill spans {span} days; the instance caps backfills at {max_days} days")
 
         with self._session() as session:
-            check_run_quota(session, org_id, self._quota_defaults, source="backfill")
+            self.quotas.check_run_admission(session, org_id, source="backfill")
             db_backfill = Backfill(
                 org_id=org_id,
                 component_id=component_id,

--- a/packages/interloper-db/src/interloper_db/store/runs.py
+++ b/packages/interloper-db/src/interloper_db/store/runs.py
@@ -19,7 +19,7 @@ from sqlmodel import Session, col, select
 from interloper_db.models import AssetExecution, Backfill, Component, Event, Run
 from interloper_db.store.base import StoreBase
 from interloper_db.store.components import stamp_component_state
-from interloper_db.store.quotas import settle_run_usage
+from interloper_db.store.quotas import QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH, settle_run_usage
 
 logger = logging.getLogger(__name__)
 
@@ -312,7 +312,7 @@ class RunMixin(StoreBase):
             The created Run row.
         """
         with self._session() as session:
-            self.quotas.check_run_admission(session, org_id)
+            self.quotas.check(session, org_id, QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH)
             db_run = Run(
                 org_id=org_id,
                 component_id=component_id,
@@ -469,7 +469,7 @@ class RunMixin(StoreBase):
             if src.status != "failed":
                 raise ValueError(f"Run {run_id} is not failed (status={src.status!r}); only failed runs can be retried")
 
-            self.quotas.check_run_admission(session, src.org_id, source="retry")
+            self.quotas.check(session, src.org_id, QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH, subject="retry")
             db_run = Run(
                 org_id=src.org_id,
                 component_id=src.component_id,
@@ -518,7 +518,7 @@ class RunMixin(StoreBase):
             raise ValueError(f"Backfill spans {span} days; the instance caps backfills at {max_days} days")
 
         with self._session() as session:
-            self.quotas.check_run_admission(session, org_id, source="backfill")
+            self.quotas.check(session, org_id, QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH, subject="backfill")
             db_backfill = Backfill(
                 org_id=org_id,
                 component_id=component_id,

--- a/packages/interloper-db/tests/store/test_components.py
+++ b/packages/interloper-db/tests/store/test_components.py
@@ -462,7 +462,7 @@ class TestQuotaGates:
 
         store = self._store(max_sources=1)
         with Session(component_db) as session:
-            session.add(Quota(org_id=_ORG, max_sources=2))
+            session.add(Quota(org_id=_ORG, key="max_sources", limit=2))
             session.commit()
         store.create_component(_ORG, kind="source", key="demo_source", children=["a"], config={"dataset": "one"})
         store.create_component(_ORG, kind="source", key="demo_source", children=["a"], config={"dataset": "two"})

--- a/packages/interloper-db/tests/store/test_quotas.py
+++ b/packages/interloper-db/tests/store/test_quotas.py
@@ -20,6 +20,8 @@ from interloper_db.models import Backfill, Component, Quota, Run, Usage
 from interloper_db.store.quotas import (
     METRIC_SUCCESSFUL_RUNS,
     QUOTAS,
+    CapacityQuota,
+    ConsumptionQuota,
     QuotaMixin,
     increment_usage,
     month_start,
@@ -358,8 +360,10 @@ class TestRegistry:
         assert set(QuotaSettings.model_fields) - guards == set(QUOTAS.keys())
 
     def test_capacity_quotas_carry_counters_and_consumption_metrics(self):
-        assert QUOTAS["max_sources"].count is not None
-        assert QUOTAS["max_successful_runs_per_month"].metric == METRIC_SUCCESSFUL_RUNS
+        sources = QUOTAS["max_sources"]
+        assert isinstance(sources, CapacityQuota) and sources.count is not None
+        runs = QUOTAS["max_successful_runs_per_month"]
+        assert isinstance(runs, ConsumptionQuota) and runs.metric == METRIC_SUCCESSFUL_RUNS
 
     def test_unregistered_key_fails_loudly(self, store: _Store):
         with Session(store._engine) as session:

--- a/packages/interloper-db/tests/store/test_quotas.py
+++ b/packages/interloper-db/tests/store/test_quotas.py
@@ -156,14 +156,14 @@ class TestSettleRunUsage:
 
 
 class TestQuotaReads:
-    def test_get_and_list_quotas(self, store: _Store):
-        assert store.get_quota(_ORG_ID) is None
+    def test_get_and_list_overrides(self, store: _Store):
+        assert store.get_quota_overrides(_ORG_ID) == {}
         with Session(store._engine) as session:
-            session.add(Quota(org_id=_ORG_ID, max_sources=3))
+            session.add(Quota(org_id=_ORG_ID, key="max_sources", limit=3))
+            session.add(Quota(org_id=_ORG_ID, key="max_assets_per_source", limit=None))  # cleared/anchor row
             session.commit()
-        quota = store.get_quota(_ORG_ID)
-        assert quota is not None and quota.max_sources == 3
-        assert [q.org_id for q in store.list_quotas()] == [_ORG_ID]
+        assert store.get_quota_overrides(_ORG_ID) == {"max_sources": 3}
+        assert store.list_quota_overrides() == {_ORG_ID: {"max_sources": 3}}
 
     def test_list_usage_filters(self, store: _Store):
         other_org = uuid4()
@@ -237,7 +237,7 @@ class TestRunCreationGate:
     def test_org_override_wins_over_default(self, store: _Store):
         store._quota_defaults = _defaults(max_successful_runs_per_month=1)
         with Session(store._engine) as session:
-            session.add(Quota(org_id=_ORG_ID, max_successful_runs_per_month=3))
+            session.add(Quota(org_id=_ORG_ID, key="max_successful_runs_per_month", limit=3))
             session.commit()
         self._exhaust(store, used=2)
         assert store.create_run(_ORG_ID).status == "queued"
@@ -329,16 +329,15 @@ class TestReconcileUsage:
 
 class TestSetQuota:
     def test_creates_then_partially_updates(self, store: _Store):
-        quota = store.set_quota(_ORG_ID, {"max_sources": 5})
-        assert (quota.max_sources, quota.max_successful_runs_per_month) == (5, None)
-
-        quota = store.set_quota(_ORG_ID, {"max_successful_runs_per_month": 100})
-        assert (quota.max_sources, quota.max_successful_runs_per_month) == (5, 100)
+        assert store.set_quota(_ORG_ID, {"max_sources": 5}) == {"max_sources": 5}
+        assert store.set_quota(_ORG_ID, {"max_successful_runs_per_month": 100}) == {
+            "max_sources": 5,
+            "max_successful_runs_per_month": 100,
+        }
 
     def test_none_clears_an_override(self, store: _Store):
         store.set_quota(_ORG_ID, {"max_sources": 5})
-        quota = store.set_quota(_ORG_ID, {"max_sources": None})
-        assert quota.max_sources is None
+        assert store.set_quota(_ORG_ID, {"max_sources": None}) == {}
 
     def test_rejects_unknown_and_negative(self, store: _Store):
         with pytest.raises(ValueError, match="Unknown quota limit"):

--- a/packages/interloper-db/tests/store/test_quotas.py
+++ b/packages/interloper-db/tests/store/test_quotas.py
@@ -19,12 +19,12 @@ from interloper_db import engine as engine_module
 from interloper_db.models import Backfill, Component, Quota, Run, Usage
 from interloper_db.store.quotas import (
     METRIC_SUCCESSFUL_RUNS,
+    QUOTAS,
     QuotaMixin,
     increment_usage,
     month_start,
     next_month_start,
     settle_run_usage,
-    try_reserve_run,
 )
 from interloper_db.store.runs import RunMixin
 
@@ -270,16 +270,17 @@ class TestTryReserveRun:
         with Session(store._engine) as session:
             db_run = session.get(Run, run.id)
             assert db_run is not None
-            assert try_reserve_run(session, db_run, None) is True
+            assert store.quotas.try_reserve_run(session, db_run) is True
             session.commit()
         assert _usage_rows(store) == {}
 
     def test_reserves_and_stamps(self, store: _Store):
+        store._quota_defaults = _defaults(max_successful_runs_per_month=1)
         run = _run(store)
         with Session(store._engine) as session:
             db_run = session.get(Run, run.id)
             assert db_run is not None
-            assert try_reserve_run(session, db_run, _defaults(max_successful_runs_per_month=1)) is True
+            assert store.quotas.try_reserve_run(session, db_run) is True
             session.commit()
         (counts,) = _usage_rows(store).values()
         assert counts == (0, 1)
@@ -292,11 +293,12 @@ class TestTryReserveRun:
             period = month_start(datetime.now(timezone.utc))
             increment_usage(session, _ORG_ID, METRIC_SUCCESSFUL_RUNS, period, used=1)
             session.commit()
+        store._quota_defaults = _defaults(max_successful_runs_per_month=1)
         run = _run(store)
         with Session(store._engine) as session:
             db_run = session.get(Run, run.id)
             assert db_run is not None
-            assert try_reserve_run(session, db_run, _defaults(max_successful_runs_per_month=1)) is False
+            assert store.quotas.try_reserve_run(session, db_run) is False
             session.commit()
         (counts,) = _usage_rows(store).values()
         assert counts == (1, 0)
@@ -305,11 +307,12 @@ class TestTryReserveRun:
             assert released is not None and released.quota_reserved_at is None
 
     def test_zero_limit_denies(self, store: _Store):
+        store._quota_defaults = _defaults(max_successful_runs_per_month=0)
         run = _run(store)
         with Session(store._engine) as session:
             db_run = session.get(Run, run.id)
             assert db_run is not None
-            assert try_reserve_run(session, db_run, _defaults(max_successful_runs_per_month=0)) is False
+            assert store.quotas.try_reserve_run(session, db_run) is False
 
 
 class TestReconcileUsage:
@@ -344,3 +347,21 @@ class TestSetQuota:
             store.set_quota(_ORG_ID, {"max_bananas": 1})
         with pytest.raises(ValueError, match=">= 0"):
             store.set_quota(_ORG_ID, {"max_sources": -1})
+
+
+class TestRegistry:
+    def test_settings_fields_match_registered_quotas(self):
+        """QuotaSettings carries exactly the per-org quota defaults plus known guards."""
+        from interloper.settings import QuotaSettings
+
+        guards = {"max_backfill_days"}
+        assert set(QuotaSettings.model_fields) - guards == set(QUOTAS.keys())
+
+    def test_capacity_quotas_carry_counters_and_consumption_metrics(self):
+        assert QUOTAS["max_sources"].count is not None
+        assert QUOTAS["max_successful_runs_per_month"].metric == METRIC_SUCCESSFUL_RUNS
+
+    def test_unregistered_key_fails_loudly(self, store: _Store):
+        with Session(store._engine) as session:
+            with pytest.raises(KeyError, match="not registered"):
+                store.quotas.effective(session, _ORG_ID, "max_bananas")

--- a/packages/interloper-scheduler/src/interloper_scheduler/cron.py
+++ b/packages/interloper-scheduler/src/interloper_scheduler/cron.py
@@ -23,7 +23,6 @@ from croniter import croniter
 from interloper.errors import ConfigError
 from interloper_db import Store, stamp_component_state
 from interloper_db.models import Backfill, Component, Run
-from interloper_db.store.quotas import run_quota_status
 from sqlalchemy import or_
 from sqlmodel import Session, select
 
@@ -124,7 +123,7 @@ class CronController(Controller):
                 # Quota-exhausted orgs skip run creation but still advance
                 # next_run_at (committed with this session) — otherwise the
                 # blocked job would re-fire every tick forever.
-                committed, limit = run_quota_status(session, job.org_id, self._store.quota_defaults)
+                committed, limit = self._store.quotas.run_status(session, job.org_id)
                 if limit is not None and committed >= limit:
                     logger.warning(
                         "Skipping job '%s' - monthly successful-run quota exhausted (%d/%d) for org %s",

--- a/packages/interloper-scheduler/src/interloper_scheduler/queue.py
+++ b/packages/interloper-scheduler/src/interloper_scheduler/queue.py
@@ -10,7 +10,6 @@ from interloper.telemetry import attributes
 from interloper.telemetry.tracer import meter, tracer
 from interloper_db import Store
 from interloper_db.models import Backfill, Event, Run
-from interloper_db.store.quotas import try_reserve_run
 from interloper_db.store.runs import cancel_backfill_runs
 from sqlmodel import Session, col, select
 
@@ -101,7 +100,7 @@ class QueueController(Controller):
                 if not run or not run.id:
                     return None
 
-                if try_reserve_run(session, run, self._store.quota_defaults):
+                if self._store.quotas.try_reserve_run(session, run):
                     run.status = "dispatched"
                     session.add(run)
                     session.commit()


### PR DESCRIPTION
Combines the row-per-key storage restructure (formerly #252, itself replacing #251), the registry/service layer, and the check delegation into one PR. Three commits, one per concern.

## 1. Storage: one row per quota key

The `quotas` table changes from one-column-per-limit to `(org_id, key, limit)` with a composite PK, mirroring the `usage` table's row-per-metric shape.

- **Finer locking**: the `FOR UPDATE` anchor is the `(org, key)` row — independent quota checks no longer serialize against each other. Null-limit rows are cleared overrides doubling as lock anchors.
- **Store surface**: `get_quota_overrides`/`list_quota_overrides`/`set_quota` speak `{key: limit}` dicts; `set_quota` upserts per key (`None` clears).
- **Wire format unchanged** — the route pivots into the existing `AdminQuotaLimits`; frontend/TS untouched.
- **Migration `009`** unpivots existing per-column overrides into rows (idempotent, full downgrade).

## 2. Declaration: registry + QuotaService

Quotas join the stack's registry idiom (the same `Registry` primitive behind kinds, launchers, runners, OAuth providers): **`QUOTAS: Registry[QuotaDefinition]`**, code-registered (no entry-point group — enforcement is welded into the store, so quotas are deliberately not a plugin surface). The `QUOTA_KEYS`/`USAGE_METRICS` frozensets are gone; validation goes through the registry with its standard loud unknown-key error. **`QuotaService`** (`store.quotas`, lazily built with a live defaults provider) owns limit resolution; call sites drop their `quota_defaults` threading. Metering stays in module functions — the ledger never depends on limits.

## 3. Semantics: checks live on the definitions

A quota's implementation is now entirely its registration block — key, semantics class, usage measurement, and rejection message together:

- **`CapacityQuota`** (sources, assets/source): checks a live `count` — or a caller-supplied *desired final* amount, the declarative flavor — under the `(org, key)` row lock.
- **`ConsumptionQuota`** (successful runs/month): checks the period ledger and owns the **atomic reservation**, generic over any future metered quota. Settlement stays run-specific (`quota_reserved_at` is a property of runs).
- The service exposes one generic `check(session, org_id, key, used=?, subject=?)` gate plus the scheduler's thin `run_status`/`try_reserve_run` entry points. `subject` is the caller-supplied message context (entity label / attempted operation).

**Adding a capacity quota is now: one `CapacityQuota` registration (count query + message) and one `quotas.check(...)` line at its enforcement site** — optional same-named `QuotaSettings` default; validation, resolution, locking, error shape, and wire sync are inherited. Sync tests pin `QuotaSettings` fields == registered keys + known guards and `AdminQuotaLimits` == registry keys.

## Verified

- Full suite green (345 tests); registry sync tests added; all rejection messages byte-identical to before.
- On real Postgres (throwaway DB, from the storage commit): composite-key upserts incl. clear-to-null, locked effective resolution with override-over-default, anchor rows invisible as overrides, and a replay of migration 009 against a hand-built legacy-shape table with data. The reservation SQL is unchanged, relocated into `ConsumptionQuota.reserve`.

By Digitl