### PR TITLE
refactor(db)!: count the backfill span quota in partitions

### DIFF
--- a/packages/interloper-api/tests/test_admin.py
+++ b/packages/interloper-api/tests/test_admin.py
@@ -280,7 +280,7 @@ def test_super_admin_reads_quota_overview(store: FakeStore) -> None:
     assert [field["key"] for field in body["fields"]] == list(QUOTAS.keys())
     by_key = {field["key"]: field for field in body["fields"]}
     assert by_key["max_sources"] == {"key": "max_sources", "label": "Max sources", "default": 10}
-    assert by_key["max_backfill_days"]["default"] is None
+    assert by_key["max_backfill_partitions"]["default"] is None
 
     (org,) = body["organisations"]
     assert org["limits"]["max_sources"] == 5

--- a/packages/interloper-api/tests/test_backfills.py
+++ b/packages/interloper-api/tests/test_backfills.py
@@ -120,7 +120,10 @@ def test_create_backfill_over_span_quota_returns_429(store: FakeStore) -> None:
 
     def _raise(org_id, **kwargs):
         raise QuotaExceededError(
-            "Backfill spans 31 days, exceeding the limit of 30", quota="max_backfill_days", limit=30, used=31
+            "Backfill spans 31 partitions, exceeding the limit of 30",
+            quota="max_backfill_partitions",
+            limit=30,
+            used=31,
         )
 
     store.get_component = lambda component_id, kind=None: _fake_backfill(component_id)  # ty: ignore[unresolved-attribute]
@@ -141,4 +144,4 @@ def test_create_backfill_over_span_quota_returns_429(store: FakeStore) -> None:
         json={"component_id": str(uuid4()), "start_date": "2026-01-01", "end_date": "2026-01-31"},
     )
     assert resp.status_code == 429
-    assert resp.json()["detail"]["quota"] == "max_backfill_days"
+    assert resp.json()["detail"]["quota"] == "max_backfill_partitions"

--- a/packages/interloper-core/src/interloper/settings.py
+++ b/packages/interloper-core/src/interloper/settings.py
@@ -252,9 +252,9 @@ class QuotaSettings(BaseSettings):
     max_sources: int | None = None
     max_assets_per_source: int | None = None
     max_successful_runs_per_month: int | None = None
-    # Global guard, not a per-org quota: caps how many runs one backfill
-    # request may create.
-    max_backfill_days: int | None = None
+    # Caps how many runs one backfill request may create. Per-org rows in the
+    # `quotas` table override this instance-wide default like any other quota.
+    max_backfill_partitions: int | None = None
 
 
 class AppSettings(BaseSettings):

--- a/packages/interloper-db/src/interloper_db/migrations/versions/011_backfill_partitions_quota.py
+++ b/packages/interloper-db/src/interloper_db/migrations/versions/011_backfill_partitions_quota.py
@@ -1,0 +1,46 @@
+"""The backfill span quota is counted in partitions, not days.
+
+``max_backfill_days`` becomes ``max_backfill_partitions``, finishing the
+vocabulary change that made a job's trailing window a partition count. The
+number it bounds is unchanged: at daily granularity, the only one an asset may
+declare, partitions and days coincide.
+
+Per-organisation overrides live in ``quotas.key``, so the rename is a data
+change. The new key cannot already exist (nothing wrote it before this
+release), which is why a plain UPDATE is safe. Idempotent: only rows still
+carrying the old key are touched.
+
+Revision ID: 011
+Revises: 010
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "011"
+down_revision: str | None = "010"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if not sa.inspect(bind).has_table("quotas"):
+        return
+
+    op.execute(
+        sa.text("UPDATE quotas SET key = 'max_backfill_partitions' WHERE key = 'max_backfill_days'")
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if not sa.inspect(bind).has_table("quotas"):
+        return
+
+    op.execute(
+        sa.text("UPDATE quotas SET key = 'max_backfill_days' WHERE key = 'max_backfill_partitions'")
+    )

--- a/packages/interloper-db/src/interloper_db/store/quotas.py
+++ b/packages/interloper-db/src/interloper_db/store/quotas.py
@@ -44,7 +44,7 @@ METRIC_SUCCESSFUL_RUNS = "successful_runs"
 QUOTA_MAX_SOURCES = "max_sources"
 QUOTA_MAX_ASSETS_PER_SOURCE = "max_assets_per_source"
 QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH = "max_successful_runs_per_month"
-QUOTA_MAX_BACKFILL_DAYS = "max_backfill_days"
+QUOTA_MAX_BACKFILL_PARTITIONS = "max_backfill_partitions"
 
 
 @dataclass(frozen=True)
@@ -453,11 +453,11 @@ QUOTAS.register(
     ),
 )
 QUOTAS.register(
-    QUOTA_MAX_BACKFILL_DAYS,
+    QUOTA_MAX_BACKFILL_PARTITIONS,
     BoundQuota(
-        key=QUOTA_MAX_BACKFILL_DAYS,
-        label="Max backfill days",
-        message=lambda used, limit, _subject: f"Backfill spans {used} days, exceeding the limit of {limit}",
+        key=QUOTA_MAX_BACKFILL_PARTITIONS,
+        label="Max backfill partitions",
+        message=lambda used, limit, _subject: f"Backfill spans {used} partitions, exceeding the limit of {limit}",
     ),
 )
 

--- a/packages/interloper-db/src/interloper_db/store/runs.py
+++ b/packages/interloper-db/src/interloper_db/store/runs.py
@@ -21,7 +21,7 @@ from interloper_db.models import AssetExecution, Backfill, Component, Event, Run
 from interloper_db.store.base import StoreBase
 from interloper_db.store.components import stamp_component_state
 from interloper_db.store.quotas import (
-    QUOTA_MAX_BACKFILL_DAYS,
+    QUOTA_MAX_BACKFILL_PARTITIONS,
     QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH,
     settle_run_usage,
 )
@@ -554,7 +554,7 @@ class RunMixin(StoreBase):
         with self._session() as session:
             # Cron top-ups (a job's `lookback` window) are deliberately not
             # bounded here — they never pass through this method.
-            self.quotas.check(session, org_id, QUOTA_MAX_BACKFILL_DAYS, used=span)
+            self.quotas.check(session, org_id, QUOTA_MAX_BACKFILL_PARTITIONS, used=span)
             self.quotas.check(session, org_id, QUOTA_MAX_SUCCESSFUL_RUNS_PER_MONTH, subject="backfill")
             db_backfill = Backfill(
                 org_id=org_id,

--- a/packages/interloper-db/tests/store/test_quotas.py
+++ b/packages/interloper-db/tests/store/test_quotas.py
@@ -20,7 +20,7 @@ from interloper_db.models import Backfill, Component, Quota, Run, Usage
 from interloper_db.store.quotas import (
     METRIC_SUCCESSFUL_RUNS,
     QUOTA_MAX_ASSETS_PER_SOURCE,
-    QUOTA_MAX_BACKFILL_DAYS,
+    QUOTA_MAX_BACKFILL_PARTITIONS,
     QUOTAS,
     BoundQuota,
     CapacityQuota,
@@ -263,15 +263,15 @@ class TestRunCreationGate:
             store.create_backfill(_ORG_ID, start_date=dt.date(2026, 1, 1), end_date=dt.date(2026, 1, 2))
 
     def test_backfill_span_override_wins(self, store: _Store):
-        store._quota_defaults = _defaults(max_backfill_days=2)
+        store._quota_defaults = _defaults(max_backfill_partitions=2)
         with Session(store._engine) as session:
-            session.add(Quota(org_id=_ORG_ID, key="max_backfill_days", limit=3))
+            session.add(Quota(org_id=_ORG_ID, key="max_backfill_partitions", limit=3))
             session.commit()
         backfill = store.create_backfill(_ORG_ID, start_date=dt.date(2026, 1, 1), end_date=dt.date(2026, 1, 3))
         assert backfill.partitions == 3
 
     def test_backfill_span_cap(self, store: _Store):
-        store._quota_defaults = _defaults(max_backfill_days=2)
+        store._quota_defaults = _defaults(max_backfill_partitions=2)
         with pytest.raises(QuotaExceededError, match="exceeding the limit of 2"):
             store.create_backfill(_ORG_ID, start_date=dt.date(2026, 1, 1), end_date=dt.date(2026, 1, 3))
         backfill = store.create_backfill(_ORG_ID, start_date=dt.date(2026, 1, 1), end_date=dt.date(2026, 1, 2))
@@ -395,7 +395,7 @@ class TestRegistry:
             ConsumptionQuota(key="max_bananas", label="Max bananas", message=lambda used, limit, subject: "")
 
     def test_bound_quota_rejects_a_declarative_check_without_used(self):
-        definition = QUOTAS[QUOTA_MAX_BACKFILL_DAYS]
+        definition = QUOTAS[QUOTA_MAX_BACKFILL_PARTITIONS]
         with pytest.raises(ValueError, match="pass used="):
             definition.check(None, _ORG_ID, 5)  # ty: ignore[invalid-argument-type]
 


### PR DESCRIPTION
Half 2 of ITLPR-123, which completes the ticket. The last day-shaped term in the partitioning vocabulary.

## Why

The value this quota bounds has been a **partition count** since `create_backfill` started measuring its span through the granularity (#256). Only the name still said days. At daily granularity — the only one an asset may declare — the number is identical, so nothing changes about what is enforced; the name simply stops disagreeing with everything around it.

## Change

`max_backfill_days` → `max_backfill_partitions` across:

* the registry key, its label ("Max backfill partitions") and its rejection message ("Backfill spans 31 partitions, exceeding the limit of 30");
* `QuotaSettings`, so the env var becomes `INTERLOPER_QUOTA_MAX_BACKFILL_PARTITIONS`;
* migration **011**, which rewrites per-organisation override rows in `quotas.key`.

**Half 1 is what made this small.** With the admin payload derived from the registry, there is no wire model and no `types/admin.ts` to touch: the key and label flow through on their own. Compare the surface list in the ticket, most of which no longer exists.

## The fail-open hazard, resolved rather than deferred

Renaming an env var **fails open**: if a deployment sets `INTERLOPER_QUOTA_MAX_BACKFILL_DAYS` and the code starts reading `..._PARTITIONS`, the limit becomes unset, meaning unlimited. A silently unenforced quota is worse than a dated name, so the deployment values had to move in the same change.

They did not need to. Checked in `interloper-kubernetes`: the var is set **nowhere**, and `mk1` is the **only** `chart: interloper` HelmRelease in the repo. Related correction to earlier caveats on ITLPR-122 and this ticket: `interloper-manifests` is not a deployed instance at all — it is a CLI-driven repo of client catalogs and run manifests with no HelmRelease, no scheduler and no persisted job configs, and it references neither `backfill_days` nor `CronJob`.

## Also here

The `QuotaSettings` comment still read "Global guard, not a per-org quota", which stopped being true when the quota was registered. It is the instance-wide default that per-org rows override, like every other quota.

## Verification

`make check` (ruff, ty, 1457 tests).

**Migration 011 against real Postgres**, with a legacy override row (`max_backfill_days: 30`) plus an unrelated one:

```
  legacy       [('max_backfill_days', 30), ('max_sources', 5)]
  upgraded     [('max_backfill_partitions', 30), ('max_sources', 5)]
  re-run       [('max_backfill_partitions', 30), ('max_sources', 5)]   # idempotent
  rolled back  [('max_backfill_days', 30), ('max_sources', 5)]         # reversible
  re-applied   [('max_backfill_partitions', 30), ('max_sources', 5)]
```

Unrelated rows untouched. A plain UPDATE is safe because nothing wrote the new key before this release, so it cannot collide with the `(org_id, key)` primary key.

**Post-rename behaviour:**

| Check | Result |
|---|---|
| Registry key / label | `max_backfill_partitions` / "Max backfill partitions" |
| Rejection message | "Backfill spans 31 partitions, exceeding the limit of 30" |
| `QuotaSettings` fields == registry keys | true (the test that pins this still passes) |
| Payload + default from settings | key present, reads 30 from `max_backfill_partitions` |

By Digitl
