### PR TITLE
feat: make the backfill span a per-organisation quota

### DIFF
--- a/packages/interloper-api/src/interloper_api/routes/admin.py
+++ b/packages/interloper-api/src/interloper_api/routes/admin.py
@@ -18,7 +18,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from interloper_db import Organisation, Profile, Store
-from interloper_db.store.quotas import METRIC_SUCCESSFUL_RUNS
+from interloper_db.store.quotas import METRIC_SUCCESSFUL_RUNS, QUOTAS
 from pydantic import BaseModel, Field
 
 from interloper_api.dependencies import get_admin_config, get_quota_defaults, get_store, require_super_admin
@@ -255,11 +255,22 @@ class AdminOrgQuotaStatus(BaseModel):
     recomputed_successful_runs: int
 
 
+class AdminQuotaField(BaseModel):
+    """One quota's display descriptor: key, registry label, instance default."""
+
+    key: str
+    label: str
+    default: int | None = None
+
+
 class AdminQuotasResponse(BaseModel):
     """Quota overview: global defaults plus per-organisation status."""
 
     period_start: dt.date
     defaults: AdminQuotaLimits
+    #: One entry per quota, in display order — admin surfaces render from
+    #: these instead of hardcoding the quota set.
+    fields: list[AdminQuotaField]
     organisations: list[AdminOrgQuotaStatus]
 
 
@@ -470,29 +481,29 @@ def _quota_limits(limits: Any) -> AdminQuotaLimits:
     """Map limits from a ``{key: limit}`` dict (store) or attributes (settings)."""
     if isinstance(limits, dict):
         return AdminQuotaLimits(**{key: limits.get(key) for key in AdminQuotaLimits.model_fields})
-    return AdminQuotaLimits(
-        max_sources=getattr(limits, "max_sources", None),
-        max_assets_per_source=getattr(limits, "max_assets_per_source", None),
-        max_successful_runs_per_month=getattr(limits, "max_successful_runs_per_month", None),
-        max_backfill_days=getattr(limits, "max_backfill_days", None),
-    )
+    return AdminQuotaLimits(**{key: getattr(limits, key, None) for key in AdminQuotaLimits.model_fields})
 
 
 def _effective_limits(overrides: AdminQuotaLimits, defaults: AdminQuotaLimits) -> AdminQuotaLimits:
     """Per-org overrides win field-by-field over the global defaults."""
     return AdminQuotaLimits(
-        max_sources=overrides.max_sources if overrides.max_sources is not None else defaults.max_sources,
-        max_assets_per_source=(
-            overrides.max_assets_per_source
-            if overrides.max_assets_per_source is not None
-            else defaults.max_assets_per_source
-        ),
-        max_successful_runs_per_month=(
-            overrides.max_successful_runs_per_month
-            if overrides.max_successful_runs_per_month is not None
-            else defaults.max_successful_runs_per_month
-        ),
+        **{
+            key: override if (override := getattr(overrides, key)) is not None else getattr(defaults, key)
+            for key in AdminQuotaLimits.model_fields
+        }
     )
+
+
+def _quota_fields(defaults: AdminQuotaLimits) -> list[AdminQuotaField]:
+    """Field descriptors for admin quota surfaces, in the wire model's order.
+
+    Labels come from the registry definitions, so the frontend renders new
+    quotas without a matching code change.
+    """
+    return [
+        AdminQuotaField(key=key, label=QUOTAS[key].label, default=getattr(defaults, key))
+        for key in AdminQuotaLimits.model_fields
+    ]
 
 
 def _require_org(store: Store, org_id: UUID) -> Organisation:
@@ -595,7 +606,12 @@ def get_quotas(
                 recomputed_successful_runs=recomputed.get(org.id, 0),
             )
         )
-    return AdminQuotasResponse(period_start=period_start, defaults=defaults, organisations=organisations)
+    return AdminQuotasResponse(
+        period_start=period_start,
+        defaults=defaults,
+        fields=_quota_fields(defaults),
+        organisations=organisations,
+    )
 
 
 def _activity_title(entry: dict[str, Any]) -> tuple[str, str | None]:

--- a/packages/interloper-api/src/interloper_api/routes/admin.py
+++ b/packages/interloper-api/src/interloper_api/routes/admin.py
@@ -234,6 +234,7 @@ class AdminQuotaLimits(BaseModel):
     max_sources: int | None = None
     max_assets_per_source: int | None = None
     max_successful_runs_per_month: int | None = None
+    max_backfill_days: int | None = None
 
 
 class AdminOrgQuotaStatus(BaseModel):
@@ -268,6 +269,7 @@ class AdminQuotaUpdateRequest(BaseModel):
     max_sources: int | None = Field(default=None, ge=0)
     max_assets_per_source: int | None = Field(default=None, ge=0)
     max_successful_runs_per_month: int | None = Field(default=None, ge=0)
+    max_backfill_days: int | None = Field(default=None, ge=0)
 
 
 class AdminActivityEntry(BaseModel):
@@ -472,6 +474,7 @@ def _quota_limits(limits: Any) -> AdminQuotaLimits:
         max_sources=getattr(limits, "max_sources", None),
         max_assets_per_source=getattr(limits, "max_assets_per_source", None),
         max_successful_runs_per_month=getattr(limits, "max_successful_runs_per_month", None),
+        max_backfill_days=getattr(limits, "max_backfill_days", None),
     )
 
 

--- a/packages/interloper-api/src/interloper_api/routes/admin.py
+++ b/packages/interloper-api/src/interloper_api/routes/admin.py
@@ -268,8 +268,6 @@ class AdminQuotasResponse(BaseModel):
 
     period_start: dt.date
     defaults: AdminQuotaLimits
-    #: One entry per quota, in display order — admin surfaces render from
-    #: these instead of hardcoding the quota set.
     fields: list[AdminQuotaField]
     organisations: list[AdminOrgQuotaStatus]
 

--- a/packages/interloper-api/src/interloper_api/routes/backfills.py
+++ b/packages/interloper-api/src/interloper_api/routes/backfills.py
@@ -100,17 +100,14 @@ def create_backfill(
     job = load_authorized(
         lambda i: store.get_component(i, kind="job"), body.component_id, user, store, label="Job", minimum="editor"
     )
-    try:
-        backfill = store.create_backfill(
-            job.org_id,
-            component_id=body.component_id,
-            start_date=body.start_date,
-            end_date=body.end_date,
-            concurrency=body.concurrency,
-            fail_fast=body.fail_fast,
-        )
-    except ValueError as e:  # span cap
-        raise HTTPException(status_code=400, detail=str(e))
+    backfill = store.create_backfill(
+        job.org_id,
+        component_id=body.component_id,
+        start_date=body.start_date,
+        end_date=body.end_date,
+        concurrency=body.concurrency,
+        fail_fast=body.fail_fast,
+    )
     return _backfill_to_response(backfill)
 
 

--- a/packages/interloper-api/tests/test_admin.py
+++ b/packages/interloper-api/tests/test_admin.py
@@ -275,6 +275,12 @@ def test_super_admin_reads_quota_overview(store: FakeStore) -> None:
     assert body["period_start"] == "2026-08-01"
     assert body["defaults"]["max_successful_runs_per_month"] == 100
 
+    # Field descriptors drive the admin UI: wire-model order, registry labels.
+    assert [field["key"] for field in body["fields"]] == list(admin_module.AdminQuotaLimits.model_fields)
+    by_key = {field["key"]: field for field in body["fields"]}
+    assert by_key["max_sources"] == {"key": "max_sources", "label": "Max sources", "default": 10}
+    assert by_key["max_backfill_days"]["default"] is None
+
     (org,) = body["organisations"]
     assert org["limits"]["max_sources"] == 5
     # Overrides win field-by-field; unset fields fall back to the defaults.

--- a/packages/interloper-api/tests/test_admin.py
+++ b/packages/interloper-api/tests/test_admin.py
@@ -299,6 +299,7 @@ def test_quota_overview_defaults_absent_means_unlimited(store: FakeStore) -> Non
         "max_sources": None,
         "max_assets_per_source": None,
         "max_successful_runs_per_month": None,
+        "max_backfill_days": None,
     }
     (org,) = body["organisations"]
     assert org["effective"]["max_assets_per_source"] is None

--- a/packages/interloper-api/tests/test_backfills.py
+++ b/packages/interloper-api/tests/test_backfills.py
@@ -115,15 +115,30 @@ def test_cancel_returns_404_for_non_member(store: FakeStore) -> None:
     assert store.cancel_calls == []
 
 
-def test_create_backfill_span_cap_returns_400(store: FakeStore) -> None:
+def test_create_backfill_over_span_quota_returns_429(store: FakeStore) -> None:
+    from interloper.errors import QuotaExceededError
+
     def _raise(org_id, **kwargs):
-        raise ValueError("Backfill spans 31 days; the instance caps backfills at 30 days")
+        raise QuotaExceededError(
+            "Backfill spans 31 days, exceeding the limit of 30", quota="max_backfill_days", limit=30, used=31
+        )
 
     store.get_component = lambda component_id, kind=None: _fake_backfill(component_id)  # ty: ignore[unresolved-attribute]
     store.create_backfill = _raise  # ty: ignore[unresolved-attribute]
-    resp = _client(store).post(
+    client = _client(store)
+
+    @client.app.exception_handler(QuotaExceededError)  # mirrors create_app's handler
+    async def _quota_handler(_request, exc: QuotaExceededError):
+        from fastapi.responses import JSONResponse
+
+        return JSONResponse(
+            status_code=429,
+            content={"detail": {"message": str(exc), "quota": exc.quota, "limit": exc.limit, "used": exc.used}},
+        )
+
+    resp = client.post(
         "/backfills/",
         json={"component_id": str(uuid4()), "start_date": "2026-01-01", "end_date": "2026-01-31"},
     )
-    assert resp.status_code == 400
-    assert "caps backfills" in resp.json()["detail"]
+    assert resp.status_code == 429
+    assert resp.json()["detail"]["quota"] == "max_backfill_days"

--- a/packages/interloper-app/app/app/components/admin/QuotaDrawer.vue
+++ b/packages/interloper-app/app/app/components/admin/QuotaDrawer.vue
@@ -26,6 +26,7 @@ const LIMIT_FIELDS = [
     { key: 'max_sources', label: 'Max sources' },
     { key: 'max_assets_per_source', label: 'Max assets per source' },
     { key: 'max_successful_runs_per_month', label: 'Max successful runs / month' },
+    { key: 'max_backfill_days', label: 'Max backfill days' },
 ] as const
 
 type LimitKey = typeof LIMIT_FIELDS[number]['key']
@@ -34,6 +35,7 @@ const form = ref<Record<LimitKey, string>>({
     max_sources: '',
     max_assets_per_source: '',
     max_successful_runs_per_month: '',
+    max_backfill_days: '',
 })
 const saving = ref(false)
 
@@ -43,6 +45,7 @@ watch(open, (opened) => {
         max_sources: props.limits?.max_sources?.toString() ?? '',
         max_assets_per_source: props.limits?.max_assets_per_source?.toString() ?? '',
         max_successful_runs_per_month: props.limits?.max_successful_runs_per_month?.toString() ?? '',
+        max_backfill_days: props.limits?.max_backfill_days?.toString() ?? '',
     }
 })
 
@@ -68,6 +71,7 @@ async function submit() {
             max_successful_runs_per_month: form.value.max_successful_runs_per_month === ''
                 ? null
                 : Number(form.value.max_successful_runs_per_month),
+            max_backfill_days: form.value.max_backfill_days === '' ? null : Number(form.value.max_backfill_days),
         })
         toast.add({ title: `Quota limits updated for ${props.orgName}`, color: 'success' })
         open.value = false

--- a/packages/interloper-app/app/app/components/admin/QuotaDrawer.vue
+++ b/packages/interloper-app/app/app/components/admin/QuotaDrawer.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 /**
  * Right drawer for editing an organisation's quota overrides.
- * String-typed fields so an emptied input means "inherit the instance
- * default"; each field hints whether it inherits or overrides.
+ * The quota set comes from the API's field descriptors (key + label +
+ * instance default), so a new quota needs no change here. String-typed
+ * fields so an emptied input means "inherit the instance default"; each
+ * field hints whether it inherits or overrides.
  */
-import type { AdminQuotaLimits } from '~/types/admin'
+import type { AdminQuotaField, AdminQuotaLimits } from '~/types/admin'
 
 const open = defineModel<boolean>('open', { required: true })
 
@@ -13,8 +15,8 @@ const props = defineProps<{
     orgName: string
     /** The org's current overrides (nulls where inherited). */
     limits: AdminQuotaLimits | null
-    /** The instance defaults the empty fields fall back to. */
-    defaults: AdminQuotaLimits | null
+    /** The quotas to edit, with the defaults the empty fields fall back to. */
+    fields: AdminQuotaField[]
 }>()
 
 const emit = defineEmits<{ saved: [] }>()
@@ -22,57 +24,32 @@ const emit = defineEmits<{ saved: [] }>()
 const adminStore = useAdminStore()
 const toast = useToast()
 
-const LIMIT_FIELDS = [
-    { key: 'max_sources', label: 'Max sources' },
-    { key: 'max_assets_per_source', label: 'Max assets per source' },
-    { key: 'max_successful_runs_per_month', label: 'Max successful runs / month' },
-    { key: 'max_backfill_days', label: 'Max backfill days' },
-] as const
-
-type LimitKey = typeof LIMIT_FIELDS[number]['key']
-
-const form = ref<Record<LimitKey, string>>({
-    max_sources: '',
-    max_assets_per_source: '',
-    max_successful_runs_per_month: '',
-    max_backfill_days: '',
-})
+const form = ref<Record<string, string>>({})
 const saving = ref(false)
 
 watch(open, (opened) => {
     if (!opened) return
-    form.value = {
-        max_sources: props.limits?.max_sources?.toString() ?? '',
-        max_assets_per_source: props.limits?.max_assets_per_source?.toString() ?? '',
-        max_successful_runs_per_month: props.limits?.max_successful_runs_per_month?.toString() ?? '',
-        max_backfill_days: props.limits?.max_backfill_days?.toString() ?? '',
-    }
+    form.value = Object.fromEntries(
+        props.fields.map(field => [field.key, props.limits?.[field.key]?.toString() ?? '']),
+    )
 })
 
-function defaultLabel(key: LimitKey): string {
-    const value = props.defaults?.[key]
-    return value != null ? value.toLocaleString() : 'unlimited'
+function defaultLabel(field: AdminQuotaField): string {
+    return field.default != null ? field.default.toLocaleString() : 'unlimited'
 }
 
-function hint(key: LimitKey): string {
-    return form.value[key] === ''
-        ? `Inheriting ${defaultLabel(key)}`
-        : `Overrides the instance default of ${defaultLabel(key)}`
+function hint(field: AdminQuotaField): string {
+    return form.value[field.key] === ''
+        ? `Inheriting ${defaultLabel(field)}`
+        : `Overrides the instance default of ${defaultLabel(field)}`
 }
 
 async function submit() {
     saving.value = true
     try {
-        await adminStore.updateOrgQuota(props.orgId, {
-            max_sources: form.value.max_sources === '' ? null : Number(form.value.max_sources),
-            max_assets_per_source: form.value.max_assets_per_source === ''
-                ? null
-                : Number(form.value.max_assets_per_source),
-            max_successful_runs_per_month: form.value.max_successful_runs_per_month === ''
-                ? null
-                : Number(form.value.max_successful_runs_per_month),
-            max_backfill_days: form.value.max_backfill_days === '' ? null : Number(form.value.max_backfill_days),
-        })
+        await adminStore.updateOrgQuota(props.orgId, Object.fromEntries(
+            props.fields.map(field => [field.key, form.value[field.key] === '' ? null : Number(form.value[field.key])]),
+        ))
         toast.add({ title: `Quota limits updated for ${props.orgName}`, color: 'success' })
         open.value = false
         emit('saved')
@@ -106,17 +83,17 @@ async function submit() {
                 Leave a field empty to inherit the instance default.
             </p>
             <div class="flex flex-col gap-4">
-                <div v-for="field in LIMIT_FIELDS"
+                <div v-for="field in fields"
                      :key="field.key"
                      class="flex flex-col gap-1.5">
                     <label class="text-[13px] font-semibold">{{ field.label }}</label>
                     <UInput v-model="form[field.key]"
                             type="number"
                             min="0"
-                            :placeholder="`Instance default (${defaultLabel(field.key)})`"
+                            :placeholder="`Instance default (${defaultLabel(field)})`"
                             class="w-full font-mono"
                             @keydown.enter="submit" />
-                    <span class="text-xs text-dimmed">{{ hint(field.key) }}</span>
+                    <span class="text-xs text-dimmed">{{ hint(field) }}</span>
                 </div>
             </div>
         </template>

--- a/packages/interloper-app/app/app/pages/admin/organisations/[id].vue
+++ b/packages/interloper-app/app/app/pages/admin/organisations/[id].vue
@@ -180,27 +180,19 @@ const usageTiles = computed(() => {
     ]
 })
 
-const LIMIT_FIELDS = [
-    { key: 'max_sources', label: 'Max sources' },
-    { key: 'max_assets_per_source', label: 'Max assets per source' },
-    { key: 'max_successful_runs_per_month', label: 'Max successful runs / month' },
-    { key: 'max_backfill_days', label: 'Max backfill days' },
-] as const
-
 const limitRows = computed(() => {
     const row = quotaRow.value
-    const defaults = quotas.value?.defaults
-    if (!row || !defaults) return []
-    return LIMIT_FIELDS.map(({ key, label }) => {
-        const override = row.limits[key]
-        const effective = row.effective[key]
+    if (!row) return []
+    return (quotas.value?.fields ?? []).map((field) => {
+        const override = row.limits[field.key]
+        const effective = row.effective[field.key]
         return {
-            key,
-            label,
+            key: field.key,
+            label: field.label,
             value: effective != null ? effective.toLocaleString() : 'Unlimited',
             overridden: override != null,
             note: override != null
-                ? `Instance default is ${defaults[key] != null ? defaults[key]!.toLocaleString() : 'unlimited'}`
+                ? `Instance default is ${field.default != null ? field.default.toLocaleString() : 'unlimited'}`
                 : 'Follows the instance default',
         }
     })
@@ -493,7 +485,7 @@ watch(orgId, loadData)
                           :org-id="orgId"
                           :org-name="org?.name ?? ''"
                           :limits="quotaRow?.limits ?? null"
-                          :defaults="quotas?.defaults ?? null"
+                          :fields="quotas?.fields ?? []"
                           @saved="reloadQuotas" />
     </div>
 </template>

--- a/packages/interloper-app/app/app/pages/admin/organisations/[id].vue
+++ b/packages/interloper-app/app/app/pages/admin/organisations/[id].vue
@@ -184,6 +184,7 @@ const LIMIT_FIELDS = [
     { key: 'max_sources', label: 'Max sources' },
     { key: 'max_assets_per_source', label: 'Max assets per source' },
     { key: 'max_successful_runs_per_month', label: 'Max successful runs / month' },
+    { key: 'max_backfill_days', label: 'Max backfill days' },
 ] as const
 
 const limitRows = computed(() => {

--- a/packages/interloper-app/app/app/pages/admin/organisations/index.vue
+++ b/packages/interloper-app/app/app/pages/admin/organisations/index.vue
@@ -49,14 +49,10 @@ const periodLabel = computed(() => {
     return new Date(quotas.value.period_start).toLocaleDateString(undefined, { month: 'long', year: 'numeric' })
 })
 
-const defaultChips = computed(() => {
-    const defaults = quotas.value?.defaults
-    if (!defaults) return []
-    return Object.entries(defaults).map(([key, value]) => ({
-        key,
-        value: value != null ? value.toLocaleString() : 'unlimited',
-    }))
-})
+const defaultChips = computed(() => (quotas.value?.fields ?? []).map(field => ({
+    key: field.key,
+    value: field.default != null ? field.default.toLocaleString() : 'unlimited',
+})))
 
 /** The quota closest to its ceiling — what the usage column reports. */
 function peakQuota(usage: AdminOrgQuotaStatus) {

--- a/packages/interloper-app/app/app/stores/admin.ts
+++ b/packages/interloper-app/app/app/stores/admin.ts
@@ -41,7 +41,7 @@ export const useAdminStore = defineStore('admin', () => {
     }
 
     /** Set an org's quota overrides; null clears a field (falls back to the default). */
-    function updateOrgQuota(orgId: string, limits: AdminQuotaLimits) {
+    function updateOrgQuota(orgId: string, limits: Partial<AdminQuotaLimits>) {
         return apiFetch<AdminQuotaLimits>(`/admin/organisations/${orgId}/quota`, {
             method: 'PATCH',
             body: limits,

--- a/packages/interloper-app/app/app/types/admin.ts
+++ b/packages/interloper-app/app/app/types/admin.ts
@@ -72,9 +72,18 @@ export interface AdminOrgQuotaStatus {
     recomputed_successful_runs: number
 }
 
+/** One quota's display descriptor: key, registry label, instance default. */
+export interface AdminQuotaField {
+    key: keyof AdminQuotaLimits
+    label: string
+    default: number | null
+}
+
 export interface AdminQuotas {
     period_start: string
     defaults: AdminQuotaLimits
+    /** One entry per quota, in display order — surfaces render from these. */
+    fields: AdminQuotaField[]
     organisations: AdminOrgQuotaStatus[]
 }
 

--- a/packages/interloper-app/app/app/types/admin.ts
+++ b/packages/interloper-app/app/app/types/admin.ts
@@ -54,6 +54,7 @@ export interface AdminQuotaLimits {
     max_sources: number | null
     max_assets_per_source: number | null
     max_successful_runs_per_month: number | null
+    max_backfill_days: number | null
 }
 
 export interface AdminOrgQuotaStatus {

--- a/packages/interloper-app/app/app/types/admin.ts
+++ b/packages/interloper-app/app/app/types/admin.ts
@@ -82,7 +82,6 @@ export interface AdminQuotaField {
 export interface AdminQuotas {
     period_start: string
     defaults: AdminQuotaLimits
-    /** One entry per quota, in display order — surfaces render from these. */
     fields: AdminQuotaField[]
     organisations: AdminOrgQuotaStatus[]
 }

--- a/packages/interloper-db/src/interloper_db/store/quotas.py
+++ b/packages/interloper-db/src/interloper_db/store/quotas.py
@@ -43,6 +43,7 @@ METRIC_SUCCESSFUL_RUNS = "successful_runs"
 QUOTA_MAX_SOURCES = "max_sources"
 QUOTA_MAX_ASSETS_PER_SOURCE = "max_assets_per_source"
 QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH = "max_successful_runs_per_month"
+QUOTA_MAX_BACKFILL_DAYS = "max_backfill_days"
 
 
 @dataclass(frozen=True)
@@ -111,6 +112,29 @@ class CapacityQuota(QuotaDefinition):
             if current >= limit:
                 self._reject(current, limit, subject)
         elif used > limit:
+            self._reject(used, limit, subject)
+
+
+@dataclass(frozen=True)
+class BoundQuota(QuotaDefinition):
+    """Bounds a single operation's magnitude (stateless — no count, no ledger).
+
+    The gate always supplies ``used`` (the operation's size); nothing is
+    measured or reserved, so no lock is needed: the check is a pure
+    comparison against the effective limit.
+    """
+
+    def check(
+        self,
+        session: Session,
+        org_id: UUID,
+        limit: int,
+        *,
+        used: int | None = None,
+        subject: str | None = None,
+    ) -> None:
+        assert used is not None  # bound quotas are always checked declaratively
+        if used > limit:
             self._reject(used, limit, subject)
 
 
@@ -411,6 +435,13 @@ QUOTAS.register(
         message=lambda used, limit, subject: (
             f"Cannot queue {subject or 'run'}: the monthly successful-run quota is exhausted ({used}/{limit})"
         ),
+    ),
+)
+QUOTAS.register(
+    QUOTA_MAX_BACKFILL_DAYS,
+    BoundQuota(
+        key=QUOTA_MAX_BACKFILL_DAYS,
+        message=lambda used, limit, _subject: f"Backfill spans {used} days, exceeding the limit of {limit}",
     ),
 )
 

--- a/packages/interloper-db/src/interloper_db/store/quotas.py
+++ b/packages/interloper-db/src/interloper_db/store/quotas.py
@@ -59,9 +59,7 @@ class QuotaDefinition(abc.ABC):
     """
 
     key: str
-    #: Human label for admin surfaces (served through the quotas API).
     label: str
-    #: ``message(used, limit, subject)`` — the rejection text.
     message: Callable[[int, int, str | None], str]
 
     #: Capacity checks resolve the limit under the ``(org, key)`` row lock;
@@ -101,7 +99,6 @@ class CapacityQuota(QuotaDefinition):
 
     requires_lock: ClassVar[bool] = True
 
-    #: Live usage count; None when every gate supplies ``used`` itself.
     count: Callable[[Session, UUID], int] | None = None
 
     def check(
@@ -151,7 +148,6 @@ class BoundQuota(QuotaDefinition):
 class ConsumptionQuota(QuotaDefinition):
     """Limits what accumulates per period, charged under ``metric`` in the ledger."""
 
-    #: Ledger metric this quota's usage is charged under.
     metric: str = ""
 
     def __post_init__(self) -> None:

--- a/packages/interloper-db/src/interloper_db/store/quotas.py
+++ b/packages/interloper-db/src/interloper_db/store/quotas.py
@@ -20,6 +20,7 @@ limits.
 
 from __future__ import annotations
 
+import abc
 import datetime as dt
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -47,8 +48,8 @@ QUOTA_MAX_BACKFILL_DAYS = "max_backfill_days"
 
 
 @dataclass(frozen=True)
-class QuotaDefinition:
-    """One per-organisation quota: its key and its check semantics.
+class QuotaDefinition(abc.ABC):
+    """One per-organisation quota: its key, label, and check semantics.
 
     Subclasses own how usage is measured and compared; the
     :class:`QuotaService` only resolves the effective limit and delegates.
@@ -58,11 +59,21 @@ class QuotaDefinition:
     """
 
     key: str
+    #: Human label for admin surfaces (served through the quotas API).
+    label: str
+    #: ``message(used, limit, subject)`` — the rejection text.
+    message: Callable[[int, int, str | None], str]
+
     #: Capacity checks resolve the limit under the ``(org, key)`` row lock;
     #: the consumption advisory check does not (its authoritative gate is
     #: the atomic ledger reservation).
     requires_lock: ClassVar[bool] = False
 
+    def __post_init__(self) -> None:
+        if not self.key or not self.label:
+            raise ValueError("A quota definition needs a key and a label")
+
+    @abc.abstractmethod
     def check(
         self,
         session: Session,
@@ -73,13 +84,9 @@ class QuotaDefinition:
         subject: str | None = None,
     ) -> None:
         """Raise :class:`QuotaExceededError` when the limit rejects the operation."""
-        raise NotImplementedError
 
     def _reject(self, used: int, limit: int, subject: str | None) -> None:
         raise QuotaExceededError(self.message(used, limit, subject), quota=self.key, limit=limit, used=used)
-
-    #: ``message(used, limit, subject)`` — the rejection text.
-    message: Callable[[int, int, str | None], str] = lambda used, limit, subject: ""
 
 
 @dataclass(frozen=True)
@@ -107,7 +114,8 @@ class CapacityQuota(QuotaDefinition):
         subject: str | None = None,
     ) -> None:
         if used is None:
-            assert self.count is not None  # capacity quota registered with its counter
+            if self.count is None:
+                raise ValueError(f"Quota '{self.key}' has no usage counter; pass used= to check it declaratively")
             current = self.count(session, org_id)
             if current >= limit:
                 self._reject(current, limit, subject)
@@ -133,7 +141,8 @@ class BoundQuota(QuotaDefinition):
         used: int | None = None,
         subject: str | None = None,
     ) -> None:
-        assert used is not None  # bound quotas are always checked declaratively
+        if used is None:
+            raise ValueError(f"Quota '{self.key}' bounds a single operation; pass used= with its size")
         if used > limit:
             self._reject(used, limit, subject)
 
@@ -144,6 +153,11 @@ class ConsumptionQuota(QuotaDefinition):
 
     #: Ledger metric this quota's usage is charged under.
     metric: str = ""
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        if not self.metric:
+            raise ValueError(f"Consumption quota '{self.key}' needs the ledger metric it charges under")
 
     def committed(self, session: Session, org_id: UUID) -> int:
         """The org's committed usage this period: ledger ``used + reserved``."""
@@ -381,7 +395,8 @@ class QuotaService:
         Limit None means unlimited (and the ledger is not read at all).
         """
         definition = QUOTAS[QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH]
-        assert isinstance(definition, ConsumptionQuota)
+        if not isinstance(definition, ConsumptionQuota):
+            raise TypeError(f"'{QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH}' is not registered as a consumption quota")
         limit = self.effective(session, org_id, QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH)
         if limit is None:
             return 0, None
@@ -398,7 +413,8 @@ class QuotaService:
             True if the run may dispatch, False when the quota is exhausted.
         """
         definition = QUOTAS[QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH]
-        assert isinstance(definition, ConsumptionQuota)
+        if not isinstance(definition, ConsumptionQuota):
+            raise TypeError(f"'{QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH}' is not registered as a consumption quota")
         limit = self.effective(session, db_run.org_id, QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH)
         if limit is None:
             return True
@@ -414,6 +430,7 @@ QUOTAS.register(
     QUOTA_MAX_SOURCES,
     CapacityQuota(
         key=QUOTA_MAX_SOURCES,
+        label="Max sources",
         count=_count_sources,
         message=lambda used, limit, _subject: f"Organisation is at its source limit ({used}/{limit})",
     ),
@@ -422,6 +439,7 @@ QUOTAS.register(
     QUOTA_MAX_ASSETS_PER_SOURCE,
     CapacityQuota(
         key=QUOTA_MAX_ASSETS_PER_SOURCE,
+        label="Max assets per source",
         message=lambda used, limit, subject: (
             f"Source '{subject}' would have {used} assets, exceeding the limit of {limit}"
         ),
@@ -431,6 +449,7 @@ QUOTAS.register(
     QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH,
     ConsumptionQuota(
         key=QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH,
+        label="Max successful runs / month",
         metric=METRIC_SUCCESSFUL_RUNS,
         message=lambda used, limit, subject: (
             f"Cannot queue {subject or 'run'}: the monthly successful-run quota is exhausted ({used}/{limit})"
@@ -441,6 +460,7 @@ QUOTAS.register(
     QUOTA_MAX_BACKFILL_DAYS,
     BoundQuota(
         key=QUOTA_MAX_BACKFILL_DAYS,
+        label="Max backfill days",
         message=lambda used, limit, _subject: f"Backfill spans {used} days, exceeding the limit of {limit}",
     ),
 )

--- a/packages/interloper-db/src/interloper_db/store/runs.py
+++ b/packages/interloper-db/src/interloper_db/store/runs.py
@@ -19,7 +19,11 @@ from sqlmodel import Session, col, select
 from interloper_db.models import AssetExecution, Backfill, Component, Event, Run
 from interloper_db.store.base import StoreBase
 from interloper_db.store.components import stamp_component_state
-from interloper_db.store.quotas import QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH, settle_run_usage
+from interloper_db.store.quotas import (
+    QUOTA_MAX_BACKFILL_DAYS,
+    QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH,
+    settle_run_usage,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -512,12 +516,11 @@ class RunMixin(StoreBase):
         Returns:
             The created Backfill row with runs.
         """
-        max_days = getattr(self._quota_defaults, "max_backfill_days", None)
-        span = (end_date - start_date).days + 1
-        if max_days is not None and span > max_days:
-            raise ValueError(f"Backfill spans {span} days; the instance caps backfills at {max_days} days")
-
         with self._session() as session:
+            # Cron top-ups (backfill_days job config) are deliberately not
+            # bounded here — they never pass through this method.
+            span = (end_date - start_date).days + 1
+            self.quotas.check(session, org_id, QUOTA_MAX_BACKFILL_DAYS, used=span)
             self.quotas.check(session, org_id, QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH, subject="backfill")
             db_backfill = Backfill(
                 org_id=org_id,

--- a/packages/interloper-db/tests/store/test_quotas.py
+++ b/packages/interloper-db/tests/store/test_quotas.py
@@ -258,9 +258,17 @@ class TestRunCreationGate:
         with pytest.raises(QuotaExceededError, match="backfill"):
             store.create_backfill(_ORG_ID, start_date=dt.date(2026, 1, 1), end_date=dt.date(2026, 1, 2))
 
+    def test_backfill_span_override_wins(self, store: _Store):
+        store._quota_defaults = _defaults(max_backfill_days=2)
+        with Session(store._engine) as session:
+            session.add(Quota(org_id=_ORG_ID, key="max_backfill_days", limit=3))
+            session.commit()
+        backfill = store.create_backfill(_ORG_ID, start_date=dt.date(2026, 1, 1), end_date=dt.date(2026, 1, 3))
+        assert backfill.partitions == 3
+
     def test_backfill_span_cap(self, store: _Store):
         store._quota_defaults = _defaults(max_backfill_days=2)
-        with pytest.raises(ValueError, match="caps backfills at 2 days"):
+        with pytest.raises(QuotaExceededError, match="exceeding the limit of 2"):
             store.create_backfill(_ORG_ID, start_date=dt.date(2026, 1, 1), end_date=dt.date(2026, 1, 3))
         backfill = store.create_backfill(_ORG_ID, start_date=dt.date(2026, 1, 1), end_date=dt.date(2026, 1, 2))
         assert backfill.partitions == 2
@@ -353,11 +361,10 @@ class TestSetQuota:
 
 class TestRegistry:
     def test_settings_fields_match_registered_quotas(self):
-        """QuotaSettings carries exactly the per-org quota defaults plus known guards."""
+        """QuotaSettings carries exactly the per-org quota defaults."""
         from interloper.settings import QuotaSettings
 
-        guards = {"max_backfill_days"}
-        assert set(QuotaSettings.model_fields) - guards == set(QUOTAS.keys())
+        assert set(QuotaSettings.model_fields) == set(QUOTAS.keys())
 
     def test_capacity_quotas_carry_counters_and_consumption_metrics(self):
         sources = QUOTAS["max_sources"]

--- a/packages/interloper-db/tests/store/test_quotas.py
+++ b/packages/interloper-db/tests/store/test_quotas.py
@@ -19,9 +19,13 @@ from interloper_db import engine as engine_module
 from interloper_db.models import Backfill, Component, Quota, Run, Usage
 from interloper_db.store.quotas import (
     METRIC_SUCCESSFUL_RUNS,
+    QUOTA_MAX_ASSETS_PER_SOURCE,
+    QUOTA_MAX_BACKFILL_DAYS,
     QUOTAS,
+    BoundQuota,
     CapacityQuota,
     ConsumptionQuota,
+    QuotaDefinition,
     QuotaMixin,
     increment_usage,
     month_start,
@@ -376,3 +380,26 @@ class TestRegistry:
         with Session(store._engine) as session:
             with pytest.raises(KeyError, match="not registered"):
                 store.quotas.effective(session, _ORG_ID, "max_bananas")
+
+    def test_definition_is_abstract(self):
+        """The base class cannot be instantiated — subclasses must implement check()."""
+        with pytest.raises(TypeError, match="abstract"):
+            QuotaDefinition(key="max_bananas", label="Max bananas", message=lambda used, limit, subject: "")
+
+    def test_definitions_require_key_and_label(self):
+        with pytest.raises(ValueError, match="key and a label"):
+            BoundQuota(key="max_bananas", label="", message=lambda used, limit, subject: "")
+
+    def test_consumption_quota_requires_a_metric(self):
+        with pytest.raises(ValueError, match="ledger metric"):
+            ConsumptionQuota(key="max_bananas", label="Max bananas", message=lambda used, limit, subject: "")
+
+    def test_bound_quota_rejects_a_declarative_check_without_used(self):
+        definition = QUOTAS[QUOTA_MAX_BACKFILL_DAYS]
+        with pytest.raises(ValueError, match="pass used="):
+            definition.check(None, _ORG_ID, 5)  # ty: ignore[invalid-argument-type]
+
+    def test_counterless_capacity_quota_rejects_a_measured_check(self):
+        definition = QUOTAS[QUOTA_MAX_ASSETS_PER_SOURCE]
+        with pytest.raises(ValueError, match="no usage counter"):
+            definition.check(None, _ORG_ID, 5)  # ty: ignore[invalid-argument-type]


### PR DESCRIPTION
First real exercise of the quota machinery: `max_backfill_days` graduates from a global instance guard (bare `ValueError` → 400) to a per-organisation quota — overridable via the drawer, registered like the others, surfaced as a structured 429.

- **New third definition family, `BoundQuota`**: bounds a single operation's magnitude — neither a live count (capacity) nor a period ledger (consumption). Stateless declarative comparison; no `(org, key)` lock, no metering.
- **The add-a-quota checklist, as designed**: one registration block (`QUOTAS.register(... BoundQuota ...)` with its message), the gate call moved inside `create_backfill`'s transaction (`quotas.check(session, org_id, KEY, used=span)`), the field on the wire models + drawer + limits card, and the settings default — which already existed — now covered by the sync tests instead of excluded as a guard.
- The backfill route's `ValueError` catch is gone; the app-level `QuotaExceededError` handler owns the surface (`{message, quota, limit, used}`).
- **Cron top-ups (`backfill_days` job config) stay deliberately unbounded** — they never pass through `create_backfill`; that's the same decision from the enforcement PR, now documented at the site.

Tests: bound gate over/under the limit, org-override-wins, settings/wire sync tests now include the key, API 429 shape. Full suite green.

**Follow-up commit — hardening pass** (the checklist above exposed residual hardcoding; this shrinks it):

- `QuotaDefinition` is now an ABC: `check()` abstract, `message` **and a new `label`** required at construction; misuse guards are explicit `ValueError`s instead of `assert`s (which strip under `-O`); `ConsumptionQuota` validates its metric.
- `GET /admin/quotas` serves `fields: [{key, label, default}]` in wire-model order; the drawer, limits card, and defaults chips all render from it — **a new quota now needs zero frontend changes**.
- `_quota_limits`/`_effective_limits` iterate `model_fields`, fixing a #255 oversight: `max_backfill_days` was silently missing from `_effective_limits`, so the admin overview dropped backfill overrides from the effective values.

By Digitl