### PR TITLE
feat(app): sync the app to the redesigned Claude Design project

### DIFF
--- a/packages/interloper-app/app/app/app.config.ts
+++ b/packages/interloper-app/app/app/app.config.ts
@@ -37,43 +37,17 @@ export default defineAppConfig({
       }
     },
     navigationMenu: {
-      // Design sidebar hierarchy: section labels lighter (#86868b) than
-      // menu entries (#3f3f44 text, #86868b icons).
+      // Design sidebar: section labels lighter than entries; 8px item padding.
       slots: {
-        label: 'text-gray-700 dark:text-gray-800'
+        label: 'text-dimmed'
       },
       variants: {
         orientation: {
           vertical: {
-            // Design sidebar items: 8px vertical padding (~36px tall).
             link: 'py-2'
           }
         }
-      },
-      compoundVariants: [
-        // Sidebar active item: accent-tinted pill (a gray pill would be
-        // invisible on the gray sidebar).
-        {
-          orientation: 'vertical',
-          variant: 'pill',
-          active: true,
-          highlight: false,
-          class: {
-            link: 'before:bg-primary/10 text-primary',
-            linkLeadingIcon: 'text-primary group-data-[state=open]:text-primary'
-          }
-        },
-        {
-          orientation: 'vertical',
-          variant: 'pill',
-          active: false,
-          disabled: false,
-          class: {
-            link: 'text-toned',
-            linkLeadingIcon: 'text-gray-700'
-          }
-        }
-      ]
+      }
     },
     input: {
       defaultVariants: {
@@ -113,22 +87,10 @@ export default defineAppConfig({
     },
     table: {
       slots: {
-        // Borderless table treatment: no card frame and no header band — the
-        // header rule (#E8E8EC) and #F2F3F5 row dividers carry the structure,
-        // closed off by a rule under the last row.
-        root: 'bg-default',
-        thead: 'bg-default',
-        th: 'text-toned',
-        tbody: 'divide-(--ui-border-muted) [&>tr:last-child]:border-b [&>tr:last-child]:border-(--ui-border-muted)'
-      },
-      variants: {
-        sticky: {
-          true: {
-            // The sticky variant's own bg-default/75 wins the class merge
-            // over slots.thead, so restate an opaque header background here.
-            thead: 'bg-default backdrop-blur-none'
-          }
-        }
+        // Unframed tables: the first column sits flush with the table edge,
+        // aligned with the toolbar and caption around it.
+        th: 'first:pl-0',
+        td: 'first:pl-0'
       }
     },
     alert: {

--- a/packages/interloper-app/app/app/assets/css/main.css
+++ b/packages/interloper-app/app/app/assets/css/main.css
@@ -17,18 +17,18 @@
     --color-blue-950: #102344;
     /* dark surfaces: header, terminal blocks */
     --color-navy: #0b2a42;
-    /* neutrals: 50 app bg · 100 sidebar · 200 controls/hover · 300 lines · 950 ink */
-    --color-gray-50: #fbfbfc;
-    --color-gray-100: #f7f7f8;
-    --color-gray-200: #f0f0f3;
-    --color-gray-300: #e8e8ec;
-    --color-gray-400: #d4d4d9;
-    --color-gray-500: #b0b0b6;
-    --color-gray-600: #9a9aa0;
-    --color-gray-700: #86868b;
-    --color-gray-800: #6b6b70;
-    --color-gray-900: #3f3f44;
-    --color-gray-950: #1d1d1f;
+    /* neutrals: Tailwind zinc — 50 app/sidebar bg · 100 controls/hover · 200 lines · 950 ink */
+    --color-gray-50: #fafafa;
+    --color-gray-100: #f4f4f5;
+    --color-gray-200: #e4e4e7;
+    --color-gray-300: #d4d4d8;
+    --color-gray-400: #a1a1aa;
+    --color-gray-500: #71717a;
+    --color-gray-600: #52525b;
+    --color-gray-700: #3f3f46;
+    --color-gray-800: #27272a;
+    --color-gray-900: #18181b;
+    --color-gray-950: #09090b;
     /* status: success #1FA463 · error #E5484D · warning #E69E2E (50 = design tints) */
     --color-green-50: #edf9f2;
     --color-green-100: #d8f2e4;
@@ -69,33 +69,34 @@
 :root {
     --ui-font-sans: "Inter", sans-serif;
     --font-mono: "JetBrains Mono", ui-monospace, monospace;
-    --ui-header-height: 4rem;
+    --ui-header-height: 3.5rem;
 }
 
 :root {
-    /* text: ink #1d1d1f · ink2 #6b6b70 · ink3 #9a9aa0 */
-    --ui-text-dimmed: var(--color-gray-600);
-    --ui-text-muted: var(--color-gray-800);
-    --ui-text-toned: var(--color-gray-900);
+    /* text: ink #09090b · ink2 #52525b · ink3 #71717a */
+    --ui-text-dimmed: var(--color-gray-500);
+    --ui-text-muted: var(--color-gray-600);
+    --ui-text-toned: var(--color-gray-700);
     --ui-text: var(--color-gray-950);
     --ui-text-highlighted: var(--color-gray-950);
     --ui-text-inverted: #ffffff;
-    /* surfaces: white content/cards/header · sidebar (muted) #F7F7F8 */
+    /* surfaces: white content/cards/header · sidebar (muted) #FAFAFA */
     --ui-bg: #ffffff;
     /* contrasted band: table headers, info strips, chart rulers */
-    --ui-bg-band: #fafafb;
-    --ui-bg-muted: var(--color-gray-100);
-    --ui-bg-elevated: var(--color-gray-200);
-    --ui-bg-accented: var(--color-gray-300);
+    --ui-bg-band: var(--color-gray-50);
+    --ui-bg-muted: var(--color-gray-50);
+    --ui-bg-elevated: var(--color-gray-100);
+    --ui-bg-accented: var(--color-gray-200);
     --ui-bg-inverted: var(--color-gray-950);
-    /* borders: #E8E8EC lines/input rings · #F2F3F5 row dividers */
-    --ui-border: var(--color-gray-300);
-    --ui-border-muted: #f2f3f5;
-    --ui-border-accented: var(--color-gray-300);
+    /* borders: one line color everywhere (#E4E4E7) */
+    --ui-border: var(--color-gray-200);
+    --ui-border-muted: var(--color-gray-200);
+    --ui-border-accented: var(--color-gray-200);
     --ui-border-inverted: var(--color-gray-950);
-    --ui-radius: 0.4rem;
+    /* Nuxt UI default: 6px controls, 8px cards */
+    --ui-radius: 0.25rem;
     /* graph canvas: dependency edges read darker than card borders */
-    --graph-edge: var(--color-gray-500);
+    --graph-edge: var(--color-gray-400);
 }
 
 /* Design mono section label ("eyebrow"): pair with a text color utility. */
@@ -109,12 +110,12 @@
 
 /* Scrollbar */
 :root {
-    --scrollbar-thumb: var(--color-gray-400);
-    --scrollbar-thumb-hover: var(--color-gray-500);
+    --scrollbar-thumb: var(--color-gray-300);
+    --scrollbar-thumb-hover: var(--color-gray-400);
 }
 
 .dark {
-    --scrollbar-thumb: var(--color-gray-900);
+    --scrollbar-thumb: var(--color-gray-700);
     --scrollbar-thumb-hover: #4a4a50;
 }
 
@@ -153,29 +154,29 @@
 .dark {
     /* dark surfaces stay bespoke: the design's gray scale is light-oriented,
        so these are ink-family (#1d1d1f) tones rather than scale slots */
-    --ui-text-dimmed: var(--color-gray-800);
-    --ui-text-muted: var(--color-gray-700);
-    --ui-text-toned: var(--color-gray-500);
-    --ui-text: var(--color-gray-400);
+    --ui-text-dimmed: var(--color-gray-600);
+    --ui-text-muted: var(--color-gray-500);
+    --ui-text-toned: var(--color-gray-400);
+    --ui-text: var(--color-gray-300);
     --ui-text-highlighted: #ffffff;
     --ui-text-inverted: var(--color-gray-950);
-    --ui-bg: #18181b;
-    --ui-bg-band: #232326;
-    --ui-bg-muted: #232326;
-    --ui-bg-elevated: #2e2e32;
-    --ui-bg-accented: var(--color-gray-900);
+    --ui-bg: var(--color-gray-900);
+    --ui-bg-band: #1f1f22;
+    --ui-bg-muted: #1f1f22;
+    --ui-bg-elevated: var(--color-gray-800);
+    --ui-bg-accented: var(--color-gray-700);
     --ui-bg-inverted: #ffffff;
-    --ui-border: #2e2e32;
-    --ui-border-muted: #29292c;
-    --ui-border-accented: var(--color-gray-900);
+    --ui-border: var(--color-gray-800);
+    --ui-border-muted: var(--color-gray-800);
+    --ui-border-accented: var(--color-gray-700);
     --ui-border-inverted: #ffffff;
-    --ui-radius: 0.4rem;
-    --graph-edge: var(--color-gray-800);
+    --ui-radius: 0.25rem;
+    --graph-edge: var(--color-gray-600);
 
     --vf-node-bg: var(--ui-bg-elevated);
     --vf-node-text: var(--color-gray-400);
-    --vf-connection-path: var(--color-gray-800);
-    --vf-handle: var(--color-gray-700);
+    --vf-connection-path: var(--color-gray-600);
+    --vf-handle: var(--color-gray-600);
 }
 
 /* Vue Flow dark mode overrides */
@@ -185,15 +186,15 @@
 
 .dark .vue-flow__controls-button {
     background: var(--ui-bg-elevated);
-    border-bottom-color: var(--color-gray-900);
+    border-bottom-color: var(--color-gray-700);
 }
 
 .dark .vue-flow__controls-button svg {
-    fill: var(--color-gray-500);
+    fill: var(--color-gray-400);
 }
 
 .dark .vue-flow__controls-button:hover {
-    background: var(--color-gray-900);
+    background: var(--color-gray-700);
 }
 
 .dark .vue-flow__minimap {

--- a/packages/interloper-app/app/app/components/admin/QuotaDrawer.vue
+++ b/packages/interloper-app/app/app/components/admin/QuotaDrawer.vue
@@ -76,7 +76,7 @@ async function submit() {
                      color="neutral"
                      variant="soft"
                      size="md"
-                     class="absolute top-[22px] right-[26px] rounded-[9px] text-muted"
+                     class="absolute top-[22px] right-[26px] rounded-md text-muted"
                      aria-label="Close"
                      @click="open = false" />
             <p class="text-[13px] text-muted leading-normal mb-4">

--- a/packages/interloper-app/app/app/components/agent/ConfirmCard.vue
+++ b/packages/interloper-app/app/app/components/agent/ConfirmCard.vue
@@ -42,7 +42,7 @@ function decide(confirmed: boolean) {
 </script>
 
 <template>
-    <div class="border border-default rounded-[13px] p-4 my-2 w-full min-w-80 max-w-md flex flex-col gap-3">
+    <div class="border border-default rounded-lg p-4 my-2 w-full min-w-80 max-w-md flex flex-col gap-3">
         <span class="text-[13px] font-semibold text-highlighted">{{ request.title }}</span>
 
         <WizardRecap :rows="rows" />

--- a/packages/interloper-app/app/app/components/agent/ConnectCard.vue
+++ b/packages/interloper-app/app/app/components/agent/ConnectCard.vue
@@ -135,7 +135,7 @@ async function submit() {
 </script>
 
 <template>
-    <div class="border border-default rounded-[13px] p-4 my-2 w-full min-w-80 max-w-md">
+    <div class="border border-default rounded-lg p-4 my-2 w-full min-w-80 max-w-md">
         <!-- Unknown type: the catalog may not carry this key anymore -->
         <div v-if="!defn"
              class="flex items-center gap-2 text-[13px] text-muted">
@@ -147,7 +147,7 @@ async function submit() {
         <!-- Created: locked summary -->
         <div v-else-if="createdName"
              class="flex items-center gap-2.5">
-            <div class="size-8 shrink-0 rounded-[9px] border border-default bg-(--ui-bg-band) flex items-center justify-center">
+            <div class="size-8 shrink-0 rounded-md border border-default bg-(--ui-bg-band) flex items-center justify-center">
                 <UIcon :name="componentIcon(request.connectionKey)"
                        class="size-4.5" />
             </div>
@@ -163,7 +163,7 @@ async function submit() {
         <div v-else
              class="flex flex-col gap-3">
             <div class="flex items-center gap-2.5">
-                <div class="size-8 shrink-0 rounded-[9px] border border-default bg-(--ui-bg-band) flex items-center justify-center">
+                <div class="size-8 shrink-0 rounded-md border border-default bg-(--ui-bg-band) flex items-center justify-center">
                     <UIcon :name="componentIcon(request.connectionKey)"
                            class="size-4.5" />
                 </div>

--- a/packages/interloper-app/app/app/components/agent/Panel.vue
+++ b/packages/interloper-app/app/app/components/agent/Panel.vue
@@ -93,7 +93,7 @@ const SUGGESTIONS = [
 
         <!-- Header -->
         <div class="flex items-center gap-3 px-[18px] h-(--ui-header-height) border-b border-default shrink-0">
-            <div class="size-8 rounded-[9px] bg-primary text-inverted flex items-center justify-center">
+            <div class="size-8 rounded-md bg-primary text-inverted flex items-center justify-center">
                 <UIcon name="i-lucide-sparkles"
                        class="size-4" />
             </div>
@@ -105,7 +105,7 @@ const SUGGESTIONS = [
                      color="neutral"
                      variant="soft"
                      size="sm"
-                     class="rounded-[9px] text-muted"
+                     class="rounded-md text-muted"
                      aria-label="Close agent panel"
                      @click="open = false" />
         </div>
@@ -164,7 +164,7 @@ const SUGGESTIONS = [
                     <button v-for="suggestion in SUGGESTIONS"
                             :key="suggestion"
                             type="button"
-                            class="flex items-center gap-2 text-left px-3 py-2.5 border border-default rounded-[10px] bg-(--ui-bg-band) text-[13px] text-toned cursor-pointer transition hover:border-primary/40"
+                            class="flex items-center gap-2 text-left px-3 py-2.5 border border-default rounded-lg bg-(--ui-bg-band) text-[13px] text-toned cursor-pointer transition hover:border-primary/40"
                             @click="submit(suggestion)">
                         <UIcon name="i-lucide-arrow-up-right"
                                class="size-3.5 text-dimmed shrink-0" />

--- a/packages/interloper-app/app/app/components/agent/SelectCard.vue
+++ b/packages/interloper-app/app/app/components/agent/SelectCard.vue
@@ -49,7 +49,7 @@ function confirm() {
 </script>
 
 <template>
-    <div class="border border-default rounded-[13px] p-4 my-2 w-full min-w-80 max-w-md flex flex-col gap-3">
+    <div class="border border-default rounded-lg p-4 my-2 w-full min-w-80 max-w-md flex flex-col gap-3">
         <div class="flex items-center justify-between gap-2">
             <span class="text-[13px] font-semibold text-highlighted">{{ request.prompt }}</span>
             <UButton v-if="request.multi && request.options.length > 3 && !submitted"

--- a/packages/interloper-app/app/app/components/catalog/Card.vue
+++ b/packages/interloper-app/app/app/components/catalog/Card.vue
@@ -26,14 +26,14 @@ withDefaults(defineProps<{
     <UCard v-if="variant === 'rich'"
            class="cursor-pointer transition hover:ring-primary/40 hover:shadow-md hover:-translate-y-0.5"
            :ui="{
-               root: 'rounded-[13px] shadow-xs divide-y-0 flex flex-col',
+               root: 'rounded-lg shadow-xs divide-y-0 flex flex-col',
                header: 'p-4 pb-0 sm:p-4 sm:pb-0',
                body: 'p-4 py-3 sm:p-4 sm:py-3 flex-1',
                footer: 'p-4 pt-0 sm:p-4 sm:pt-0',
            }">
         <template #header>
             <div class="flex items-center gap-3">
-                <div class="size-[38px] shrink-0 rounded-[10px] border border-default flex items-center justify-center">
+                <div class="size-[38px] shrink-0 rounded-lg border border-default flex items-center justify-center">
                     <UIcon :name="icon"
                            class="size-5" />
                 </div>
@@ -78,11 +78,11 @@ withDefaults(defineProps<{
                ? 'cursor-pointer transition hover:ring-primary/40 hover:shadow-md hover:-translate-y-0.5'
                : 'bg-(--ui-bg-band)'"
            :ui="{
-               root: 'rounded-[13px] shadow-xs',
+               root: 'rounded-lg shadow-xs',
                body: 'p-3.5 px-4 sm:p-3.5 sm:px-4',
            }">
         <div class="flex items-center gap-3">
-            <div class="size-10 shrink-0 rounded-[11px] border border-default bg-default flex items-center justify-center">
+            <div class="size-10 shrink-0 rounded-lg border border-default bg-default flex items-center justify-center">
                 <UIcon :name="icon"
                        class="size-6" />
             </div>

--- a/packages/interloper-app/app/app/components/chart/ExecutionTimeline.vue
+++ b/packages/interloper-app/app/app/components/chart/ExecutionTimeline.vue
@@ -75,7 +75,7 @@ function getStatusColor(status: string) {
  **********************/
 const BAR_HEIGHT = 28
 const ROW_HEIGHT = 40
-const AXIS_HEIGHT = 28
+const AXIS_HEIGHT = 30
 const OVERSCAN = 4
 const MAX_ZOOM = 200
 /**
@@ -83,7 +83,7 @@ const MAX_ZOOM = 200
  * labels don't sit flush against the panel edges. The ruler and the rows share
  * it, which keeps ticks, gridlines and bars on the same scale.
  */
-const PLOT_GUTTER = 12
+const PLOT_GUTTER = 16
 
 function clamp(v: number, min: number, max: number) {
     return Math.min(Math.max(v, min), max)
@@ -517,7 +517,7 @@ watch(axisMax, () => {
          @click="onBlankClick"
          @dblclick="resetZoom">
         <!-- Time axis / ruler: sticky, and the drag-to-pan surface when zoomed. -->
-        <div class="sticky top-0 z-30 flex select-none border-b border-default bg-(--ui-bg-band)"
+        <div class="sticky top-0 z-30 flex select-none border-b border-default bg-default"
              :class="fitted ? '' : 'cursor-ew-resize'"
              :style="{ height: AXIS_HEIGHT + 'px' }"
              @pointerdown="onRulerPointerDown"
@@ -534,7 +534,7 @@ watch(axisMax, () => {
                  :style="{ marginInline: PLOT_GUTTER + 'px' }">
                 <div v-for="t in ticks"
                      :key="t.value"
-                     class="absolute top-0 flex h-full items-center whitespace-nowrap text-xs text-muted"
+                     class="absolute top-0 flex h-full items-center whitespace-nowrap text-[12.5px] font-medium text-muted"
                      :style="{
                          left: `min(${t.percent}%, calc(100% - 1px))`,
                          transform: t.percent <= 1 ? 'translateX(0)' : t.percent >= 96 ? 'translateX(-100%)' : 'translateX(-50%)',
@@ -585,7 +585,7 @@ watch(axisMax, () => {
                 <!-- Gridlines -->
                 <div v-for="t in ticks"
                      :key="`grid-${t.value}`"
-                     class="absolute top-0 bottom-0 w-px bg-default"
+                     class="absolute top-0 bottom-0 w-px bg-elevated"
                      :style="{ left: `${t.percent}%` }" />
 
                 <!-- Bars (virtualized: only rows intersecting the viewport are rendered) -->
@@ -593,7 +593,7 @@ watch(axisMax, () => {
                           :key="row.id ?? row.name">
                     <!-- Nothing to draw: a placeholder carrying the row's status -->
                     <div v-if="placeholder && !labelWidth"
-                         class="absolute flex max-w-[45%] items-center gap-1.5 overflow-hidden rounded-md border border-dashed border-default px-2 cursor-pointer text-muted transition-opacity"
+                         class="absolute flex max-w-[45%] items-center gap-1.5 overflow-hidden rounded-md border border-dashed border-accented px-2 cursor-pointer text-dimmed transition-opacity"
                          :style="{
                              top: index * ROW_HEIGHT + (ROW_HEIGHT - BAR_HEIGHT) / 2 + 'px',
                              left: '0',
@@ -616,10 +616,10 @@ watch(axisMax, () => {
                              top: index * ROW_HEIGHT + (ROW_HEIGHT - BAR_HEIGHT) / 2 + 'px',
                              left: `${layout.geometry.left}%`,
                              width: `${layout.geometry.width}%`,
-                             minWidth: labelWidth ? '3px' : '2px',
+                             minWidth: '6px',
                              height: BAR_HEIGHT + 'px',
                              backgroundColor: getStatusColor(layout.bar.status),
-                             opacity: rowOpacity(row.id) * 0.95,
+                             opacity: rowOpacity(row.id) * 0.96,
                          }"
                          :title="barTooltip(row, layout)"
                          @click.stop="onBarClick(layout, row)">

--- a/packages/interloper-app/app/app/components/executions/RunSummary.vue
+++ b/packages/interloper-app/app/app/components/executions/RunSummary.vue
@@ -80,12 +80,12 @@ const metaItems = computed(() => [
                         type="button"
                         :disabled="b.count === 0"
                         :aria-pressed="statusFilter === b.key"
-                        class="flex items-center gap-1.5 rounded-md px-2 py-1 text-xs transition-colors"
+                        class="flex items-center gap-1.5 rounded-lg px-[9px] py-1 text-xs transition-colors"
                         :class="[
-                            b.count === 0 ? 'cursor-default opacity-50' : 'cursor-pointer hover:bg-elevated',
+                            b.count === 0 ? 'cursor-default opacity-50' : 'cursor-pointer',
                             statusFilter === b.key
-                                ? 'bg-elevated ring-1 ring-inset ring-primary'
-                                : 'bg-accented',
+                                ? 'bg-default ring-1 ring-inset ring-primary shadow-sm'
+                                : 'bg-elevated',
                             statusFilter && statusFilter !== b.key ? 'opacity-60' : '',
                         ]"
                         @click="toggleStatus(b)">
@@ -101,8 +101,8 @@ const metaItems = computed(() => [
         <div class="grid shrink-0 grid-cols-2 gap-2 lg:w-80">
             <div v-for="m in metaItems"
                  :key="m.label"
-                 class="flex flex-col gap-1 rounded-md border border-default bg-default px-3 py-2">
-                <div class="flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-wide text-muted">
+                 class="flex flex-col gap-1 rounded-lg border border-default bg-default px-3 py-2">
+                <div class="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wide text-dimmed">
                     <UIcon :name="m.icon"
                            class="size-3" />
                     {{ m.label }}

--- a/packages/interloper-app/app/app/components/graph/GraphCanvas.vue
+++ b/packages/interloper-app/app/app/components/graph/GraphCanvas.vue
@@ -766,8 +766,8 @@ function onEdgeContextMenu({ edge, event }: { edge: Edge; event: MouseEvent | To
             <Panel v-if="editable && sourceEntries.length === 0"
                    position="top-left"
                    class="!inset-0 !m-0 flex items-center justify-center pointer-events-none">
-                <div class="pointer-events-auto w-[430px] max-w-[92%] bg-default border border-default rounded-[20px] shadow-2xl px-8 py-9 text-center">
-                    <div class="size-14 mx-auto rounded-[16px] bg-primary/10 text-primary flex items-center justify-center">
+                <div class="pointer-events-auto w-[430px] max-w-[92%] bg-default border border-default rounded-lg shadow-2xl px-8 py-9 text-center">
+                    <div class="size-14 mx-auto rounded-lg bg-primary/10 text-primary flex items-center justify-center">
                         <UIcon name="i-lucide-workflow"
                                class="size-7" />
                     </div>

--- a/packages/interloper-app/app/app/components/graph/SourceNode.vue
+++ b/packages/interloper-app/app/app/components/graph/SourceNode.vue
@@ -239,11 +239,11 @@ const ringClass = computed(() => {
 
             <!-- Main card: one header row in both states; expanded grows downward
                  (assets render as nested canvas nodes). -->
-            <div class="relative flex h-full w-full flex-col overflow-hidden rounded-2xl border-2 border-[var(--ui-border-accented)]"
+            <div class="relative flex h-full w-full flex-col overflow-hidden rounded-xl border-2 border-[var(--ui-border-accented)]"
                  :class="[container ? 'bg-muted' : 'bg-default', ringClass]">
                 <div class="flex h-[68px] shrink-0 items-center gap-3 px-4"
                      :class="container && 'border-b border-default bg-default'">
-                    <div class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-elevated">
+                    <div class="flex size-10 shrink-0 items-center justify-center rounded-lg bg-elevated">
                         <UIcon :name="icon"
                                class="size-5" />
                     </div>

--- a/packages/interloper-app/app/app/components/graph/SourceTypeNode.vue
+++ b/packages/interloper-app/app/app/components/graph/SourceTypeNode.vue
@@ -54,7 +54,7 @@ const ringClass = computed(() => {
 
         <!-- Collapsed: solid card standing in for the members.
              Expanded: dashed outline over the canvas, members nest inside. -->
-        <div class="relative flex h-full w-full flex-col rounded-2xl"
+        <div class="relative flex h-full w-full flex-col rounded-xl"
              :class="[
                  open
                      ? 'border-2 border-dashed border-[var(--ui-text-dimmed)]/50 bg-transparent'
@@ -62,7 +62,7 @@ const ringClass = computed(() => {
                  ringClass,
              ]">
             <div class="flex h-[68px] shrink-0 items-center gap-3 px-4">
-                <div class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-elevated">
+                <div class="flex size-10 shrink-0 items-center justify-center rounded-lg bg-elevated">
                     <UIcon :name="icon"
                            class="size-5" />
                 </div>

--- a/packages/interloper-app/app/app/components/hooks/ComponentSelect.vue
+++ b/packages/interloper-app/app/app/components/hooks/ComponentSelect.vue
@@ -42,7 +42,7 @@ function toggle(id: string) {
                 <UCheckbox :model-value="selectedIds.includes(component.id)"
                            @click.stop
                            @update:model-value="toggle(component.id)" />
-                <div class="size-10 shrink-0 rounded-[11px] border border-default bg-default flex items-center justify-center">
+                <div class="size-10 shrink-0 rounded-lg border border-default bg-default flex items-center justify-center">
                     <UIcon :name="componentIcon(component.key)"
                            class="size-6" />
                 </div>

--- a/packages/interloper-app/app/app/components/jobs/SourceSelect.vue
+++ b/packages/interloper-app/app/app/components/jobs/SourceSelect.vue
@@ -63,7 +63,7 @@ function deselectAll() {
                 <UCheckbox :model-value="selectedIds.includes(source.id)"
                            @click.stop
                            @update:model-value="toggle(source.id)" />
-                <div class="size-10 shrink-0 rounded-[11px] border border-default bg-default flex items-center justify-center">
+                <div class="size-10 shrink-0 rounded-lg border border-default bg-default flex items-center justify-center">
                     <UIcon :name="sourceIcon(source)"
                            class="size-6" />
                 </div>

--- a/packages/interloper-app/app/app/components/nav/Actions.vue
+++ b/packages/interloper-app/app/app/components/nav/Actions.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+/**
+ * Renders its content into the page navbar's right side (the layout's
+ * #navbar-right outlet) — the design keeps page-level actions in the 56px
+ * header, not in the content body. The outlet belongs to the layout, which
+ * can re-render in the same flush as a client-side navigation, so wait one
+ * tick for it to exist before teleporting.
+ */
+const ready = ref(false)
+onMounted(async () => {
+    await nextTick()
+    ready.value = true
+})
+</script>
+
+<template>
+    <Teleport v-if="ready"
+              to="#navbar-right">
+        <slot />
+    </Teleport>
+</template>

--- a/packages/interloper-app/app/app/components/nav/Title.vue
+++ b/packages/interloper-app/app/app/components/nav/Title.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+/**
+ * Renders its content into the page navbar's title area (the layout's
+ * #navbar-title outlet, present when the page sets meta customNavbar).
+ * Same one-tick wait as NavActions, for client-side navigations.
+ */
+const ready = ref(false)
+onMounted(async () => {
+    await nextTick()
+    ready.value = true
+})
+</script>
+
+<template>
+    <Teleport v-if="ready"
+              to="#navbar-title">
+        <slot />
+    </Teleport>
+</template>

--- a/packages/interloper-app/app/app/components/organization/MembersTable.vue
+++ b/packages/interloper-app/app/app/components/organization/MembersTable.vue
@@ -71,7 +71,7 @@ const columns = computed<TableColumn<OrgMember>[]>(() => {
                     ? h('span', { class: 'font-semibold text-highlighted' }, member.name)
                     : h('span', { class: 'text-dimmed' }, '—')
                 const you = member.id === userStore.user?.id
-                    ? h('span', { class: 'px-1.5 py-px rounded-[5px] bg-elevated text-[11px] font-semibold text-dimmed' }, 'You')
+                    ? h('span', { class: 'px-1.5 py-px rounded-md bg-elevated text-[11px] font-semibold text-dimmed' }, 'You')
                     : null
                 return h('div', { class: 'flex items-center gap-3' }, [avatar, name, you])
             },
@@ -86,7 +86,7 @@ const columns = computed<TableColumn<OrgMember>[]>(() => {
             cell: ({ row }) => {
                 const role = row.getValue<string>('role')
                 return h('span', {
-                    class: `inline-block px-2.5 py-1 rounded-[7px] text-xs font-semibold ${ROLE_TINTS[role] ?? ROLE_TINTS.viewer}`,
+                    class: `inline-block px-2.5 py-1 rounded-md text-xs font-semibold ${ROLE_TINTS[role] ?? ROLE_TINTS.viewer}`,
                 }, role.charAt(0).toUpperCase() + role.slice(1))
             },
         },
@@ -137,6 +137,7 @@ const columns = computed<TableColumn<OrgMember>[]>(() => {
                    :row-actions="isAdmin ? getRowMenuItems : undefined"
                    no-actions
                    no-row-click
+                   bordered
                    search-placeholder="Search members...">
             <template #toolbar>
                 <slot name="toolbar" />

--- a/packages/interloper-app/app/app/components/sources/DestinationStep.vue
+++ b/packages/interloper-app/app/app/components/sources/DestinationStep.vue
@@ -122,7 +122,7 @@ function destLabel(key: string) {
                     <UCheckbox :model-value="isSelected(dest.id)"
                                @click.stop
                                @update:model-value="toggle(dest.id)" />
-                    <div class="size-10 shrink-0 rounded-[11px] border border-default bg-default flex items-center justify-center">
+                    <div class="size-10 shrink-0 rounded-lg border border-default bg-default flex items-center justify-center">
                         <UIcon :name="destIcon(dest.key)"
                                class="size-6" />
                     </div>

--- a/packages/interloper-app/app/app/components/sources/ResourceStep.vue
+++ b/packages/interloper-app/app/app/components/sources/ResourceStep.vue
@@ -168,7 +168,7 @@ defineExpose({ formData })
                            :selected="selectedId === inst.id"
                            class="flex items-center gap-3 px-4 py-3"
                            @select="selectedId = inst.id">
-                <div class="size-10 shrink-0 rounded-[11px] border border-default bg-default flex items-center justify-center">
+                <div class="size-10 shrink-0 rounded-lg border border-default bg-default flex items-center justify-center">
                     <UIcon :name="componentIcon(definition.key)"
                            class="size-6" />
                 </div>

--- a/packages/interloper-app/app/app/components/ui/DataTable.vue
+++ b/packages/interloper-app/app/app/components/ui/DataTable.vue
@@ -17,6 +17,11 @@ const props = defineProps<{
     /** When true, rows are read-only: no pointer cursor, since clicking one leads nowhere. */
     noRowClick?: boolean
     /**
+     * Design "bordered" table: an outer rounded frame replaces the floating
+     * header band (detail/settings pages); list pages keep the band.
+     */
+    bordered?: boolean
+    /**
      * Impact preview for deleting the given ids (e.g.
      * `componentsStore.deleteImpact`). `blocking` referrers disable the
      * destructive button; `detaching` ones are listed as a heads-up — the
@@ -144,7 +149,7 @@ const showEmpty = computed(() => hasLoaded.value && props.data.length === 0 && !
 </script>
 
 <template>
-    <div class="w-full flex flex-col gap-4">
+    <div class="w-full flex flex-col gap-2">
         <div v-if="!showEmpty"
              class="flex items-center gap-3">
             <UInput v-model="globalFilter"
@@ -178,7 +183,11 @@ const showEmpty = computed(() => hasLoaded.value && props.data.length === 0 && !
                 :global-filter="globalFilter"
                 :pagination-options="{ getPaginationRowModel: getPaginationRowModel() }"
                 sticky
-                :ui="{ tr: noRowClick ? '' : 'cursor-pointer' }"
+                :ui="{
+                    tr: noRowClick ? '' : 'cursor-pointer',
+                    ...(bordered && { thead: '[&>tr]:bg-muted', th: 'first:pl-4', td: 'first:pl-4' }),
+                }"
+                :class="bordered && 'rounded-lg border border-default'"
                 class="max-h-[calc(100vh-16rem)]"
                 @select="(_e: Event, row: any) => emit('edit', row.original)"
                 @contextmenu="onRowContextMenu">

--- a/packages/interloper-app/app/app/components/ui/EmptyState.vue
+++ b/packages/interloper-app/app/app/components/ui/EmptyState.vue
@@ -8,8 +8,8 @@ defineProps<{
 </script>
 
 <template>
-    <div class="w-full border border-default rounded-[18px] px-8 py-[42px] text-center bg-gradient-to-b from-[#FCFCFD] to-[#F6F7F9] dark:from-transparent dark:to-(--ui-bg-muted)">
-        <div class="size-[58px] mx-auto rounded-[16px] bg-primary/10 text-primary flex items-center justify-center">
+    <div class="w-full border border-default rounded-lg px-8 py-[42px] text-center bg-gradient-to-b from-gray-50 to-gray-100 dark:from-transparent dark:to-(--ui-bg-muted)">
+        <div class="size-[58px] mx-auto rounded-lg bg-primary/10 text-primary flex items-center justify-center">
             <UIcon :name="icon"
                    class="size-7" />
         </div>

--- a/packages/interloper-app/app/app/components/ui/InlineEmptyState.vue
+++ b/packages/interloper-app/app/app/components/ui/InlineEmptyState.vue
@@ -10,8 +10,8 @@ const emit = defineEmits<{ action: [] }>()
 </script>
 
 <template>
-    <div class="flex flex-col items-center gap-3 rounded-[14px] border border-dashed border-accented bg-(--ui-bg-band) px-6 py-8">
-        <div class="size-10 rounded-[11px] border border-default bg-default flex items-center justify-center">
+    <div class="flex flex-col items-center gap-3 rounded-lg border border-dashed border-accented bg-(--ui-bg-band) px-6 py-8">
+        <div class="size-10 rounded-lg border border-default bg-default flex items-center justify-center">
             <UIcon :name="icon"
                    class="size-6" />
         </div>

--- a/packages/interloper-app/app/app/components/ui/PanelCard.vue
+++ b/packages/interloper-app/app/app/components/ui/PanelCard.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+/**
+ * Design "Panel": a naked header (icon + title + description) above a bordered,
+ * muted card whose rows divide with the line color. The danger tone tints the
+ * card red for destructive sections.
+ */
+withDefaults(defineProps<{
+    title: string
+    description?: string
+    icon?: string
+    iconClass?: string
+    /** Small neutral badge at the right of the header (e.g. a count). */
+    badge?: string | number
+    /** Accent link at the right of the header. */
+    linkLabel?: string
+    linkTo?: string
+    tone?: 'default' | 'danger'
+}>(), {
+    tone: 'default',
+    description: undefined,
+    icon: undefined,
+    iconClass: undefined,
+    badge: undefined,
+    linkLabel: undefined,
+    linkTo: undefined,
+})
+</script>
+
+<template>
+    <section>
+        <div class="mb-3 flex items-center gap-2.5">
+            <UIcon v-if="icon"
+                   :name="icon"
+                   class="size-4 shrink-0"
+                   :class="iconClass ?? 'text-muted'" />
+            <div class="min-w-0">
+                <div class="text-[15px] font-semibold"
+                     :class="tone === 'danger' ? 'text-error' : 'text-highlighted'">{{ title }}</div>
+                <div v-if="description"
+                     class="mt-1 text-[13.5px] leading-normal text-dimmed">{{ description }}</div>
+            </div>
+            <UBadge v-if="badge !== undefined"
+                    color="neutral"
+                    size="sm"
+                    class="ml-auto"
+                    :label="String(badge)" />
+            <ULink v-else-if="linkLabel && linkTo"
+                   :to="linkTo"
+                   class="ml-auto whitespace-nowrap text-[13px] font-medium text-primary">{{ linkLabel }} →</ULink>
+        </div>
+        <div class="overflow-hidden rounded-lg border"
+             :class="tone === 'danger'
+                 ? 'border-error/30 bg-error/5 divide-y divide-error/20'
+                 : 'border-default bg-muted divide-y divide-default'">
+            <slot />
+        </div>
+    </section>
+</template>

--- a/packages/interloper-app/app/app/components/ui/SelectionCard.vue
+++ b/packages/interloper-app/app/app/components/ui/SelectionCard.vue
@@ -15,7 +15,7 @@ const emit = defineEmits<{ select: [] }>()
 <template>
     <component :is="as"
                :type="as === 'button' ? 'button' : undefined"
-               class="rounded-[13px] border-2 text-left cursor-pointer transition"
+               class="rounded-lg border-2 text-left cursor-pointer transition"
                :class="selected
                    ? 'border-primary bg-primary/5'
                    : 'border-default bg-default hover:border-primary/40'"

--- a/packages/interloper-app/app/app/components/ui/StatusPill.vue
+++ b/packages/interloper-app/app/app/components/ui/StatusPill.vue
@@ -17,7 +17,7 @@ const COLOR_CLASSES: Record<NonNullable<typeof props.color>, string> = {
 </script>
 
 <template>
-    <span class="inline-flex items-center gap-1.5 px-2.5 py-[3px] rounded-full text-[11px] font-semibold"
+    <span class="inline-flex items-center gap-1.5 px-2 py-[3px] rounded-md text-xs font-medium"
           :class="COLOR_CLASSES[color]">
         <span v-if="dot"
               class="size-1.5 rounded-full bg-current" />

--- a/packages/interloper-app/app/app/components/wizard/Drawer.vue
+++ b/packages/interloper-app/app/app/components/wizard/Drawer.vue
@@ -43,7 +43,7 @@ withDefaults(defineProps<{
                      color="neutral"
                      variant="soft"
                      size="md"
-                     class="absolute top-[22px] right-[26px] rounded-[9px] text-muted"
+                     class="absolute top-[22px] right-[26px] rounded-md text-muted"
                      aria-label="Close"
                      @click="open = false" />
             <slot />

--- a/packages/interloper-app/app/app/components/wizard/Recap.vue
+++ b/packages/interloper-app/app/app/components/wizard/Recap.vue
@@ -6,7 +6,7 @@ defineProps<{
 </script>
 
 <template>
-    <div class="border border-default rounded-[12px] px-3.5 py-1 bg-default">
+    <div class="border border-default rounded-lg px-3.5 py-1 bg-default">
         <div v-for="(row, i) in rows"
              :key="row.label"
              class="flex items-center gap-2.5 py-2.5"

--- a/packages/interloper-app/app/app/components/wizard/TypeSelect.vue
+++ b/packages/interloper-app/app/app/components/wizard/TypeSelect.vue
@@ -73,7 +73,7 @@ const groups = computed(() => {
                                    :selected="selectedKey === defn.key"
                                    class="flex flex-col items-center gap-2.5 px-3.5 py-[18px]"
                                    @select="selectedKey = defn.key">
-                        <div class="size-11 shrink-0 rounded-xl border border-default bg-default flex items-center justify-center">
+                        <div class="size-11 shrink-0 rounded-lg border border-default bg-default flex items-center justify-center">
                             <UIcon :name="componentIcon(defn.key)"
                                    class="size-[26px]" />
                         </div>

--- a/packages/interloper-app/app/app/composables/runStats.ts
+++ b/packages/interloper-app/app/app/composables/runStats.ts
@@ -16,8 +16,8 @@ const STATUS_META: StatusMeta[] = [
     { key: 'running', label: 'Running', statuses: ['running'], colorClass: 'bg-blue-500' },
     { key: 'failed', label: 'Failed', statuses: ['failed'], colorClass: 'bg-red-500' },
     { key: 'canceled', label: 'Canceled', statuses: ['canceled'], colorClass: 'bg-amber-500' },
-    { key: 'skipped', label: 'Skipped', statuses: ['skipped'], colorClass: 'bg-gray-500' },
-    { key: 'pending', label: 'Pending', statuses: ['pending', 'queued'], colorClass: 'bg-gray-800' },
+    { key: 'skipped', label: 'Skipped', statuses: ['skipped'], colorClass: 'bg-gray-400' },
+    { key: 'pending', label: 'Pending', statuses: ['pending', 'queued'], colorClass: 'bg-gray-600' },
 ]
 
 /** Always shown in the legend, even at zero. Pending only appears when present. */

--- a/packages/interloper-app/app/app/layouts/admin.vue
+++ b/packages/interloper-app/app/app/layouts/admin.vue
@@ -8,13 +8,14 @@ const appVersion = useRuntimeConfig().public.version
 interface PageHeaderMeta {
     title: string
     description?: string
+    eyebrow?: string
 }
 const pageHeader = computed(() => route.meta.pageHeader as PageHeaderMeta | undefined)
 
-/** Eyebrow-styled page title; breadcrumb pages set titleInBreadcrumb and render it as their first crumb. */
-const pageTitle = computed(() => route.meta.titleInBreadcrumb
-    ? undefined
-    : pageHeader.value?.title ?? (route.meta.title as string | undefined))
+/** Navbar title; pages with a bespoke navbar teleport into it instead. */
+const pageTitle = computed(() => pageHeader.value?.title ?? (route.meta.title as string | undefined))
+/** Pages that fill the navbar themselves (crumb + name) via #navbar-title. */
+const customNavbar = computed(() => !!route.meta.customNavbar)
 
 const items = computed<NavigationMenuItem[]>(() => [
     {
@@ -51,7 +52,8 @@ const items = computed<NavigationMenuItem[]>(() => [
                            :ui="{ footer: 'border-t border-default' }">
             <template #header="{ collapsed }">
                 <NavLogo v-if="!collapsed" />
-                <UDashboardSidebarCollapse :class="collapsed ? 'mx-auto' : 'ms-auto'" />
+                <LogoIcon v-else
+                          class="mx-auto h-6 w-auto text-primary" />
             </template>
 
             <template #default="{ collapsed }">
@@ -62,6 +64,7 @@ const items = computed<NavigationMenuItem[]>(() => [
                         label="Admin portal" />
                 <UNavigationMenu :collapsed="collapsed"
                                  :items="items"
+                                 color="neutral"
                                  orientation="vertical" />
             </template>
 
@@ -86,16 +89,36 @@ const items = computed<NavigationMenuItem[]>(() => [
 
         <UDashboardPanel
                          :ui="{ body: '!p-0 !gap-0 overflow-hidden [&>*]:flex-1 [&>*]:flex [&>*]:flex-col [&>*]:min-h-0' }">
+            <template #header>
+                <UDashboardNavbar :title="customNavbar ? undefined : pageTitle"
+                                  :ui="{ root: 'sm:px-4', title: 'text-[15px]' }">
+                    <template #leading>
+                        <UDashboardSidebarCollapse />
+                    </template>
+                    <template v-if="customNavbar"
+                              #title>
+                        <div id="navbar-title"
+                             class="flex min-w-0 items-center gap-2.5" />
+                    </template>
+                    <template #right>
+                        <div id="navbar-right"
+                             class="flex items-center gap-2" />
+                    </template>
+                </UDashboardNavbar>
+            </template>
             <template #body>
-                <div class="flex-1 min-h-0 w-full overflow-y-auto">
-                    <div class="p-4 w-full max-w-[1040px] mx-auto">
-                        <div v-if="pageTitle"
-                             class="mb-4">
-                            <PageBreadcrumb :items="[titleCrumb(pageTitle)]" />
-                            <p v-if="pageHeader?.description"
-                               class="text-[15px] text-muted leading-relaxed max-w-[660px] mt-2.5">
-                                {{ pageHeader.description }}
-                            </p>
+                <!-- Full-bleed pages (tabbed detail views) manage their own frame. -->
+                <slot v-if="route.meta.fullBleed" />
+                <div v-else
+                     class="flex-1 min-h-0 w-full overflow-y-auto">
+                    <div class="p-6 w-full">
+                        <div v-if="pageHeader"
+                             class="mb-6 max-w-[660px]">
+                            <p v-if="pageHeader.eyebrow"
+                               class="eyebrow text-primary">{{ pageHeader.eyebrow }}</p>
+                            <h1 class="mt-2.5 text-[28px] font-bold leading-tight tracking-[-0.022em]">{{ pageHeader.title }}</h1>
+                            <p v-if="pageHeader.description"
+                               class="mt-2.5 text-[15px] leading-relaxed text-muted">{{ pageHeader.description }}</p>
                         </div>
                         <slot />
                     </div>

--- a/packages/interloper-app/app/app/layouts/default.vue
+++ b/packages/interloper-app/app/app/layouts/default.vue
@@ -17,13 +17,14 @@ const appVersion = useRuntimeConfig().public.version
 interface PageHeaderMeta {
     title: string
     description?: string
+    eyebrow?: string
 }
 const pageHeader = computed(() => route.meta.pageHeader as PageHeaderMeta | undefined)
 
-/** Eyebrow-styled page title; breadcrumb pages set titleInBreadcrumb and render it as their first crumb. */
-const pageTitle = computed(() => route.meta.titleInBreadcrumb
-    ? undefined
-    : pageHeader.value?.title ?? (route.meta.title as string | undefined))
+/** Navbar title; pages with a bespoke navbar (run/backfill) teleport into it instead. */
+const pageTitle = computed(() => pageHeader.value?.title ?? (route.meta.title as string | undefined))
+/** Pages that fill the navbar themselves (crumb + id + status) via #navbar-title. */
+const customNavbar = computed(() => !!route.meta.customNavbar)
 
 const navSections = useNavSections()
 
@@ -52,7 +53,8 @@ const items = computed<NavigationMenuItem[]>(() => navSections.value.flatMap((se
                                :ui="{ footer: 'border-t border-default' }">
                 <template #header="{ collapsed }">
                     <NavLogo v-if="!collapsed" />
-                    <UDashboardSidebarCollapse :class="collapsed ? 'mx-auto' : 'ms-auto'" />
+                    <LogoIcon v-else
+                              class="mx-auto h-6 w-auto text-primary" />
                 </template>
 
                 <template #default="{ collapsed }">
@@ -75,6 +77,7 @@ const items = computed<NavigationMenuItem[]>(() => navSections.value.flatMap((se
 
                     <UNavigationMenu :collapsed="collapsed"
                                      :items="items"
+                                     color="neutral"
                                      orientation="vertical" />
                 </template>
 
@@ -92,20 +95,37 @@ const items = computed<NavigationMenuItem[]>(() => navSections.value.flatMap((se
 
             <UDashboardPanel
                              :ui="{ body: '!p-0 !gap-0 overflow-hidden [&>*]:flex-1 [&>*]:flex [&>*]:flex-col [&>*]:min-h-0' }">
+                <template #header>
+                    <UDashboardNavbar :title="customNavbar ? undefined : pageTitle"
+                                      :ui="{ root: 'sm:px-4', title: 'text-[15px]' }">
+                        <template #leading>
+                            <UDashboardSidebarCollapse />
+                        </template>
+                        <template v-if="customNavbar"
+                                  #title>
+                            <!-- Detail pages teleport their crumb + status here. -->
+                            <div id="navbar-title"
+                                 class="flex min-w-0 items-center gap-2.5" />
+                        </template>
+                        <template #right>
+                            <div id="navbar-right"
+                                 class="flex items-center gap-2" />
+                        </template>
+                    </UDashboardNavbar>
+                </template>
                 <template #body>
                     <!-- Full-bleed pages (canvas/split views) manage their own frame. -->
                     <slot v-if="route.meta.fullBleed" />
                     <div v-else
                          class="flex-1 min-h-0 w-full overflow-y-auto">
-                        <div class="p-4 w-full"
-                             :class="pageHeader && 'max-w-[1040px] mx-auto'">
-                            <div v-if="pageTitle"
-                                 class="mb-4">
-                                <PageBreadcrumb :items="[titleCrumb(pageTitle)]" />
-                                <p v-if="pageHeader?.description"
-                                   class="text-[15px] text-muted leading-relaxed max-w-[660px] mt-2.5">
-                                    {{ pageHeader.description }}
-                                </p>
+                        <div class="p-6 w-full">
+                            <div v-if="pageHeader"
+                                 class="mb-6 max-w-[660px]">
+                                <p v-if="pageHeader.eyebrow"
+                                   class="eyebrow text-primary">{{ pageHeader.eyebrow }}</p>
+                                <h1 class="mt-2.5 text-[28px] font-bold leading-tight tracking-[-0.022em]">{{ pageHeader.title }}</h1>
+                                <p v-if="pageHeader.description"
+                                   class="mt-2.5 text-[15px] leading-relaxed text-muted">{{ pageHeader.description }}</p>
                             </div>
                             <slot />
                         </div>

--- a/packages/interloper-app/app/app/pages/admin/config.vue
+++ b/packages/interloper-app/app/app/pages/admin/config.vue
@@ -1,15 +1,7 @@
 <script setup lang="ts">
 import type { AdminConfig } from '~/types/admin'
 
-definePageMeta({
-    title: 'Config',
-    layout: 'admin',
-    middleware: 'super-admin',
-    pageHeader: {
-        title: 'Instance configuration',
-        description: 'How this deployment is wired — read-only, sourced from the running instance. Secrets are redacted; dimmed values are class defaults.',
-    },
-})
+definePageMeta({ title: 'Instance configuration', layout: 'admin', middleware: 'super-admin' })
 
 const adminStore = useAdminStore()
 
@@ -191,7 +183,11 @@ const sections = computed<ConfigSection[]>(() => {
 </script>
 
 <template>
-    <div class="flex flex-col gap-3">
+    <div class="mx-auto flex w-full max-w-[1040px] flex-col gap-3">
+        <p class="mb-3 max-w-[660px] text-[14.5px] leading-relaxed text-muted">
+            How this deployment is wired — read-only, sourced from the running instance.
+            Secrets are redacted; dimmed values are class defaults.
+        </p>
         <div v-if="loading"
              class="flex items-center justify-center py-16">
             <UIcon name="i-lucide-loader-circle"
@@ -205,19 +201,14 @@ const sections = computed<ConfigSection[]>(() => {
 
         <div v-else
              class="flex flex-col gap-4">
-            <section v-for="section in sections"
+            <PanelCard v-for="section in sections"
                      :key="section.title"
-                     class="overflow-hidden rounded-lg border border-default bg-default">
-                <div class="flex items-center gap-2 border-b border-default bg-muted px-4 py-2.5">
-                    <UIcon :name="section.icon"
-                           class="size-4 text-muted" />
-                    <span class="text-sm font-semibold text-highlighted">{{ section.title }}</span>
-                </div>
-
-                <div class="divide-y divide-default">
-                    <div v-for="row in section.rows"
-                         :key="row.label"
-                         class="flex items-start gap-4 px-4 py-2.5 text-sm">
+                     :title="section.title"
+                     :icon="section.icon"
+                     class="mb-4">
+                <div v-for="row in section.rows"
+                     :key="row.label"
+                     class="flex items-start gap-4 px-4 py-3 text-sm">
                         <span class="w-56 shrink-0 pt-px text-muted">{{ row.label }}</span>
                         <div class="min-w-0 flex-1">
                             <div v-if="row.pill || row.badges || row.value"
@@ -240,7 +231,7 @@ const sections = computed<ConfigSection[]>(() => {
                                  :class="(row.pill || row.badges || row.value) && 'mt-1.5'">
                                 <span v-for="attr in row.attrs"
                                       :key="attr.key"
-                                      class="whitespace-nowrap rounded-[5px] px-1.5 py-0.5 font-mono text-xs"
+                                      class="whitespace-nowrap rounded-md px-1.5 py-0.5 font-mono text-xs"
                                       :class="attr.dim ? 'bg-elevated/50 text-dimmed' : 'bg-elevated'"
                                       :title="attr.dim ? 'Class default (not configured)' : undefined">
                                     <span class="text-muted">{{ attr.key }}=</span>{{ attr.value }}
@@ -254,8 +245,7 @@ const sections = computed<ConfigSection[]>(() => {
                             </div>
                         </div>
                     </div>
-                </div>
-            </section>
+            </PanelCard>
         </div>
     </div>
 </template>

--- a/packages/interloper-app/app/app/pages/admin/index.vue
+++ b/packages/interloper-app/app/app/pages/admin/index.vue
@@ -2,13 +2,9 @@
 import type { AdminOrganisation, AdminQuotas, AdminUser } from '~/types/admin'
 
 definePageMeta({
-    title: 'Admin overview',
+    title: 'Overview',
     layout: 'admin',
     middleware: 'super-admin',
-    pageHeader: {
-        title: 'Overview',
-        description: 'Platform-wide health and activity at a glance.',
-    },
 })
 
 const adminStore = useAdminStore()
@@ -234,33 +230,28 @@ const activity = computed(() => {
     </div>
 
     <div v-else
-         class="flex flex-col gap-3">
-        <div class="grid grid-cols-2 xl:grid-cols-4 gap-3">
+         class="flex flex-col gap-7">
+        <div class="grid grid-cols-2 xl:grid-cols-4 gap-px overflow-hidden rounded-lg border border-default bg-(--ui-border)">
             <div v-for="tile in tiles"
                  :key="tile.label"
-                 class="rounded-lg border border-default bg-default px-4 py-3.5">
-                <div class="flex items-center gap-1.5 text-[11.5px] font-semibold uppercase tracking-wider text-dimmed">
+                 class="flex flex-col gap-2.5 bg-muted p-4">
+                <span class="flex size-[34px] items-center justify-center rounded-full bg-primary/10 text-primary ring-1 ring-inset ring-primary/25">
                     <UIcon :name="tile.icon"
-                           class="size-3.5" />
-                    {{ tile.label }}
+                           class="size-4" />
+                </span>
+                <div class="text-xs uppercase tracking-wider text-dimmed">{{ tile.label }}</div>
+                <div class="flex items-baseline gap-2 min-w-0">
+                    <span class="text-2xl font-semibold tracking-tight tabular-nums">{{ tile.value }}</span>
+                    <span class="truncate text-[12.5px] text-muted">{{ tile.sub }}</span>
                 </div>
-                <div class="text-[27px] font-bold tracking-tight tabular-nums mt-2">{{ tile.value }}</div>
-                <div class="text-xs text-muted mt-0.5">{{ tile.sub }}</div>
             </div>
         </div>
 
-        <div class="grid lg:grid-cols-2 gap-3 items-start">
-            <section class="overflow-hidden rounded-lg border border-default bg-default">
-                <div class="flex items-center gap-2 border-b border-default px-4 py-2.5">
-                    <UIcon name="i-lucide-alert-triangle"
-                           class="size-4 text-warning" />
-                    <span class="text-sm font-semibold">Needs attention</span>
-                    <UBadge :label="String(attention.length)"
-                            color="warning"
-                            variant="subtle"
-                            size="sm"
-                            class="ml-auto" />
-                </div>
+        <div class="grid lg:grid-cols-2 gap-5 items-start">
+            <PanelCard title="Needs attention"
+                     icon="i-lucide-alert-triangle"
+                     icon-class="text-warning"
+                     :badge="attention.length">
                 <div v-if="attention.length === 0"
                      class="flex items-center gap-2.5 px-4 py-6 text-sm text-muted">
                     <UIcon name="i-lucide-check-circle"
@@ -269,7 +260,7 @@ const activity = computed(() => {
                 </div>
                 <div v-for="item in attention"
                      :key="item.title"
-                     class="flex items-start gap-3 px-4 py-3 border-b border-muted last:border-b-0">
+                     class="flex items-start gap-3 px-4 py-3">
                     <span class="flex size-6.5 shrink-0 items-center justify-center rounded-lg mt-0.5"
                           :class="ATTENTION_TILE[item.tone]">
                         <UIcon :name="item.icon"
@@ -284,18 +275,12 @@ const activity = computed(() => {
                         {{ item.action }} →
                     </NuxtLink>
                 </div>
-            </section>
+            </PanelCard>
 
-            <section class="overflow-hidden rounded-lg border border-default bg-default">
-                <div class="flex items-center gap-2 border-b border-default px-4 py-2.5">
-                    <UIcon name="i-lucide-gauge"
-                           class="size-4 text-muted" />
-                    <span class="text-sm font-semibold">Quota pressure</span>
-                    <NuxtLink to="/admin/organisations"
-                              class="ml-auto text-xs font-semibold text-primary">
-                        All organisations →
-                    </NuxtLink>
-                </div>
+            <PanelCard title="Quota pressure"
+                     icon="i-lucide-gauge"
+                     link-label="All organisations"
+                     link-to="/admin/organisations">
                 <div v-if="pressure.length === 0"
                      class="px-4 py-6 text-sm text-muted">
                     No run limits configured — usage is unmetered pressure-wise.
@@ -317,18 +302,19 @@ const activity = computed(() => {
                         <div class="text-[11.5px] text-dimmed mt-1">{{ entry.note }}</div>
                     </div>
                 </div>
-            </section>
+            </PanelCard>
         </div>
 
-        <div class="grid lg:grid-cols-2 gap-3 items-start">
-            <section class="overflow-hidden rounded-lg border border-default bg-default">
-                <div class="flex items-center gap-2 border-b border-default px-4 py-2.5">
+        <div class="grid lg:grid-cols-2 gap-5 items-start">
+            <section>
+                <div class="mb-3 flex items-center gap-2.5">
                     <UIcon name="i-lucide-trending-up"
                            class="size-4 text-muted" />
-                    <span class="text-sm font-semibold">Top organisations by usage</span>
-                    <span class="ml-auto text-[11.5px] text-dimmed">{{ periodLabel }}</span>
+                    <span class="text-[15px] font-semibold text-highlighted">Top organisations by usage</span>
+                    <span class="ml-auto text-xs text-dimmed">{{ periodLabel }}</span>
                 </div>
-                <div class="flex items-center gap-3 px-4 py-2 border-b border-muted text-xs font-medium text-muted">
+                <div class="overflow-hidden rounded-lg border border-default divide-y divide-default">
+                <div class="flex items-center gap-3 bg-muted px-4 py-3 text-sm font-semibold text-highlighted">
                     <span class="flex-1 min-w-0">Organisation</span>
                     <span class="w-16 text-right shrink-0">Runs</span>
                     <span class="w-14 text-right shrink-0">Sources</span>
@@ -341,7 +327,7 @@ const activity = computed(() => {
                 <NuxtLink v-for="org in topOrgs"
                           :key="org.id"
                           :to="`/admin/organisations/${org.id}`"
-                          class="flex items-center gap-3 px-4 py-3 border-b border-muted last:border-b-0 text-[13px] hover:bg-elevated/50">
+                          class="flex items-center gap-3 bg-default px-4 py-3 text-[13px] hover:bg-muted">
                     <span class="flex-1 min-w-0 flex items-center gap-2.5">
                         <span class="w-[5px] h-[22px] rounded shrink-0"
                               :style="{ background: org.tint }" />
@@ -351,21 +337,18 @@ const activity = computed(() => {
                     <span class="w-14 text-right tabular-nums text-muted shrink-0">{{ org.sources }}</span>
                     <span class="w-14 text-right tabular-nums text-muted shrink-0">{{ org.members }}</span>
                 </NuxtLink>
+                </div>
             </section>
 
-            <section class="overflow-hidden rounded-lg border border-default bg-default">
-                <div class="flex items-center gap-2 border-b border-default px-4 py-2.5">
-                    <UIcon name="i-lucide-activity"
-                           class="size-4 text-muted" />
-                    <span class="text-sm font-semibold">Recent activity</span>
-                </div>
+            <PanelCard title="Recent activity"
+                     icon="i-lucide-activity">
                 <div v-if="activity.length === 0"
                      class="px-4 py-6 text-sm text-muted">
                     Nothing yet.
                 </div>
                 <div v-for="entry in activity"
                      :key="entry.when + entry.text"
-                     class="flex items-start gap-3 px-4 py-2.5 border-b border-muted last:border-b-0">
+                     class="flex items-start gap-3 px-4 py-2.5">
                     <span class="flex size-6 shrink-0 items-center justify-center rounded-md bg-elevated text-muted mt-0.5">
                         <UIcon :name="entry.icon"
                                class="size-3.5" />
@@ -375,7 +358,7 @@ const activity = computed(() => {
                         <div class="text-[11.5px] text-dimmed mt-0.5">{{ entry.who }} · {{ entry.whenLabel }}</div>
                     </div>
                 </div>
-            </section>
+            </PanelCard>
         </div>
     </div>
 </template>

--- a/packages/interloper-app/app/app/pages/admin/organisations/[id].vue
+++ b/packages/interloper-app/app/app/pages/admin/organisations/[id].vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import type { BreadcrumbItem, TabsItem } from '@nuxt/ui'
+import type { TabsItem } from '@nuxt/ui'
 import type { AdminActivityEntry, AdminOrganisation, AdminOrgQuotaStatus, AdminQuotas } from '~/types/admin'
 import type { Organisation, OrgMember } from '~/types/organisation'
 
-definePageMeta({ title: 'Manage organisation', layout: 'admin', middleware: 'super-admin', titleInBreadcrumb: true })
+definePageMeta({ title: 'Manage organisation', layout: 'admin', middleware: 'super-admin', customNavbar: true, fullBleed: true })
 
 const route = useRoute()
 const orgId = computed(() => route.params.id as string)
@@ -24,11 +24,6 @@ const isMember = computed(() =>
     rows.value.some(r => r.status === 'active' && r.id === userStore.user?.id))
 
 const inviteEndpoint = computed(() => `/admin/organisations/${orgId.value}/invitations`)
-
-const breadcrumbs = computed<BreadcrumbItem[]>(() => [
-    titleCrumb('Organisations', '/admin/organisations'),
-    entityCrumb(org.value?.name ?? '…', 'i-lucide-building-2'),
-])
 
 const quotaRow = computed<AdminOrgQuotaStatus | null>(() =>
     quotas.value?.organisations.find(row => row.id === orgId.value) ?? null)
@@ -198,6 +193,15 @@ const limitRows = computed(() => {
     })
 })
 
+/** Day-of-period progress for the usage strip (quota counters reset monthly). */
+const periodElapsed = computed(() => {
+    if (!quotas.value) return null
+    const start = new Date(quotas.value.period_start)
+    const end = new Date(start.getFullYear(), start.getMonth() + 1, 0)
+    const day = Math.min(new Date().getDate(), end.getDate())
+    return { label: `Day ${day} of ${end.getDate()}`, pct: Math.round((day / end.getDate()) * 100) }
+})
+
 const ledgerInSync = computed(() =>
     quotaRow.value != null && quotaRow.value.successful_runs === quotaRow.value.recomputed_successful_runs)
 
@@ -252,6 +256,7 @@ async function openWorkspace() {
 
 const deleteConfirmName = ref('')
 const deleting = ref(false)
+const deleteOpen = ref(false)
 
 async function submitDelete() {
     const target = org.value
@@ -276,209 +281,262 @@ watch(orgId, loadData)
 
 <template>
     <div class="flex flex-col flex-1 min-h-0">
-        <div class="pb-4 shrink-0">
-            <PageBreadcrumb :items="breadcrumbs" />
-        </div>
+        <NavTitle>
+            <ULink to="/admin/organisations"
+                   class="text-[15px] font-medium text-muted hover:text-highlighted">Organisations</ULink>
+            <span class="text-[15px] text-dimmed">/</span>
+            <span class="truncate text-[15px] font-semibold">{{ org?.name ?? '…' }}</span>
+        </NavTitle>
+        <NavActions v-if="isMember">
+            <UButton icon="i-lucide-external-link"
+                     label="Open workspace"
+                     color="neutral"
+                     variant="outline"
+                     size="sm"
+                     @click="openWorkspace" />
+        </NavActions>
 
-        <div class="flex items-center gap-3.5 mb-5">
-            <span class="flex size-11 shrink-0 items-center justify-center rounded-xl text-white text-[17px] font-bold"
-                  :style="{ background: avatarColor(orgId) }">
-                {{ (org?.name ?? '?').charAt(0).toUpperCase() }}
-            </span>
-            <div class="min-w-0">
-                <h1 class="text-[21px] font-bold tracking-tight truncate">{{ org?.name ?? '…' }}</h1>
-                <div class="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[13px] text-muted mt-0.5">
-                    <span>{{ rows.filter(r => r.status === 'active').length }} members</span>
-                    <span class="size-[3px] rounded-full bg-accented" />
-                    <span>{{ quotaRow?.sources ?? 0 }} sources</span>
-                    <span class="size-[3px] rounded-full bg-accented" />
-                    <span>Created {{ formatDay(org?.created_at) }}</span>
-                    <span class="size-[3px] rounded-full bg-accented" />
-                    <span class="font-mono text-xs">{{ orgId.slice(0, 8) }}</span>
-                </div>
-            </div>
-        </div>
-
+        <!-- Tab strip flush under the navbar, rule across the full panel. -->
         <UTabs v-model="tab"
                :items="tabItems"
                :content="false"
                variant="link"
-               class="mb-5 shrink-0" />
+               class="shrink-0"
+               :ui="{ list: 'px-6' }" />
 
-        <div v-if="tab === 'members'"
-             class="flex flex-col flex-1 min-h-0">
-            <OrganizationMembersTable :members="rows"
-                                      :loading="loading"
-                                      is-admin
-                                      @remove-member="removeMember"
-                                      @cancel-invite="cancelInvite"
-                                      @resend-invite="resendInvite">
-                <template #toolbar>
-                    <UButton v-if="!loading && !isMember"
-                             icon="i-lucide-log-in"
-                             label="Join"
-                             variant="outline"
-                             @click="joinOrganisation" />
-                    <UButton icon="i-lucide-user-plus"
-                             label="Invite"
-                             @click="inviteOpen = true" />
-                </template>
-            </OrganizationMembersTable>
+        <div class="flex-1 min-h-0 overflow-y-auto">
+            <div class="mx-auto w-full max-w-[1040px] px-6 py-8">
 
-            <OrganizationInviteModal v-model:open="inviteOpen"
-                                     :endpoint="inviteEndpoint"
-                                     @invited="loadData" />
-        </div>
+                <div v-if="tab === 'members'"
+                     class="flex flex-col min-h-0">
+                    <OrganizationMembersTable :members="rows"
+                                              :loading="loading"
+                                              is-admin
+                                              @remove-member="removeMember"
+                                              @cancel-invite="cancelInvite"
+                                              @resend-invite="resendInvite">
+                        <template #toolbar>
+                            <UButton v-if="!loading && !isMember"
+                                     icon="i-lucide-log-in"
+                                     label="Join"
+                                     variant="outline"
+                                     @click="joinOrganisation" />
+                            <UButton icon="i-lucide-user-plus"
+                                     label="Invite"
+                                     @click="inviteOpen = true" />
+                        </template>
+                    </OrganizationMembersTable>
 
-        <div v-else-if="tab === 'usage'"
-             class="flex flex-col gap-3">
-            <div class="grid grid-cols-2 xl:grid-cols-4 gap-3">
-                <div v-for="tile in usageTiles"
-                     :key="tile.label"
-                     class="rounded-lg border border-default bg-default px-4 py-3.5">
-                    <div class="text-[11.5px] font-semibold uppercase tracking-wider text-dimmed">{{ tile.label }}</div>
-                    <div class="text-[23px] font-bold tracking-tight tabular-nums mt-1.5">{{ tile.value }}</div>
-                    <div class="text-xs text-muted mt-0.5">{{ tile.sub }}</div>
-                    <AdminUsageMeter :used="tile.used"
-                                     :limit="tile.limit"
-                                     :show-label="false"
-                                     class="mt-2.5" />
+                    <OrganizationInviteModal v-model:open="inviteOpen"
+                                             :endpoint="inviteEndpoint"
+                                             @invited="loadData" />
                 </div>
+
+                <div v-else-if="tab === 'usage'"
+                     class="flex flex-col gap-7">
+                    <!-- Usage strip: fused stat cells over a period-elapsed bar. -->
+                    <div class="overflow-hidden rounded-lg border border-default bg-(--ui-border)">
+                        <div class="grid grid-cols-2 xl:grid-cols-4 gap-px">
+                            <div v-for="tile in usageTiles"
+                                 :key="tile.label"
+                                 class="flex flex-col gap-2.5 bg-muted p-4">
+                                <div class="text-xs uppercase tracking-wider text-dimmed">{{ tile.label }}</div>
+                                <div class="flex items-baseline gap-2 min-w-0">
+                                    <span class="text-2xl font-semibold tracking-tight tabular-nums">{{ tile.value }}</span>
+                                    <span class="truncate text-[12.5px] text-muted">{{ tile.sub }}</span>
+                                </div>
+                                <AdminUsageMeter v-if="tile.limit != null"
+                                                 :used="tile.used"
+                                                 :limit="tile.limit"
+                                                 :show-label="false" />
+                            </div>
+                        </div>
+                        <div v-if="periodElapsed"
+                             class="border-t border-default bg-default px-4 py-3.5">
+                            <div class="flex items-baseline gap-2">
+                                <span class="flex-1 truncate text-[13.5px] font-medium">Period elapsed · {{ periodLabel }}</span>
+                                <span class="whitespace-nowrap text-[12.5px] text-muted">{{ periodElapsed.label }}</span>
+                                <span class="whitespace-nowrap text-[12.5px] font-semibold text-primary">{{ periodElapsed.pct }}%</span>
+                            </div>
+                            <div class="mt-2 h-1.5 overflow-hidden rounded-full bg-accented">
+                                <div class="h-full rounded-full bg-primary"
+                                     :style="{ width: periodElapsed.pct + '%' }" />
+                            </div>
+                        </div>
+                    </div>
+
+                    <PanelCard v-if="quotaRow"
+                             title="Ledger"
+                             :description="ledgerInSync
+                                 ? 'The runs counter and a recount from the runs table agree.'
+                                 : 'The runs counter and a recount from the runs table disagree — inspect recent runs.'">
+                        <div class="flex items-start gap-3 px-4 py-3">
+                            <span class="w-56 shrink-0 text-sm text-muted">Status</span>
+                            <UBadge :label="ledgerInSync ? 'In sync' : 'Drift'"
+                                    :color="ledgerInSync ? 'success' : 'warning'"
+                                    :icon="ledgerInSync ? 'i-lucide-check' : 'i-lucide-triangle-alert'" />
+                        </div>
+                        <div class="flex items-start gap-3 px-4 py-3">
+                            <span class="w-56 shrink-0 text-sm text-muted">Counter</span>
+                            <span class="font-mono text-[13px] font-medium">{{ quotaRow.successful_runs.toLocaleString() }}</span>
+                        </div>
+                        <div class="flex items-start gap-3 px-4 py-3">
+                            <span class="w-56 shrink-0 text-sm text-muted">Runs table</span>
+                            <span class="font-mono text-[13px] font-medium">{{ quotaRow.recomputed_successful_runs.toLocaleString() }}</span>
+                        </div>
+                        <div class="flex items-start gap-3 px-4 py-3">
+                            <span class="w-56 shrink-0 text-sm text-muted">Reserved</span>
+                            <span class="font-mono text-[13px] font-medium">{{ quotaRow.reserved_runs.toLocaleString() }}</span>
+                        </div>
+                    </PanelCard>
+
+                    <section>
+                        <div class="mb-3 flex items-center gap-2.5">
+                            <div class="min-w-0">
+                                <div class="text-[15px] font-semibold text-highlighted">Limits</div>
+                            </div>
+                            <span class="ml-auto text-xs text-dimmed">Current period: {{ periodLabel }}</span>
+                            <UButton icon="i-lucide-pencil"
+                                     label="Edit limits"
+                                     color="neutral"
+                                     variant="outline"
+                                     size="sm"
+                                     @click="editOpen = true" />
+                        </div>
+                        <div class="overflow-hidden rounded-lg border border-default">
+                            <div class="flex items-center gap-4 border-b border-default bg-muted px-4 py-3 text-sm font-semibold text-highlighted">
+                                <span class="w-56 shrink-0">Limit</span>
+                                <span class="flex-1">Value</span>
+                                <span class="w-24">Source</span>
+                            </div>
+                            <div v-for="row in limitRows"
+                                 :key="row.key"
+                                 class="flex items-center gap-4 border-b border-default px-4 py-3 last:border-b-0">
+                                <span class="w-56 shrink-0 text-sm font-medium">{{ row.label }}</span>
+                                <span class="flex-1 min-w-0">
+                                    <span class="font-mono text-[13px] font-medium">{{ row.value }}</span>
+                                    <span class="ml-2 text-xs text-dimmed">{{ row.note }}</span>
+                                </span>
+                                <span class="w-24">
+                                    <UBadge :label="row.overridden ? 'Override' : 'Inherited'"
+                                            :color="row.overridden ? 'info' : 'neutral'"
+                                            size="sm" />
+                                </span>
+                            </div>
+                        </div>
+                    </section>
+                </div>
+
+                <PanelCard v-else-if="tab === 'activity'"
+                         title="Activity"
+                         description="Derived from membership, invitation, quota and run records">
+                    <div v-if="activity.length === 0"
+                         class="px-4 py-6 text-sm text-muted">
+                        Nothing recorded yet.
+                    </div>
+                    <div v-for="entry in activity"
+                         :key="entry.kind + entry.when"
+                         class="flex items-start gap-3 px-4 py-3">
+                        <span class="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-md bg-elevated text-muted">
+                            <UIcon :name="ACTIVITY_ICONS[entry.kind] ?? 'i-lucide-circle'"
+                                   class="size-3.5" />
+                        </span>
+                        <div class="flex-1 min-w-0">
+                            <div class="text-[13.5px] leading-snug">{{ entry.title }}</div>
+                            <div class="mt-0.5 text-xs text-dimmed">
+                                <template v-if="entry.detail">{{ entry.detail }} · </template>{{ timeSince(new Date(entry.when)) }} ago
+                            </div>
+                        </div>
+                    </div>
+                </PanelCard>
+
+                <div v-else-if="tab === 'settings'"
+                     class="flex flex-col gap-8">
+                    <PanelCard title="General"
+                             description="Naming and your own access to this organisation.">
+                        <div class="flex items-center gap-4 px-4 py-3.5">
+                            <div class="flex-1 min-w-0">
+                                <div class="text-sm font-medium">Organisation name</div>
+                                <div class="mt-0.5 text-[13px] text-dimmed">Members see this name everywhere in the app.</div>
+                            </div>
+                            <UInput v-model="renameValue"
+                                    class="w-60 max-w-[50%]"
+                                    @keydown.enter="submitRename" />
+                            <UButton label="Save"
+                                     :disabled="!renameValue.trim() || renameValue.trim() === org?.name || renaming"
+                                     :loading="renaming"
+                                     @click="submitRename" />
+                        </div>
+                        <div class="flex items-center gap-4 px-4 py-3.5">
+                            <div class="flex-1 min-w-0">
+                                <div class="text-sm font-medium">Your membership</div>
+                                <div class="mt-0.5 text-[13px] text-dimmed">
+                                    <template v-if="isMember">You are an active member, so you can open this workspace directly.</template>
+                                    <template v-else>You are not a member of this organisation. Join it to open its workspace.</template>
+                                </div>
+                            </div>
+                            <UButton v-if="isMember"
+                                     icon="i-lucide-log-in"
+                                     label="Open workspace"
+                                     color="neutral"
+                                     variant="outline"
+                                     @click="openWorkspace" />
+                            <UButton v-else
+                                     icon="i-lucide-log-in"
+                                     label="Join"
+                                     color="neutral"
+                                     variant="outline"
+                                     @click="joinOrganisation" />
+                        </div>
+                    </PanelCard>
+
+                    <PanelCard tone="danger"
+                             icon="i-lucide-octagon-alert"
+                             icon-class="text-error"
+                             title="Danger zone"
+                             description="Irreversible actions. Proceed only if you are certain.">
+                        <div class="flex items-center gap-4 px-4 py-3.5">
+                            <div class="flex-1 min-w-0">
+                                <div class="text-sm font-medium">Delete organisation</div>
+                                <div class="mt-0.5 text-[13px] text-dimmed">
+                                    Permanently deletes {{ org?.name ?? 'this organisation' }} with all its members,
+                                    invitations, components and execution history.
+                                </div>
+                            </div>
+                            <UButton label="Delete this organisation"
+                                     color="error"
+                                     @click="deleteOpen = true" />
+                        </div>
+                    </PanelCard>
+
+                    <UModal v-model:open="deleteOpen"
+                            :title="`Delete ${org?.name ?? 'organisation'}?`"
+                            description="This permanently deletes the organisation with all its members, invitations, components and execution history. This action cannot be undone.">
+                        <template #body>
+                            <UFormField :label="`Type “${org?.name}” to confirm`">
+                                <UInput v-model="deleteConfirmName"
+                                        :placeholder="org?.name"
+                                        class="w-full"
+                                        @keydown.enter="submitDelete" />
+                            </UFormField>
+                        </template>
+                        <template #footer>
+                            <div class="flex w-full justify-end gap-2">
+                                <UButton label="Cancel"
+                                         color="neutral"
+                                         variant="outline"
+                                         @click="deleteOpen = false" />
+                                <UButton label="Delete organisation"
+                                         color="error"
+                                         :disabled="deleteConfirmName !== org?.name || deleting"
+                                         :loading="deleting"
+                                         @click="submitDelete" />
+                            </div>
+                        </template>
+                    </UModal>
+                </div>
+
             </div>
-
-            <section class="overflow-hidden rounded-lg border border-default bg-default">
-                <div class="flex items-center gap-2 border-b border-default px-4 py-3">
-                    <span class="text-sm font-semibold">Limits</span>
-                    <span class="text-xs text-dimmed">Current period: {{ periodLabel }}</span>
-                    <UButton icon="i-lucide-pencil"
-                             label="Edit limits"
-                             variant="outline"
-                             size="sm"
-                             class="ml-auto"
-                             @click="editOpen = true" />
-                </div>
-                <div v-for="row in limitRows"
-                     :key="row.key"
-                     class="flex items-center gap-4 px-4 py-3 border-b border-muted">
-                    <span class="w-64 shrink-0 text-[13.5px] text-muted">{{ row.label }}</span>
-                    <span class="font-mono text-[13px] font-semibold">{{ row.value }}</span>
-                    <UBadge :label="row.overridden ? 'Override' : 'Inherited'"
-                            :color="row.overridden ? 'info' : 'neutral'"
-                            variant="subtle"
-                            size="sm" />
-                    <span class="text-xs text-dimmed">{{ row.note }}</span>
-                </div>
-                <div v-if="quotaRow"
-                     class="flex items-center gap-2.5 px-4 py-3 bg-elevated/40 text-[13.5px]">
-                    <UIcon :name="ledgerInSync ? 'i-lucide-check-circle' : 'i-lucide-triangle-alert'"
-                           class="size-4 shrink-0"
-                           :class="ledgerInSync ? 'text-success' : 'text-warning'" />
-                    <span v-if="ledgerInSync">
-                        Ledger in sync — the runs counter and the runs table both report
-                        <b>{{ quotaRow.successful_runs.toLocaleString() }}</b> successful runs.
-                    </span>
-                    <span v-else>
-                        Ledger drift — the counter reads <b>{{ quotaRow.successful_runs.toLocaleString() }}</b>,
-                        the runs table gives <b>{{ quotaRow.recomputed_successful_runs.toLocaleString() }}</b>.
-                    </span>
-                </div>
-            </section>
-        </div>
-
-        <div v-else-if="tab === 'activity'"
-             class="overflow-hidden rounded-lg border border-default bg-default">
-            <div class="border-b border-default px-4 py-3">
-                <div class="text-sm font-semibold">Activity</div>
-                <div class="text-xs text-dimmed mt-0.5">
-                    Derived from membership, invitation, source and run records
-                </div>
-            </div>
-            <div v-if="activity.length === 0"
-                 class="px-4 py-6 text-sm text-muted">
-                Nothing recorded yet.
-            </div>
-            <div v-for="entry in activity"
-                 :key="entry.kind + entry.when"
-                 class="flex items-start gap-3 px-4 py-3 border-b border-muted last:border-b-0">
-                <span class="flex size-6.5 shrink-0 items-center justify-center rounded-lg bg-elevated text-muted mt-0.5">
-                    <UIcon :name="ACTIVITY_ICONS[entry.kind] ?? 'i-lucide-circle'"
-                           class="size-3.5" />
-                </span>
-                <div class="flex-1 min-w-0">
-                    <div class="text-[13.5px] leading-snug">{{ entry.title }}</div>
-                    <div v-if="entry.detail"
-                         class="text-xs text-dimmed mt-0.5">{{ entry.detail }}</div>
-                </div>
-                <span class="shrink-0 text-xs text-dimmed whitespace-nowrap mt-0.5">
-                    {{ timeSince(new Date(entry.when)) }} ago
-                </span>
-            </div>
-        </div>
-
-        <div v-else-if="tab === 'settings'"
-             class="flex flex-col gap-3">
-            <section class="rounded-lg border border-default bg-default p-4 max-w-[660px] w-full">
-                <div class="text-sm font-semibold">Organisation name</div>
-                <p class="text-[13px] text-muted leading-normal mt-1">
-                    Shown across the app and in invitation emails.
-                </p>
-                <div class="flex items-center gap-2 mt-3">
-                    <UInput v-model="renameValue"
-                            class="flex-1"
-                            @keydown.enter="submitRename" />
-                    <UButton label="Save"
-                             :disabled="!renameValue.trim() || renameValue.trim() === org?.name || renaming"
-                             :loading="renaming"
-                             @click="submitRename" />
-                </div>
-            </section>
-
-            <section class="rounded-lg border border-default bg-default p-4 max-w-[660px] w-full">
-                <div class="text-sm font-semibold">Your membership</div>
-                <p class="text-[13px] text-muted leading-normal mt-1">
-                    <template v-if="isMember">
-                        You are an active member of this organisation, so you can open its workspace directly.
-                    </template>
-                    <template v-else>
-                        You are not a member of this organisation. Join it to open its workspace.
-                    </template>
-                </p>
-                <div class="mt-3">
-                    <UButton v-if="isMember"
-                             icon="i-lucide-log-in"
-                             label="Open workspace"
-                             variant="outline"
-                             @click="openWorkspace" />
-                    <UButton v-else
-                             icon="i-lucide-log-in"
-                             label="Join"
-                             variant="outline"
-                             @click="joinOrganisation" />
-                </div>
-            </section>
-
-            <section class="rounded-lg border border-error/40 bg-error/5 p-4 max-w-[660px] w-full">
-                <div class="flex items-center gap-2 text-sm font-semibold text-error">
-                    <UIcon name="i-lucide-octagon-alert"
-                           class="size-4" />
-                    Delete organisation
-                </div>
-                <p class="text-[13px] leading-relaxed mt-1 text-error/90">
-                    This permanently deletes {{ org?.name ?? 'this organisation' }} with all its members,
-                    invitations, components, and execution history. This action cannot be undone.
-                </p>
-                <div class="flex items-center gap-2 mt-3">
-                    <UInput v-model="deleteConfirmName"
-                            :placeholder="`Type “${org?.name}” to confirm`"
-                            class="flex-1"
-                            @keydown.enter="submitDelete" />
-                    <UButton label="Delete"
-                             color="error"
-                             :disabled="deleteConfirmName !== org?.name || deleting"
-                             :loading="deleting"
-                             @click="submitDelete" />
-                </div>
-            </section>
         </div>
 
         <AdminQuotaDrawer v-model:open="editOpen"

--- a/packages/interloper-app/app/app/pages/admin/organisations/index.vue
+++ b/packages/interloper-app/app/app/pages/admin/organisations/index.vue
@@ -44,16 +44,6 @@ async function loadData() {
 const usageByOrg = computed(() => new Map<string, AdminOrgQuotaStatus>(
     (quotas.value?.organisations ?? []).map(row => [row.id, row])))
 
-const periodLabel = computed(() => {
-    if (!quotas.value) return ''
-    return new Date(quotas.value.period_start).toLocaleDateString(undefined, { month: 'long', year: 'numeric' })
-})
-
-const defaultChips = computed(() => (quotas.value?.fields ?? []).map(field => ({
-    key: field.key,
-    value: field.default != null ? field.default.toLocaleString() : 'unlimited',
-})))
-
 /** The quota closest to its ceiling — what the usage column reports. */
 function peakQuota(usage: AdminOrgQuotaStatus) {
     const candidates = [
@@ -171,34 +161,17 @@ onMounted(loadData)
 
 <template>
     <div class="flex flex-col flex-1 min-h-0 gap-3">
-        <div v-if="quotas"
-             class="flex flex-wrap items-center gap-2.5 text-sm text-muted shrink-0">
-            <span class="flex items-center gap-1.5">
-                <UIcon name="i-lucide-calendar"
-                       class="size-4" />
-                Quota usage for <b class="text-default font-semibold">{{ periodLabel }}</b>
-            </span>
-            <span class="size-[3px] rounded-full bg-accented" />
-            <span>Instance defaults</span>
-            <span v-for="chip in defaultChips"
-                  :key="chip.key"
-                  class="rounded-md border border-default bg-default px-2 py-0.5 font-mono text-xs text-toned">
-                {{ chip.key }}=<b class="font-semibold">{{ chip.value }}</b>
-            </span>
-        </div>
-
+        <NavActions>
+            <UButton icon="i-lucide-plus"
+                     label="New organisation"
+                     @click="openCreate" />
+        </NavActions>
         <DataTable :columns="columns"
                    :data="rows"
                    :loading="loading"
                    no-actions
                    search-placeholder="Search organisations..."
-                   @edit="openOrg">
-            <template #toolbar>
-                <UButton icon="i-lucide-plus"
-                         label="New organisation"
-                         @click="openCreate" />
-            </template>
-        </DataTable>
+                   @edit="openOrg"/>
 
         <UModal v-model:open="createOpen"
                 title="New organisation"

--- a/packages/interloper-app/app/app/pages/admin/users/index.vue
+++ b/packages/interloper-app/app/app/pages/admin/users/index.vue
@@ -141,7 +141,7 @@ onMounted(loadData)
 </script>
 
 <template>
-    <div class="flex flex-col flex-1 min-h-0">
+    <div class="mx-auto flex w-full max-w-[1040px] flex-col flex-1 min-h-0">
         <DataTable :columns="columns"
                    :data="filteredRows"
                    :loading="loading"

--- a/packages/interloper-app/app/app/pages/destinations.vue
+++ b/packages/interloper-app/app/app/pages/destinations.vue
@@ -40,7 +40,6 @@ function typeName(key: string): string {
 }
 
 const columns: TableColumn<ComponentRecord>[] = [
-    { accessorKey: 'select' as any, header: '' },
     {
         accessorKey: 'key',
         header: 'Destination',
@@ -99,6 +98,11 @@ function handleSaved() {
 
 <template>
     <div>
+        <NavActions>
+            <UButton icon="i-lucide-plus"
+                     label="New destination"
+                     @click="handleCreate" />
+        </NavActions>
         <div class="flex flex-col flex-1 min-h-0">
             <DataTable :columns="columns"
                        :data="destinations"
@@ -107,11 +111,6 @@ function handleSaved() {
                        search-placeholder="Search destinations..."
                        @delete="handleDelete"
                        @edit="handleEdit">
-                <template #toolbar>
-                    <UButton icon="i-lucide-plus"
-                             label="New destination"
-                             @click="handleCreate" />
-                </template>
 
                 <template #empty>
                     <EmptyState icon="i-lucide-hard-drive"

--- a/packages/interloper-app/app/app/pages/executions/backfills/[backfill].vue
+++ b/packages/interloper-app/app/app/pages/executions/backfills/[backfill].vue
@@ -1,22 +1,17 @@
 <script setup lang="ts">
 import { h, resolveComponent } from 'vue'
-import type { TableColumn, BreadcrumbItem } from '@nuxt/ui'
+import type { TableColumn } from '@nuxt/ui'
 import type { Run } from '~/types/run'
 import type { Backfill } from '~/types/backfill'
 
 // orgSwitchTarget: this page is bespoke to one org's backfill — switching org
 // from the nav lands on the backfills list instead.
-definePageMeta({ title: 'Backfill', orgSwitchTarget: '/executions?tab=backfills', titleInBreadcrumb: true })
+definePageMeta({ title: 'Backfill', orgSwitchTarget: '/executions?tab=backfills', customNavbar: true })
 
 const UBadge = resolveComponent('UBadge')
 
 const route = useRoute()
 const backfillId = route.params.backfill!.toString()
-
-const breadcrumbs: BreadcrumbItem[] = [
-    titleCrumb('Backfills', '/executions?tab=backfills'),
-    { ...entityCrumb(backfillId.substring(0, 8), 'i-lucide-calendar-range'), class: 'font-mono' },
-]
 
 const { apiFetch } = useApi()
 const backfillsStore = useBackfillsStore()
@@ -128,23 +123,25 @@ const columns: TableColumn<Run>[] = withSortableHeaders([
              back-to="/executions?tab=backfills"
              resource-label="backfill">
         <div>
-            <div class="flex items-center gap-3 mb-4 shrink-0">
-            <PageBreadcrumb :items="breadcrumbs" />
-            <UBadge v-if="backfill"
-                    :color="statusColor(backfill.status)">
-                {{ statusLabel(backfill.status) }}
-            </UBadge>
-            <UButton v-if="cancellable"
-                     color="error"
-                     variant="subtle"
-                     size="xs"
-                     icon="i-lucide-ban"
-                     :loading="cancelling"
-                     class="ml-auto"
-                     @click="onCancel">
-                Cancel
-            </UButton>
-        </div>
+            <NavTitle>
+                <ULink to="/executions?tab=backfills"
+                       class="text-[15px] font-medium text-muted hover:text-highlighted">Backfills</ULink>
+                <span class="text-[15px] text-dimmed">/</span>
+                <span class="truncate font-mono text-[15px] font-semibold">{{ backfillId.substring(0, 8) }}</span>
+                <StatusPill v-if="backfill"
+                            :label="statusLabel(backfill.status)"
+                            :color="statusPillColor(backfill.status)" />
+            </NavTitle>
+            <NavActions v-if="cancellable">
+                <UButton color="error"
+                         variant="subtle"
+                         size="sm"
+                         icon="i-lucide-ban"
+                         :loading="cancelling"
+                         @click="onCancel">
+                    Cancel
+                </UButton>
+            </NavActions>
 
         <div v-if="backfill"
              class="flex items-center gap-4 mb-4 text-sm text-muted">

--- a/packages/interloper-app/app/app/pages/executions/index.vue
+++ b/packages/interloper-app/app/app/pages/executions/index.vue
@@ -26,7 +26,6 @@ onMounted(() => {
         <UTabs :items="items"
                variant="link"
                :model-value="activeTab"
-               :ui="{ list: 'mb-4' }"
                @update:model-value="activeTab = $event as string">
             <template #runs>
                 <ExecutionsRunsTable />

--- a/packages/interloper-app/app/app/pages/executions/runs/[run].vue
+++ b/packages/interloper-app/app/app/pages/executions/runs/[run].vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import type { BreadcrumbItem } from '@nuxt/ui'
 import type { RunEvent } from '~/stores/events'
 import type { Run } from '~/types/run'
 import type { EventCategory } from '~/utils/events'
@@ -7,15 +6,10 @@ import { SplitterGroup, SplitterPanel, SplitterResizeHandle } from 'reka-ui'
 
 // orgSwitchTarget: this page is bespoke to one org's run — switching org from
 // the nav lands on the runs list instead.
-definePageMeta({ title: 'Run', orgSwitchTarget: '/executions?tab=runs', fullBleed: true })
+definePageMeta({ title: 'Run', orgSwitchTarget: '/executions?tab=runs', fullBleed: true, customNavbar: true })
 
 const route = useRoute()
 const runId = route.params.run!.toString()
-
-const breadcrumbs: BreadcrumbItem[] = [
-    titleCrumb('Runs', '/executions?tab=runs'),
-    { ...entityCrumb(runId, 'i-lucide-activity'), class: 'font-mono' },
-]
 
 const runsStore = useRunsStore()
 const eventsStore = useEventsStore()
@@ -77,6 +71,13 @@ const viewTabs = [
     { value: 'graph', label: 'Graph', icon: 'i-lucide-workflow' },
 ]
 
+/** Design's table caption for the events panel, honest about server paging. */
+const eventCaption = computed(() => {
+    const loaded = eventsStore.events.length
+    if (eventsStore.hasMore) return `${loaded} of ${eventsStore.total} events`
+    return `${loaded} event${loaded === 1 ? '' : 's'}`
+})
+
 const markerTime = computed(() => eventInFocus.value?.timestamp ? new Date(eventInFocus.value.timestamp) : null)
 const highlightedAsset = computed(() => eventInFocus.value?.component_id ?? null)
 
@@ -133,32 +134,33 @@ onUnmounted(() => {
              :error="fetchError"
              back-to="/executions?tab=runs"
              resource-label="run">
+        <NavTitle>
+            <ULink to="/executions?tab=runs"
+                   class="text-[15px] font-medium text-muted hover:text-highlighted">Runs</ULink>
+            <span class="text-[15px] text-dimmed">/</span>
+            <span class="truncate font-mono text-[15px] font-semibold">{{ runId }}</span>
+            <StatusPill v-if="run"
+                        :label="statusLabel(run.status)"
+                        :color="statusPillColor(run.status)" />
+        </NavTitle>
+        <NavActions v-if="run?.status === 'failed'">
+            <UButton label="Retry failed"
+                     icon="i-lucide-list-restart"
+                     color="neutral"
+                     variant="outline"
+                     size="sm"
+                     :loading="retrying"
+                     @click="onRetry('failed')" />
+            <UButton label="Retry all"
+                     icon="i-lucide-rotate-ccw"
+                     color="neutral"
+                     variant="outline"
+                     size="sm"
+                     :loading="retrying"
+                     @click="onRetry('all')" />
+        </NavActions>
         <div class="flex flex-col h-full min-h-0">
-            <div class="flex flex-col gap-4 mb-4 shrink-0 px-4 pt-4">
-                <div class="flex items-center gap-3">
-                    <PageBreadcrumb :items="breadcrumbs" />
-                    <UBadge v-if="run"
-                            :color="statusColor(run.status)">
-                        {{ statusLabel(run.status) }}
-                    </UBadge>
-                    <div v-if="run?.status === 'failed'"
-                         class="ml-auto flex items-center gap-2">
-                        <UButton label="Retry failed"
-                                 icon="i-lucide-list-restart"
-                                 color="neutral"
-                                 variant="outline"
-                                 size="sm"
-                                 :loading="retrying"
-                                 @click="onRetry('failed')" />
-                        <UButton label="Retry all"
-                                 icon="i-lucide-rotate-ccw"
-                                 color="neutral"
-                                 variant="outline"
-                                 size="sm"
-                                 :loading="retrying"
-                                 @click="onRetry('all')" />
-                    </div>
-                </div>
+            <div class="flex flex-col mb-4 shrink-0 px-4 pt-4">
                 <ExecutionsRunSummary v-if="run"
                                       v-model:status-filter="statusFilter"
                                       :run="run"
@@ -167,12 +169,12 @@ onUnmounted(() => {
 
         <SplitterGroup direction="vertical"
                        auto-save-id="run-panels"
-                       class="flex-1 min-h-0 rounded-lg px-4 pb-4">
+                       class="flex-1 min-h-0">
             <SplitterPanel :default-size="40"
                            :min-size="15"
                            class="flex flex-col overflow-hidden">
-                <div class="flex flex-col flex-1 min-h-0 border border-default rounded-xl bg-default overflow-hidden">
-                    <div class="flex items-center px-3.5 py-2 shrink-0 border-b border-default">
+                <div class="flex flex-col flex-1 min-h-0 overflow-hidden">
+                    <div class="flex items-center px-4 pt-4 pb-3 shrink-0">
                         <UTabs v-model="view"
                                :items="viewTabs"
                                variant="pill"
@@ -200,29 +202,20 @@ onUnmounted(() => {
             </SplitterPanel>
 
             <SplitterResizeHandle
-                class="relative flex items-center justify-center bg-default rounded-lg data-[state=hover]:bg-accented data-[state=drag]:bg-accented transition-colors">
-                <div class="z-10 flex h-2 w-8 items-center justify-center rounded-md bg-muted">
-                    <UIcon name="i-lucide-grip-horizontal"
-                           class="size-3 text-muted" />
-                </div>
-            </SplitterResizeHandle>
+                class="relative h-px shrink-0 cursor-ns-resize bg-(--ui-border) transition-colors data-[state=hover]:bg-primary/30 data-[state=drag]:bg-primary/30 before:absolute before:inset-x-0 before:-top-1.5 before:-bottom-1.5 before:z-1" />
 
             <SplitterPanel :default-size="60"
                            :min-size="20"
                            class="flex flex-col min-h-0">
-                <div class="flex flex-col flex-1 min-h-0 border border-default rounded-xl bg-default overflow-hidden">
-                    <div class="flex items-center gap-2 px-3.5 py-2 shrink-0 border-b border-default">
+                <div class="flex flex-col flex-1 min-h-0 overflow-hidden">
+                    <div class="flex items-center gap-2 px-4 pt-4 pb-3 shrink-0">
                         <UTabs v-model="eventCategory"
                                :items="eventTabs"
                                variant="pill"
                                size="xs"
                                :content="false" />
-                        <span class="ml-auto text-xs font-medium uppercase tracking-wide text-muted">Events</span>
-                        <UBadge v-if="!eventsStore.loading"
-                                color="neutral"
-                                size="sm">
-                            {{ eventsStore.hasMore ? `${eventsStore.events.length} / ${eventsStore.total}` : eventsStore.events.length }}
-                        </UBadge>
+                        <span v-if="!eventsStore.loading"
+                              class="ml-auto text-[13.5px] text-muted">{{ eventCaption }}</span>
                     </div>
                     <div class="flex-1 min-h-0">
                         <ExecutionsEventsTable v-model:event-in-focus="eventInFocus"

--- a/packages/interloper-app/app/app/pages/hooks.vue
+++ b/packages/interloper-app/app/app/pages/hooks.vue
@@ -29,7 +29,6 @@ componentsStore.fetchAll()
 componentsStore.fetchRelations()
 
 const columns = computed<TableColumn<ComponentRecord>[]>(() => [
-    { accessorKey: 'select' as any, header: '' },
     {
         accessorKey: 'name',
         header: 'Name',
@@ -103,6 +102,11 @@ async function handleDelete(ids: string[]) {
 
 <template>
     <div>
+        <NavActions>
+            <UButton icon="i-lucide-plus"
+                     label="New hook"
+                     @click="handleCreate" />
+        </NavActions>
         <div class="flex flex-col flex-1 min-h-0">
             <DataTable :columns="columns"
                        :data="hooks"
@@ -111,11 +115,6 @@ async function handleDelete(ids: string[]) {
                        search-placeholder="Search hooks..."
                        @delete="handleDelete"
                        @edit="handleEdit">
-                <template #toolbar>
-                    <UButton icon="i-lucide-plus"
-                             label="New hook"
-                             @click="handleCreate" />
-                </template>
 
                 <template #empty>
                     <EmptyState icon="i-carbon-lightning"

--- a/packages/interloper-app/app/app/pages/jobs.vue
+++ b/packages/interloper-app/app/app/pages/jobs.vue
@@ -58,7 +58,6 @@ watchEffect(() => {
 })
 
 const columns = computed<TableColumn<ComponentRecord>[]>(() => [
-    { accessorKey: 'select' as any, header: '' },
     {
         accessorKey: 'name',
         header: 'Name',
@@ -131,6 +130,11 @@ async function handleDelete(ids: string[]) {
 
 <template>
     <div>
+        <NavActions>
+            <UButton icon="i-lucide-plus"
+                     label="New job"
+                     @click="handleCreate" />
+        </NavActions>
         <div class="flex flex-col flex-1 min-h-0">
             <DataTable :columns="columns"
                        :data="jobs"
@@ -140,11 +144,6 @@ async function handleDelete(ids: string[]) {
                        search-placeholder="Search jobs..."
                        @delete="handleDelete"
                        @edit="handleEdit">
-                <template #toolbar>
-                    <UButton icon="i-lucide-plus"
-                             label="New job"
-                             @click="handleCreate" />
-                </template>
 
                 <template #empty>
                     <EmptyState icon="i-lucide-calendar-clock"

--- a/packages/interloper-app/app/app/pages/organization.vue
+++ b/packages/interloper-app/app/app/pages/organization.vue
@@ -4,6 +4,7 @@ import type { OrgMember } from '~/types/organisation'
 definePageMeta({
     title: 'Organization',
     pageHeader: {
+        eyebrow: 'Workspace',
         title: 'Members',
         description: 'Invite your team to your workspace and give everyone the right level of access. '
             + 'Roles control who can build pipelines, who can only read data, and who can manage the workspace.',
@@ -158,7 +159,7 @@ const ROLE_CARDS = [
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <div v-for="role in ROLE_CARDS"
                  :key="role.name"
-                 class="border border-default rounded-xl p-[18px] bg-default">
+                 class="border border-default rounded-lg p-[18px] bg-default">
                 <div class="flex items-center gap-2.5">
                     <div class="size-[34px] rounded-lg flex items-center justify-center"
                          :class="role.tile">

--- a/packages/interloper-app/app/app/pages/resources/[kind].vue
+++ b/packages/interloper-app/app/app/pages/resources/[kind].vue
@@ -45,7 +45,6 @@ componentsStore.fetchRelations()
 watch(kind, () => componentsStore.fetchAll([kind.value]))
 
 const columns: TableColumn<ComponentRecord>[] = [
-    { accessorKey: 'select' as any, header: '' },
     { accessorKey: 'name', header: 'Name' },
     {
         accessorKey: 'key',
@@ -105,6 +104,11 @@ const emptyCopy = computed(() => EMPTY_COPY[kind.value] ?? {
 
 <template>
     <div>
+        <NavActions>
+            <UButton icon="i-lucide-plus"
+                     :label="`New ${kind}`"
+                     @click="handleCreate" />
+        </NavActions>
         <div class="flex flex-col flex-1 min-h-0">
             <DataTable :columns="columns"
                        :data="resources"
@@ -113,12 +117,6 @@ const emptyCopy = computed(() => EMPTY_COPY[kind.value] ?? {
                        :search-placeholder="`Search ${pageTitle.toLowerCase()}...`"
                        @delete="handleDelete"
                        @edit="handleEdit">
-                <template #toolbar>
-                    <UButton icon="i-lucide-plus"
-                             :label="`New ${kind}`"
-                             @click="handleCreate" />
-                </template>
-
                 <template #empty>
                     <EmptyState :icon="KIND_ICONS[kind] ?? 'i-lucide-box'"
                                 :title="`No ${pageTitle.toLowerCase()} yet`"
@@ -146,7 +144,7 @@ const emptyCopy = computed(() => EMPTY_COPY[kind.value] ?? {
                     </div>
 
                     <div v-if="kind === 'connection'"
-                         class="flex items-center gap-3 border border-default rounded-[14px] px-5 py-4 bg-(--ui-bg-band) mt-6">
+                         class="flex items-center gap-3 border border-default rounded-lg px-5 py-4 bg-(--ui-bg-band) mt-6">
                         <UIcon name="i-lucide-info"
                                class="size-5 text-primary shrink-0" />
                         <div class="flex-1 text-[13.5px] text-toned leading-normal">

--- a/packages/interloper-app/app/app/pages/sources.vue
+++ b/packages/interloper-app/app/app/pages/sources.vue
@@ -82,7 +82,6 @@ function rowActions(source: ComponentRecord): DropdownMenuItem[][] {
 }
 
 const columns: TableColumn<ComponentRecord>[] = [
-    { accessorKey: 'select' as any, header: '' },
     {
         accessorKey: 'name',
         header: 'Source',
@@ -160,6 +159,11 @@ async function handleDelete(ids: string[]) {
 
 <template>
     <div>
+        <NavActions>
+            <UButton icon="i-lucide-plus"
+                     label="New source"
+                     @click="handleCreate" />
+        </NavActions>
         <DriftBanner />
 
         <div class="flex flex-col flex-1 min-h-0">
@@ -171,11 +175,6 @@ async function handleDelete(ids: string[]) {
                        search-placeholder="Search sources..."
                        @delete="handleDelete"
                        @edit="handleEdit">
-                <template #toolbar>
-                    <UButton icon="i-lucide-plus"
-                             label="New source"
-                             @click="handleCreate" />
-                </template>
 
                 <template #empty>
                     <SourcesEmptyState @create="handleCreate"

--- a/packages/interloper-app/app/app/pages/timeline.vue
+++ b/packages/interloper-app/app/app/pages/timeline.vue
@@ -58,24 +58,26 @@ onUnmounted(() => {
                    size="xs"
                    :content="false" />
 
-            <div class="ml-auto flex items-center gap-2">
-                <UBadge v-if="truncated"
-                        color="warning"
-                        variant="subtle"
-                        icon="i-lucide-triangle-alert"
-                        :title="`Only the ${runCount} most recent of ${total} runs in this window are shown — narrow the window to see them all.`">
-                    Showing {{ runCount }} of {{ total }}
-                </UBadge>
-                <span v-else
-                      class="text-xs text-muted">{{ runCount }} run(s)</span>
-                <UButton icon="i-lucide-refresh-cw"
-                         color="neutral"
-                         variant="outline"
-                         :loading="loading"
-                         aria-label="Refresh"
-                         @click="timelineStore.fetch()" />
-            </div>
         </div>
+
+        <NavActions>
+            <UBadge v-if="truncated"
+                    color="warning"
+                    variant="subtle"
+                    icon="i-lucide-triangle-alert"
+                    :title="`Only the ${runCount} most recent of ${total} runs in this window are shown — narrow the window to see them all.`">
+                Showing {{ runCount }} of {{ total }}
+            </UBadge>
+            <span v-else
+                  class="text-xs text-muted">{{ runCount }} run(s)</span>
+            <UButton icon="i-lucide-refresh-cw"
+                     color="neutral"
+                     variant="outline"
+                     size="sm"
+                     :loading="loading"
+                     aria-label="Refresh"
+                     @click="timelineStore.fetch()" />
+        </NavActions>
 
         <div class="flex flex-1 min-h-0 flex-col">
             <div v-if="!loading && !rows.length"

--- a/packages/interloper-app/app/app/utils/chartColors.ts
+++ b/packages/interloper-app/app/app/utils/chartColors.ts
@@ -7,11 +7,11 @@ export const CHART_STATUS_COLORS: Record<string, { light: string, dark: string }
     failed: { light: '#e5484d', dark: '#ea686c' }, // red-500 / red-400
     running: { light: '#2d7df6', dark: '#5c9ef8' }, // blue-500 / blue-400
     canceled: { light: '#e69e2e', dark: '#e9ac46' }, // amber-500 / amber-400
-    default: { light: '#d4d4d9', dark: '#6b6b70' }, // gray-400 / gray-800
+    default: { light: '#d4d4d8', dark: '#71717a' }, // gray-300 / gray-500
 }
 
 export const CHART_AXIS_COLORS = {
-    axis: { light: '#6b6b70', dark: '#9a9aa0' }, // gray-800 / gray-600
-    grid: { light: '#e8e8ec', dark: '#3f3f44' }, // gray-300 / gray-900
+    axis: { light: '#52525b', dark: '#71717a' }, // gray-600 / gray-500
+    grid: { light: '#e4e4e7', dark: '#3f3f46' }, // gray-200 / gray-700
     bar: { light: '#2d7df6', dark: '#5c9ef8' }, // blue-500 / blue-400
 }

--- a/packages/interloper-app/app/app/utils/status.ts
+++ b/packages/interloper-app/app/app/utils/status.ts
@@ -11,6 +11,12 @@ export function statusColor(status?: string | null): 'success' | 'error' | 'info
     }
 }
 
+/** StatusPill palette for a status — its vocabulary has no `info`; running reads as the accent. */
+export function statusPillColor(status?: string | null): 'success' | 'error' | 'warning' | 'neutral' | 'primary' {
+    const color = statusColor(status)
+    return color === 'info' ? 'primary' : color
+}
+
 export function statusLabel(status?: string | null): string {
     if (!status) return '—'
     return status.charAt(0).toUpperCase() + status.slice(1)

--- a/packages/interloper-app/app/app/utils/table.ts
+++ b/packages/interloper-app/app/app/utils/table.ts
@@ -26,7 +26,7 @@ export function sortableHeader<T>(label: string) {
             label,
             icon,
             trailing: true,
-            class: '-mx-2.5 data-[state=open]:bg-elevated',
+            class: '-mx-2.5 text-sm font-semibold text-highlighted data-[state=open]:bg-elevated',
             'aria-label': `Sort by ${label}`,
             onClick: () => column.toggleSorting(column.getIsSorted() === 'asc'),
         })


### PR DESCRIPTION
## What

Syncs the whole app to the redesigned Claude Design project. The design was rebuilt on the **Nuxt UI dashboard template** (per the project's own `github.md`), so much of this PR *removes* bespoke theming and lets Nuxt UI defaults through.

### Tokens

- Neutrals are now **Tailwind zinc verbatim** — ink `#09090b/#52525b/#71717a`, one line color `#E4E4E7`, surfaces `#FAFAFA/#F4F4F5`. Note the slot shift: borders moved from `gray-300` to `gray-200`, so any future direct `gray-N` utility needs checking against the new scale.
- `--ui-radius` drops to the Nuxt UI default `0.25rem` (6px controls / 8px cards); all bespoke `rounded-[Npx]` literals normalized onto those two steps. Graph nodes are the deliberate exception at 12px, per the design.
- Dark mode re-pointed to zinc equivalents; `chartColors.ts` mirror updated.

### Page chrome

- Every page gets a 56px `UDashboardNavbar` (rendered by the layouts, title from route meta); the sidebar collapse control lives there now.
- Pages put actions in the navbar via **`NavActions`**, and detail pages (run, backfill, admin org) fill the title area with crumb + id + status via **`NavTitle`**. Both gate on `onMounted` + `nextTick`: a raw `<Teleport defer>` works on fresh loads but **misses the layout outlet on client-side navigations** — worth knowing before reaching for a raw Teleport to `#navbar-*`.
- Body padding is 24px; settings-style pages (Members, admin) render the design hero (eyebrow + h1 + description).

### Tables

- Stock Nuxt UI styling for unframed tables (plain header + hairline + divided rows); the earlier band and edge-to-edge bleeds are gone.
- New `bordered` DataTable variant (outer frame + muted header) for members/admin detail tables.
- Dropped the vestigial `select` columns — Nuxt UI v4 never rendered them, they were just a ~44px dead gutter. **Side effect worth knowing**: checkbox bulk-select was already unreachable because of this (no checkbox ever rendered); row-level delete via the row menu is unaffected. DataTable still carries the bulk-delete plumbing if we want real checkboxes later.
- First column sits flush with the table edge on unframed tables; sortable headers now match plain headers' typography (`text-sm font-semibold` — the `sm` ghost button had been shrinking them).

### Admin portal

Rebuilt to the design's anatomy: shared **`PanelCard`** (naked header above a muted framed card) across Overview / Config / org detail; org detail gets a flush tab strip under the navbar, a usage strip with period-elapsed bar, a ledger panel, a limits table, and a **type-to-confirm delete modal** (previously an inline confirm); Overview's stat tiles become the fused StatStrip; Users + Config constrained to the 1040 column.

## Deliberate deviations from the mocks

- Run-page in-bar labels stay 12px (11px was reviewed as too small earlier).
- No search box on the run page's events table — events are server-paged, a client-side search would lie about what it searched.
- The run page's splitter stays a thin draggable divider rather than the design's grip, per review feedback.

## Verification

Driven live against a seeded instance (headless Chrome), light + dark: all main pages, all four admin screens, wizard drawer, quota drawer, delete modal, and client-side navigations into the teleporting detail pages. No console errors. `eslint` and `nuxt typecheck` clean; Python suite untouched by these changes and passing.

By Digitl
