### PR TITLE
refactor(api): derive the admin quota payload from the registry

### DIFF
--- a/packages/interloper-api/src/interloper_api/routes/admin.py
+++ b/packages/interloper-api/src/interloper_api/routes/admin.py
@@ -19,7 +19,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Request
 from interloper_db import Organisation, Profile, Store
 from interloper_db.store.quotas import METRIC_SUCCESSFUL_RUNS, QUOTAS
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, RootModel, field_validator
 
 from interloper_api.dependencies import get_admin_config, get_quota_defaults, get_store, require_super_admin
 from interloper_api.email import send_invite_email
@@ -228,13 +228,11 @@ class AdminDataConfig(BaseModel):
     catalog: dict[str, list[str]]
 
 
-class AdminQuotaLimits(BaseModel):
-    """One set of quota limits; null means unlimited (or unset, for overrides)."""
-
-    max_sources: int | None = None
-    max_assets_per_source: int | None = None
-    max_successful_runs_per_month: int | None = None
-    max_backfill_days: int | None = None
+#: One set of quota limits, keyed by quota key; null means unlimited (or
+#: unset, for overrides). Derived from the ``QUOTAS`` registry rather than
+#: declared field-by-field, so registering a quota surfaces it here — and in
+#: the frontend, which already indexes these by key — with no code change.
+AdminQuotaLimits = dict[str, int | None]
 
 
 class AdminOrgQuotaStatus(BaseModel):
@@ -272,13 +270,30 @@ class AdminQuotasResponse(BaseModel):
     organisations: list[AdminOrgQuotaStatus]
 
 
-class AdminQuotaUpdateRequest(BaseModel):
-    """Per-org quota overrides. Omitted fields keep their value; null clears one."""
+class AdminQuotaUpdateRequest(RootModel[AdminQuotaLimits]):
+    """Per-org quota overrides. Omitted keys keep their value; null clears one.
 
-    max_sources: int | None = Field(default=None, ge=0)
-    max_assets_per_source: int | None = Field(default=None, ge=0)
-    max_successful_runs_per_month: int | None = Field(default=None, ge=0)
-    max_backfill_days: int | None = Field(default=None, ge=0)
+    Keys are checked against the registry here so an unknown quota is a 422
+    at the boundary rather than a ``KeyError`` out of the store.
+    """
+
+    @field_validator("root")
+    @classmethod
+    def _known_keys_and_non_negative(cls, value: AdminQuotaLimits) -> AdminQuotaLimits:
+        """Validate the payload against the quota registry.
+
+        Returns:
+            The payload unchanged.
+
+        Raises:
+            ValueError: If a key names no registered quota, or a limit is
+                negative.
+        """
+        if unknown := sorted(set(value) - set(QUOTAS.keys())):
+            raise ValueError(f"Unknown quota(s): {', '.join(unknown)}. Known: {', '.join(sorted(QUOTAS.keys()))}")
+        if negative := sorted(key for key, limit in value.items() if limit is not None and limit < 0):
+            raise ValueError(f"Quota limits must be >= 0: {', '.join(negative)}")
+        return value
 
 
 class AdminActivityEntry(BaseModel):
@@ -476,32 +491,40 @@ def build_config_snapshot(settings: Any, features: dict[str, bool], catalog: Any
 
 
 def _quota_limits(limits: Any) -> AdminQuotaLimits:
-    """Map limits from a ``{key: limit}`` dict (store) or attributes (settings)."""
+    """Map limits from a ``{key: limit}`` dict (store) or attributes (settings).
+
+    Returns:
+        Every registered quota's limit, ``None`` where unset.
+    """
     if isinstance(limits, dict):
-        return AdminQuotaLimits(**{key: limits.get(key) for key in AdminQuotaLimits.model_fields})
-    return AdminQuotaLimits(**{key: getattr(limits, key, None) for key in AdminQuotaLimits.model_fields})
+        return {key: limits.get(key) for key in QUOTAS.keys()}
+    return {key: getattr(limits, key, None) for key in QUOTAS.keys()}
 
 
 def _effective_limits(overrides: AdminQuotaLimits, defaults: AdminQuotaLimits) -> AdminQuotaLimits:
-    """Per-org overrides win field-by-field over the global defaults."""
-    return AdminQuotaLimits(
-        **{
-            key: override if (override := getattr(overrides, key)) is not None else getattr(defaults, key)
-            for key in AdminQuotaLimits.model_fields
-        }
-    )
+    """Per-org overrides win key-by-key over the global defaults.
+
+    Returns:
+        The effective limit of every registered quota.
+    """
+    return {
+        key: override if (override := overrides.get(key)) is not None else defaults.get(key)
+        for key in QUOTAS.keys()
+    }
 
 
 def _quota_fields(defaults: AdminQuotaLimits) -> list[AdminQuotaField]:
-    """Field descriptors for admin quota surfaces, in the wire model's order.
+    """Field descriptors for admin quota surfaces, in registry order.
 
-    Labels come from the registry definitions, so the frontend renders new
-    quotas without a matching code change.
+    Keys, labels and defaults all come from the registry, so registering a
+    quota is the whole change: no wire model, no frontend edit. ``Registry``
+    sorts its keys, so the admin surfaces list quotas alphabetically rather
+    than in the order they happen to be registered.
+
+    Returns:
+        One descriptor per registered quota.
     """
-    return [
-        AdminQuotaField(key=key, label=QUOTAS[key].label, default=getattr(defaults, key))
-        for key in AdminQuotaLimits.model_fields
-    ]
+    return [AdminQuotaField(key=key, label=QUOTAS[key].label, default=defaults.get(key)) for key in QUOTAS.keys()]
 
 
 def _require_org(store: Store, org_id: UUID) -> Organisation:
@@ -657,9 +680,9 @@ def update_org_quota(
     user: Profile = Depends(require_super_admin),
     store: Store = Depends(get_store),
 ) -> AdminQuotaLimits:
-    """Set an organisation's quota overrides; omitted fields keep their value, null clears one."""
+    """Set an organisation's quota overrides; omitted keys keep their value, null clears one."""
     _require_org(store, org_id)
-    overrides = store.set_quota(org_id, body.model_dump(exclude_unset=True))
+    overrides = store.set_quota(org_id, body.root)
     return _quota_limits(overrides)
 
 

--- a/packages/interloper-api/tests/test_admin.py
+++ b/packages/interloper-api/tests/test_admin.py
@@ -15,6 +15,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from interloper.errors import NotFoundError
+from interloper_db.store.quotas import QUOTAS
 
 from interloper_api.dependencies import get_admin_config, get_current_user, get_store
 from interloper_api.routes import admin as admin_module
@@ -275,8 +276,8 @@ def test_super_admin_reads_quota_overview(store: FakeStore) -> None:
     assert body["period_start"] == "2026-08-01"
     assert body["defaults"]["max_successful_runs_per_month"] == 100
 
-    # Field descriptors drive the admin UI: wire-model order, registry labels.
-    assert [field["key"] for field in body["fields"]] == list(admin_module.AdminQuotaLimits.model_fields)
+    # Field descriptors drive the admin UI: registry order (sorted), registry labels.
+    assert [field["key"] for field in body["fields"]] == list(QUOTAS.keys())
     by_key = {field["key"]: field for field in body["fields"]}
     assert by_key["max_sources"] == {"key": "max_sources", "label": "Max sources", "default": 10}
     assert by_key["max_backfill_days"]["default"] is None
@@ -301,12 +302,7 @@ def test_quota_overview_defaults_absent_means_unlimited(store: FakeStore) -> Non
     resp = client.get("/admin/quotas")
     assert resp.status_code == 200
     body = resp.json()
-    assert body["defaults"] == {
-        "max_sources": None,
-        "max_assets_per_source": None,
-        "max_successful_runs_per_month": None,
-        "max_backfill_days": None,
-    }
+    assert body["defaults"] == dict.fromkeys(QUOTAS.keys())
     (org,) = body["organisations"]
     assert org["effective"]["max_assets_per_source"] is None
 
@@ -549,8 +545,18 @@ def test_activity_feed_composes_titles(store: FakeStore) -> None:
     ]
 
 
-def test_quota_wire_model_matches_the_registry() -> None:
-    """AdminQuotaLimits must expose exactly the registered quota keys."""
-    from interloper_db.store.quotas import QUOTAS
+def test_quota_payload_is_derived_from_the_registry() -> None:
+    """Registering a quota surfaces it in the payload with no wire-model edit."""
+    assert set(admin_module._quota_limits({})) == set(QUOTAS.keys())
+    assert [field.key for field in admin_module._quota_fields({})] == list(QUOTAS.keys())
 
-    assert set(admin_module.AdminQuotaLimits.model_fields) == set(QUOTAS.keys())
+
+def test_update_quota_rejects_an_unknown_quota(store: FakeStore) -> None:
+    """A bad key is a 422 at the boundary, not a KeyError out of the store."""
+    resp = _client(store, is_super_admin=True).patch(
+        f"/admin/organisations/{store.org.id}/quota",
+        json={"max_bananas": 5},
+    )
+    assert resp.status_code == 422
+    assert "max_bananas" in resp.text
+    assert store.quota_updates == []

--- a/packages/interloper-app/app/app/pages/admin/index.vue
+++ b/packages/interloper-app/app/app/pages/admin/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { AdminOrganisation, AdminQuotas, AdminUser } from '~/types/admin'
+import type { AdminOrganisation, AdminQuotaLimits, AdminQuotas, AdminUser } from '~/types/admin'
 
 definePageMeta({
     title: 'Admin overview',
@@ -97,7 +97,7 @@ interface AttentionItem {
     to: string
 }
 
-function runPct(row: { successful_runs: number, effective: { max_successful_runs_per_month: number | null } }) {
+function runPct(row: { successful_runs: number, effective: AdminQuotaLimits }) {
     const limit = row.effective.max_successful_runs_per_month
     if (limit == null || limit <= 0) return null
     return Math.round((row.successful_runs / limit) * 100)

--- a/packages/interloper-app/app/app/pages/admin/organisations/[id].vue
+++ b/packages/interloper-app/app/app/pages/admin/organisations/[id].vue
@@ -150,7 +150,7 @@ const usageTiles = computed(() => {
             value: row.sources.toLocaleString(),
             sub: eff.max_sources != null ? `of ${eff.max_sources.toLocaleString()} allowed` : 'no limit set',
             used: row.sources,
-            limit: eff.max_sources,
+            limit: eff.max_sources ?? null,
         },
         {
             label: 'Assets / source',
@@ -159,7 +159,7 @@ const usageTiles = computed(() => {
                 ? `largest source, of ${eff.max_assets_per_source.toLocaleString()}`
                 : 'largest source',
             used: row.max_assets_per_source,
-            limit: eff.max_assets_per_source,
+            limit: eff.max_assets_per_source ?? null,
         },
         {
             label: 'Successful runs',
@@ -168,7 +168,7 @@ const usageTiles = computed(() => {
                 ? `of ${eff.max_successful_runs_per_month.toLocaleString()} this period`
                 : 'this period',
             used: row.successful_runs,
-            limit: eff.max_successful_runs_per_month,
+            limit: eff.max_successful_runs_per_month ?? null,
         },
         {
             label: 'Reserved runs',

--- a/packages/interloper-app/app/app/types/admin.ts
+++ b/packages/interloper-app/app/app/types/admin.ts
@@ -50,12 +50,13 @@ export interface AdminConfig {
     quotas: AdminQuotaLimits
 }
 
-export interface AdminQuotaLimits {
-    max_sources: number | null
-    max_assets_per_source: number | null
-    max_successful_runs_per_month: number | null
-    max_backfill_days: number | null
-}
+/**
+ * Quota limits keyed by quota key; null means unlimited (or unset, for
+ * overrides). Keyed rather than declared field-by-field because the API
+ * derives the payload from its quota registry: a new quota arrives here
+ * without a matching type edit, and the drawer already indexes by key.
+ */
+export type AdminQuotaLimits = Record<string, number | null>
 
 export interface AdminOrgQuotaStatus {
     id: string
@@ -74,7 +75,7 @@ export interface AdminOrgQuotaStatus {
 
 /** One quota's display descriptor: key, registry label, instance default. */
 export interface AdminQuotaField {
-    key: keyof AdminQuotaLimits
+    key: string
     label: string
     default: number | null
 }


### PR DESCRIPTION
Half 1 of ITLPR-123. The rename it enables (`max_backfill_days` → `max_backfill_partitions`) is **not** in this PR.

## Problem

Quotas are a registry, and the admin surfaces almost derive from it already: labels come from the definitions, the API maps limits by iterating fields, and `QuotaDrawer` is fully generic — it renders the `fields` descriptors and indexes `limits` by key.

The wire model was the one static piece. `AdminQuotaLimits` declared one pydantic field per quota, `AdminQuotaUpdateRequest` declared them again, and `_quota_fields` therefore iterated the *model* instead of `QUOTAS`. That is why its docstring's claim that "the frontend renders new quotas without a matching code change" was only half true: a newly registered quota got its label for free, but never reached the payload until someone added a field in `admin.py` **and** in `types/admin.ts`.

## Change

Limits are a mapping keyed by quota key on both sides, built from `QUOTAS`:

* `AdminQuotaLimits` → `dict[str, int | None]` (Python) and `Record<string, number | null>` (TS).
* `AdminQuotaUpdateRequest` → a `RootModel` over the same mapping, validating keys against the registry and rejecting negatives.
* `_quota_limits`, `_effective_limits` and `_quota_fields` iterate `QUOTAS.keys()`.

**The wire shape does not change.** The drawer already PATCHed a flat `{key: limit}` object built from the descriptors, so no frontend request or form code needed touching — only the types.

## Two behaviour differences

1. **An unrecognized key is now a 422**, with a message listing the known quotas. Previously pydantic ignored unknown fields, so `{"max_bananas": 1}` became a **200 no-op** — a silent failure for anyone driving the API directly.
2. **Admin surfaces list quotas alphabetically**, because `Registry.keys()` sorts. The old order was the wire model's declaration order (`max_sources` first). This is visible in the drawer, the limits table and the defaults chips. Calling it out because it is a real, if minor, UI change and not something the diff makes obvious.

## Verification

`make check` (ruff, ty, 1457 tests, eslint, nuxt typecheck).

**The acceptance criterion, exercised directly** — registering a quota at runtime with no other edit:

```
before:                    ['max_assets_per_source', 'max_backfill_days', 'max_sources', 'max_successful_runs_per_month']
after registering max_bananas:
  payload keys:            [..., 'max_bananas', ...]
  field descriptors:       [..., ('max_bananas', 'Max bananas'), ...]
  effective merge:         {'max_bananas': 3, 'max_sources': 9, ...}
```

**API, against a seeded instance:**

| Request | Result |
|---|---|
| `GET /admin/quotas` | keyed `defaults` / `limits` / `effective`, descriptors with registry labels |
| `PATCH {"max_sources": 42}` | 200, override set |
| `PATCH {"max_sources": null}` | 200, override cleared |
| `PATCH {"max_bananas": 1}` | **422**, "Unknown quota(s): max_bananas. Known: …" |
| `PATCH {"max_sources": -3}` | 422 |

**UI, driven headlessly:** the org "Usage & quotas" tab renders its tiles and the Override/Inherited limits table, the "Edit limits" drawer lists all four quotas with their registry labels, and a save round-trips with the success toast. The organisations list renders the instance-default chips from the same descriptors. Dev DB left as found (the override this created was cleared, session row deleted).

Typechecking caught two places still assuming per-field access — `runPct` in `admin/index.vue` and the usage-meter tiles in `organisations/[id].vue`, where indexing a mapping can yield `undefined`. Both fixed rather than cast away.

## Follow-up

Half 2 (the rename) stays on ITLPR-123. Its env-var half **fails open** — an unset limit means unlimited — so deployment values must move in the same change. `INTERLOPER_QUOTA_MAX_BACKFILL_DAYS` is set nowhere in this repo, but the deployment repo needs checking before that work starts.

By Digitl
