### PR TITLE
feat!: support hourly, monthly, and yearly time partitioning

### DIFF
--- a/docs/features/cli.md
+++ b/docs/features/cli.md
@@ -27,7 +27,8 @@ interloper run interloper_assets.demo.source.DemoSource
 ### Partitions
 
 ```sh
-interloper run <target> --date 2025-01-15                       # single partition
+interloper run <target> --date 2025-01-15                       # single partition (daily)
+interloper run <target> --date 2025-01                          # single partition (monthly asset)
 interloper run <target> --start-date 2025-01-01 --end-date 2025-01-07   # window (backfill)
 ```
 
@@ -37,7 +38,7 @@ interloper run <target> --start-date 2025-01-01 --end-date 2025-01-07   # window
 |--------|-------------|
 | `-f, --file PATH` | Run a declarative manifest (see below) |
 | `--dry-run` | Validate and print the plan without executing |
-| `--date ISO` | Single partition date |
+| `--date KEY` | Single partition key (`2025-01-15`, `2025-01`, `2025`, `2025-01-15T13`) |
 | `--start-date ISO` / `--end-date ISO` | Partition window |
 | `--events [pretty\|json]` | Event output format (default `pretty`) |
 | `--run-id ID` | Optional run identifier forwarded to the runner |

--- a/docs/features/partitioning.md
+++ b/docs/features/partitioning.md
@@ -45,11 +45,25 @@ and the granularity says how long the period lasts. `TimePartitionConfig` declar
 def daily_data(context: il.ExecutionContext): ...
 ```
 
-`DAY` is the default and, today, the only accepted value. `TimeGranularity` declares the wider
-vocabulary (`HOUR`, `DAY`, `WEEK`, `MONTH`, `QUARTER`, `YEAR`) and implements the arithmetic for
-every member, but the rest of the stack is still day-shaped (runs store a `DATE`, the CLI takes
-`--date`, database destinations delete a partition by equality), so declaring anything else raises
-rather than half-working.
+`DAY` is the default. An asset may declare any of the granularities BigQuery time partitioning
+offers — `HOUR`, `DAY`, `MONTH`, `YEAR`. `WEEK` and `QUARTER` exist in the vocabulary with full
+arithmetic but cannot be declared: a partition id is a storage contract, and no destination needs
+those two.
+
+Each granularity has a canonical partition id, an ISO-8601 prefix whose shape carries the
+granularity:
+
+| Granularity | Id | Period |
+|---|---|---|
+| `HOUR` | `2026-08-21T13` | one hour, labelled in UTC |
+| `DAY` | `2026-08-21` | one day |
+| `MONTH` | `2026-08` | one calendar month |
+| `YEAR` | `2026` | one calendar year |
+
+`il.parse_partition_key("2026-08")` turns an id back into its `TimePartition`, inferring the
+granularity from the shape. Rows of a partition may carry column values anywhere inside the
+period (a monthly partition whose rows hold daily dates): destinations scope reads and replaces
+by the partition's half-open `bounds`, not by equality on its id.
 
 Every piece of partition arithmetic goes through the granularity, so assets and destinations never
 hardcode "a day":
@@ -63,6 +77,9 @@ g.bounds(dt.date(2026, 5, 20))              # (2026-05-20, 2026-05-21)  half-ope
 g.periods_between(a, b)                     # whole periods from a to b
 g.format(dt.date(2026, 5, 20))              # "2026-05-20" (the partition id)
 ```
+
+The CLI's date flags take partition keys, so `--date 2026-05` materializes a monthly asset's May
+partition and `--start-date 2026-01 --end-date 2026-06` is a six-month window.
 
 ## Bounding the history
 

--- a/packages/interloper-core/src/interloper/__init__.py
+++ b/packages/interloper-core/src/interloper/__init__.py
@@ -34,6 +34,7 @@ from interloper.partitioning import (
     TimePartitionConfig,
     TimePartitionWindow,
     lookback_window,
+    parse_partition_key,
 )
 from interloper.registry import Registry
 from interloper.resource import Resource, ResourceDefinition, ResourceRef
@@ -157,6 +158,7 @@ __all__ = [
     "fetch_field_provider",
     "is_fetch_field_provider",
     "lookback_window",
+    "parse_partition_key",
     "run",
     "schema",
     "source",

--- a/packages/interloper-core/src/interloper/cli/commands/run.py
+++ b/packages/interloper-core/src/interloper/cli/commands/run.py
@@ -42,7 +42,6 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import datetime as dt
 import logging
 from typing import TYPE_CHECKING
 
@@ -109,17 +108,17 @@ def register(
     run_parser.add_argument(
         "--date",
         default=None,
-        help="Partition date (ISO format, e.g. 2026-04-09)",
+        help="Partition key (e.g. 2026-04-09; also 2026-04, 2026, or 2026-04-09T13)",
     )
     run_parser.add_argument(
         "--start-date",
         default=None,
-        help="Partition window start date (ISO format). Must be used with --end-date.",
+        help="Partition window start key. Must be used with --end-date and share its granularity.",
     )
     run_parser.add_argument(
         "--end-date",
         default=None,
-        help="Partition window end date (ISO format). Must be used with --start-date.",
+        help="Partition window end key. Must be used with --start-date and share its granularity.",
     )
     run_parser.add_argument(
         "target",
@@ -303,6 +302,10 @@ def _print_plan(
 def _resolve_partition(args: argparse.Namespace) -> Partition | PartitionWindow | None:
     """Convert CLI date flags into a Partition or PartitionWindow.
 
+    The flags take partition keys, whose shape carries the granularity:
+    ``2026`` (year), ``2026-08`` (month), ``2026-08-21`` (day),
+    ``2026-08-21T13`` (hour). A window's two keys must share one shape.
+
     Returns:
         ``TimePartition`` for ``--date``, ``TimePartitionWindow`` for
         ``--start-date``/``--end-date``, or ``None`` if neither is set.
@@ -310,7 +313,7 @@ def _resolve_partition(args: argparse.Namespace) -> Partition | PartitionWindow 
     Raises:
         SystemExit: If the date arguments are invalid or inconsistent.
     """
-    from interloper.partitioning.time import TimePartition, TimePartitionWindow
+    from interloper.partitioning.time import TimePartitionWindow, parse_partition_key
 
     has_date = args.date is not None
     has_window = args.start_date is not None or args.end_date is not None
@@ -320,7 +323,7 @@ def _resolve_partition(args: argparse.Namespace) -> Partition | PartitionWindow 
 
     if has_date:
         try:
-            return TimePartition(dt.date.fromisoformat(args.date))
+            return parse_partition_key(args.date)
         except ValueError as exc:
             raise SystemExit(f"Error: invalid --date value: {exc}") from exc
 
@@ -328,10 +331,15 @@ def _resolve_partition(args: argparse.Namespace) -> Partition | PartitionWindow 
         if not (args.start_date and args.end_date):
             raise SystemExit("Error: both --start-date and --end-date must be provided.")
         try:
-            start = dt.date.fromisoformat(args.start_date)
-            end = dt.date.fromisoformat(args.end_date)
+            start = parse_partition_key(args.start_date)
+            end = parse_partition_key(args.end_date)
         except ValueError as exc:
             raise SystemExit(f"Error: invalid start/end date: {exc}") from exc
-        return TimePartitionWindow(start=start, end=end)
+        if start.granularity is not end.granularity:
+            raise SystemExit(
+                f"Error: --start-date is a {start.granularity.value} key but --end-date is a "
+                f"{end.granularity.value} key; a window's bounds must share one granularity."
+            )
+        return TimePartitionWindow(start=start.value, end=end.value, granularity=start.granularity)
 
     return None

--- a/packages/interloper-core/src/interloper/destination/database.py
+++ b/packages/interloper-core/src/interloper/destination/database.py
@@ -13,6 +13,7 @@ from interloper.destination.context import IOContext
 from interloper.destination.partitioned import PartitionedDestination
 from interloper.normalizer import MaterializationStrategy
 from interloper.partitioning.base import Partition, PartitionWindow
+from interloper.partitioning.time import TimePartition
 from interloper.representation import REPRESENTATIONS, Representation
 from interloper.resource.fields import SelectField
 from interloper.utils.data import is_empty
@@ -93,6 +94,17 @@ class DatabaseDestination(PartitionedDestination):
         """Delete rows matching a single partition value."""
 
     @abstractmethod
+    def _delete_partition_range(
+        self,
+        table: str,
+        schema: str | None,
+        column: str,
+        start: Any,
+        end: Any,
+    ) -> None:
+        """Delete rows whose *column* falls in ``[start, end)``."""
+
+    @abstractmethod
     def _select_all(self, table: str, schema: str | None) -> list[dict[str, Any]]:
         """Select all rows from the target table."""
 
@@ -105,6 +117,17 @@ class DatabaseDestination(PartitionedDestination):
         value: Any,
     ) -> list[dict[str, Any]]:
         """Select rows matching a single partition value."""
+
+    @abstractmethod
+    def _select_partition_range(
+        self,
+        table: str,
+        schema: str | None,
+        column: str,
+        start: Any,
+        end: Any,
+    ) -> list[dict[str, Any]]:
+        """Select rows whose *column* falls in ``[start, end)``."""
 
     # -- Introspection ---------------------------------------------------------
 
@@ -199,14 +222,14 @@ class DatabaseDestination(PartitionedDestination):
                 col = context.asset.partitioning.column
                 if replacing:
                     for partition in context.partition_or_window:
-                        self._delete_partition(table, schema, col, partition.id)
+                        self._delete_scope(table, schema, col, partition)
 
             else:
                 assert isinstance(context.partition_or_window, Partition)
                 assert context.asset.partitioning
                 col = context.asset.partitioning.column
                 if replacing:
-                    self._delete_partition(table, schema, col, context.partition_or_window.id)
+                    self._delete_scope(table, schema, col, context.partition_or_window)
 
             self._insert_data(table, schema, data, context)
 
@@ -233,6 +256,19 @@ class DatabaseDestination(PartitionedDestination):
         conformer.validate(data, context.schema, strict=True)
         return data
 
+    def _delete_scope(self, table: str, schema: str | None, column: str, partition: Partition) -> None:
+        """Delete one partition's rows: by bounds for a time partition, by id otherwise.
+
+        A time partition's rows may carry values anywhere inside the period
+        (a monthly partition whose rows hold daily dates), so equality on the
+        period start would miss them; the half-open bounds cannot.
+        """
+        if isinstance(partition, TimePartition):
+            start, end = partition.bounds
+            self._delete_partition_range(table, schema, column, start, end)
+        else:
+            self._delete_partition(table, schema, column, partition.id)
+
     def _read_scope(self, context: IOContext, partition: Partition | None) -> Any:
         """Load one scope from the database table.
 
@@ -245,4 +281,7 @@ class DatabaseDestination(PartitionedDestination):
             return self._from_rows(self._select_all(table, schema))
         assert context.asset.partitioning
         column = context.asset.partitioning.column
+        if isinstance(partition, TimePartition):
+            start, end = partition.bounds
+            return self._from_rows(self._select_partition_range(table, schema, column, start, end))
         return self._from_rows(self._select_partition(table, schema, column, partition.id))

--- a/packages/interloper-core/src/interloper/destination/partitioned.py
+++ b/packages/interloper-core/src/interloper/destination/partitioned.py
@@ -7,6 +7,7 @@ from typing import Any
 from interloper.destination.base import Destination
 from interloper.destination.context import IOContext
 from interloper.partitioning.base import Partition, PartitionWindow
+from interloper.partitioning.time import TimePartition
 from interloper.representation import Representation
 
 
@@ -83,14 +84,18 @@ class PartitionedDestination(Destination):
 def _partition_slice(data: Any, column: str, partition: Partition) -> Any:
     """Return the partition's slice of *data*.
 
-    Data recognized by a registered representation is filtered on the
-    partition column (compared as strings); other shapes pass through
-    unchanged since they cannot be split.
+    A time partition selects by its half-open bounds, because rows may carry
+    values anywhere inside the period (a monthly partition whose rows hold
+    daily dates); any other partition selects by id equality. Data no
+    registered representation recognizes passes through unchanged since it
+    cannot be split.
 
     Returns:
         The partition's slice of the data.
     """
     rep = Representation.of(data)
-    if rep.matches(data):
-        return rep.filter_eq(data, column, partition.id)
-    return data
+    if not rep.matches(data):
+        return data
+    if isinstance(partition, TimePartition):
+        return rep.filter_range(data, column, *partition.bounds)
+    return rep.filter_eq(data, column, partition.id)

--- a/packages/interloper-core/src/interloper/partitioning/__init__.py
+++ b/packages/interloper-core/src/interloper/partitioning/__init__.py
@@ -11,6 +11,7 @@ from interloper.partitioning.time import (
     TimePartitionConfig,
     TimePartitionWindow,
     lookback_window,
+    parse_partition_key,
 )
 
 __all__ = [
@@ -22,4 +23,5 @@ __all__ = [
     "TimePartitionConfig",
     "TimePartitionWindow",
     "lookback_window",
+    "parse_partition_key",
 ]

--- a/packages/interloper-core/src/interloper/partitioning/time.py
+++ b/packages/interloper-core/src/interloper/partitioning/time.py
@@ -2,10 +2,11 @@
 
 A time partition is a **period identified by its start**: the value is the
 period's first instant, and the :class:`TimeGranularity` says how long the
-period lasts. Daily is the only granularity accepted today (see
-:data:`SUPPORTED_GRANULARITIES`), but every piece of time arithmetic goes
-through the granularity, so widening it is a local change rather than a
-sweep through the codebase.
+period lasts. The granularities an asset may declare are the ones BigQuery
+time partitioning offers — hourly, daily, monthly, yearly (see
+:data:`SUPPORTED_GRANULARITIES`) — and every piece of time arithmetic goes
+through the granularity, so nothing outside this module hardcodes a period
+length.
 """
 
 from __future__ import annotations
@@ -60,10 +61,10 @@ def coerce_to_datetime(value: object) -> dt.datetime:
     Accepts a ``datetime``, a ``date`` (midnight is assumed), or an ISO-8601
     datetime string. Anything else raises ``TypeError``.
 
-    Partition values are period *labels*, not instants: they stay exactly as
-    naive or as aware as they arrive, so a window never mixes the two.
-    Choosing the timezone a period is labelled in belongs to whoever computes
-    "now".
+    Partition values are period *labels* in UTC, not instants: an aware
+    datetime is converted to UTC and stripped of its tzinfo, so ids, bounds
+    and comparisons never mix aware and naive values. This matches BigQuery,
+    whose time partitions are UTC-based.
 
     Args:
         value: The partition value to coerce.
@@ -75,12 +76,14 @@ def coerce_to_datetime(value: object) -> dt.datetime:
         TypeError: If the value cannot be interpreted as a datetime.
     """
     if isinstance(value, dt.datetime):
+        if value.tzinfo is not None:
+            return value.astimezone(dt.timezone.utc).replace(tzinfo=None)
         return value
     if isinstance(value, dt.date):
         return dt.datetime(value.year, value.month, value.day)  # noqa: DTZ001 — a label, not an instant
     if isinstance(value, str):
         try:
-            return dt.datetime.fromisoformat(value)
+            return coerce_to_datetime(dt.datetime.fromisoformat(value))
         except ValueError as e:
             raise TypeError(
                 f"Could not parse partition value {value!r} as a datetime: expected an ISO-8601 datetime string."
@@ -115,11 +118,10 @@ class TimeGranularity(str, Enum):
     fully testable, and it is what makes the granularity a real seam rather
     than a placeholder.
 
-    Partition *identity* (:meth:`format` / :meth:`parse`) is implemented for
-    ``DAY`` only. An id is a storage contract: it lands in hive paths, object
-    prefixes and ``DELETE`` predicates, so the id format for the other
-    granularities stays deliberately unspecified until a destination needs
-    one.
+    Partition *identity* (:meth:`format` / :meth:`parse`) exists for the
+    declarable granularities. An id is a storage contract — it lands in hive
+    paths, object prefixes and ``DELETE`` predicates — so ``WEEK`` and
+    ``QUARTER``, which nothing may declare, deliberately have none.
 
     Only the granularities in :data:`SUPPORTED_GRANULARITIES` may be declared
     on a :class:`TimePartitionConfig`.
@@ -220,15 +222,28 @@ class TimeGranularity(str, Enum):
     def format(self, value: object) -> str:
         """Render a value as a partition id.
 
+        Ids are ISO-8601 prefixes — ``2026``, ``2026-08``, ``2026-08-21``,
+        ``2026-08-21T13`` — so they sort chronologically as strings, embed in
+        hive paths and object prefixes unchanged, and each shape names its
+        granularity unambiguously (see :func:`parse_partition_key`).
+
         Returns:
             The canonical id of the period containing *value*.
 
         Raises:
             NotImplementedError: For granularities whose id format is not
-                yet defined.
+                yet defined (``WEEK``/``QUARTER``: an id is a storage
+                contract, and BigQuery parity does not need them).
         """
+        start = self.truncate(value)
+        if self is TimeGranularity.HOUR:
+            return start.strftime("%Y-%m-%dT%H")
         if self is TimeGranularity.DAY:
-            return self.truncate(value).isoformat()
+            return start.isoformat()
+        if self is TimeGranularity.MONTH:
+            return start.strftime("%Y-%m")
+        if self is TimeGranularity.YEAR:
+            return start.strftime("%Y")
         raise NotImplementedError(
             f"No partition id format is defined for {self.value!r} granularity. "
             f"Supported: {', '.join(sorted(g.value for g in _FORMATTABLE))}."
@@ -243,24 +258,66 @@ class TimeGranularity(str, Enum):
         Raises:
             NotImplementedError: For granularities whose id format is not
                 yet defined.
+            ValueError: If *key* is not this granularity's format.
         """
-        if self is TimeGranularity.DAY:
-            return coerce_to_date(key)
-        raise NotImplementedError(
-            f"No partition id format is defined for {self.value!r} granularity. "
-            f"Supported: {', '.join(sorted(g.value for g in _FORMATTABLE))}."
-        )
+        if self not in _FORMATTABLE:
+            raise NotImplementedError(
+                f"No partition id format is defined for {self.value!r} granularity. "
+                f"Supported: {', '.join(sorted(g.value for g in _FORMATTABLE))}."
+            )
+        pattern = _KEY_FORMATS[self]
+        try:
+            parsed = dt.datetime.strptime(key, pattern)  # noqa: DTZ007 — a label, not an instant
+        except ValueError as e:
+            raise ValueError(
+                f"Partition key {key!r} is not a {self.value} key (expected the shape {pattern!r})."
+            ) from e
+        return parsed if self is TimeGranularity.HOUR else parsed.date()
 
 
-_FORMATTABLE = frozenset({TimeGranularity.DAY})
+#: The strptime shape of each granularity's partition id.
+_KEY_FORMATS: dict[TimeGranularity, str] = {
+    TimeGranularity.HOUR: "%Y-%m-%dT%H",
+    TimeGranularity.DAY: "%Y-%m-%d",
+    TimeGranularity.MONTH: "%Y-%m",
+    TimeGranularity.YEAR: "%Y",
+}
 
-SUPPORTED_GRANULARITIES = frozenset({TimeGranularity.DAY})
-"""Granularities an asset may declare today.
+_FORMATTABLE = frozenset(_KEY_FORMATS)
 
-The arithmetic covers every member of :class:`TimeGranularity`, but the rest
-of the stack is still day-shaped (``Run.partition_date`` is a ``DATE``, the
-CLI takes ``--date``, ``DatabaseDestination`` deletes a partition by
-equality), so declaring anything else is rejected rather than half-honoured.
+
+def parse_partition_key(key: str) -> TimePartition:
+    """Parse a partition id into a :class:`TimePartition`, inferring its granularity.
+
+    The id shapes are mutually unambiguous (``2026`` / ``2026-08`` /
+    ``2026-08-21`` / ``2026-08-21T13``), so the key alone carries the
+    granularity: storage and transport need one string, not a pair.
+
+    Returns:
+        The partition the key names.
+
+    Raises:
+        ValueError: If *key* matches no known id shape.
+    """
+    for granularity, pattern in _KEY_FORMATS.items():
+        try:
+            parsed = dt.datetime.strptime(key, pattern)  # noqa: DTZ007 — a label, not an instant
+        except ValueError:
+            continue
+        value = parsed if granularity is TimeGranularity.HOUR else parsed.date()
+        return TimePartition(value, granularity)
+    shapes = ", ".join(repr(p) for p in _KEY_FORMATS.values())
+    raise ValueError(f"Partition key {key!r} matches no granularity (known shapes: {shapes}).")
+
+
+SUPPORTED_GRANULARITIES = frozenset(
+    {TimeGranularity.HOUR, TimeGranularity.DAY, TimeGranularity.MONTH, TimeGranularity.YEAR}
+)
+"""Granularities an asset may declare: the set BigQuery time partitioning offers.
+
+``WEEK`` and ``QUARTER`` keep their arithmetic (it is pure and tested) but
+have no id format and cannot be declared — a partition id is a storage
+contract, and no destination needs those two.
 """
 
 

--- a/packages/interloper-core/src/interloper/representation/__init__.py
+++ b/packages/interloper-core/src/interloper/representation/__init__.py
@@ -1,3 +1,3 @@
-from interloper.representation.base import REPRESENTATIONS, Representation, RowsRepresentation
+from interloper.representation.base import REPRESENTATIONS, Representation, RowsRepresentation, iso_label
 
-__all__ = ["REPRESENTATIONS", "Representation", "RowsRepresentation"]
+__all__ = ["REPRESENTATIONS", "Representation", "RowsRepresentation", "iso_label"]

--- a/packages/interloper-core/src/interloper/representation/base.py
+++ b/packages/interloper-core/src/interloper/representation/base.py
@@ -20,6 +20,7 @@ dependence, no explicit registration calls.
 
 from __future__ import annotations
 
+import datetime as dt
 from abc import ABC, abstractmethod
 from typing import Any, ClassVar
 
@@ -39,6 +40,25 @@ def _adopt_representation(_name: str, loaded: Any) -> tuple[str, Representation]
 
 
 REPRESENTATIONS: Registry[Representation] = Registry("interloper.representations", adopt=_adopt_representation)
+
+
+def iso_label(value: Any) -> str:
+    """Normalize a time-partition column value for lexicographic comparison.
+
+    Dates and datetimes render as ISO-8601 with the ``T`` separator; strings
+    get their first space replaced by ``T`` (``str(datetime)`` and most SQL
+    text renderings use a space). Uniform ISO strings compare correctly as
+    strings, including a date against a datetime: the date is a prefix, and a
+    half-open range keeps prefix ordering exact at both bounds.
+
+    Returns:
+        The value as a comparable ISO-8601 string.
+    """
+    if isinstance(value, dt.datetime):
+        return value.isoformat()
+    if isinstance(value, dt.date):
+        return value.isoformat()
+    return str(value).replace(" ", "T", 1)
 
 
 class Representation(ABC):
@@ -70,6 +90,16 @@ class Representation(ABC):
     @abstractmethod
     def filter_eq(self, data: Any, column: str, value: Any) -> Any:
         """Return the subset of *data* whose *column* equals *value* (compared as strings)."""
+
+    @abstractmethod
+    def filter_range(self, data: Any, column: str, start: Any, end: Any) -> Any:
+        """Return the rows whose *column* falls in ``[start, end)``.
+
+        Values and bounds are compared as ISO-8601 strings (see
+        :func:`iso_label`): the scoping primitive for time partitions, whose
+        rows may carry values anywhere inside the period rather than the
+        period's start.
+        """
 
     @property
     @abstractmethod
@@ -139,6 +169,17 @@ class RowsRepresentation(Representation):
             The matching rows.
         """
         return [row for row in data if str(row.get(column)) == str(value)]
+
+    def filter_range(
+        self, data: list[dict[str, Any]], column: str, start: Any, end: Any
+    ) -> list[dict[str, Any]]:
+        """Return the rows whose *column* falls in ``[start, end)``.
+
+        Returns:
+            The matching rows.
+        """
+        lo, hi = iso_label(start), iso_label(end)
+        return [row for row in data if lo <= iso_label(row.get(column)) < hi]
 
     @property
     def conformer(self) -> Conformer:

--- a/packages/interloper-core/tests/cli/commands/test_run.py
+++ b/packages/interloper-core/tests/cli/commands/test_run.py
@@ -173,3 +173,47 @@ class TestRunJobSpecMode:
         spec_file.write_text(yaml.safe_dump(job.to_spec().model_dump(mode="json", exclude_none=True)))
 
         _cmd_run(_args(file=str(spec_file)))
+
+
+class TestResolvePartition:
+    """Partition keys on the CLI date flags: the shape carries the granularity."""
+
+    def test_day_key_stays_daily(self) -> None:
+        from interloper.cli.commands.run import _resolve_partition
+        from interloper.partitioning.time import TimeGranularity, TimePartition
+
+        partition = _resolve_partition(_args(date="2026-06-01"))
+        assert isinstance(partition, TimePartition)
+        assert partition.granularity is TimeGranularity.DAY
+
+    def test_month_key_yields_a_monthly_partition(self) -> None:
+        import datetime as dt
+
+        from interloper.cli.commands.run import _resolve_partition
+        from interloper.partitioning.time import TimeGranularity, TimePartition
+
+        partition = _resolve_partition(_args(date="2026-06"))
+        assert isinstance(partition, TimePartition)
+        assert partition.granularity is TimeGranularity.MONTH
+        assert partition.value == dt.date(2026, 6, 1)
+
+    def test_window_keys_must_share_a_granularity(self) -> None:
+        from interloper.cli.commands.run import _resolve_partition
+
+        with pytest.raises(SystemExit, match="must share one granularity"):
+            _resolve_partition(_args(start_date="2026-06", end_date="2026-08-01"))
+
+    def test_monthly_window(self) -> None:
+        from interloper.cli.commands.run import _resolve_partition
+        from interloper.partitioning.time import TimeGranularity, TimePartitionWindow
+
+        window = _resolve_partition(_args(start_date="2026-06", end_date="2026-08"))
+        assert isinstance(window, TimePartitionWindow)
+        assert window.granularity is TimeGranularity.MONTH
+        assert window.partition_count() == 3
+
+    def test_unknown_shape_is_a_clean_error(self) -> None:
+        from interloper.cli.commands.run import _resolve_partition
+
+        with pytest.raises(SystemExit, match="invalid --date"):
+            _resolve_partition(_args(date="not-a-key"))

--- a/packages/interloper-core/tests/destination/test_database.py
+++ b/packages/interloper-core/tests/destination/test_database.py
@@ -30,10 +30,18 @@ class RecordingDB(DatabaseDestination):
     def _delete_partition(self, table, schema, column, value):
         self.calls.append(("delete_partition", (table, schema, column, value)))
 
+    def _delete_partition_range(self, table, schema, column, start, end):
+        self.calls.append(("delete_partition_range", (table, schema, column, start, end)))
+
     def _select_all(self, table, schema):
         return []
 
     def _select_partition(self, table, schema, column, value):
+        self.calls.append(("select_partition", (table, schema, column, value)))
+        return []
+
+    def _select_partition_range(self, table, schema, column, start, end):
+        self.calls.append(("select_partition_range", (table, schema, column, start, end)))
         return []
 
     def _count_by_partition(self, table, schema, column):
@@ -81,22 +89,60 @@ class TestWrite:
         dest.write(make_ctx(plain_asset()), [{"a": 1}])
         assert [c[0] for c in dest.calls] == ["insert"]
 
-    def test_single_partition_deletes_partition(self):
+    def test_single_time_partition_deletes_its_bounds(self):
+        # A time partition's rows may carry any value inside the period, so
+        # replacement deletes by half-open bounds rather than id equality.
         dest = RecordingDB(id="db")
         partition = TimePartition(datetime.date(2024, 1, 1))
         dest.write(make_ctx(partitioned_asset(), partition), [{"date": "2024-01-01"}])
-        assert dest.calls[0] == ("delete_partition", ("partitioned_asset", None, "date", "2024-01-01"))
+        assert dest.calls[0] == (
+            "delete_partition_range",
+            ("partitioned_asset", None, "date", datetime.date(2024, 1, 1), datetime.date(2024, 1, 2)),
+        )
         assert dest.calls[1][0] == "insert"
+
+    def test_non_time_partition_deletes_by_id(self):
+        from interloper.partitioning.base import Partition, PartitionConfig
+
+        @il.asset(partitioning=PartitionConfig(column="region"))
+        def regional(context: il.ExecutionContext) -> list:
+            return []
+
+        dest = RecordingDB(id="db")
+        dest.write(make_ctx(regional(), Partition("eu")), [{"region": "eu"}])
+        assert dest.calls[0] == ("delete_partition", ("regional", None, "region", "eu"))
 
     def test_window_deletes_each_partition_inserts_once(self):
         dest = RecordingDB(id="db")
         window = TimePartitionWindow(datetime.date(2024, 1, 1), datetime.date(2024, 1, 3))
         rows = [{"date": "2024-01-01"}, {"date": "2024-01-02"}, {"date": "2024-01-03"}]
         dest.write(make_ctx(partitioned_asset(), window), rows)
-        deletes = [c for c in dest.calls if c[0] == "delete_partition"]
+        deletes = [c for c in dest.calls if c[0] == "delete_partition_range"]
         inserts = [c for c in dest.calls if c[0] == "insert"]
         assert len(deletes) == 3
         assert len(inserts) == 1
+
+    def test_monthly_partition_bounds_span_the_month(self):
+        @il.asset(partitioning=il.TimePartitionConfig(column="date", granularity=il.TimeGranularity.MONTH))
+        def monthly(context: il.ExecutionContext) -> list:
+            return []
+
+        dest = RecordingDB(id="db")
+        partition = TimePartition(datetime.date(2024, 2, 10), il.TimeGranularity.MONTH)
+        dest.write(make_ctx(monthly(), partition), [{"date": "2024-02-10"}])
+        assert dest.calls[0] == (
+            "delete_partition_range",
+            ("monthly", None, "date", datetime.date(2024, 2, 1), datetime.date(2024, 3, 1)),
+        )
+
+    def test_time_partition_reads_by_bounds(self):
+        dest = RecordingDB(id="db")
+        partition = TimePartition(datetime.date(2024, 1, 1))
+        dest.read(make_ctx(partitioned_asset(), partition))
+        assert dest.calls[0] == (
+            "select_partition_range",
+            ("partitioned_asset", None, "date", datetime.date(2024, 1, 1), datetime.date(2024, 1, 2)),
+        )
 
     def test_empty_data_is_a_noop(self):
         dest = RecordingDB(id="db")

--- a/packages/interloper-core/tests/destination/test_partitioned.py
+++ b/packages/interloper-core/tests/destination/test_partitioned.py
@@ -69,6 +69,27 @@ class TestWriteDispatch:
         assert by_scope["2024-01-01"] == [{"date": "2024-01-01", "v": 1}]
         assert by_scope["2024-01-02"] == [{"date": "2024-01-02", "v": 2}, {"date": "2024-01-02", "v": 3}]
 
+    def test_monthly_window_slices_rows_by_period(self):
+        # Rows carry daily dates; each monthly partition's slice is its whole
+        # month, which id equality on the period start would miss entirely.
+        @il.asset(partitioning=il.TimePartitionConfig(column="date", granularity=il.TimeGranularity.MONTH))
+        def monthly(context: il.ExecutionContext) -> list:
+            return []
+
+        dest = RecordingScopes(id="d")
+        rows = [
+            {"date": "2024-01-15", "v": 1},
+            {"date": "2024-02-10", "v": 2},
+            {"date": "2024-02-20", "v": 3},
+        ]
+        window = TimePartitionWindow(
+            datetime.date(2024, 1, 1), datetime.date(2024, 2, 1), il.TimeGranularity.MONTH
+        )
+        dest.write(ctx(monthly(), window), rows)
+        by_scope = {scope: data for kind, scope, data in dest.calls}
+        assert by_scope["2024-01"] == [{"date": "2024-01-15", "v": 1}]
+        assert by_scope["2024-02"] == [{"date": "2024-02-10", "v": 2}, {"date": "2024-02-20", "v": 3}]
+
     def test_window_write_splits_dataframes_natively(self):
         pd = pytest.importorskip("pandas")
 

--- a/packages/interloper-core/tests/partitioning/test_time.py
+++ b/packages/interloper-core/tests/partitioning/test_time.py
@@ -13,6 +13,7 @@ from interloper.partitioning.time import (
     coerce_to_date,
     coerce_to_datetime,
     lookback_window,
+    parse_partition_key,
     period_range,
 )
 
@@ -38,9 +39,15 @@ class TestCoerceToDate:
 
 
 class TestCoerceToDatetime:
-    def test_returns_datetime_unchanged(self) -> None:
-        value = dt.datetime(2026, 1, 1, 9, 30, tzinfo=dt.timezone.utc)
+    def test_returns_naive_datetime_unchanged(self) -> None:
+        value = dt.datetime(2026, 1, 1, 9, 30)  # noqa: DTZ001
         assert coerce_to_datetime(value) is value
+
+    def test_aware_datetime_becomes_naive_utc(self) -> None:
+        # Labels are UTC: mixing aware and naive values would poison every
+        # comparison downstream (bounds, clamps, window ordering).
+        cet = dt.timezone(dt.timedelta(hours=2))
+        assert coerce_to_datetime(dt.datetime(2026, 1, 1, 9, 30, tzinfo=cet)) == dt.datetime(2026, 1, 1, 7, 30)  # noqa: DTZ001
 
     def test_date_becomes_midnight(self) -> None:
         assert coerce_to_datetime(dt.date(2026, 1, 1)) == dt.datetime(2026, 1, 1)  # noqa: DTZ001
@@ -136,21 +143,52 @@ class TestTimeGranularityPeriodsBetween:
 
 
 class TestTimeGranularityIdentity:
-    def test_day_formats_as_iso_date(self) -> None:
-        assert TimeGranularity.DAY.format(dt.date(2026, 1, 1)) == "2026-01-01"
-
-    def test_day_parse_round_trips(self) -> None:
-        assert TimeGranularity.DAY.parse("2026-01-01") == dt.date(2026, 1, 1)
-
     @pytest.mark.parametrize(
-        "granularity",
-        [TimeGranularity.HOUR, TimeGranularity.WEEK, TimeGranularity.MONTH],
+        ("granularity", "value", "key"),
+        [
+            (TimeGranularity.HOUR, dt.datetime(2026, 8, 21, 13, 45), "2026-08-21T13"),  # noqa: DTZ001
+            (TimeGranularity.DAY, dt.date(2026, 8, 21), "2026-08-21"),
+            (TimeGranularity.MONTH, dt.date(2026, 8, 21), "2026-08"),
+            (TimeGranularity.YEAR, dt.date(2026, 8, 21), "2026"),
+        ],
     )
-    def test_other_granularities_have_no_id_format_yet(self, granularity: TimeGranularity) -> None:
+    def test_format_and_parse_round_trip(self, granularity: TimeGranularity, value: object, key: str) -> None:
+        assert granularity.format(value) == key
+        assert granularity.parse(key) == granularity.truncate(value)
+
+    def test_parse_rejects_a_key_of_another_shape(self) -> None:
+        with pytest.raises(ValueError, match="not a month key"):
+            TimeGranularity.MONTH.parse("2026-01-01")
+
+    @pytest.mark.parametrize("granularity", [TimeGranularity.WEEK, TimeGranularity.QUARTER])
+    def test_undeclarable_granularities_have_no_id_format(self, granularity: TimeGranularity) -> None:
         with pytest.raises(NotImplementedError, match="partition id format"):
             granularity.format(dt.date(2026, 1, 1))
         with pytest.raises(NotImplementedError, match="partition id format"):
             granularity.parse("2026-01-01")
+
+
+class TestParsePartitionKey:
+    @pytest.mark.parametrize(
+        ("key", "granularity", "value"),
+        [
+            ("2026", TimeGranularity.YEAR, dt.date(2026, 1, 1)),
+            ("2026-08", TimeGranularity.MONTH, dt.date(2026, 8, 1)),
+            ("2026-08-21", TimeGranularity.DAY, dt.date(2026, 8, 21)),
+            ("2026-08-21T13", TimeGranularity.HOUR, dt.datetime(2026, 8, 21, 13)),  # noqa: DTZ001
+        ],
+    )
+    def test_the_key_shape_carries_the_granularity(
+        self, key: str, granularity: TimeGranularity, value: object
+    ) -> None:
+        partition = parse_partition_key(key)
+        assert partition.granularity is granularity
+        assert partition.value == value
+        assert partition.id == key
+
+    def test_rejects_an_unknown_shape(self) -> None:
+        with pytest.raises(ValueError, match="matches no granularity"):
+            parse_partition_key("2026-W33")
 
 
 class TestPeriodRange:
@@ -174,8 +212,13 @@ class TestTimePartitionConfig:
     def test_defaults_to_daily(self) -> None:
         assert TimePartitionConfig(column="date").granularity is TimeGranularity.DAY
 
-    def test_day_is_the_only_supported_granularity(self) -> None:
-        assert SUPPORTED_GRANULARITIES == {TimeGranularity.DAY}
+    def test_supported_set_is_bigquery_parity(self) -> None:
+        assert SUPPORTED_GRANULARITIES == {
+            TimeGranularity.HOUR,
+            TimeGranularity.DAY,
+            TimeGranularity.MONTH,
+            TimeGranularity.YEAR,
+        }
 
     @pytest.mark.parametrize(
         "granularity",

--- a/packages/interloper-core/tests/representation/test_base.py
+++ b/packages/interloper-core/tests/representation/test_base.py
@@ -69,6 +69,36 @@ class TestRowsRepresentation:
         assert RowsRepresentation().columns([{"a": 1, "b": 2}]) == ["a", "b"]
         assert RowsRepresentation().columns([]) == []
 
+    def test_filter_range_is_half_open(self):
+        import datetime as dt
+
+        rows = [{"d": "2024-01-31"}, {"d": "2024-02-01"}, {"d": "2024-02-15"}, {"d": "2024-03-01"}]
+        out = RowsRepresentation().filter_range(rows, "d", dt.date(2024, 2, 1), dt.date(2024, 3, 1))
+        assert out == [{"d": "2024-02-01"}, {"d": "2024-02-15"}]
+
+    def test_filter_range_spans_dates_and_datetimes(self):
+        import datetime as dt
+
+        # A date bound is an ISO prefix of any datetime inside the period, so
+        # string comparison keeps the half-open range exact at both ends.
+        rows = [
+            {"d": "2024-01-31T23:00:00"},
+            {"d": "2024-02-01 00:30:00"},
+            {"d": dt.datetime(2024, 2, 29, 23, 59)},  # noqa: DTZ001
+            {"d": "2024-03-01T00:00:00"},
+        ]
+        out = RowsRepresentation().filter_range(rows, "d", dt.date(2024, 2, 1), dt.date(2024, 3, 1))
+        assert [str(r["d"])[:7] for r in out] == ["2024-02", "2024-02"]
+
+    def test_iso_label_normalizes_the_separator(self):
+        import datetime as dt
+
+        from interloper.representation import iso_label
+
+        assert iso_label(dt.datetime(2024, 2, 1, 10, 30)) == "2024-02-01T10:30:00"  # noqa: DTZ001
+        assert iso_label("2024-02-01 10:30:00") == "2024-02-01T10:30:00"
+        assert iso_label(dt.date(2024, 2, 1)) == "2024-02-01"
+
     def test_filter_eq_compares_as_strings(self):
         rows = [{"d": "2024-01-01", "v": 1}, {"d": "2024-01-02", "v": 2}]
         assert RowsRepresentation().filter_eq(rows, "d", "2024-01-02") == [{"d": "2024-01-02", "v": 2}]

--- a/packages/interloper-google-cloud/src/interloper_google_cloud/bigquery/destination.py
+++ b/packages/interloper-google-cloud/src/interloper_google_cloud/bigquery/destination.py
@@ -20,7 +20,7 @@ from interloper.destination import IOContext, destination
 from interloper.destination.database import DatabaseDestination
 from interloper.errors import ConfigError, DataNotFoundError
 from interloper.normalizer import MaterializationStrategy
-from interloper.partitioning import PartitionConfig, TimePartitionConfig
+from interloper.partitioning import PartitionConfig, TimeGranularity, TimePartitionConfig
 from interloper.representation import Representation
 from interloper.resource.fields import FetchField, InputField, SelectField
 from interloper.schema import FieldSpec, Schema
@@ -368,6 +368,38 @@ class BigQueryDestination(DatabaseDestination):
         job_config = bigquery.QueryJobConfig(query_parameters=[_partition_param(bq_table, column, value)])
         self.client.query(query, job_config=job_config).result()
 
+    def _delete_partition_range(
+        self,
+        table: str,
+        schema: str | None,
+        column: str,
+        start: Any,
+        end: Any,
+    ) -> None:
+        """Delete rows whose *column* falls in ``[start, end)``.
+
+        No-op when the table does not exist yet.
+
+        Args:
+            table: Target table name.
+            schema: Database schema (dataset).
+            column: Partition column name.
+            start: The period's first instant (inclusive).
+            end: The period's end (exclusive).
+        """
+        bq_table = self._get_table(table, schema)
+        if bq_table is None:
+            return
+        ref = self._table_ref(table, schema)
+        query = f"DELETE FROM `{ref}` WHERE `{column}` >= @partition_start AND `{column}` < @partition_end"
+        job_config = bigquery.QueryJobConfig(
+            query_parameters=[
+                _partition_param(bq_table, column, start, name="partition_start"),
+                _partition_param(bq_table, column, end, name="partition_end"),
+            ]
+        )
+        self.client.query(query, job_config=job_config).result()
+
     def _select_all(self, table: str, schema: str | None) -> list[dict[str, Any]]:
         """Select all rows from the BigQuery table.
 
@@ -416,6 +448,44 @@ class BigQueryDestination(DatabaseDestination):
         ref = self._table_ref(table, schema)
         query = f"SELECT * FROM `{ref}` WHERE `{column}` = @partition_value"
         job_config = bigquery.QueryJobConfig(query_parameters=[_partition_param(bq_table, column, value)])
+        rows = self.client.query(query, job_config=job_config).result()
+        return [dict(row) for row in rows]
+
+    def _select_partition_range(
+        self,
+        table: str,
+        schema: str | None,
+        column: str,
+        start: Any,
+        end: Any,
+    ) -> list[dict[str, Any]]:
+        """Select rows whose *column* falls in ``[start, end)``.
+
+        Args:
+            table: Target table name.
+            schema: Database schema (dataset).
+            column: Partition column name.
+            start: The period's first instant (inclusive).
+            end: The period's end (exclusive).
+
+        Returns:
+            Matching rows as list of dicts.
+
+        Raises:
+            DataNotFoundError: If the table does not exist.
+        """
+        bq_table = self._get_table(table, schema)
+        if bq_table is None:
+            qualified = self._table_ref(table, schema)
+            raise DataNotFoundError(f"Table '{qualified}' does not exist. Has the asset been materialized?")
+        ref = self._table_ref(table, schema)
+        query = f"SELECT * FROM `{ref}` WHERE `{column}` >= @partition_start AND `{column}` < @partition_end"
+        job_config = bigquery.QueryJobConfig(
+            query_parameters=[
+                _partition_param(bq_table, column, start, name="partition_start"),
+                _partition_param(bq_table, column, end, name="partition_end"),
+            ]
+        )
         rows = self.client.query(query, job_config=job_config).result()
         return [dict(row) for row in rows]
 
@@ -509,35 +579,57 @@ def _asset_description(asset: Any) -> str | None:
 _TIME_PARTITIONABLE_TYPES = {"DATE", "DATETIME", "TIMESTAMP"}
 
 
+#: BigQuery's partitioning types, by the asset's declared granularity.
+_GRANULARITY_TO_BQ_TYPE = {
+    TimeGranularity.HOUR: bigquery.TimePartitioningType.HOUR,
+    TimeGranularity.DAY: bigquery.TimePartitioningType.DAY,
+    TimeGranularity.MONTH: bigquery.TimePartitioningType.MONTH,
+    TimeGranularity.YEAR: bigquery.TimePartitioningType.YEAR,
+}
+
+
 def _time_partitioning(
     config: PartitionConfig | None,
     bq_schema: list[bigquery.SchemaField] | None,
 ) -> bigquery.TimePartitioning | None:
     """Resolve the asset's partition config into a BigQuery time partitioning spec.
 
-    Daily partitioning on the partition column, when BigQuery supports it:
-    the column must be DATE / DATETIME / TIMESTAMP.  When the column type is
-    known (from the schema) and is not time-partitionable, or the config is
-    not time-based and no schema is available, returns ``None`` — the table
-    is created unpartitioned, which is always valid.
+    Partitioning at the asset's declared granularity, when BigQuery supports
+    it: the column must be DATE / DATETIME / TIMESTAMP, and hourly requires a
+    sub-day type (BigQuery rejects HOUR partitioning on a DATE column). When
+    the column type is known (from the schema) and does not support the
+    granularity, or the config is not time-based and no schema is available,
+    returns ``None`` — the table is created unpartitioned, which is always
+    valid.
 
     Args:
         config: The asset's partition config, if any.
         bq_schema: The table's field definitions, when known.
 
     Returns:
-        A daily ``TimePartitioning`` on the partition column, or ``None``.
+        A ``TimePartitioning`` at the asset's granularity, or ``None``.
     """
     if config is None:
         return None
 
+    granularity = config.granularity if isinstance(config, TimePartitionConfig) else TimeGranularity.DAY
     if bq_schema is not None:
         field = next((f for f in bq_schema if f.name == config.column), None)
-        if field is None or field.field_type not in _TIME_PARTITIONABLE_TYPES:
+        unsupported = (
+            field is None
+            or field.field_type not in _TIME_PARTITIONABLE_TYPES
+            or (granularity is TimeGranularity.HOUR and field.field_type == "DATE")
+        )
+        if unsupported:
             if isinstance(config, TimePartitionConfig):
+                reason = (
+                    "missing from the schema"
+                    if field is None
+                    else f"of type {field.field_type}"
+                    + (" (hourly partitioning needs DATETIME or TIMESTAMP)" if field.field_type == "DATE" else "")
+                )
                 warnings.warn(
-                    f"Partition column '{config.column}' is "
-                    f"{'missing from the schema' if field is None else f'of type {field.field_type}'}; "
+                    f"Partition column '{config.column}' is {reason}; "
                     "the BigQuery table will not be time-partitioned.",
                     UserWarning,
                     stacklevel=2,
@@ -546,7 +638,7 @@ def _time_partitioning(
     elif not isinstance(config, TimePartitionConfig):
         return None
 
-    return bigquery.TimePartitioning(type_=bigquery.TimePartitioningType.DAY, field=config.column)
+    return bigquery.TimePartitioning(type_=_GRANULARITY_TO_BQ_TYPE[granularity], field=config.column)
 
 
 def _merge_field_descriptions(
@@ -609,22 +701,25 @@ def _partition_param(
     bq_table: bigquery.Table,
     column: str,
     value: Any,
+    name: str = "partition_value",
 ) -> bigquery.ScalarQueryParameter:
-    """Build the partition-predicate query parameter, typed from the table.
+    """Build a partition-predicate query parameter, typed from the table.
 
-    Partition values arrive as strings (``Partition.id``), but the column may
-    be DATE / TIMESTAMP / INTEGER — BigQuery does not coerce a STRING
-    parameter in an equality predicate, so the parameter type must match the
-    actual column type.  Falls back to inferring from the value when the
-    column is not in the table schema.
+    Partition values arrive as strings (``Partition.id``) or as the period
+    bounds of a time partition (dates/datetimes), but the column may be
+    DATE / TIMESTAMP / INTEGER — BigQuery does not coerce a STRING parameter
+    in a comparison predicate, so the parameter type must match the actual
+    column type.  Falls back to inferring from the value when the column is
+    not in the table schema.
 
     Args:
         bq_table: The target table (for column type lookup).
         column: Partition column name.
-        value: Partition value.
+        value: Partition value or bound.
+        name: The query parameter's name.
 
     Returns:
-        A ``partition_value`` scalar parameter with the matching type.
+        A scalar parameter with the matching type.
     """
     field = next((f for f in bq_table.schema if f.name == column), None)
     if field is not None:
@@ -638,7 +733,28 @@ def _partition_param(
             value = datetime.datetime.fromisoformat(value)
         except ValueError:
             pass
-    return bigquery.ScalarQueryParameter("partition_value", param_type, value)
+    if param_type in ("TIMESTAMP", "DATETIME") and isinstance(value, datetime.date) and not isinstance(
+        value, datetime.datetime
+    ):
+        # A date bound against a datetime-typed column: promote to midnight so
+        # the client serializes it in the parameter's declared type.
+        value = datetime.datetime(value.year, value.month, value.day)  # noqa: DTZ001 — a label, not an instant
+    if param_type == "DATE" and isinstance(value, datetime.datetime):
+        # A datetime bound against a DATE column loses sub-day precision by
+        # definition; the caller guards hourly-on-DATE at table creation.
+        value = value.date()
+    if param_type == "STRING" and not isinstance(value, str):
+        value = _iso_string(value)
+    return bigquery.ScalarQueryParameter(name, param_type, value)
+
+
+def _iso_string(value: Any) -> str:
+    """Render a bound as an ISO-8601 string for STRING-typed columns.
+
+    Returns:
+        The ISO rendering of *value*.
+    """
+    return value.isoformat() if isinstance(value, (datetime.date, datetime.datetime)) else str(value)
 
 
 def _py_type_to_bq_type(py_type: Any) -> str:

--- a/packages/interloper-google-cloud/tests/test_bigquery.py
+++ b/packages/interloper-google-cloud/tests/test_bigquery.py
@@ -441,6 +441,28 @@ class TestTimePartitioning:
             tp = _time_partitioning(il.TimePartitionConfig(column="nope"), _schema_to_bq_fields(_RowSchema))
         assert tp is None
 
+    @pytest.mark.parametrize(
+        ("granularity", "bq_type"),
+        [
+            (il.TimeGranularity.DAY, "DAY"),
+            (il.TimeGranularity.MONTH, "MONTH"),
+            (il.TimeGranularity.YEAR, "YEAR"),
+        ],
+    )
+    def test_granularity_maps_to_the_bq_partitioning_type(self, granularity, bq_type):
+        config = il.TimePartitionConfig(column="day", granularity=granularity)
+        tp = _time_partitioning(config, _schema_to_bq_fields(_RowSchema))
+        assert tp is not None
+        assert tp.type_ == bq_type
+
+    def test_hourly_on_a_date_column_warns_and_skips(self):
+        # BigQuery rejects HOUR partitioning on a DATE column; falling back to
+        # an unpartitioned table beats a failed create.
+        config = il.TimePartitionConfig(column="day", granularity=il.TimeGranularity.HOUR)
+        with pytest.warns(UserWarning, match="hourly partitioning needs DATETIME or TIMESTAMP"):
+            tp = _time_partitioning(config, _schema_to_bq_fields(_RowSchema))
+        assert tp is None
+
 
 class TestCreateTableMetadata:
     """New tables carry partitioning, field descriptions, and table description."""
@@ -596,6 +618,39 @@ class TestPartitionParam:
         table.schema = []
         assert _partition_param(table, "day", "2024-01-01").type_ == "STRING"
         assert _partition_param(table, "n", 3).type_ == "INT64"
+
+    def test_range_params_are_typed_and_named(self):
+        import datetime as dt
+
+        table = MagicMock()
+        table.schema = [bigquery.SchemaField("day", "DATE")]
+        start = _partition_param(table, "day", dt.date(2024, 2, 1), name="partition_start")
+        end = _partition_param(table, "day", dt.date(2024, 3, 1), name="partition_end")
+        assert (start.name, start.type_, start.value) == ("partition_start", "DATE", dt.date(2024, 2, 1))
+        assert (end.name, end.type_) == ("partition_end", "DATE")
+
+    def test_date_bound_promotes_to_midnight_for_datetime_columns(self):
+        import datetime as dt
+
+        table = MagicMock()
+        table.schema = [bigquery.SchemaField("ts", "TIMESTAMP")]
+        param = _partition_param(table, "ts", dt.date(2024, 2, 1), name="partition_start")
+        assert param.type_ == "TIMESTAMP"
+        assert param.value == dt.datetime(2024, 2, 1)  # noqa: DTZ001
+
+    def test_delete_partition_range_builds_a_half_open_predicate(self):
+        import datetime as dt
+
+        dest, mock_client = _make_destination(dataset="ds")
+        mock_client.get_table.return_value.schema = [bigquery.SchemaField("day", "DATE")]
+
+        dest._delete_partition_range("tbl", "ds", "day", dt.date(2024, 2, 1), dt.date(2024, 3, 1))
+
+        query = mock_client.query.call_args.args[0]
+        assert ">= @partition_start" in query
+        assert "< @partition_end" in query
+        params = mock_client.query.call_args.kwargs["job_config"].query_parameters
+        assert [p.name for p in params] == ["partition_start", "partition_end"]
 
     def test_delete_partition_uses_column_type(self):
         dest, mock_client = _make_destination(dataset="ds")

--- a/packages/interloper-pandas/src/interloper_pandas/representation.py
+++ b/packages/interloper-pandas/src/interloper_pandas/representation.py
@@ -10,7 +10,7 @@ from typing import Any, ClassVar
 
 import pandas as pd
 from interloper.conformer import Conformer
-from interloper.representation import Representation
+from interloper.representation import Representation, iso_label
 
 from interloper_pandas.conformer import DATAFRAME_CONFORMER, dataframe_to_records
 
@@ -59,6 +59,15 @@ class DataFrameRepresentation(Representation):
             The matching rows.
         """
         return data[data[column].astype(str) == str(value)]
+
+    def filter_range(self, data: pd.DataFrame, column: str, start: Any, end: Any) -> pd.DataFrame:
+        """Return the rows whose *column* falls in ``[start, end)``.
+
+        Returns:
+            The matching rows.
+        """
+        labels = data[column].map(iso_label)
+        return data[(labels >= iso_label(start)) & (labels < iso_label(end))]
 
     @property
     def conformer(self) -> Conformer:

--- a/packages/interloper-pandas/tests/test_representation.py
+++ b/packages/interloper-pandas/tests/test_representation.py
@@ -38,6 +38,13 @@ class TestDataFrameRepresentation:
         df = pd.DataFrame({"a": [1], "b": [2]})
         assert DataFrameRepresentation().columns(df) == ["a", "b"]
 
+    def test_filter_range_is_half_open(self):
+        import datetime as dt
+
+        df = pd.DataFrame({"d": ["2024-01-31", "2024-02-01", "2024-02-15", "2024-03-01"], "v": [0, 1, 2, 3]})
+        out = DataFrameRepresentation().filter_range(df, "d", dt.date(2024, 2, 1), dt.date(2024, 3, 1))
+        assert out["v"].tolist() == [1, 2]
+
     def test_filter_eq_compares_as_strings(self):
         df = pd.DataFrame({"d": ["2024-01-01", "2024-01-02"], "v": [1, 2]})
         out = DataFrameRepresentation().filter_eq(df, "d", "2024-01-02")


### PR DESCRIPTION
The framework half of ITLPR-124: assets can declare hourly, monthly, or yearly partitioning — the set BigQuery time partitioning offers — and everything from the CLI through the destinations honours it. The platform half (run/backfill storage, scheduler, app) is tracked separately; see "Out of scope".

## Partition identity (item 1 of the ticket)

Ids are ISO-8601 prefixes whose **shape carries the granularity**:

| Granularity | Id |
|---|---|
| `HOUR` | `2026-08-21T13` (UTC) |
| `DAY` | `2026-08-21` |
| `MONTH` | `2026-08` |
| `YEAR` | `2026` |

They sort chronologically as strings and embed in hive paths unchanged, and `il.parse_partition_key("2026-08")` recovers the partition from the id alone — storage and transport need one string, not a (key, granularity) pair. That property is what keeps the platform half's migration small.

`WEEK`/`QUARTER` keep their arithmetic but stay undeclarable: no BigQuery counterpart, no id format, and `SUPPORTED_GRANULARITIES` says so.

**Hour labels are UTC.** `coerce_to_datetime` converts aware datetimes to naive UTC, so ids, bounds and `start`-clamps never mix aware and naive values (which cannot even be compared). Matches BigQuery's UTC-based hourly partitions.

## Range scoping (item 3)

The load-bearing change: a time partition's rows may carry column values **anywhere inside the period** — a monthly partition whose rows hold daily dates — so scoping by equality on the period start silently misses them.

- `Representation.filter_range` (rows + pandas) selects `[start, end)` by ISO-normalized string comparison; `iso_label` handles date-vs-datetime and space-vs-`T` renderings, and a date bound being an ISO prefix keeps the half-open range exact at both ends.
- The window write splitter slices time partitions by bounds (non-time partitions keep `filter_eq`).
- `DatabaseDestination` grows `_delete_partition_range` / `_select_partition_range`; the template dispatches `TimePartition` → range, other partitions → id equality. BigQuery implements both with parameters typed from the table schema (a date bound promotes to midnight for TIMESTAMP/DATETIME columns).
- BigQuery table creation maps the granularity onto `TimePartitioningType.{HOUR,DAY,MONTH,YEAR}`, and refuses hourly on a DATE column (BigQuery rejects it) via the existing unpartitioned-fallback warning.

CSV, memory, file and GCS destinations need no changes: they store per scope keyed by the id.

## CLI (part of item 4's smaller tail)

`--date` / `--start-date` / `--end-date` take partition keys: `--date 2026-05` materializes a monthly asset's May partition, `--start-date 2026-01 --end-date 2026-06` is a six-month window. A window's two keys must share one shape, and daily usage is byte-for-byte unchanged.

## Verification

`make check` (ruff, ty, 1482 tests, eslint, nuxt typecheck — 29 new tests).

End to end, executed: a monthly asset whose rows carry daily dates and an hourly asset materialize to CSV under `date=2026-02/` and `ts=2026-02-10T13/`; **re-running the same month replaces instead of duplicating** (3 rows before and after — the failure mode equality scoping would have caused); partition read-back returns the period's rows; a daily partition against a monthly asset still fails preflight with the granularity mismatch.

## Out of scope (the platform half)

`Run.partition_date` and `Backfill.start_date/end_date` are still `DATE` columns, the scheduler still pins `DAY` in `_backfill_window`, and the app's backfill pickers are day-shaped — so non-daily assets work via CLI/manifests and `dag.materialize`, but **not yet as platform jobs**. That half needs a storage migration (`partition_key`, enabled by the self-describing ids above), granularity resolution from a job's targets, and UI decisions; it is filed as its own ticket rather than ridden along here.

BREAKING CHANGE: `Representation` implementations must provide `filter_range`; `DatabaseDestination` subclasses must implement `_delete_partition_range` / `_select_partition_range`.

Refs ITLPR-124

By Digitl
