### PR TITLE
chore(core)!: drop the legacy backfill_days shims

### DIFF
--- a/packages/interloper-core/src/interloper/job/cron.py
+++ b/packages/interloper-core/src/interloper/job/cron.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from pydantic import Field
 
 from interloper.job.base import Job
@@ -36,17 +34,3 @@ class CronJob(Job):
         description="How many partitions back from the current one the window ends",
     )
 
-    def __init__(self, /, **data: Any) -> None:
-        """Construct the job, accepting the pre-0.60 ``backfill_days`` key.
-
-        Persisted configs written before ``lookback``/``offset`` existed carry
-        ``backfill_days``, which :class:`~interloper.component.base.Component`
-        would reject as an unknown kwarg. Reading both keys for one release is
-        what lets the images roll and the migration run in either order; the
-        shim goes away once every deployment has migrated.
-        """
-        if "backfill_days" in data:
-            legacy = data.pop("backfill_days")
-            data.setdefault("lookback", legacy)
-            data.setdefault("offset", 1)
-        super().__init__(**data)

--- a/packages/interloper-core/tests/job/test_base.py
+++ b/packages/interloper-core/tests/job/test_base.py
@@ -51,23 +51,6 @@ class TestDefinition:
         assert job.offset == 1
 
 
-class TestLegacyConfig:
-    """The pre-0.60 ``backfill_days`` key, read for one release."""
-
-    def test_backfill_days_maps_onto_lookback(self):
-        job = il.CronJob(cron="0 6 * * *", partitioned=True, backfill_days=7)
-        assert job.lookback == 7
-        assert job.offset == 1
-
-    def test_new_keys_win_over_the_legacy_one(self):
-        job = il.CronJob(cron="0 6 * * *", partitioned=True, backfill_days=7, lookback=2, offset=0)
-        assert (job.lookback, job.offset) == (2, 0)
-
-    def test_a_null_backfill_days_stays_null(self):
-        job = il.CronJob(cron="0 6 * * *", backfill_days=None)
-        assert job.lookback is None
-
-
 class TestDag:
     """Compiling targets into an executable DAG."""
 

--- a/packages/interloper-scheduler/src/interloper_scheduler/cron.py
+++ b/packages/interloper-scheduler/src/interloper_scheduler/cron.py
@@ -197,13 +197,7 @@ class CronController(Controller):
         """
         if not config.get("partitioned"):
             return None
-        # Pre-0.60 rows carry `backfill_days`, always with an implicit offset
-        # of 1. Read here as well as in `CronJob.__init__` because this is the
-        # other reader of a raw config: without it, a job whose row the
-        # migration has not rewritten yet would fall through to a single
-        # unpartitioned run, which then fails preflight against a partitioned
-        # target. Removed with the constructor shim.
-        lookback = config.get("lookback", config.get("backfill_days"))
+        lookback = config.get("lookback")
         if not lookback:
             return None
         return lookback_window(

--- a/packages/interloper-scheduler/tests/test_cron.py
+++ b/packages/interloper-scheduler/tests/test_cron.py
@@ -159,23 +159,6 @@ class TestScheduling:
             backfill = session.exec(select(Backfill)).one()
         assert backfill.start_date == backfill.end_date == now.date()
 
-    def test_legacy_backfill_days_config_still_schedules(self, store: Store) -> None:
-        # A row the migration has not rewritten yet: it must schedule exactly
-        # as it did before the rename, not degrade to an unpartitioned run.
-        now = dt.datetime.now(dt.timezone.utc)
-        _job(
-            store,
-            config={"cron": "0 * * * *", "enabled": True, "partitioned": True, "backfill_days": 3},
-            state={"next_run_at": now.isoformat()},
-        )
-        CronController(store=store)._tick()
-
-        with Session(store.engine) as session:
-            backfill = session.exec(select(Backfill)).one()
-        assert backfill.partitions == 3
-        assert backfill.end_date == now.date() - dt.timedelta(days=1)
-        assert len(_runs(store)) == 3
-
     def test_partitioned_job_without_lookback_creates_one_plain_run(self, store: Store) -> None:
         now = dt.datetime.now(dt.timezone.utc)
         _job(


### PR DESCRIPTION
Closes ITLPR-122. **Draft on purpose: do not merge until 0.60.0 is rolled out everywhere.**

## The gate

0.60.0 is published but, at the time of writing, **not deployed** — the chart bump in the deployment repo is still outstanding. Merging and releasing this before that rollout would reintroduce the exact race the shims exist for: a draining pre-0.60 pod reading a row the db-init Job has already migrated to `lookback`/`offset`.

Merge once both hold:

* No pre-0.60 pod can still be alive (prod, plus any client instance on interloper-manifests).
* Every database is at `alembic_version` 010 or later.

I could not verify prod's pinned chart version from here (GitLab global search is disabled for blobs and the project path I tried was not found), so please confirm the rollout rather than taking the release publish as proof of it.

## Change

The contract half of the `lookback`/`offset` rename. Both readers of a raw job config accepted the pre-0.60 `backfill_days` key for one release; with the rollout done that tolerance is dead weight, and keeping it contradicts the codebase's stance that a stale persisted config key is drift and should fail loudly (`Component.__init__`).

Removed:

* `CronJob.__init__` — existed only for the shim; the plain pydantic constructor is back, and `typing.Any` is no longer imported.
* The fallback in `CronController._backfill_window`, now `config.get("lookback")` alone.
* The four tests pinning the shim: `TestLegacyConfig` (3, core) and `test_legacy_backfill_days_config_still_schedules` (scheduler). Deleted rather than left failing, so nobody reinstates the shim to make them green.

Untouched: the `max_backfill_days` **quota** key, which is a different thing entirely and belongs to ITLPR-123.

## Verification

`make check` (ruff, ty, 1449 tests — four fewer, as expected).

Behaviour after removal, exercised directly:

| Input | Result |
|---|---|
| `CronJob(lookback=7, offset=2)` | works, `7` / `2` |
| `CronJob(backfill_days=7)` | `TypeError: CronJob got unexpected keyword argument(s): backfill_days` |
| `_backfill_window({"partitioned": True, "lookback": 3})` | `2026-08-16:2026-08-18` |
| `_backfill_window({"partitioned": True, "backfill_days": 3})` | `None` |

That last row is the regression the gate protects against: an unmigrated row now resolves to no window and falls through to a single unpartitioned run, which then fails preflight against a partitioned target.

By Digitl
