### PR TITLE
feat(app): add a Timeline page over job runs

### DIFF
--- a/packages/interloper-api/src/interloper_api/routes/runs.py
+++ b/packages/interloper-api/src/interloper_api/routes/runs.py
@@ -172,6 +172,8 @@ def list_runs(
     component_id: UUID | None = None,
     backfill_id: UUID | None = None,
     status: str | None = None,
+    after: dt.datetime | None = None,
+    before: dt.datetime | None = None,
     limit: int = 50,
     offset: int = 0,
     user: Profile = Depends(require_viewer),
@@ -180,16 +182,25 @@ def list_runs(
 ) -> list[RunResponse]:
     """List runs with optional filters.
 
+    ``after``/``before`` bound the runs to those whose execution overlaps that
+    window — a run occupies ``started_at`` → ``completed_at`` (open-ended while
+    running), so runs that never started match no window. This is what a
+    timeline view over a time range asks for.
+
     The total number of matching runs (ignoring ``limit``/``offset``) is
     returned in the ``X-Total-Count`` response header so clients can paginate.
     """
-    total = store.count_runs(org_id, component_id=component_id, backfill_id=backfill_id, status=status)
+    total = store.count_runs(
+        org_id, component_id=component_id, backfill_id=backfill_id, status=status, after=after, before=before
+    )
     response.headers["X-Total-Count"] = str(total)
     runs = store.list_runs(
         org_id,
         component_id=component_id,
         backfill_id=backfill_id,
         status=status,
+        after=after,
+        before=before,
         limit=limit,
         offset=offset,
     )

--- a/packages/interloper-api/tests/test_runs.py
+++ b/packages/interloper-api/tests/test_runs.py
@@ -6,6 +6,7 @@ tests, matching the style of ``test_admin.py``.
 
 from __future__ import annotations
 
+import datetime as dt
 from types import SimpleNamespace
 from uuid import UUID, uuid4
 
@@ -14,7 +15,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from interloper.errors import NotFoundError
 
-from interloper_api.dependencies import get_current_user, get_store
+from interloper_api.dependencies import get_current_user, get_org_id, get_store, require_viewer
 from interloper_api.routes import runs as runs_module
 
 _ORG_ID = uuid4()
@@ -42,6 +43,8 @@ class FakeStore:
 
     def __init__(self) -> None:
         self.retry_calls: list[tuple[UUID, str]] = []
+        self.list_calls: list[dict[str, object]] = []
+        self.count_calls: list[dict[str, object]] = []
         self.raise_not_found = False
         self.raise_value_error: str | None = None
         #: Role the fake user holds in the run's org. None = not a member.
@@ -56,6 +59,14 @@ class FakeStore:
 
     def get_user_role(self, user_id: UUID, org_id: UUID) -> str | None:
         return self.role
+
+    def list_runs(self, org_id: UUID, **kwargs):
+        self.list_calls.append(kwargs)
+        return []
+
+    def count_runs(self, org_id: UUID, **kwargs):
+        self.count_calls.append(kwargs)
+        return 0
 
     def retry_run(self, run_id: UUID, *, scope: str = "all"):
         self.retry_calls.append((run_id, scope))
@@ -192,3 +203,33 @@ def test_quota_exceeded_maps_to_429(store: FakeStore) -> None:
     detail = resp.json()["detail"]
     assert detail["quota"] == "max_successful_runs_per_month"
     assert (detail["limit"], detail["used"]) == (3, 3)
+
+
+# -- Listing -------------------------------------------------------------------
+
+
+def test_list_runs_forwards_the_time_window(store: FakeStore) -> None:
+    """A timeline view asks for one window; both the listing and its count honour it."""
+    client = _client(store)
+    client.app.dependency_overrides[require_viewer] = lambda: SimpleNamespace(id=uuid4())
+    client.app.dependency_overrides[get_org_id] = lambda: _ORG_ID
+
+    resp = client.get("/runs/", params={"after": "2026-02-04T00:00:00Z", "before": "2026-02-05T00:00:00Z"})
+
+    assert resp.status_code == 200
+    assert resp.headers["X-Total-Count"] == "0"
+    window = (
+        dt.datetime(2026, 2, 4, tzinfo=dt.timezone.utc),
+        dt.datetime(2026, 2, 5, tzinfo=dt.timezone.utc),
+    )
+    assert (store.list_calls[0]["after"], store.list_calls[0]["before"]) == window
+    assert (store.count_calls[0]["after"], store.count_calls[0]["before"]) == window
+
+
+def test_list_runs_without_window_passes_none(store: FakeStore) -> None:
+    client = _client(store)
+    client.app.dependency_overrides[require_viewer] = lambda: SimpleNamespace(id=uuid4())
+    client.app.dependency_overrides[get_org_id] = lambda: _ORG_ID
+
+    assert client.get("/runs/").status_code == 200
+    assert (store.list_calls[0]["after"], store.list_calls[0]["before"]) == (None, None)

--- a/packages/interloper-app/app/app/components/chart/ExecutionTimeline.vue
+++ b/packages/interloper-app/app/app/components/chart/ExecutionTimeline.vue
@@ -1,35 +1,63 @@
 <script setup lang="ts">
-import type { AssetExecution, ExecutionStatus } from '~/types/asset_execution'
+import type { TimelineBar, TimelineRow } from '~/types/timeline'
 
 /**********************
  * Models
  **********************/
-const selectedAsset = defineModel<string | null>('selectedAsset')
+/** Row in focus: everything else dims. Null clears the focus. */
+const selectedId = defineModel<string | null>('selectedId')
 
 /**********************
  * Props
  **********************/
 interface Props {
-    assetExecutions: AssetExecution[]
-    status?: ExecutionStatus
+    /** Lanes, in display order — sorting and grouping belong to the caller. */
+    rows: TimelineRow[]
+    /**
+     * Explicit time window in epoch ms. Without it the axis fits the data,
+     * spanning the earliest start to the latest end (a run's own duration);
+     * with it the axis spans the window (a wall-clock period), still growing
+     * to the right while something runs past its end.
+     */
+    rangeStart?: number | null
+    rangeEnd?: number | null
+    /** Tick labels: elapsed time from the window start, or wall-clock time. */
+    axis?: 'duration' | 'clock'
+    /** Width of the left label column in px; 0 renders labels inside the bars. */
+    labelWidth?: number
+    /** Heading for the label column, shown in the ruler above it. */
+    labelTitle?: string
+    /**
+     * Floor on a bar's rendered length as a fraction of the data extent, so
+     * brief executions stay legible when they're read as durations. Distorts
+     * the axis, so leave it at 0 for wall-clock windows.
+     */
+    minBarRatio?: number
     refreshRate?: number
     markerTime?: Date | null
-    highlightedAsset?: string | null
+    /** Row highlighted from outside (e.g. the event in focus); loses to a selection. */
+    highlightedId?: string | null
+    emptyMessage?: string
 }
 
 const props = withDefaults(defineProps<Props>(), {
+    rangeStart: null,
+    rangeEnd: null,
+    axis: 'duration',
+    labelWidth: 0,
+    labelTitle: '',
+    minBarRatio: 0,
     // 0 → advance every animation frame (display refresh rate). A positive value
     // throttles the layout updates to at most once per `refreshRate` ms.
     refreshRate: 0,
     markerTime: null,
-    highlightedAsset: null,
-    status: 'pending',
+    highlightedId: null,
+    emptyMessage: 'No executions yet',
 })
 
-const isRunning = computed(() => props.status === 'running')
-
-const assetDisplayName = useAssetDisplayName()
-const assetIcon = useAssetIcon()
+const emit = defineEmits<{
+    barClick: [bar: TimelineBar, row: TimelineRow]
+}>()
 
 /**********************
  * Colors
@@ -50,8 +78,12 @@ const ROW_HEIGHT = 40
 const AXIS_HEIGHT = 28
 const OVERSCAN = 4
 const MAX_ZOOM = 200
-
-const DEFAULT_ICON = 'i-lucide-box'
+/**
+ * Breathing room on both ends of the time track, so the first and last tick
+ * labels don't sit flush against the panel edges. The ruler and the rows share
+ * it, which keeps ticks, gridlines and bars on the same scale.
+ */
+const PLOT_GUTTER = 12
 
 function clamp(v: number, min: number, max: number) {
     return Math.min(Math.max(v, min), max)
@@ -61,105 +93,84 @@ function clamp(v: number, min: number, max: number) {
  * Data Processing
  *
  * `baseRows` is purely data-driven — it does NOT read the live clock, so it only
- * recomputes when `assetExecutions` change. Per-frame growth of running bars is
- * handled downstream (axisMax + the template), keeping animation work scoped to
- * the running rows rather than re-deriving the whole list every frame.
+ * recomputes when `rows` change. Per-frame growth of running bars is handled
+ * downstream (axisMax + the template), keeping animation work scoped to the
+ * running bars rather than re-deriving the whole list every frame.
  **********************/
-interface BaseRow {
-    id: string | null
-    name: string
-    icon: string
-    status: ExecutionStatus
-    /** Has a start time → render a time bar; otherwise a not-started placeholder. */
-    timed: boolean
+interface LayoutBar {
+    bar: TimelineBar
     running: boolean
     /** Relative ms from baseTime. */
     start: number
-    /** Relative ms from baseTime; undefined for running (grows live) and untimed rows. */
+    /** Relative ms from baseTime; undefined while running (grows live). */
     fixedEnd?: number
 }
 
-/** Sort weight: assets that ran sort first, non-started assets sink to the bottom. */
-const STATUS_WEIGHT: Record<string, number> = {
-    success: 0,
-    running: 1,
-    failed: 2,
-    canceled: 3,
-    skipped: 4,
-    queued: 5,
-    pending: 5,
+interface LayoutRow {
+    row: TimelineRow
+    bars: LayoutBar[]
 }
 
-interface Parsed {
-    id: string | null
-    name: string
-    icon: string
-    status: ExecutionStatus
-    startTime?: number
-    endTime?: number
-}
-
-const parsed = computed<Parsed[]>(() => {
-    return props.assetExecutions
-        .map(parseExecution)
-        .sort((a, b) => {
-            const wa = STATUS_WEIGHT[a.status] ?? 9
-            const wb = STATUS_WEIGHT[b.status] ?? 9
-            if (wa !== wb) return wa - wb
-            return (a.startTime ?? Infinity) - (b.startTime ?? Infinity)
-        })
-})
-
-function parseExecution(record: AssetExecution): Parsed {
-    const displayName = record.asset_id ? assetDisplayName.value.get(record.asset_id)?.label : undefined
-    return {
-        id: record.asset_id,
-        name: displayName ?? record.asset_key,
-        icon: (record.asset_id ? assetIcon.value.get(record.asset_id) : undefined) ?? DEFAULT_ICON,
-        status: record.status ?? 'pending',
-        startTime: record.started_at ? new Date(record.started_at).getTime() : undefined,
-        endTime: record.completed_at ? new Date(record.completed_at).getTime() : undefined,
-    }
-}
-
-/** Earliest start across the run; the zero of the relative time axis. */
+/** Zero of the relative time axis: the window start, or the earliest execution. */
 const baseTime = computed(() => {
-    const starts = parsed.value.map(p => p.startTime).filter((t): t is number => t !== undefined)
-    return starts.length ? Math.min(...starts) : 0
+    if (props.rangeStart !== null) return props.rangeStart
+    let earliest = Infinity
+    for (const row of props.rows) {
+        for (const bar of row.bars) if (bar.start < earliest) earliest = bar.start
+    }
+    return Number.isFinite(earliest) ? earliest : 0
 })
 
 /**
- * Largest relative end across all *settled* timed rows (running rows grow live and
- * are folded in via `axisMax`). Drives the min-visual-duration floor and the axis
- * extent without depending on the clock.
+ * Largest relative end across all *settled* bars, as the data reports it — the
+ * scale the minimum-bar floor is a fraction of. Clock-free, so it only moves
+ * when the data does.
  */
-const staticMaxEnd = computed(() => {
+const dataExtent = computed(() => {
     let max = 0
-    for (const p of parsed.value) {
-        if (p.startTime === undefined || p.status === 'running') continue
-        const end = (p.endTime ?? p.startTime) - baseTime.value
-        if (end > max) max = end
+    for (const row of props.rows) {
+        for (const bar of row.bars) {
+            if (bar.end === null) continue
+            const end = bar.end - baseTime.value
+            if (end > max) max = end
+        }
     }
     return max
 })
 
-const minVisualDuration = computed(() => Math.max(staticMaxEnd.value * 0.05, 1))
-
-const baseRows = computed<BaseRow[]>(() => {
-    return parsed.value.map((p) => {
-        const timed = p.startTime !== undefined
-        const running = p.status === 'running'
-        const start = timed ? p.startTime! - baseTime.value : 0
-        let fixedEnd: number | undefined
-        if (timed && !running) {
-            const rawEnd = (p.endTime ?? p.startTime!) - baseTime.value
-            fixedEnd = Math.max(rawEnd, start + minVisualDuration.value)
-        }
-        return { id: p.id, name: p.name, icon: p.icon, status: p.status, timed, running, start, fixedEnd }
-    })
+const minVisualDuration = computed(() => {
+    if (props.minBarRatio <= 0) return 0
+    return Math.max(dataExtent.value * props.minBarRatio, 1)
 })
 
-const hasRunning = computed(() => baseRows.value.some(r => r.running))
+const baseRows = computed<LayoutRow[]>(() => props.rows.map(row => ({
+    row,
+    bars: row.bars.map((bar) => {
+        const running = bar.end === null
+        const start = bar.start - baseTime.value
+        const fixedEnd = running
+            ? undefined
+            : Math.max(bar.end! - baseTime.value, start + minVisualDuration.value)
+        return { bar, running, start, fixedEnd }
+    }),
+})))
+
+const hasRunning = computed(() => baseRows.value.some(r => r.bars.some(b => b.running)))
+
+/**
+ * Right edge of the settled data *as laid out* — the floor can widen a bar past
+ * the raw extent, and the axis has to cover it or that bar renders as a sliver
+ * clipped against the edge.
+ */
+const settledExtent = computed(() => {
+    let max = dataExtent.value
+    for (const row of baseRows.value) {
+        for (const bar of row.bars) {
+            if (bar.fixedEnd !== undefined && bar.fixedEnd > max) max = bar.fixedEnd
+        }
+    }
+    return max
+})
 
 /**********************
  * Live clock (running bars only)
@@ -170,21 +181,22 @@ let lastTick = 0
 
 const relativeNow = computed(() => now.value - baseTime.value)
 
-/** Live end of a row in relative ms — only running rows depend on the clock. */
-function rowEnd(row: BaseRow): number {
-    if (row.running) return relativeNow.value
-    return row.fixedEnd ?? row.start
+/** Live end of a bar in relative ms — only running bars depend on the clock. */
+function barEnd(bar: LayoutBar): number {
+    if (bar.running) return relativeNow.value
+    return bar.fixedEnd ?? bar.start
 }
 
-/** Right edge of the data (100% when fitted). Only moves while something runs. */
+/** Right edge of the window (100% when fitted). Only moves while something runs. */
 const axisMax = computed(() => {
-    const settled = staticMaxEnd.value
+    const windowEnd = props.rangeEnd !== null ? props.rangeEnd - baseTime.value : 0
+    const settled = Math.max(settledExtent.value, windowEnd)
     const live = hasRunning.value ? Math.max(settled, relativeNow.value) : settled
     return Math.max(live, 1)
 })
 
 /**********************
- * Time viewport (zoom / pan) — #6
+ * Time viewport (zoom / pan)
  *
  * When `fitted`, the viewport tracks [0, axisMax] and follows the run live. Any
  * zoom/pan freezes it to an explicit [start, start+span] window in ms, so the
@@ -204,6 +216,15 @@ const view = computed(() => {
 function toPercent(relativeTime: number): number {
     const { start, span } = view.value
     return ((relativeTime - start) / span) * 100
+}
+
+/** Rendered edges of a bar, clipped to the viewport. */
+function barGeometry(bar: LayoutBar): { left: number, width: number, visible: boolean } {
+    const left = toPercent(bar.start)
+    const right = toPercent(barEnd(bar))
+    if (right < 0 || left > 100) return { left: 0, width: 0, visible: false }
+    const clippedLeft = clamp(left, 0, 100)
+    return { left: clippedLeft, width: Math.max(clamp(right, 0, 100) - clippedLeft, 0), visible: true }
 }
 
 function resetZoom() {
@@ -234,7 +255,7 @@ function panByMs(deltaMs: number) {
 /**********************
  * Axis ticks
  **********************/
-function formatTime(val: number): string {
+function formatDuration(val: number): string {
     if (val === 0) return '0'
     if (val < 1000) return `${Math.round(val)}ms`
     if (val < 60000) return `${(val / 1000).toFixed(1)}s`
@@ -242,17 +263,59 @@ function formatTime(val: number): string {
     return `${(val / 3600000).toFixed(1)}h`
 }
 
+const SECOND = 1000
+const MINUTE = 60 * SECOND
+const HOUR = 60 * MINUTE
+const DAY = 24 * HOUR
+
+/** Steps a wall-clock reader expects to see ticks on. */
+const CLOCK_STEPS = [
+    SECOND, 5 * SECOND, 15 * SECOND, 30 * SECOND,
+    MINUTE, 5 * MINUTE, 15 * MINUTE, 30 * MINUTE,
+    HOUR, 2 * HOUR, 3 * HOUR, 6 * HOUR, 12 * HOUR,
+    DAY, 7 * DAY,
+]
+
+/** Local midnight of the day containing `ms` — the anchor clock ticks align to. */
+function dayStart(ms: number): number {
+    const date = new Date(ms)
+    date.setHours(0, 0, 0, 0)
+    return date.getTime()
+}
+
+function formatClock(absolute: number, step: number): string {
+    const date = new Date(absolute)
+    const midnight = date.getHours() === 0 && date.getMinutes() === 0 && date.getSeconds() === 0
+    if (step >= DAY || midnight) {
+        return date.toLocaleDateString(undefined, { day: 'numeric', month: 'short' })
+    }
+    return date.toLocaleTimeString(undefined, {
+        hour: '2-digit',
+        minute: '2-digit',
+        ...(step < MINUTE ? { second: '2-digit' } : {}),
+    })
+}
+
 /** "Nice" evenly-spaced ticks across the current viewport. */
 const ticks = computed(() => {
     const { start, end, span } = view.value
+    const result: { value: number, percent: number, label: string }[] = []
+
+    if (props.axis === 'clock') {
+        const step = CLOCK_STEPS.find(s => span / s <= 8) ?? CLOCK_STEPS.at(-1)!
+        const anchor = dayStart(baseTime.value + start) - baseTime.value
+        for (let v = anchor + Math.ceil((start - anchor) / step) * step; v <= end; v += step) {
+            result.push({ value: v, percent: toPercent(v), label: formatClock(baseTime.value + v, step) })
+        }
+        return result
+    }
+
     const rawStep = span / 6
     const magnitude = 10 ** Math.floor(Math.log10(rawStep))
     const normalized = rawStep / magnitude
     const step = (normalized < 1.5 ? 1 : normalized < 3 ? 2 : normalized < 7 ? 5 : 10) * magnitude
-
-    const result: { value: number; percent: number; label: string }[] = []
     for (let v = Math.ceil(start / step) * step; v <= end + step * 0.001; v += step) {
-        result.push({ value: v, percent: toPercent(v), label: formatTime(v) })
+        result.push({ value: v, percent: toPercent(v), label: formatDuration(v) })
     }
     return result
 })
@@ -268,9 +331,10 @@ const markerPercent = computed(() => {
 })
 
 /**********************
- * Virtualization — #5
+ * Virtualization
  **********************/
 const scrollEl = ref<HTMLElement | null>(null)
+const plotEl = ref<HTMLElement | null>(null)
 const scrollTop = ref(0)
 const viewportH = ref(600)
 
@@ -288,35 +352,62 @@ const visibleRange = computed(() => {
     return { start: clamp(first, 0, total), end: clamp(last, 0, total) }
 })
 
+/**
+ * Rows intersecting the viewport, each carrying only the bars visible in the
+ * current time window and their rendered geometry. Recomputed per frame while
+ * something runs, which is the only work the live clock should cost.
+ */
 const visibleRows = computed(() => {
     const { start, end } = visibleRange.value
-    return baseRows.value.slice(start, end).map((row, i) => ({ row, index: start + i }))
+    return baseRows.value.slice(start, end).map((layout, i) => ({
+        row: layout.row,
+        index: start + i,
+        /** The row had nothing to draw at all — not merely nothing in view. */
+        placeholder: layout.bars.length === 0,
+        bars: layout.bars
+            .map(bar => ({ ...bar, geometry: barGeometry(bar) }))
+            .filter(bar => bar.geometry.visible),
+    }))
 })
 
 /**********************
  * Focus / selection
  **********************/
-const focusedAsset = computed(() => selectedAsset.value ?? props.highlightedAsset)
+const focusedId = computed(() => selectedId.value ?? props.highlightedId)
 
 function rowOpacity(id: string | null): number {
-    if (!focusedAsset.value) return 1
-    return id === focusedAsset.value ? 1 : 0.25
+    if (!focusedId.value) return 1
+    return id === focusedId.value ? 1 : 0.25
 }
 
-function onBarClick(id: string | null) {
-    selectedAsset.value = id
+function onBarClick(layout: LayoutBar, row: TimelineRow) {
+    selectedId.value = row.id
+    emit('barClick', layout.bar, row)
 }
 
 function onBlankClick() {
-    selectedAsset.value = null
+    selectedId.value = null
+}
+
+/** Row name, the execution's own context, then how long it took. */
+function barTooltip(row: TimelineRow, layout: LayoutBar): string {
+    const parts = [row.name]
+    if (layout.bar.detail) parts.push(layout.bar.detail)
+    if (props.axis === 'clock') parts.push(formatDate(new Date(layout.bar.start)))
+    parts.push(formatElapsed(new Date(layout.bar.start), layout.bar.end ? new Date(layout.bar.end) : null))
+    return parts.join(' · ')
 }
 
 /**********************
  * Interaction: wheel zoom/pan + drag-to-pan the ruler
  **********************/
+function plotRect(): DOMRect | null {
+    return plotEl.value?.getBoundingClientRect() ?? null
+}
+
 function onWheel(e: WheelEvent) {
-    if (!scrollEl.value) return
-    const rect = scrollEl.value.getBoundingClientRect()
+    const rect = plotRect()
+    if (!rect) return
 
     if (e.ctrlKey || e.metaKey) {
         // Ctrl/⌘ + wheel (and trackpad pinch) → zoom at the cursor.
@@ -347,12 +438,12 @@ function onRulerPointerDown(e: PointerEvent) {
 }
 
 function onRulerPointerMove(e: PointerEvent) {
-    if (!dragging.value || !scrollEl.value) return
-    const width = scrollEl.value.getBoundingClientRect().width
+    const rect = plotRect()
+    if (!dragging.value || !rect) return
     const dx = e.clientX - dragX
     dragX = e.clientX
     // Dragging right reveals earlier time → viewStart decreases.
-    panByMs((-dx / width) * view.value.span)
+    panByMs((-dx / rect.width) * view.value.span)
 }
 
 function onRulerPointerUp() {
@@ -363,7 +454,7 @@ function onRulerPointerUp() {
  * Live ticking — advance running bars on requestAnimationFrame
  **********************/
 function frame(timestamp: number) {
-    if (!isRunning.value) return
+    if (!hasRunning.value) return
     if (timestamp - lastTick >= props.refreshRate) {
         now.value = Date.now()
         lastTick = timestamp
@@ -399,7 +490,7 @@ onMounted(() => {
         })
         resizeObserver.observe(scrollEl.value)
     }
-    if (isRunning.value) start()
+    if (hasRunning.value) start()
 })
 
 onUnmounted(() => {
@@ -408,7 +499,7 @@ onUnmounted(() => {
     scrollEl.value?.removeEventListener('wheel', onWheel)
 })
 
-watch(isRunning, (running) => {
+watch(hasRunning, (running) => {
     if (running) start()
     else stop()
 })
@@ -426,94 +517,131 @@ watch(axisMax, () => {
          @click="onBlankClick"
          @dblclick="resetZoom">
         <!-- Time axis / ruler: sticky, and the drag-to-pan surface when zoomed. -->
-        <div class="sticky top-0 z-20 flex select-none border-b border-default bg-(--ui-bg-band)"
+        <div class="sticky top-0 z-30 flex select-none border-b border-default bg-(--ui-bg-band)"
              :class="fitted ? '' : 'cursor-ew-resize'"
              :style="{ height: AXIS_HEIGHT + 'px' }"
              @pointerdown="onRulerPointerDown"
              @pointermove="onRulerPointerMove"
              @pointerup="onRulerPointerUp"
              @pointercancel="onRulerPointerUp">
-            <div v-for="t in ticks"
-                 :key="t.value"
-                 class="absolute top-0 flex h-full items-center whitespace-nowrap text-[10px] text-muted"
-                 :style="{
-                     left: `min(${t.percent}%, calc(100% - 1px))`,
-                     transform: t.percent <= 1 ? 'translateX(0)' : t.percent >= 99 ? 'translateX(-100%)' : 'translateX(-50%)',
-                 }">
-                {{ t.label }}
+            <div v-if="labelWidth"
+                 class="flex shrink-0 items-center border-r border-default px-4"
+                 :style="{ width: labelWidth + 'px' }">
+                <span class="truncate text-xs font-medium uppercase tracking-wide text-muted">{{ labelTitle }}</span>
             </div>
+            <div ref="plotEl"
+                 class="relative flex-1"
+                 :style="{ marginInline: PLOT_GUTTER + 'px' }">
+                <div v-for="t in ticks"
+                     :key="t.value"
+                     class="absolute top-0 flex h-full items-center whitespace-nowrap text-xs text-muted"
+                     :style="{
+                         left: `min(${t.percent}%, calc(100% - 1px))`,
+                         transform: t.percent <= 1 ? 'translateX(0)' : t.percent >= 96 ? 'translateX(-100%)' : 'translateX(-50%)',
+                     }">
+                    {{ t.label }}
+                </div>
 
-            <UButton v-if="!fitted"
-                     icon="i-lucide-zoom-out"
-                     label="Reset zoom"
-                     size="xs"
-                     color="neutral"
-                     variant="subtle"
-                     class="absolute right-2 top-1/2 z-30 -translate-y-1/2"
-                     @click.stop="resetZoom"
-                     @pointerdown.stop
-                     @dblclick.stop />
+                <UButton v-if="!fitted"
+                         icon="i-lucide-zoom-out"
+                         label="Reset zoom"
+                         size="xs"
+                         color="neutral"
+                         variant="subtle"
+                         class="absolute right-2 top-1/2 z-30 -translate-y-1/2"
+                         @click.stop="resetZoom"
+                         @pointerdown.stop
+                         @dblclick.stop />
+            </div>
         </div>
 
         <!-- Rows -->
         <div v-if="baseRows.length"
              class="relative"
-             :style="{ height: totalHeight + 'px' }">
-            <!-- Gridlines -->
-            <div v-for="t in ticks"
-                 :key="`grid-${t.value}`"
-                 class="absolute top-0 bottom-0 w-px bg-default"
-                 :style="{ left: `${t.percent}%` }" />
-
-            <!-- Bars (virtualized: only rows intersecting the viewport are rendered) -->
-            <template v-for="{ row, index } in visibleRows"
-                      :key="row.id ?? row.name">
-                <!-- Not-started placeholder (#3) -->
-                <div v-if="!row.timed"
-                     class="absolute flex max-w-[45%] items-center gap-1.5 overflow-hidden rounded-md border border-dashed border-default px-2 cursor-pointer text-muted transition-opacity"
+             :style="{ height: totalHeight + 'px', minHeight: `calc(100% - ${AXIS_HEIGHT}px)` }">
+            <!-- Label gutter -->
+            <div v-if="labelWidth"
+                 class="absolute inset-y-0 left-0 z-20 border-r border-default bg-default"
+                 :style="{ width: labelWidth + 'px' }">
+                <div v-for="{ row, index } in visibleRows"
+                     :key="`label-${row.id ?? row.name}`"
+                     class="absolute flex w-full items-center gap-2 px-4 cursor-pointer transition-opacity"
                      :style="{
-                         top: index * ROW_HEIGHT + (ROW_HEIGHT - BAR_HEIGHT) / 2 + 'px',
-                         left: '0',
-                         height: BAR_HEIGHT + 'px',
+                         top: index * ROW_HEIGHT + 'px',
+                         height: ROW_HEIGHT + 'px',
                          opacity: rowOpacity(row.id),
                      }"
-                     :title="`${row.name} — ${row.status}`"
-                     @click.stop="onBarClick(row.id)">
+                     :title="row.name"
+                     @click.stop="selectedId = row.id">
                     <UIcon :name="row.icon"
-                           class="size-3.5 shrink-0" />
-                    <span class="truncate text-[11px] font-medium">{{ row.name }}</span>
+                           class="size-4 shrink-0 text-muted" />
+                    <span class="truncate text-sm font-medium">{{ row.name }}</span>
                 </div>
+            </div>
 
-                <!-- Time bar -->
-                <div v-else
-                     class="absolute flex items-center gap-1.5 overflow-hidden rounded-md px-2 cursor-pointer transition-opacity"
-                     :style="{
-                         top: index * ROW_HEIGHT + (ROW_HEIGHT - BAR_HEIGHT) / 2 + 'px',
-                         left: `${toPercent(row.start)}%`,
-                         width: `${Math.max(toPercent(rowEnd(row)) - toPercent(row.start), 0)}%`,
-                         minWidth: '2px',
-                         height: BAR_HEIGHT + 'px',
-                         backgroundColor: getStatusColor(row.status),
-                         opacity: rowOpacity(row.id) * 0.95,
-                     }"
-                     :title="`${row.name} — ${((rowEnd(row) - row.start) / 1000).toFixed(1)}s`"
-                     @click.stop="onBarClick(row.id)">
-                    <UIcon :name="row.icon"
-                           class="size-3.5 shrink-0 text-white" />
-                    <span class="truncate text-[11px] font-bold text-white">{{ row.name }}</span>
-                </div>
-            </template>
+            <!-- Plot area: gridlines, bars, marker -->
+            <div class="absolute inset-y-0"
+                 :style="{ left: labelWidth + PLOT_GUTTER + 'px', right: PLOT_GUTTER + 'px' }">
+                <!-- Gridlines -->
+                <div v-for="t in ticks"
+                     :key="`grid-${t.value}`"
+                     class="absolute top-0 bottom-0 w-px bg-default"
+                     :style="{ left: `${t.percent}%` }" />
 
-            <!-- Marker -->
-            <div v-if="markerPercent !== null"
-                 class="pointer-events-none absolute top-0 bottom-0 z-10 w-0.5 bg-primary/50"
-                 :style="{ left: `${markerPercent}%` }" />
+                <!-- Bars (virtualized: only rows intersecting the viewport are rendered) -->
+                <template v-for="{ row, bars, index, placeholder } in visibleRows"
+                          :key="row.id ?? row.name">
+                    <!-- Nothing to draw: a placeholder carrying the row's status -->
+                    <div v-if="placeholder && !labelWidth"
+                         class="absolute flex max-w-[45%] items-center gap-1.5 overflow-hidden rounded-md border border-dashed border-default px-2 cursor-pointer text-muted transition-opacity"
+                         :style="{
+                             top: index * ROW_HEIGHT + (ROW_HEIGHT - BAR_HEIGHT) / 2 + 'px',
+                             left: '0',
+                             height: BAR_HEIGHT + 'px',
+                             opacity: rowOpacity(row.id),
+                         }"
+                         :title="`${row.name} — ${statusLabel(row.status)}`"
+                         @click.stop="selectedId = row.id">
+                        <UIcon :name="row.icon"
+                               class="size-3.5 shrink-0" />
+                        <span class="truncate text-xs font-medium">{{ row.name }}</span>
+                    </div>
+
+                    <!-- Time bars -->
+                    <div v-for="layout in bars"
+                         :key="layout.bar.id"
+                         class="absolute flex items-center gap-1.5 overflow-hidden rounded-md cursor-pointer transition-opacity"
+                         :class="labelWidth ? '' : 'px-2'"
+                         :style="{
+                             top: index * ROW_HEIGHT + (ROW_HEIGHT - BAR_HEIGHT) / 2 + 'px',
+                             left: `${layout.geometry.left}%`,
+                             width: `${layout.geometry.width}%`,
+                             minWidth: labelWidth ? '3px' : '2px',
+                             height: BAR_HEIGHT + 'px',
+                             backgroundColor: getStatusColor(layout.bar.status),
+                             opacity: rowOpacity(row.id) * 0.95,
+                         }"
+                         :title="barTooltip(row, layout)"
+                         @click.stop="onBarClick(layout, row)">
+                        <template v-if="!labelWidth">
+                            <UIcon :name="row.icon"
+                                   class="size-3.5 shrink-0 text-white" />
+                            <span class="truncate text-xs font-bold text-white">{{ row.name }}</span>
+                        </template>
+                    </div>
+                </template>
+
+                <!-- Marker -->
+                <div v-if="markerPercent !== null"
+                     class="pointer-events-none absolute top-0 bottom-0 z-10 w-0.5 bg-primary/50"
+                     :style="{ left: `${markerPercent}%` }" />
+            </div>
         </div>
 
         <!-- Empty state -->
         <div v-else
              class="flex h-full items-center justify-center text-sm text-muted">
-            No asset executions yet
+            {{ emptyMessage }}
         </div>
     </div>
 </template>

--- a/packages/interloper-app/app/app/composables/navigation.ts
+++ b/packages/interloper-app/app/app/composables/navigation.ts
@@ -33,6 +33,7 @@ export function useNavSections() {
         {
             label: 'Overview',
             pages: [
+                { label: 'Timeline', icon: 'i-lucide-gantt-chart', to: '/timeline', keywords: ['gantt', 'schedule', 'runs', 'history'] },
                 { label: 'Graph', icon: 'i-lucide-workflow', to: '/graph', keywords: ['dag', 'pipeline', 'lineage'] },
                 { label: 'Collection', icon: 'i-lucide-library', to: '/collection', keywords: ['catalog', 'library'] },
             ],

--- a/packages/interloper-app/app/app/composables/timelineRows.ts
+++ b/packages/interloper-app/app/app/composables/timelineRows.ts
@@ -1,0 +1,143 @@
+import type { ComputedRef, MaybeRefOrGetter } from 'vue'
+import type { AssetExecution, ExecutionStatus } from '~/types/asset_execution'
+import type { Run } from '~/types/run'
+import type { TimelineBar, TimelineRow } from '~/types/timeline'
+
+/**
+ * Row builders for `ChartExecutionTimeline`. The component renders lanes in the
+ * order it is given, so each view decides here what a lane is: an asset of one
+ * run, or a job across a window of wall-clock time.
+ */
+
+const DEFAULT_ICON = 'i-lucide-box'
+const JOB_ICON = 'i-lucide-calendar-clock'
+const DELETED_ICON = 'i-lucide-circle-slash'
+const DELETED_LABEL = 'Deleted target'
+
+/** Sort weight: assets that ran sort first, non-started assets sink to the bottom. */
+const STATUS_WEIGHT: Record<string, number> = {
+    success: 0,
+    running: 1,
+    failed: 2,
+    canceled: 3,
+    skipped: 4,
+    queued: 5,
+    pending: 5,
+}
+
+/** Statuses that will never advance — the bar they carry is closed. */
+const TERMINAL_STATUSES = new Set(['success', 'failed', 'canceled', 'skipped'])
+
+function byName(a: TimelineRow, b: TimelineRow): number {
+    return a.name.localeCompare(b.name)
+}
+
+/** Absolute bounds of an execution, or null when it never started. */
+function bounds(
+    status: string,
+    startedAt: string | null,
+    completedAt: string | null,
+): { start: number, end: number | null } | null {
+    if (!startedAt) return null
+    const start = new Date(startedAt).getTime()
+    const completed = completedAt ? new Date(completedAt).getTime() : null
+    // Still in flight → open-ended, so the bar grows with the clock.
+    return { start, end: completed ?? (TERMINAL_STATUSES.has(status) ? start : null) }
+}
+
+/** One row per asset execution of a single run, ordered as its timeline reads best. */
+export function useAssetExecutionRows(
+    executions: MaybeRefOrGetter<AssetExecution[]>,
+): ComputedRef<TimelineRow[]> {
+    const assetDisplayName = useAssetDisplayName()
+    const assetIcon = useAssetIcon()
+
+    return computed(() => toValue(executions)
+        .map((execution) => {
+            const interval = bounds(execution.status, execution.started_at, execution.completed_at)
+            const names = execution.asset_id ? assetDisplayName.value.get(execution.asset_id) : undefined
+            return {
+                id: execution.asset_id,
+                name: names?.label ?? execution.asset_key,
+                icon: (execution.asset_id ? assetIcon.value.get(execution.asset_id) : undefined) ?? DEFAULT_ICON,
+                status: execution.status,
+                bars: interval
+                    ? [{ id: `${execution.run_id}:${execution.asset_key}`, status: execution.status, ...interval }]
+                    : [],
+            }
+        })
+        .sort((a, b) => {
+            const wa = STATUS_WEIGHT[a.status] ?? 9
+            const wb = STATUS_WEIGHT[b.status] ?? 9
+            if (wa !== wb) return wa - wb
+            return (a.bars[0]?.start ?? Infinity) - (b.bars[0]?.start ?? Infinity)
+        }))
+}
+
+/**
+ * One row per job, carrying every run of that job in the given set — the
+ * scheduling view of execution history. Jobs without a run in the window keep
+ * their (empty) row so the schedule still reads; runs launched straight at a
+ * source or asset get their own rows after the jobs rather than being dropped.
+ */
+export function useRunTimelineRows(runs: MaybeRefOrGetter<Run[]>): ComputedRef<TimelineRow[]> {
+    const componentsStore = useComponentsStore()
+    const assetDisplayName = useAssetDisplayName()
+    const assetIcon = useAssetIcon()
+
+    return computed(() => {
+        const barsByTarget = new Map<string, TimelineBar[]>()
+        const orphaned: TimelineBar[] = []
+
+        for (const run of toValue(runs)) {
+            const interval = bounds(run.status, run.started_at, run.completed_at)
+            if (!interval) continue
+            const bar: TimelineBar = {
+                id: run.id,
+                status: run.status as ExecutionStatus,
+                ...interval,
+                detail: run.partition_date ?? undefined,
+            }
+            const target = run.component_id && componentsStore.byId(run.component_id) ? run.component_id : null
+            if (!target) {
+                orphaned.push(bar)
+                continue
+            }
+            const existing = barsByTarget.get(target)
+            if (existing) existing.push(bar)
+            else barsByTarget.set(target, [bar])
+        }
+
+        const jobs = componentsStore.byKind('job')
+        const jobRows = jobs
+            .map(job => ({
+                id: job.id,
+                name: job.name ?? job.key,
+                icon: JOB_ICON,
+                bars: barsByTarget.get(job.id) ?? [],
+            }))
+            .sort(byName)
+
+        const jobIds = new Set(jobs.map(job => job.id))
+        const adHocRows: TimelineRow[] = []
+        for (const [id, bars] of barsByTarget) {
+            if (jobIds.has(id)) continue
+            const component = componentsStore.byId(id)!
+            const names = component.kind === 'asset' ? assetDisplayName.value.get(id) : undefined
+            adHocRows.push({
+                id,
+                name: names?.label ?? component.name ?? component.key,
+                icon: component.kind === 'asset'
+                    ? assetIcon.value.get(id) ?? DEFAULT_ICON
+                    : componentIcon(component.key),
+                bars,
+            })
+        }
+
+        return [
+            ...jobRows,
+            ...adHocRows.sort(byName),
+            ...(orphaned.length ? [{ id: null, name: DELETED_LABEL, icon: DELETED_ICON, bars: orphaned }] : []),
+        ]
+    })
+}

--- a/packages/interloper-app/app/app/pages/executions/runs/[run].vue
+++ b/packages/interloper-app/app/app/pages/executions/runs/[run].vue
@@ -2,7 +2,6 @@
 import type { BreadcrumbItem } from '@nuxt/ui'
 import type { RunEvent } from '~/stores/events'
 import type { Run } from '~/types/run'
-import type { ExecutionStatus } from '~/types/asset_execution'
 import type { EventCategory } from '~/utils/events'
 import { SplitterGroup, SplitterPanel, SplitterResizeHandle } from 'reka-ui'
 
@@ -39,7 +38,7 @@ const eventInFocus = ref<RunEvent | null>(null)
 const filterStatuses = computed(() => statusFilter.value ? statusesForKey(statusFilter.value) : null)
 
 /** Timeline rows, narrowed to the active status pill. */
-const filteredAssetExecutions = computed(() => {
+const timelineRows = useAssetExecutionRows(() => {
     const statuses = filterStatuses.value
     if (!statuses) return assetExecutions.value
     return assetExecutions.value.filter(e => statuses.includes(e.status))
@@ -187,11 +186,12 @@ onUnmounted(() => {
                         <span class="text-sm">Run is currently queued...</span>
                     </div>
                     <ChartExecutionTimeline v-else-if="view === 'timeline'"
-                                            v-model:selected-asset="selectedAsset"
-                                            :asset-executions="filteredAssetExecutions"
-                                            :status="(run?.status as ExecutionStatus)"
+                                            v-model:selected-id="selectedAsset"
+                                            :rows="timelineRows"
+                                            :min-bar-ratio="0.05"
                                             :marker-time="markerTime"
-                                            :highlighted-asset="highlightedAsset" />
+                                            :highlighted-id="highlightedAsset"
+                                            empty-message="No asset executions yet" />
                     <ExecutionsRunGraph v-else
                                         v-model:selected-asset="selectedAsset"
                                         :run-id="runId" />

--- a/packages/interloper-app/app/app/pages/timeline.vue
+++ b/packages/interloper-app/app/app/pages/timeline.vue
@@ -1,0 +1,107 @@
+<script setup lang="ts">
+import type { TimelineBar } from '~/types/timeline'
+
+definePageMeta({ title: 'Timeline', fullBleed: true })
+
+/** Width of the row-label gutter, wide enough for a job name. */
+const LABEL_WIDTH = 220
+
+/** How often the window re-anchors to now, so the view keeps up on its own. */
+const REFRESH_INTERVAL = 60_000
+
+const timelineStore = useTimelineStore()
+const componentsStore = useComponentsStore()
+const catalogStore = useCatalogStore()
+
+const { runs, span, rangeStart, rangeEnd, loading, total, truncated } = storeToRefs(timelineStore)
+
+const rows = useRunTimelineRows(runs)
+const selectedId = ref<string | null>(null)
+
+const spanItems = TIMELINE_SPANS.map(s => ({ label: s.label, value: String(s.value) }))
+const activeSpan = computed({
+    get: () => String(span.value),
+    set: (value: string) => timelineStore.setSpan(Number(value)),
+})
+
+const runCount = computed(() => runs.value.reduce((n, run) => n + (run.started_at ? 1 : 0), 0))
+
+function onBarClick(bar: TimelineBar) {
+    navigateTo(`/executions/runs/${bar.id}`)
+}
+
+let refreshTimer: ReturnType<typeof setInterval> | null = null
+
+onMounted(async () => {
+    await Promise.all([
+        timelineStore.fetch(),
+        // Jobs give the rows; sources/assets name and icon the ad-hoc ones.
+        componentsStore.fetchAll(['job', 'source', 'asset']),
+        catalogStore.loaded ? Promise.resolve() : catalogStore.fetchCatalog(),
+    ])
+    refreshTimer = setInterval(() => timelineStore.fetch(), REFRESH_INTERVAL)
+})
+
+onUnmounted(() => {
+    if (refreshTimer) clearInterval(refreshTimer)
+    timelineStore.$reset()
+})
+</script>
+
+<template>
+    <div class="flex flex-col flex-1 min-h-0">
+        <div class="flex shrink-0 items-center gap-2 border-b border-default px-4 py-2">
+            <span class="text-xs text-muted">Window</span>
+            <UTabs v-model="activeSpan"
+                   :items="spanItems"
+                   variant="pill"
+                   size="xs"
+                   :content="false" />
+
+            <div class="ml-auto flex items-center gap-2">
+                <UBadge v-if="truncated"
+                        color="warning"
+                        variant="subtle"
+                        icon="i-lucide-triangle-alert"
+                        :title="`Only the ${runCount} most recent of ${total} runs in this window are shown — narrow the window to see them all.`">
+                    Showing {{ runCount }} of {{ total }}
+                </UBadge>
+                <span v-else
+                      class="text-xs text-muted">{{ runCount }} run(s)</span>
+                <UButton icon="i-lucide-refresh-cw"
+                         color="neutral"
+                         variant="outline"
+                         :loading="loading"
+                         aria-label="Refresh"
+                         @click="timelineStore.fetch()" />
+            </div>
+        </div>
+
+        <div class="flex flex-1 min-h-0 flex-col">
+            <div v-if="!loading && !rows.length"
+                 class="w-full max-w-[1040px] mx-auto p-4">
+                <EmptyState icon="i-lucide-gantt-chart"
+                            title="Nothing scheduled yet"
+                            description="The timeline lays every job's runs out on a wall-clock axis, so you can see what ran when, what overlapped, and what took longer than it should.">
+                    <UButton icon="i-lucide-calendar-plus"
+                             label="Create a job"
+                             class="mt-5"
+                             to="/jobs" />
+                </EmptyState>
+            </div>
+
+            <div v-else
+                 class="flex flex-1 min-h-0 flex-col overflow-hidden">
+                <ChartExecutionTimeline v-model:selected-id="selectedId"
+                                        :rows="rows"
+                                        :range-start="rangeStart"
+                                        :range-end="rangeEnd"
+                                        axis="clock"
+                                        :label-width="LABEL_WIDTH"
+                                        label-title="Jobs"
+                                        empty-message="No runs in this window"
+                                        @bar-click="onBarClick" />
+            </div>
+        </div>
+    </div>
+</template>

--- a/packages/interloper-app/app/app/stores/timeline.ts
+++ b/packages/interloper-app/app/app/stores/timeline.ts
@@ -1,0 +1,148 @@
+import type { Run } from '~/types/run'
+
+/**
+ * Runs of one wall-clock window, for the Timeline page.
+ *
+ * Separate from the runs store on purpose: that one pages the runs *table*
+ * (50 newest, offset-paged), while a timeline asks a different question — every
+ * run that executed inside a period, however many pages of history back that
+ * reaches.
+ */
+
+/** Selectable window lengths, in ms. */
+export const TIMELINE_SPANS = [
+    { value: 3_600_000, label: '1h' },
+    { value: 6 * 3_600_000, label: '6h' },
+    { value: 12 * 3_600_000, label: '12h' },
+    { value: 24 * 3_600_000, label: '24h' },
+    { value: 7 * 24 * 3_600_000, label: '7d' },
+    { value: 30 * 24 * 3_600_000, label: '30d' },
+]
+
+/** Cap on one window's runs; anything beyond is reported, never silently dropped. */
+const MAX_RUNS = 1000
+
+export const useTimelineStore = defineStore('timeline', () => {
+    const { apiFetchRaw } = useApi()
+    const orgStore = useOrganisationStore()
+
+    /**********************
+     * State
+     **********************/
+    const runs = ref<Run[]>([])
+    const span = ref(24 * 3_600_000)
+    /** Window bounds in epoch ms, anchored at the last fetch. */
+    const rangeStart = ref(Date.now() - span.value)
+    const rangeEnd = ref(Date.now())
+    const total = ref(0)
+    const loading = ref(false)
+    const error = ref<Error | null>(null)
+
+    /**********************
+     * Getters
+     **********************/
+    /** The window holds more runs than were loaded — the view is partial. */
+    const truncated = computed(() => total.value > runs.value.length)
+
+    /**********************
+     * Internals
+     **********************/
+    /**
+     * Whether a run belongs to the current window. Only the left edge is
+     * enforced: a run that started after the window was anchored is the live
+     * edge of the timeline, which grows to meet it.
+     */
+    function _inWindow(run: Run): boolean {
+        if (!run.started_at) return false
+        if (!run.completed_at) return true
+        return new Date(run.completed_at).getTime() >= rangeStart.value
+    }
+
+    function _upsert(run: Partial<Run> & { id: string }) {
+        const idx = runs.value.findIndex(r => r.id === run.id)
+        const existing = runs.value[idx]
+        if (idx >= 0 && existing) {
+            // Strip undefined values so realtime partials don't overwrite richer API data
+            const clean = Object.fromEntries(Object.entries(run).filter(([, v]) => v !== undefined)) as Partial<Run>
+            const merged = { ...existing, ...clean }
+            if (_inWindow(merged)) runs.value[idx] = merged
+            else runs.value.splice(idx, 1)
+        }
+        else if (_inWindow(run as Run)) {
+            runs.value.push(run as Run)
+            total.value++
+        }
+    }
+
+    function _remove(id: string) {
+        const existed = runs.value.some(r => r.id === id)
+        runs.value = runs.value.filter(r => r.id !== id)
+        if (existed) total.value = Math.max(0, total.value - 1)
+    }
+
+    /**********************
+     * Realtime
+     **********************/
+    useRealtimeSubscription({
+        table: 'runs',
+        scope: () => orgStore.organisation?.id,
+        onInsert: (record: Record<string, any>) => _upsert(record as Run),
+        onUpdate: (record: Record<string, any>) => _upsert(record as Run),
+        onDelete: (record: Record<string, any>) => _remove(record.id),
+    })
+
+    /**********************
+     * Actions
+     **********************/
+    /** Re-anchor the window to now and load the runs that executed inside it. */
+    async function fetch() {
+        loading.value = true
+        error.value = null
+        rangeEnd.value = Date.now()
+        rangeStart.value = rangeEnd.value - span.value
+        try {
+            const params = new URLSearchParams({
+                after: new Date(rangeStart.value).toISOString(),
+                before: new Date(rangeEnd.value).toISOString(),
+                limit: String(MAX_RUNS),
+            })
+            const res = await apiFetchRaw<Run[]>(`/runs?${params}`)
+            runs.value = res._data ?? []
+            total.value = Number(res.headers.get('X-Total-Count') ?? runs.value.length)
+        }
+        catch (e) {
+            error.value = e as Error
+        }
+        finally {
+            loading.value = false
+        }
+    }
+
+    async function setSpan(ms: number) {
+        span.value = ms
+        await fetch()
+    }
+
+    function $reset() {
+        runs.value = []
+        total.value = 0
+        loading.value = false
+        error.value = null
+    }
+
+    useOrgScopedRefetch(() => fetch(), $reset)
+
+    return {
+        runs,
+        span,
+        rangeStart,
+        rangeEnd,
+        total,
+        truncated,
+        loading,
+        error,
+        fetch,
+        setSpan,
+        $reset,
+    }
+})

--- a/packages/interloper-app/app/app/types/timeline.ts
+++ b/packages/interloper-app/app/app/types/timeline.ts
@@ -1,0 +1,28 @@
+import type { ExecutionStatus } from '~/types/asset_execution'
+
+/** One execution drawn as a bar on a timeline row. */
+export interface TimelineBar {
+    /** Identity of the execution itself (e.g. a run id); carried back on click. */
+    id: string
+    status: ExecutionStatus
+    /** Absolute epoch ms. */
+    start: number
+    /** Absolute epoch ms, or null while still running — the bar then grows with the clock. */
+    end: number | null
+    /** Extra tooltip context, e.g. a partition date. */
+    detail?: string
+}
+
+/**
+ * One lane of a timeline: an entity and the executions it had in view. Rows
+ * render in the given order — the caller owns sorting and grouping.
+ */
+export interface TimelineRow {
+    /** Identity of the entity (asset, job, …); null when it no longer exists. */
+    id: string | null
+    name: string
+    icon: string
+    /** Rendered by the placeholder of a row with nothing to draw. */
+    status?: ExecutionStatus
+    bars: TimelineBar[]
+}

--- a/packages/interloper-db/src/interloper_db/store/runs.py
+++ b/packages/interloper-db/src/interloper_db/store/runs.py
@@ -171,8 +171,15 @@ def _run_filters(
     component_id: UUID | None,
     backfill_id: UUID | None,
     status: str | None,
+    after: datetime | None = None,
+    before: datetime | None = None,
 ) -> list[Any]:
     """The shared where-clauses of :meth:`RunMixin.list_runs` / ``count_runs``.
+
+    ``after``/``before`` select the runs whose execution *overlaps* the window
+    — a run occupies ``[started_at, completed_at)``, left open-ended while it
+    is still running. Runs that never started occupy no time and so fall
+    outside every window.
 
     Returns:
         Filter expressions for the given criteria.
@@ -184,6 +191,14 @@ def _run_filters(
         filters.append(Run.backfill_id == backfill_id)
     if status:
         filters.append(Run.status == status)
+    if after is not None:
+        filters.append(col(Run.completed_at).is_(None) | (col(Run.completed_at) >= after))
+    if before is not None:
+        filters.append(col(Run.started_at) <= before)
+    if after is not None and before is None:
+        # An `after` bound alone still means "ran at some point", so a
+        # never-started run must not slip through on the NULL completed_at.
+        filters.append(col(Run.started_at).is_not(None))
     return filters
 
 
@@ -354,6 +369,8 @@ class RunMixin(StoreBase):
         component_id: UUID | None = None,
         backfill_id: UUID | None = None,
         status: str | None = None,
+        after: datetime | None = None,
+        before: datetime | None = None,
         limit: int = 50,
         offset: int = 0,
     ) -> list[Run]:
@@ -364,6 +381,8 @@ class RunMixin(StoreBase):
             component_id: Optional target component filter.
             backfill_id: Optional backfill filter.
             status: Optional status filter.
+            after: Keep runs still executing at or after this instant.
+            before: Keep runs that had started by this instant.
             limit: Max results (default 50).
             offset: Pagination offset.
 
@@ -373,7 +392,7 @@ class RunMixin(StoreBase):
         with self._session() as session:
             statement = (
                 select(Run)
-                .where(*_run_filters(org_id, component_id, backfill_id, status))
+                .where(*_run_filters(org_id, component_id, backfill_id, status, after, before))
                 .order_by(col(Run.created_at).desc())
                 .offset(offset)
                 .limit(limit)
@@ -387,6 +406,8 @@ class RunMixin(StoreBase):
         component_id: UUID | None = None,
         backfill_id: UUID | None = None,
         status: str | None = None,
+        after: datetime | None = None,
+        before: datetime | None = None,
     ) -> int:
         """Count runs matching the same filters as :meth:`list_runs`.
 
@@ -395,13 +416,17 @@ class RunMixin(StoreBase):
             component_id: Optional target component filter.
             backfill_id: Optional backfill filter.
             status: Optional status filter.
+            after: Keep runs still executing at or after this instant.
+            before: Keep runs that had started by this instant.
 
         Returns:
             Total number of matching runs (ignoring limit/offset).
         """
         with self._session() as session:
             statement = (
-                select(func.count()).select_from(Run).where(*_run_filters(org_id, component_id, backfill_id, status))
+                select(func.count())
+                .select_from(Run)
+                .where(*_run_filters(org_id, component_id, backfill_id, status, after, before))
             )
             return session.exec(statement).one()
 

--- a/packages/interloper-db/tests/store/test_runs.py
+++ b/packages/interloper-db/tests/store/test_runs.py
@@ -164,3 +164,75 @@ class TestCancelBackfill:
     def test_cancel_missing_backfill_raises(self, store: RunMixin):
         with pytest.raises(NotFoundError):
             store.cancel_backfill(uuid4())
+
+
+def _H(hours: int) -> dt.timedelta:
+    return dt.timedelta(hours=hours)
+
+
+def _timed_run(
+    store: RunMixin,
+    *,
+    started_at: dt.datetime | None,
+    completed_at: dt.datetime | None,
+    org_id: UUID = _ORG_ID,
+) -> UUID:
+    """Insert a run occupying a known interval."""
+    with Session(store._engine) as session:
+        run = Run(
+            id=uuid4(),
+            org_id=org_id,
+            status="success" if completed_at else "running",
+            started_at=started_at,
+            completed_at=completed_at,
+        )
+        session.add(run)
+        session.commit()
+        return run.id
+
+
+class TestListRunsWindow:
+    """`after`/`before` select runs whose execution overlaps the window."""
+
+    def test_overlapping_runs_only(self, store: RunMixin):
+        base = dt.datetime(2026, 2, 4, 12, 0, tzinfo=dt.timezone.utc)
+        before_window = _timed_run(store, started_at=base - _H(3), completed_at=base - _H(2))
+        straddling_start = _timed_run(store, started_at=base - _H(2), completed_at=base + _H(1))
+        inside = _timed_run(store, started_at=base + _H(2), completed_at=base + _H(3))
+        after_window = _timed_run(store, started_at=base + _H(6), completed_at=base + _H(7))
+
+        found = store.list_runs(_ORG_ID, after=base, before=base + _H(4), limit=100)
+
+        assert {r.id for r in found} == {straddling_start, inside}
+        assert before_window not in {r.id for r in found}
+        assert after_window not in {r.id for r in found}
+
+    def test_running_run_is_open_ended(self, store: RunMixin):
+        base = dt.datetime(2026, 2, 4, 12, 0, tzinfo=dt.timezone.utc)
+        running = _timed_run(store, started_at=base - _H(5), completed_at=None)
+
+        found = store.list_runs(_ORG_ID, after=base, before=base + _H(1), limit=100)
+
+        assert [r.id for r in found] == [running]
+
+    def test_never_started_runs_are_excluded(self, store: RunMixin):
+        base = dt.datetime(2026, 2, 4, 12, 0, tzinfo=dt.timezone.utc)
+        _timed_run(store, started_at=None, completed_at=None)
+
+        assert store.list_runs(_ORG_ID, after=base, before=base + _H(1), limit=100) == []
+        assert store.list_runs(_ORG_ID, after=base, limit=100) == []
+        assert store.count_runs(_ORG_ID, after=base) == 0
+
+    def test_count_matches_the_same_window(self, store: RunMixin):
+        base = dt.datetime(2026, 2, 4, 12, 0, tzinfo=dt.timezone.utc)
+        _timed_run(store, started_at=base + _H(1), completed_at=base + _H(2))
+        _timed_run(store, started_at=base + _H(9), completed_at=base + _H(10))
+
+        assert store.count_runs(_ORG_ID, after=base, before=base + _H(4)) == 1
+
+    def test_unbounded_listing_keeps_every_run(self, store: RunMixin):
+        base = dt.datetime(2026, 2, 4, 12, 0, tzinfo=dt.timezone.utc)
+        _timed_run(store, started_at=base, completed_at=base + _H(1))
+        _timed_run(store, started_at=None, completed_at=None)
+
+        assert len(store.list_runs(_ORG_ID, limit=100)) == 2


### PR DESCRIPTION
## What

Adds a **Timeline** page as the first item of the Overview nav: one lane per job, with that job's runs laid out on a wall-clock axis over a selectable window (1h → 30d). It answers the questions the runs table can't — what ran when, what overlapped, what took longer than it should.

- Jobs keep their lane even with no runs in the window, so the schedule still reads.
- Runs launched straight at a source or asset (not through a job) get their own lanes after the jobs, rather than being dropped; runs whose target was deleted collect in one lane.
- A bar clicks through to its run page; realtime keeps the view live, and the window re-anchors to now every 60s.
- When a window holds more runs than one page can carry, the toolbar says `Showing N of M` instead of silently drawing a partial timeline.

## Why the component was refactored

`ChartExecutionTimeline` only knew how to draw *one asset execution per row* for a single run. A jobs view needs many bars per lane, an absolute time window, and clock labels. Rather than fork it, it now takes ordered `TimelineRow[]` (rows of bars) and gained: an explicit `rangeStart`/`rangeEnd` window (vs fitting the data), `axis="clock"` tick labels, a label column with its own heading, and an opt-in `minBarRatio` floor. Row building moved out to the callers ([`composables/timelineRows.ts`](packages/interloper-app/app/app/composables/timelineRows.ts)), so sorting and naming stay with the view that owns them. The run page renders through the same component with `minBarRatio="0.05"`.

Two rendering bugs surfaced and are fixed here:

- The axis stopped at the raw data extent, so bars widened by the minimum-width floor fell off the right edge and rendered as invisible slivers — visible on any run where one asset dominates the duration and the rest finish in under a millisecond.
- The time track is now inset at both ends, so the first and last tick labels don't sit flush against the panel edge. The ruler and the rows share one gutter constant, which keeps ticks, gridlines and bars on the same scale (verified: a tick's centre and its gridline land on the same pixel).

## API

`GET /runs` gains `after`/`before`, selecting runs whose execution **overlaps** the window — a run occupies `started_at → completed_at`, left open-ended while running, so runs that never started match no window. Threaded through `list_runs`/`count_runs` in `interloper-db`.

The alternative was fetching the newest N runs and filtering client-side, which would quietly show an incomplete timeline on a busy org. Ordering, existing filters, and the unbounded listing are untouched.

## Notes for review

- **New store.** `stores/timeline.ts` is deliberately separate from `stores/runs.ts`: that one pages the runs *table* (50 newest, offset-paged), while a timeline asks for everything inside a period. Sharing one store would have the two clobber each other's state.
- **Window membership** only enforces the left edge — a run starting after the window was anchored is the live edge the timeline grows to meet.
- **Chrome.** The page has no card border (the timeline *is* the content, like the graph canvas) and its toolbar matches the graph toolbar's height (both 53px, measured). Labels, ticks and headings use the app's type scale rather than one-off pixel sizes.

## Verification

Checks: `ruff`, `ty`, `pytest` (1460 passing, incl. 7 new window-filter tests across the db store and the API route), `eslint`, `nuxt typecheck` — all clean.

Driven live against a seeded instance (headless Chrome), in light and dark:

- window switching (1h → 1 run, 24h → 14, 30d → 16, matching the API's own counts), clock ticks per window (15-min through daily steps, midnight labelled as a date)
- ctrl+wheel zoom and reset, drag-to-pan, bar tooltips, click-through to the run page
- a real run appearing live via realtime while the page sat open, and a running bar growing against the clock
- the run page's timeline plus its status-pill filter, to confirm the refactor didn't regress it

By Digitl
