### PR TITLE
fix(core): require a time partition for a time-partitioned asset

### DIFF
--- a/packages/interloper-core/src/interloper/asset/base.py
+++ b/packages/interloper-core/src/interloper/asset/base.py
@@ -870,21 +870,33 @@ class Asset(Component):
     ) -> None:
         """Validate a scope against the asset's time partitioning.
 
+        A time-partitioned asset requires a *time* partition: only those carry
+        the granularity, so anything else would reach the asset as a scope that
+        cannot answer ``granularity`` or ``bounds`` — the contract
+        ``context.partition`` rests on.
+
         Raises:
-            PartitionError: If the scope's granularity disagrees with the
-                asset's, or it reaches before the asset's ``start``.
+            PartitionError: If the scope is not a time partition, its
+                granularity disagrees with the asset's, or it reaches before
+                the asset's ``start``.
         """
         scope = partition_or_window
-        if (
-            isinstance(scope, (TimePartition, TimePartitionWindow))
-            and scope.granularity is not partitioning.granularity
-        ):
+        if scope is None:
+            return
+
+        if not isinstance(scope, (TimePartition, TimePartitionWindow)):
+            raise PartitionError(
+                f"Asset '{self.key}' is time-partitioned, but the run was given a "
+                f"{type(scope).__name__}. Use `TimePartition` or `TimePartitionWindow`."
+            )
+
+        if scope.granularity is not partitioning.granularity:
             raise PartitionError(
                 f"Asset '{self.key}' is partitioned by {partitioning.granularity.value}, "
                 f"but the run was given a {scope.granularity.value} partition."
             )
 
-        if partitioning.start is None or scope is None:
+        if partitioning.start is None:
             return
 
         earliest = scope.start if isinstance(scope, PartitionWindow) else scope.value

--- a/packages/interloper-core/src/interloper/asset/context.py
+++ b/packages/interloper-core/src/interloper/asset/context.py
@@ -7,12 +7,7 @@ from typing import Any
 
 from interloper.events import EventLogger
 from interloper.partitioning.base import Partition, PartitionConfig, PartitionWindow
-from interloper.partitioning.time import (
-    TimeGranularity,
-    TimePartitionConfig,
-    TimePartitionWindow,
-    coerce_to_date,
-)
+from interloper.partitioning.time import TimeGranularity, TimePartitionConfig, TimePartitionWindow
 
 
 class ExecutionContext:
@@ -122,10 +117,12 @@ class ExecutionContext:
     def partition_date(self) -> dt.date:
         """The partition value as a datetime.date object.
 
-        Sugar over ``context.partition.value`` for the daily case, which is
-        essentially every asset: it asserts the granularity rather than
-        assuming it. Any other granularity reads :attr:`partition` (or
-        :attr:`window`) and asks the partition itself.
+        The typed reading of ``context.partition.value``, which is annotated
+        ``Any`` on the base class: this is the only accessor that hands an
+        asset a real ``date`` without narrowing a type first, and it asserts
+        the daily granularity rather than assuming it. Any other granularity
+        reads :attr:`partition` (or :attr:`window`) and asks the partition
+        itself.
 
         Raises:
             AttributeError: If the asset is not time-partitioned, is
@@ -140,7 +137,7 @@ class ExecutionContext:
                 f"{partitioning.granularity.value}. Use `context.partition` instead."
             )
 
-        return coerce_to_date(partition.value)
+        return partition.value
 
     # -- Internals -------------------------------------------------------------
 

--- a/packages/interloper-core/tests/asset/test_base.py
+++ b/packages/interloper-core/tests/asset/test_base.py
@@ -422,6 +422,17 @@ class TestTimePartitioning:
     def test_unbounded_asset_accepts_any_partition(self):
         FakeAssetDaily()._validate_partitioning(TimePartition(dt.date(1999, 1, 1)))
 
+    def test_a_non_time_partition_is_rejected(self):
+        # Only time partitions carry a granularity, so anything else would
+        # reach the asset as a scope that cannot answer `granularity`/`bounds`.
+        with pytest.raises(PartitionError, match="is time-partitioned, but the run was given a FakePartition"):
+            FakeAssetDaily()._validate_partitioning(FakePartition(value="2026-01-01"))
+
+    def test_a_non_time_window_is_rejected(self):
+        window = FakePartitionWindow(start="2026-01-01", end="2026-01-03")
+        with pytest.raises(PartitionError, match="is time-partitioned"):
+            FakeAssetDaily()._validate_partitioning(window)
+
 
 # -- __call__ reconfiguration --------------------------------------------------
 

--- a/packages/interloper-core/tests/asset/test_context.py
+++ b/packages/interloper-core/tests/asset/test_context.py
@@ -98,16 +98,11 @@ class TestPartitionDate:
         ctx = _context(TimePartition(dt.date(2026, 1, 1)))
         assert ctx.partition_date == dt.date(2026, 1, 1)
 
-    def test_coerces_string_value_from_base_partition(self) -> None:
-        # A base ``Partition`` does not type its value, so a string can slip
-        # through; the context must still hand the asset a real ``date``.
-        ctx = _context(Partition("2026-01-01"))
+    def test_returns_the_period_start(self) -> None:
+        # `TimePartition` truncated the value on construction, so the context
+        # has nothing left to coerce: it hands back what the partition holds.
+        ctx = _context(TimePartition(dt.datetime(2026, 1, 1, 9, 30, tzinfo=dt.timezone.utc)))
         assert ctx.partition_date == dt.date(2026, 1, 1)
-
-    def test_raises_type_error_on_unparseable_value(self) -> None:
-        ctx = _context(Partition("not-a-date"))
-        with pytest.raises(TypeError):
-            ctx.partition_date
 
     def test_raises_on_a_window(self) -> None:
         ctx = _context(


### PR DESCRIPTION
Follow-up to #256, closing a loose end found while reviewing it.

## Problem

`_validate_partitioning` checked the granularity only when the scope *happened* to be a `TimePartition` or `TimePartitionWindow`. A base `Partition` holding a raw value passed straight through to an asset declaring `TimePartitionConfig`:

```py
daily._validate_partitioning(il.Partition("2026-05-20"))   # accepted
daily._validate_partitioning(il.Partition(42))             # also accepted
```

That was tolerable while the context flattened everything into scalars and coerced defensively. It is not tolerable now that #256 made the context hand the asset the scope itself: only time partitions carry a granularity, so such a scope arrives at `context.partition` unable to answer `granularity` or `bounds`, which is exactly the contract asset code now rests on.

## Change

A time-partitioned asset requires a time partition, with the scope-type check ahead of the granularity and `start` checks:

```
Asset 'daily' is time-partitioned, but the run was given a Partition.
Use `TimePartition` or `TimePartitionWindow`.
```

With the invariant enforced, `context.partition_date` stops coercing. `TimePartition` already truncated its value through the granularity on construction, and the framework's single `ExecutionContext` construction site is preceded by this validation on the same path (`asset/base.py:437`), so the `coerce_to_date` call was dead. A malformed value now fails at `TimePartition` construction, naming the value, instead of being silently rescued mid-run.

`partition_date` keeps its place for the reason that actually holds up: `Partition.value` is annotated `Any` on the base class, so this is the only accessor that hands an asset a real `date` without narrowing a type first. Its docstring now says that rather than calling itself sugar.

## Verification

`make check` (ruff, ty, 1453 tests, eslint, nuxt typecheck).

Live: a valid `TimePartition` run completes; base partitions carrying an ISO string *and* an int are both rejected with the message above; `context.partition_date` still returns a real `date` (`2026-05-20`, type `date`) with the coercion gone.

Two tests changed rather than being deleted: the pair that fed a base `Partition` to a time-partitioned asset covered coercion that is now unreachable, so they are replaced by a test that the value comes back already truncated, plus two tests in `test_base.py` asserting the rejection for a partition and a window.

By Digitl
