### PR TITLE
refactor(app): render the job form's partition fields from the definition

### DIFF
--- a/packages/interloper-app/app/app/components/jobs/Stepper.vue
+++ b/packages/interloper-app/app/app/components/jobs/Stepper.vue
@@ -43,8 +43,17 @@ const name = ref('')
 const cron = ref('')
 const tags = ref<string[]>([])
 const enabled = ref(true)
-const lookback = ref<number | null>(null)
-const offset = ref<number>(1)
+/**
+ * Config fields rendered from `cron_job`'s definition rather than by hand.
+ * The bespoke ones are excluded: `cron` has presets and a human-readable
+ * rendering, `partitioned` is derived from the targets rather than asked, and
+ * `tags` is a list, which SchemaForm has no widget for (the same reason the
+ * hooks stepper excludes its `events`).
+ */
+const JOB_KEY = 'cron_job'
+const OWN_FIELDS = ['cron', 'partitioned', 'tags', 'enabled']
+const partitionConfig = ref<Record<string, unknown>>({})
+const partitionConfigValid = ref(true)
 const selectedSourceIds = ref<string[]>([])
 /** Asset targets carried through unchanged — the stepper only edits source targets. */
 const selectedAssetIds = ref<string[]>([])
@@ -52,14 +61,20 @@ const submitting = ref(false)
 
 const isEditing = computed(() => !!props.job)
 
+/** `cron_job`'s config schema, the source of every non-bespoke field below. */
+const jobSchema = computed(() => catalogStore.catalog[JOB_KEY]?.config_schema)
+
 /**
  * The dates a run today would cover, mirroring `lookback_window` on the
  * backend: `offset` partitions back from today, spanning `lookback` of them.
  * Daily is the only granularity an asset can declare, so days are safe here.
  */
+const lookback = computed(() => Number(partitionConfig.value.lookback ?? 0))
+const offset = computed(() => Number(partitionConfig.value.offset ?? 1))
+
 const windowPreview = computed(() => {
-    const span = lookback.value ?? 0
-    if (span < 1 || offset.value < 0) return null
+    const span = lookback.value
+    if (!Number.isFinite(span) || span < 1 || offset.value < 0) return null
     const end = new Date()
     end.setUTCDate(end.getUTCDate() - offset.value)
     const start = new Date(end)
@@ -77,8 +92,7 @@ onMounted(async () => {
         cron.value = jobCron(props.job)
         tags.value = [...jobTags(props.job)]
         enabled.value = jobEnabled(props.job)
-        lookback.value = jobLookback(props.job)
-        offset.value = jobOffset(props.job)
+        partitionConfig.value = { lookback: jobLookback(props.job), offset: jobOffset(props.job) }
         selectedSourceIds.value = jobTargetIds(props.job, 'source')
         selectedAssetIds.value = jobTargetIds(props.job, 'asset')
     }
@@ -156,7 +170,7 @@ const recapRows = computed(() => {
 
 // ── Validation ──────────────────────────────────────────────────
 const detailsValid = computed(() =>
-    !!name.value.trim() && !!cron.value.trim(),
+    !!name.value.trim() && !!cron.value.trim() && (!partitioned.value || partitionConfigValid.value),
 )
 
 const canProceed = computed(() => {
@@ -175,7 +189,7 @@ async function submit() {
             tags: [...tags.value],
             enabled: enabled.value,
             partitioned: partitioned.value,
-            lookback: partitioned.value ? (lookback.value ?? null) : null,
+            lookback: partitioned.value ? (lookback.value || null) : null,
             offset: partitioned.value ? offset.value : 1,
         })
         return
@@ -191,8 +205,7 @@ async function submit() {
                 tags: tags.value,
                 enabled: enabled.value,
                 partitioned: partitioned.value,
-                lookback: partitioned.value ? (lookback.value ?? null) : null,
-                offset: partitioned.value ? offset.value : 1,
+                ...(partitioned.value ? partitionConfig.value : { lookback: null, offset: 1 }),
             },
             relations: {
                 target: targetIds.map(id => ({ dst_id: id })),
@@ -305,27 +318,12 @@ defineExpose({ canProceed, hasPrev, isLastStep, submitting, submitLabel, title, 
                         <span>Partitioned — selected sources contain date-partitioned assets.</span>
                     </div>
 
-                    <div class="grid grid-cols-2 gap-3">
-                        <UFormField label="Lookback"
-                                    description="Partitions covered on every run.">
-                            <UInput v-model.number="lookback"
-                                    type="number"
-                                    :min="1"
-                                    :max="365"
-                                    placeholder="1"
-                                    class="w-full" />
-                        </UFormField>
-
-                        <UFormField label="Offset"
-                                    description="Partitions to stay behind the current one.">
-                            <UInput v-model.number="offset"
-                                    type="number"
-                                    :min="0"
-                                    :max="365"
-                                    placeholder="1"
-                                    class="w-full" />
-                        </UFormField>
-                    </div>
+                    <SchemaForm v-if="jobSchema"
+                                v-model:data="partitionConfig"
+                                v-model:is-valid="partitionConfigValid"
+                                :schema="jobSchema"
+                                :component-key="JOB_KEY"
+                                :exclude="OWN_FIELDS" />
 
                     <p v-if="windowPreview"
                        class="text-sm text-muted">


### PR DESCRIPTION
Closes the first half of ITLPR-121.

## Problem

The job stepper was the only component form that hardcoded its config fields. Every other stepper renders them from the catalog definition's `config_schema` via `SchemaForm` (destinations, sources, resources, hooks). `lookback` and `offset` restated in the template exactly what `CronJob` declares — labels, descriptions and `ge=` bounds — so the two could only drift.

## Change

Those two now render from `cron_job`'s schema, with the bespoke fields named in an `OWN_FIELDS` exclude list: the same shape `components/hooks/Stepper.vue` already uses.

What stays hand-written, and why (a naive switch to `SchemaForm` would have regressed all four):

* **`cron`** — preset chips plus the `cronstrue` rendering, no schema equivalent.
* **`partitioned`** — derived from whether the selected targets carry partitioned assets, never asked.
* **`tags`** — a list, and **SchemaForm has no array widget**: `resolveWidget` falls through to `default: 'text'`, which would bind a string to a `list[str]`. This is why the hooks stepper also excludes its `events` list, and it is the reason the ticket's original acceptance criterion (generate `tags` too) is not achievable yet.
* **`enabled`** — its copy ("Job will run on the configured schedule") is UI-only, not a restatement of anything in core, so generating it would *lose* text rather than deduplicate it.

The window preview stays bespoke, since it is derived from two fields rather than being a field, and now reads the schema-owned values. An invalid generated field blocks the submit, consistent with the other steppers.

Worth noting for reviewers: `lookback` is `int | None`, which pydantic encodes as `anyOf: [{integer, minimum: 1}, {null}]`. `SchemaForm.resolveProperty` resolves to the first non-null branch and keeps sibling keys, so it renders as a number input with `min=1` and core's description intact. That is verified below, not assumed.

## Verification

`make check` (ruff, ty, 1453 tests, eslint, nuxt typecheck).

Driven headlessly against a seeded instance:

| Check | Result |
|---|---|
| Field labels and help text | "Lookback" / "Offset" with `How many partitions each run covers` and `How many partitions back from the current one the window ends` — i.e. core's `Field(description=...)`, not template copy |
| Bounds from `ge=` | `min=1` on lookback, `min=0` on offset |
| Defaults from the schema | both `1` |
| Create | stored `{"lookback": 4, "offset": 2, "partitioned": true, ...}` |
| Edit | reopens with `4` / `2` |
| Preview still live | `lookback=4, offset=2` → "2026-08-14 to 2026-08-17"; `offset=0` → includes today; `lookback=1` → a single date |
| Bespoke fields intact | cron presets, Tags and Enabled all still render |

## Left for the ticket

Two items stay open on ITLPR-121, both deliberately out of this PR:

1. **`partitioned` is a denormalized config key** that belongs to the targets. Resolving it at tick time (the reasoning that kept `granularity` off the job config in #256) would drop it from the schema and the form, but it touches the scheduler and needs a migration.
2. **Array support in SchemaForm**, which would let `tags` here and `events` in the hooks stepper stop being bespoke.

By Digitl
